### PR TITLE
fix(release): forward-port 1.2 fixes and thread repair

### DIFF
--- a/.github/workflows/reborn-release-compile.yml
+++ b/.github/workflows/reborn-release-compile.yml
@@ -101,6 +101,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: reborn-release-${{ matrix.target }}
+          cache-on-failure: true
 
       - id: build
         name: Compile ironclaw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-13
+
+Stable promotion of `1.2.0-rc.3`, including the fixes validated in RC2 and
+RC3 and the complete RC1 feature set below.
+
+### Fixed in 1.2.0-rc.3
+
+- The runtime container image now installs `curl`, so in-container HTTP
+  healthchecks can execute. Orchestrators probe the worker with
+  `curl -fsS http://localhost:3000/`; the image shipped no HTTP client, so the
+  probe could never run, the container was never marked healthy, and the deploy
+  timed out into `error` while the listener served 200s throughout.
+
+### Fixed in 1.2.0-rc.2
+
+- Windows first-start filesystem publication now uses native atomic rename
+  semantics instead of hard links and tolerates unsupported directory syncs.
+- Release smoke runs preserve the Windows account identity required to secure
+  the standalone secrets key, isolate workspace state, and keep `icacls`
+  status output from contaminating machine-readable CLI JSON.
+
 ### Added
 
 - **Slack channel context.** Pinging the bot at the top level of a channel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,7 +3684,7 @@ checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "ironclaw"
-version = "1.1.0-rc.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,6 +4395,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,7 @@ FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bb
 RUN apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         ca-certificates \
+        curl \
         postgresql-client \
         sqlite3 \
     && rm -rf /var/lib/apt/lists/*

--- a/crates/app/ironclaw_cli/Cargo.toml
+++ b/crates/app/ironclaw_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw"
-version = "1.1.0-rc.1"
+version = "1.2.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"

--- a/crates/app/ironclaw_cli/tests/extension.rs
+++ b/crates/app/ironclaw_cli/tests/extension.rs
@@ -177,12 +177,15 @@ fn extension_install_auto_advances_and_remove_uses_persisted_installation_state(
 }
 
 fn run_extension_json(reborn_home: &Path, args: &[&str]) -> serde_json::Value {
-    let output = Command::new(reborn_bin())
+    let mut command = Command::new(reborn_bin());
+    command
         .arg("extension")
         .args(args)
         .env_clear()
         .env("IRONCLAW_DISABLE_OS_KEYCHAIN", "1")
-        .env("IRONCLAW_REBORN_HOME", reborn_home)
+        .env("IRONCLAW_REBORN_HOME", reborn_home);
+    preserve_windows_runtime_environment(&mut command);
+    let output = command
         .output()
         .expect("ironclaw-reborn extension command should run");
 
@@ -193,6 +196,17 @@ fn run_extension_json(reborn_home: &Path, args: &[&str]) -> serde_json::Value {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     serde_json::from_str(stdout.trim()).expect("valid JSON")
+}
+
+fn preserve_windows_runtime_environment(command: &mut Command) {
+    #[cfg(windows)]
+    for key in ["PATH", "SystemRoot", "WINDIR", "USERNAME", "USERDOMAIN"] {
+        if let Some(value) = std::env::var_os(key) {
+            command.env(key, value);
+        }
+    }
+    #[cfg(not(windows))]
+    let _ = command;
 }
 
 fn standalone_runtime_root(reborn_home: &Path) -> std::path::PathBuf {

--- a/crates/app/ironclaw_cli/tests/smoke.rs
+++ b/crates/app/ironclaw_cli/tests/smoke.rs
@@ -429,9 +429,19 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
         );
     }
 
+    let rust_cache_step = compile_workflow
+        .split("      - name: Restore Rust cache\n")
+        .nth(1)
+        .and_then(|tail| tail.split("      - id: build\n").next())
+        .expect("release compile workflow must contain the Rust cache step before the build step");
+    assert!(
+        rust_cache_step.contains("uses: Swatinem/rust-cache@")
+            && rust_cache_step.contains("cache-on-failure: true"),
+        "the release Rust cache step must preserve failed build caches"
+    );
+
     assert!(
         compile_workflow.contains("fail-fast: false")
-            && compile_workflow.contains("cache-on-failure: true")
             && compile_workflow.contains("cargo build --locked --profile dist")
             && compile_workflow.contains("--package ironclaw")
             && compile_workflow.contains("            --bin ironclaw \\\n")

--- a/crates/app/ironclaw_cli/tests/smoke.rs
+++ b/crates/app/ironclaw_cli/tests/smoke.rs
@@ -431,6 +431,7 @@ fn release_ci_compiles_reborn_for_all_supported_targets() {
 
     assert!(
         compile_workflow.contains("fail-fast: false")
+            && compile_workflow.contains("cache-on-failure: true")
             && compile_workflow.contains("cargo build --locked --profile dist")
             && compile_workflow.contains("--package ironclaw")
             && compile_workflow.contains("            --bin ironclaw \\\n")

--- a/crates/app/ironclaw_composition/src/factory.rs
+++ b/crates/app/ironclaw_composition/src/factory.rs
@@ -1029,22 +1029,25 @@ fn write_standalone_secret_master_key(path: &Path, key: &str) -> Result<(), Rebo
                 reason: "standalone secrets master key could not be restricted: USERNAME is unset"
                     .to_string(),
             })?;
-        let status = std::process::Command::new("icacls")
+        // `icacls` writes a success banner to stdout. Capture it so commands
+        // such as `ironclaw extension search --json` keep stdout machine-clean.
+        let output = std::process::Command::new("icacls")
             .arg(path)
             .arg("/inheritance:r")
             .arg("/grant:r")
             .arg(format!("{account}:F"))
-            .status()
+            .output()
             .map_err(|error| RebornBuildError::InvalidConfig {
                 reason: format!(
                     "standalone secrets master key permissions could not be set: {error}"
                 ),
             })?;
-        if !status.success() {
+        if !output.status.success() {
             let _ = std::fs::remove_file(path);
             return Err(RebornBuildError::InvalidConfig {
                 reason: format!(
-                    "standalone secrets master key permissions could not be set: icacls exited with {status}"
+                    "standalone secrets master key permissions could not be set: icacls exited with {}",
+                    output.status
                 ),
             });
         }

--- a/crates/app/ironclaw_composition/src/factory.rs
+++ b/crates/app/ironclaw_composition/src/factory.rs
@@ -1044,11 +1044,20 @@ fn write_standalone_secret_master_key(path: &Path, key: &str) -> Result<(), Rebo
             })?;
         if !output.status.success() {
             let _ = std::fs::remove_file(path);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = stderr.trim();
             return Err(RebornBuildError::InvalidConfig {
-                reason: format!(
-                    "standalone secrets master key permissions could not be set: icacls exited with {}",
-                    output.status
-                ),
+                reason: if stderr.is_empty() {
+                    format!(
+                        "standalone secrets master key permissions could not be set: icacls exited with {}",
+                        output.status
+                    )
+                } else {
+                    format!(
+                        "standalone secrets master key permissions could not be set: icacls exited with {}: {stderr}",
+                        output.status
+                    )
+                },
             });
         }
         file.write_all(key.as_bytes())

--- a/crates/domains/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service.rs
@@ -192,6 +192,7 @@ where
     thread_index_declaration_lock: tokio::sync::Mutex<()>,
     thread_index_touch_state: Arc<thread_index::ThreadIndexTouchState>,
     thread_index_touch_flush_interval: Duration,
+    thread_index_projection_repair_state: Arc<thread_index::ThreadIndexProjectionRepairState>,
     one_shot_context_windows: Mutex<HashMap<String, ContextWindow>>,
 }
 
@@ -211,7 +212,7 @@ pub(super) enum IndexDeclarationPolicy {
 
 impl<F> FilesystemSessionThreadService<F>
 where
-    F: RootFilesystem,
+    F: RootFilesystem + 'static,
 {
     pub fn new(filesystem: Arc<ScopedFilesystem<F>>) -> Self {
         Self {
@@ -222,6 +223,9 @@ where
             thread_index_declaration_lock: tokio::sync::Mutex::new(()),
             thread_index_touch_state: Arc::new(thread_index::ThreadIndexTouchState::default()),
             thread_index_touch_flush_interval: DEFAULT_THREAD_INDEX_TOUCH_FLUSH_INTERVAL,
+            thread_index_projection_repair_state: Arc::new(
+                thread_index::ThreadIndexProjectionRepairState::default(),
+            ),
             one_shot_context_windows: Mutex::new(HashMap::new()),
         }
     }
@@ -1453,7 +1457,7 @@ where
 
 impl<F> FilesystemSessionThreadService<F>
 where
-    F: RootFilesystem,
+    F: RootFilesystem + 'static,
 {
     /// One-time, per-scope backfill: stamp the `prepared_context` marker onto
     /// pre-marker subagent threads (their legacy metadata is

--- a/crates/domains/ironclaw_threads/src/filesystem_service/message_read.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/message_read.rs
@@ -47,7 +47,7 @@ pub(super) enum MessageReadResult {
 
 impl<F> FilesystemSessionThreadService<F>
 where
-    F: RootFilesystem,
+    F: RootFilesystem + 'static,
 {
     pub(super) async fn read_thread_messages(
         &self,

--- a/crates/domains/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use ironclaw_filesystem::{
     CasApply, CasExpectation, ContentType, Entry, FileType, Filter, IndexKey, IndexKind, IndexName,
     IndexSpec, IndexValue, OrderedPage, OrderedQueryCursor, Page, RecordKind, RootFilesystem,
-    ScopedFilesystem, SortDirection, cas_update,
+    ScopedFilesystem, SortDirection, VersionedEntry, cas_update,
 };
 use ironclaw_host_api::{ids::ThreadId, path::ScopedPath};
 use serde::{Deserialize, Serialize};
@@ -27,6 +27,11 @@ const THREAD_ACTIVITY_SORT_KEY: &str = "activity_sort";
 const THREAD_ID_INDEX_KEY: &str = "thread_id";
 const THREAD_INDEX_KNOWN_ROW_MAX: usize = 100_000;
 const THREAD_INDEX_TOUCH_STATE_MAX: usize = 100_000;
+const THREAD_INDEX_SCOPE_CACHE_MAX_ENTRIES: usize = 128;
+const THREAD_INDEX_SUFFIX: &str = ".json";
+
+mod projection_repair;
+pub(super) use projection_repair::ThreadIndexProjectionRepairState;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) struct ThreadIndexRecord {
@@ -77,7 +82,7 @@ enum ThreadIndexTouchAction {
 
 impl<F> FilesystemSessionThreadService<F>
 where
-    F: RootFilesystem,
+    F: RootFilesystem + 'static,
 {
     fn thread_index_entry(record: &ThreadIndexRecord) -> Result<Entry, SessionThreadError> {
         let body = serialize_pretty(record)?;
@@ -123,6 +128,7 @@ where
                 .await?
                 .is_some()
             {
+                self.schedule_thread_index_projection_repair(scope);
                 return Ok(());
             }
         }
@@ -143,6 +149,7 @@ where
                 .await?
                 .is_some()
             {
+                self.schedule_thread_index_projection_repair(scope);
                 return Ok(());
             }
         }
@@ -160,16 +167,16 @@ where
         .await?;
         if let Ok(mut ready) = self.ready_thread_index_scopes.lock() {
             ready.insert(scope_key.clone());
-            evict_entry_over_limit(&mut ready, 128, &scope_key);
+            evict_entry_over_limit(&mut ready, THREAD_INDEX_SCOPE_CACHE_MAX_ENTRIES, &scope_key);
         }
         if required {
             let marker = thread_index_migration_marker_path(scope)?;
-            if self
+            let migration_was_already_complete = self
                 .filesystem
                 .get(&scope.to_resource_scope(), &marker)
                 .await?
-                .is_none()
-            {
+                .is_some();
+            if !migration_was_already_complete {
                 if let Err(error) = self.migrate_thread_index_for_scope(scope).await {
                     if let Ok(mut ready) = self.ready_thread_index_scopes.lock() {
                         ready.remove(&scope_key);
@@ -194,6 +201,9 @@ where
                         "thread index migration marker was not durable after write".to_string(),
                     ));
                 }
+            }
+            if migration_was_already_complete {
+                self.schedule_thread_index_projection_repair(scope);
             }
         }
         Ok(())
@@ -605,16 +615,11 @@ where
         limit: usize,
     ) -> Result<(Vec<ThreadIndexRecord>, bool), SessionThreadError> {
         self.ensure_thread_index_query(scope, true).await?;
-        let root = thread_index_root(scope)?;
-        let mut page = OrderedPage::new(
-            thread_index_name()?,
-            thread_index_key(THREAD_ACTIVITY_SORT_KEY)?,
-            thread_index_key(THREAD_ID_INDEX_KEY)?,
-            SortDirection::Ascending,
+        let mut page = Self::thread_index_ordered_page(
             u32::try_from(limit.saturating_add(1))
                 .unwrap_or(Page::MAX_LIMIT)
                 .min(Page::MAX_LIMIT),
-        );
+        )?;
         if let Some(cursor) = cursor {
             let cursor = self.decode_thread_index_cursor(scope, cursor).await?;
             page = page.after(OrderedQueryCursor {
@@ -622,18 +627,7 @@ where
                 tie_breaker: IndexValue::Text(cursor.thread_id),
             });
         }
-        let rows = self
-            .filesystem
-            .query_ordered(
-                &scope.to_resource_scope(),
-                &root,
-                &Filter::Eq {
-                    key: thread_index_key(THREAD_SCOPE_INDEX_KEY)?,
-                    value: IndexValue::Text(thread_index_cache_key(scope)),
-                },
-                &page,
-            )
-            .await?;
+        let rows = self.query_thread_index_rows(scope, &page).await?;
         let has_more = rows.len() > limit;
         let records = rows
             .into_iter()
@@ -644,6 +638,38 @@ where
         // explicit migration/repair path; rereading every source row here
         // turns each user-facing page into an N+1 storage operation.
         Ok((records, has_more))
+    }
+
+    /// The canonical ordered page shape for the thread-listing projection.
+    pub(super) fn thread_index_ordered_page(limit: u32) -> Result<OrderedPage, SessionThreadError> {
+        Ok(OrderedPage::new(
+            thread_index_name()?,
+            thread_index_key(THREAD_ACTIVITY_SORT_KEY)?,
+            thread_index_key(THREAD_ID_INDEX_KEY)?,
+            SortDirection::Ascending,
+            limit,
+        ))
+    }
+
+    /// Query thread-listing projection rows for one scope.
+    pub(super) async fn query_thread_index_rows(
+        &self,
+        scope: &ThreadScope,
+        page: &OrderedPage,
+    ) -> Result<Vec<VersionedEntry>, SessionThreadError> {
+        let root = thread_index_root(scope)?;
+        self.filesystem
+            .query_ordered(
+                &scope.to_resource_scope(),
+                &root,
+                &Filter::Eq {
+                    key: thread_index_key(THREAD_SCOPE_INDEX_KEY)?,
+                    value: IndexValue::Text(thread_index_cache_key(scope)),
+                },
+                page,
+            )
+            .await
+            .map_err(Into::into)
     }
 
     async fn decode_thread_index_cursor(

--- a/crates/domains/ironclaw_threads/src/filesystem_service/thread_index/projection_repair.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/thread_index/projection_repair.rs
@@ -6,7 +6,7 @@
 //! after every row succeeds; failures remain retryable on a later listing.
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
 };
 
@@ -28,10 +28,12 @@ use crate::filesystem_service::{
 
 const MAX_CONCURRENT_PROJECTION_REPAIRS: usize = 2;
 const MAX_PENDING_PROJECTION_REPAIRS: usize = 128;
+const MAX_PROJECTION_REPAIR_FAILURES_PER_SCOPE: u32 = 3;
 
 pub(crate) struct ThreadIndexProjectionRepairState {
     active_scopes: Mutex<HashSet<String>>,
     completed_scopes: Mutex<HashSet<String>>,
+    failed_scope_attempts: Mutex<HashMap<String, u32>>,
     permits: Arc<tokio::sync::Semaphore>,
 }
 
@@ -40,6 +42,7 @@ impl Default for ThreadIndexProjectionRepairState {
         Self {
             active_scopes: Mutex::new(HashSet::new()),
             completed_scopes: Mutex::new(HashSet::new()),
+            failed_scope_attempts: Mutex::new(HashMap::new()),
             permits: Arc::new(tokio::sync::Semaphore::new(
                 MAX_CONCURRENT_PROJECTION_REPAIRS,
             )),
@@ -61,6 +64,17 @@ where
             .completed_scopes
             .lock()
             .is_ok_and(|completed| completed.contains(&scope_key))
+        {
+            return;
+        }
+        if self
+            .thread_index_projection_repair_state
+            .failed_scope_attempts
+            .lock()
+            .is_ok_and(|failed| {
+                failed.get(&scope_key).copied().unwrap_or_default()
+                    >= MAX_PROJECTION_REPAIR_FAILURES_PER_SCOPE
+            })
         {
             return;
         }
@@ -89,24 +103,49 @@ where
                 return;
             };
             let result = repair_thread_index_projection(Arc::clone(&filesystem), &scope).await;
-            if result.is_ok()
-                && let Ok(mut completed) = state.completed_scopes.lock()
-            {
-                completed.insert(scope_key.clone());
-                evict_entry_over_limit(
-                    &mut completed,
-                    THREAD_INDEX_SCOPE_CACHE_MAX_ENTRIES,
-                    &scope_key,
-                );
+            let failed_attempts = if result.is_ok() {
+                if let Ok(mut failed) = state.failed_scope_attempts.lock() {
+                    failed.remove(&scope_key);
+                }
+                if let Ok(mut completed) = state.completed_scopes.lock() {
+                    completed.insert(scope_key.clone());
+                    evict_entry_over_limit(
+                        &mut completed,
+                        THREAD_INDEX_SCOPE_CACHE_MAX_ENTRIES,
+                        &scope_key,
+                    );
+                }
+                0
+            } else if let Ok(mut failed) = state.failed_scope_attempts.lock() {
+                if failed.len() >= THREAD_INDEX_SCOPE_CACHE_MAX_ENTRIES
+                    && !failed.contains_key(&scope_key)
+                    && let Some(victim) = failed.keys().next().cloned()
+                {
+                    failed.remove(&victim);
+                }
+                let attempts = failed.entry(scope_key.clone()).or_default();
+                *attempts = attempts.saturating_add(1);
+                *attempts
+            } else {
+                0
+            };
+            if let Err(error) = &result {
+                if failed_attempts >= MAX_PROJECTION_REPAIR_FAILURES_PER_SCOPE {
+                    tracing::warn!(
+                        error = %error,
+                        attempts = failed_attempts,
+                        "thread-index projection repair exhausted its per-process retry budget"
+                    );
+                } else {
+                    tracing::debug!(
+                        error = %error,
+                        attempts = failed_attempts,
+                        "background thread-index projection repair failed; a later listing will retry"
+                    );
+                }
             }
             if let Ok(mut active) = state.active_scopes.lock() {
                 active.remove(&scope_key);
-            }
-            if let Err(error) = result {
-                tracing::debug!(
-                    error = %error,
-                    "background thread-index projection repair failed; a later listing will retry"
-                );
             }
             drop(permit);
         });
@@ -130,28 +169,41 @@ where
     }
 
     let root = thread_index_root(scope)?;
-    let durable = match filesystem.list_dir(&scope.to_resource_scope(), &root).await {
-        Ok(entries) => entries,
-        Err(error) if is_not_found(&error) => Vec::new(),
-        Err(error) => return Err(error.into()),
-    };
-    let index_rows: Vec<ThreadId> = durable
-        .into_iter()
-        .filter(|entry| entry.file_type == FileType::File)
-        .filter_map(|entry| {
-            entry
-                .name
-                .strip_suffix(THREAD_INDEX_SUFFIX)
-                .map(str::to_owned)
-        })
-        .map(|raw_id| ThreadId::new(raw_id).map_err(invalid_path))
-        .collect::<Result<_, _>>()?;
-
-    for page in index_rows.chunks(Page::MAX_LIMIT as usize) {
-        for thread_id in page {
-            restore_thread_index_projection(filesystem.as_ref(), scope, thread_id).await?;
+    let page_limit = Page::MAX_LIMIT as usize;
+    let mut after = None;
+    loop {
+        let page = match filesystem
+            .list_dir_page(
+                &scope.to_resource_scope(),
+                &root,
+                after.as_deref(),
+                page_limit,
+            )
+            .await
+        {
+            Ok(entries) => entries,
+            Err(error) if is_not_found(&error) => Vec::new(),
+            Err(error) => return Err(error.into()),
+        };
+        if page.is_empty() {
+            break;
         }
+        let page_len = page.len();
+        for entry in &page {
+            if entry.file_type != FileType::File {
+                continue;
+            }
+            let Some(raw_id) = entry.name.strip_suffix(THREAD_INDEX_SUFFIX) else {
+                continue;
+            };
+            let thread_id = ThreadId::new(raw_id.to_string()).map_err(invalid_path)?;
+            restore_thread_index_projection(filesystem.as_ref(), scope, &thread_id).await?;
+        }
+        after = page.last().map(|entry| entry.name.clone());
         tokio::task::yield_now().await;
+        if page_len < page_limit {
+            break;
+        }
     }
 
     filesystem

--- a/crates/domains/ironclaw_threads/src/filesystem_service/thread_index/projection_repair.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/thread_index/projection_repair.rs
@@ -1,0 +1,242 @@
+//! One-time recovery for thread-index rows whose listing projection is absent.
+//!
+//! Repair is scheduled after a scope is first listed, but it never runs on the
+//! listing request itself. A small admission limit prevents one process from
+//! accumulating unbounded repair tasks. Completion is durable and written only
+//! after every row succeeds; failures remain retryable on a later listing.
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+use ironclaw_filesystem::{
+    CasApply, CasExpectation, Entry, FileType, Page, RootFilesystem, ScopedFilesystem, cas_update,
+};
+use ironclaw_host_api::{ids::ThreadId, path::ScopedPath};
+
+use crate::{FilesystemSessionThreadService, SessionThreadError, ThreadScope};
+
+use super::{
+    THREAD_INDEX_SCOPE_CACHE_MAX_ENTRIES, THREAD_INDEX_SUFFIX, ThreadIndexRecord,
+    evict_entry_over_limit, no_op_thread_index_record, thread_activity_index_spec,
+    thread_index_cache_key, thread_index_record_path, thread_index_root,
+};
+use crate::filesystem_service::{
+    deserialize, invalid_path, is_not_found, map_cas_error, scoped_path,
+};
+
+const MAX_CONCURRENT_PROJECTION_REPAIRS: usize = 2;
+const MAX_PENDING_PROJECTION_REPAIRS: usize = 128;
+
+pub(crate) struct ThreadIndexProjectionRepairState {
+    active_scopes: Mutex<HashSet<String>>,
+    completed_scopes: Mutex<HashSet<String>>,
+    permits: Arc<tokio::sync::Semaphore>,
+}
+
+impl Default for ThreadIndexProjectionRepairState {
+    fn default() -> Self {
+        Self {
+            active_scopes: Mutex::new(HashSet::new()),
+            completed_scopes: Mutex::new(HashSet::new()),
+            permits: Arc::new(tokio::sync::Semaphore::new(
+                MAX_CONCURRENT_PROJECTION_REPAIRS,
+            )),
+        }
+    }
+}
+
+impl<F> FilesystemSessionThreadService<F>
+where
+    F: RootFilesystem + 'static,
+{
+    /// Schedule a retryable repair without adding latency to the listing that
+    /// discovers the scope. The pending set is bounded; if it is full, a later
+    /// listing retries admission after earlier repairs have drained.
+    pub(super) fn schedule_thread_index_projection_repair(&self, scope: &ThreadScope) {
+        let scope_key = thread_index_cache_key(scope);
+        if self
+            .thread_index_projection_repair_state
+            .completed_scopes
+            .lock()
+            .is_ok_and(|completed| completed.contains(&scope_key))
+        {
+            return;
+        }
+        {
+            let Ok(mut active) = self
+                .thread_index_projection_repair_state
+                .active_scopes
+                .lock()
+            else {
+                return;
+            };
+            if active.contains(&scope_key) || active.len() >= MAX_PENDING_PROJECTION_REPAIRS {
+                return;
+            }
+            active.insert(scope_key.clone());
+        }
+
+        let filesystem = Arc::clone(&self.filesystem);
+        let state = Arc::clone(&self.thread_index_projection_repair_state);
+        let scope = scope.clone();
+        tokio::spawn(async move {
+            let Ok(permit) = Arc::clone(&state.permits).acquire_owned().await else {
+                if let Ok(mut active) = state.active_scopes.lock() {
+                    active.remove(&scope_key);
+                }
+                return;
+            };
+            let result = repair_thread_index_projection(Arc::clone(&filesystem), &scope).await;
+            if result.is_ok()
+                && let Ok(mut completed) = state.completed_scopes.lock()
+            {
+                completed.insert(scope_key.clone());
+                evict_entry_over_limit(
+                    &mut completed,
+                    THREAD_INDEX_SCOPE_CACHE_MAX_ENTRIES,
+                    &scope_key,
+                );
+            }
+            if let Ok(mut active) = state.active_scopes.lock() {
+                active.remove(&scope_key);
+            }
+            if let Err(error) = result {
+                tracing::debug!(
+                    error = %error,
+                    "background thread-index projection repair failed; a later listing will retry"
+                );
+            }
+            drop(permit);
+        });
+    }
+}
+
+async fn repair_thread_index_projection<F>(
+    filesystem: Arc<ScopedFilesystem<F>>,
+    scope: &ThreadScope,
+) -> Result<(), SessionThreadError>
+where
+    F: RootFilesystem + 'static,
+{
+    let marker = thread_index_projection_repair_marker_path(scope)?;
+    if filesystem
+        .get(&scope.to_resource_scope(), &marker)
+        .await?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    let root = thread_index_root(scope)?;
+    let durable = match filesystem.list_dir(&scope.to_resource_scope(), &root).await {
+        Ok(entries) => entries,
+        Err(error) if is_not_found(&error) => Vec::new(),
+        Err(error) => return Err(error.into()),
+    };
+    let index_rows: Vec<ThreadId> = durable
+        .into_iter()
+        .filter(|entry| entry.file_type == FileType::File)
+        .filter_map(|entry| {
+            entry
+                .name
+                .strip_suffix(THREAD_INDEX_SUFFIX)
+                .map(str::to_owned)
+        })
+        .map(|raw_id| ThreadId::new(raw_id).map_err(invalid_path))
+        .collect::<Result<_, _>>()?;
+
+    for page in index_rows.chunks(Page::MAX_LIMIT as usize) {
+        for thread_id in page {
+            restore_thread_index_projection(filesystem.as_ref(), scope, thread_id).await?;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    filesystem
+        .put(
+            &scope.to_resource_scope(),
+            &marker,
+            Entry::bytes(b"thread-index-projection-v2".to_vec()),
+            CasExpectation::Any,
+        )
+        .await?;
+    if filesystem
+        .get(&scope.to_resource_scope(), &marker)
+        .await?
+        .is_none()
+    {
+        return Err(SessionThreadError::Backend(
+            "thread-index projection repair marker was not durable after write".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn restore_thread_index_projection<F>(
+    filesystem: &ScopedFilesystem<F>,
+    scope: &ThreadScope,
+    thread_id: &ThreadId,
+) -> Result<(), SessionThreadError>
+where
+    F: RootFilesystem + 'static,
+{
+    let path = thread_index_record_path(scope, thread_id)?;
+    let Some(versioned) = filesystem.get(&scope.to_resource_scope(), &path).await? else {
+        return Ok(());
+    };
+    let record = deserialize::<ThreadIndexRecord>(&versioned.entry.body)?;
+    if record.record.scope != *scope || record.record.thread_id != *thread_id {
+        return Ok(());
+    }
+    let rebuilt = FilesystemSessionThreadService::<F>::thread_index_entry(&record)?;
+    let projection_current = thread_activity_index_spec()?
+        .keys
+        .iter()
+        .all(|key| versioned.entry.indexed.get(key) == rebuilt.indexed.get(key));
+    if projection_current {
+        return Ok(());
+    }
+
+    let resource_scope = scope.to_resource_scope();
+    let scope_for_retry = scope.clone();
+    let thread_id_for_retry = thread_id.clone();
+    cas_update(
+        filesystem,
+        &resource_scope,
+        &path,
+        |bytes: &[u8]| deserialize::<ThreadIndexRecord>(bytes),
+        |record: &ThreadIndexRecord| {
+            FilesystemSessionThreadService::<F>::thread_index_entry(record)
+        },
+        |current: Option<ThreadIndexRecord>| {
+            let scope = scope_for_retry.clone();
+            let thread_id = thread_id_for_retry.clone();
+            async move {
+                let Some(record) = current else {
+                    return Ok(CasApply::no_op(
+                        no_op_thread_index_record(scope, thread_id),
+                        false,
+                    ));
+                };
+                if record.record.scope != scope || record.record.thread_id != thread_id {
+                    return Ok(CasApply::no_op(record, false));
+                }
+                Ok(CasApply::force_write(record, true))
+            }
+        },
+    )
+    .await
+    .map_err(map_cas_error)?;
+    Ok(())
+}
+
+fn thread_index_projection_repair_marker_path(
+    scope: &ThreadScope,
+) -> Result<ScopedPath, SessionThreadError> {
+    scoped_path(&format!(
+        "{}/index-migrations/thread-index-projection-v2.complete",
+        super::scope_axes_string(scope)
+    ))
+}

--- a/crates/domains/ironclaw_threads/src/filesystem_service/transcript_migration.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/transcript_migration.rs
@@ -45,7 +45,7 @@ fn transcript_migration_conflict(error: &ironclaw_filesystem::FilesystemError) -
 
 impl<F> FilesystemSessionThreadService<F>
 where
-    F: RootFilesystem,
+    F: RootFilesystem + 'static,
 {
     /// Idempotent rebuild for message, summary, and exact-lookup projections.
     pub async fn migrate_transcript_indexes_for_scope(

--- a/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -4238,6 +4238,94 @@ async fn filesystem_list_threads_degrades_to_projected_rows_when_reconcile_fails
     assert!(repaired_ids.contains(&"projected-before-failure-b"));
 }
 
+/// A corrupt row or permanently unavailable backend path must not trigger a
+/// full-scope repair scan on every later sidebar request. The process gives
+/// transient failures a bounded retry budget, then stops admitting the scope
+/// without ever writing the durable completion marker for partial work.
+#[tokio::test]
+async fn filesystem_list_threads_bounds_persistent_projection_repair_failures() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(
+        Arc::clone(&backend),
+        "tenant-index-reconcile-persistent-failure",
+        "alice",
+    );
+    let scope = scope("index-reconcile-persistent-failure");
+    let seeding_service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    seeding_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("persistent-failure-thread").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("persistent failure thread".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    seeding_service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("seed listing writes the completed v1 migration marker");
+
+    backend.add_fault(
+        Fault::on(FilesystemOperation::ListDir)
+            .path("/thread_index")
+            .backend("projection repair remains unavailable"),
+    );
+    let baseline = backend.count(FilesystemOperation::ListDir);
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+
+    for expected_attempts in 1..=3 {
+        restarted
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: scope.clone(),
+                limit: None,
+                cursor: None,
+            })
+            .await
+            .expect("listing remains available while background repair fails");
+        timeout(Duration::from_secs(5), async {
+            while backend.count(FilesystemOperation::ListDir) < baseline + expected_attempts {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the admitted background repair attempt must finish");
+    }
+
+    for _ in 0..5 {
+        restarted
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: scope.clone(),
+                limit: None,
+                cursor: None,
+            })
+            .await
+            .expect("listing remains available after the retry budget is exhausted");
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        backend.count(FilesystemOperation::ListDir),
+        baseline + 3,
+        "persistent failure must stop scheduling a full-scope scan on every listing"
+    );
+    assert!(
+        scoped
+            .get(
+                &scope.to_resource_scope(),
+                &thread_index_projection_repair_marker_path_for_test(&scope),
+            )
+            .await
+            .unwrap()
+            .is_none(),
+        "a scope that exhausted its retry budget must remain durably incomplete"
+    );
+}
+
 /// A current-version record can still be invisible when its entry sidecar
 /// loses the ordered keys. Repair must use the shared CAS retry loop rather
 /// than a one-shot conditional put, because a benign concurrent rewrite can
@@ -4323,8 +4411,8 @@ async fn filesystem_list_threads_retries_reconcile_projection_repair_after_cas_r
 /// the background and writes completion only after the entire scope succeeds.
 #[tokio::test]
 async fn filesystem_list_threads_repairs_oversized_scope_in_background() {
-    let backend = Arc::new(InMemoryBackend::new());
-    let scoped = scoped_threads_fs_at(backend, "tenant-index-oversized", "alice");
+    let backend = Arc::new(QueryCountingBackend::new());
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-index-oversized", "alice");
     let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
     let scope = scope("index-oversized");
     let damaged_id = ThreadId::new("thread-oversized-hidden").unwrap();
@@ -4415,6 +4503,18 @@ async fn filesystem_list_threads_repairs_oversized_scope_in_background() {
         listed_ids.contains(&damaged_id),
         "the background repair must restore a damaged row beyond one backend page"
     );
+    let page_calls = backend.directory_page_calls().await;
+    assert_eq!(
+        page_calls.len(),
+        2,
+        "1,025 durable rows must be enumerated as two bounded keyset pages"
+    );
+    assert_eq!(page_calls[0], (None, Page::MAX_LIMIT as usize));
+    assert!(
+        page_calls[1].0.is_some(),
+        "the second page must continue after the prior page's stable final name"
+    );
+    assert_eq!(page_calls[1].1, Page::MAX_LIMIT as usize);
 }
 
 #[tokio::test]
@@ -5682,6 +5782,7 @@ struct QueryCountingBackend {
     query_count: AtomicUsize,
     get_count: AtomicUsize,
     thread_index_put_count: AtomicUsize,
+    directory_page_calls: Mutex<Vec<(Option<String>, usize)>>,
 }
 
 /// Holds the first reconcile directory scan for one scope so the caller test
@@ -5728,6 +5829,7 @@ impl QueryCountingBackend {
             query_count: AtomicUsize::new(0),
             get_count: AtomicUsize::new(0),
             thread_index_put_count: AtomicUsize::new(0),
+            directory_page_calls: Mutex::new(Vec::new()),
         }
     }
 
@@ -5741,6 +5843,10 @@ impl QueryCountingBackend {
 
     fn thread_index_put_count(&self) -> usize {
         self.thread_index_put_count.load(Ordering::SeqCst)
+    }
+
+    async fn directory_page_calls(&self) -> Vec<(Option<String>, usize)> {
+        self.directory_page_calls.lock().await.clone()
     }
 
     fn reset_thread_index_put_count(&self) {
@@ -5914,6 +6020,19 @@ impl RootFilesystem for QueryCountingBackend {
 
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
         self.inner.list_dir(path).await
+    }
+
+    async fn list_dir_page(
+        &self,
+        path: &VirtualPath,
+        after: Option<&str>,
+        max_entries: usize,
+    ) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.directory_page_calls
+            .lock()
+            .await
+            .push((after.map(str::to_owned), max_entries));
+        self.inner.list_dir_page(path, after, max_entries).await
     }
 
     async fn query(

--- a/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -48,7 +48,10 @@ use ironclaw_threads::{
     ToolResultReferenceEnvelope, ToolResultSafeSummary, UpdateAssistantDraftRequest,
     UpdateToolResultReferenceRequest,
 };
-use tokio::sync::{Barrier, Mutex, OwnedMutexGuard};
+use tokio::{
+    sync::{Barrier, Mutex, OwnedMutexGuard},
+    time::{Duration, timeout},
+};
 
 fn provider_call_reference(call_id: &str) -> ProviderToolCallReferenceEnvelope {
     ProviderToolCallReferenceEnvelope {
@@ -3648,6 +3651,772 @@ async fn filesystem_list_threads_merges_partial_thread_index_with_source_rows() 
     assert!(ids.contains(&"legacy-missing"));
 }
 
+/// Break caught: an index row can exist with its projection keys missing —
+/// observed in staging, where a thread kept its record, its index row and all
+/// of its messages but never appeared in the sidebar. The ordered projection
+/// only emits a row when `indexed` carries the listing keys, so such a row is
+/// invisible to `list_threads`, and the scope's completion marker makes the
+/// repair pass skip the scope on every later start. Without self-healing the
+/// thread stays unreachable for the rest of the volume's life.
+#[tokio::test]
+async fn filesystem_list_threads_recovers_index_row_without_projection_keys() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-index-unprojected", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("index-unprojected");
+
+    for id in ["projected-thread", "unprojected-thread"] {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    // Listing once writes the scope's thread-index completion marker, which is
+    // what later suppresses the repair pass.
+    let seeded = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        seeded.threads.len(),
+        2,
+        "both threads must list before the index row is damaged"
+    );
+
+    // Reproduce the staging row shape: no ordered-projection metadata on the
+    // entry while the durable record body remains intact.
+    let index_path = thread_index_record_path_for_test(&scope, "unprojected-thread");
+    let damaged: serde_json::Value = serde_json::from_slice(
+        &scoped
+            .get(&scope.to_resource_scope(), &index_path)
+            .await
+            .unwrap()
+            .expect("ensure_thread writes a derived index row")
+            .entry
+            .body,
+    )
+    .unwrap();
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &index_path,
+            Entry::bytes(serde_json::to_vec_pretty(&damaged).unwrap()),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup rewrites the index row without projection keys");
+
+    // A fresh service stands in for a process restart: no in-memory scope
+    // cache, so the scope is re-declared from durable state alone.
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    wait_for_thread_index_projection_repair(scoped.as_ref(), &scope).await;
+    let listed = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let ids: Vec<&str> = listed
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert!(
+        ids.contains(&"projected-thread"),
+        "the undamaged thread must still list; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&"unprojected-thread"),
+        "a thread whose index row lost its projection keys must still be \
+         listable after a restart; got {ids:?}"
+    );
+}
+
+/// Break caught: repairing through the merge helper is not enough. `cas_update`
+/// compares only the decoded body, so an index row whose body already matches a
+/// rebuilt record — but whose projection keys are gone — takes the equality
+/// no-op path and is never physically rewritten. The repair then reports
+/// success while the thread stays invisible, and every later start repeats the
+/// scan for nothing. Recovery must not depend on the body differing.
+#[tokio::test]
+async fn filesystem_list_threads_recovers_current_version_index_row_without_projection_keys() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-index-unprojected-current", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("index-unprojected-current");
+
+    for id in ["projected-thread", "unprojected-thread"] {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+    service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+
+    // Strip only the projection metadata: the body is left byte-for-byte as
+    // written, so a rebuilt record compares equal to it.
+    let index_path = thread_index_record_path_for_test(&scope, "unprojected-thread");
+    let body = scoped
+        .get(&scope.to_resource_scope(), &index_path)
+        .await
+        .unwrap()
+        .expect("ensure_thread writes a derived index row")
+        .entry
+        .body;
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &index_path,
+            Entry::bytes(body),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup strips the projection metadata only");
+
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    wait_for_thread_index_projection_repair(scoped.as_ref(), &scope).await;
+    let listed = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let ids: Vec<&str> = listed
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert!(
+        ids.contains(&"unprojected-thread"),
+        "recovery must not depend on the record body differing from a rebuild; \
+         got {ids:?}"
+    );
+}
+
+/// Break caught: the repair's completeness check only looked for `scope_key`.
+/// The ordered projection also sorts and paginates on `activity_sort` and
+/// `thread_id`, so a row that kept `scope_key` but lost either of those two
+/// keys took the early-return "already projected" path and was never
+/// rewritten — invisible to `list_threads` forever, same as a row missing all
+/// three keys.
+#[tokio::test]
+async fn filesystem_list_threads_recovers_index_row_missing_only_activity_sort_key() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-index-partial-keys", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("index-partial-keys");
+
+    for id in ["projected-thread", "partial-keys-thread"] {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+    service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+
+    // Rewrite the row keeping `scope_key` (the only key the old check looked
+    // at) but dropping `activity_sort` and `thread_id` — the two keys
+    // `query_ordered` actually sorts and paginates on.
+    let index_path = thread_index_record_path_for_test(&scope, "partial-keys-thread");
+    let versioned = scoped
+        .get(&scope.to_resource_scope(), &index_path)
+        .await
+        .unwrap()
+        .expect("ensure_thread writes a derived index row");
+    let mut damaged = versioned.entry.clone();
+    damaged.indexed.retain(|key, _| key.as_str() == "scope_key");
+    assert_eq!(
+        damaged.indexed.len(),
+        1,
+        "test setup must strip every key except scope_key"
+    );
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &index_path,
+            damaged,
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup rewrites the index row missing activity_sort/thread_id");
+
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    wait_for_thread_index_projection_repair(scoped.as_ref(), &scope).await;
+    let listed = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let ids: Vec<&str> = listed
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert!(
+        ids.contains(&"projected-thread"),
+        "the undamaged thread must still list; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&"partial-keys-thread"),
+        "a row retaining scope_key but missing activity_sort/thread_id must \
+         still be repaired and listable; got {ids:?}"
+    );
+}
+
+/// Break caught: `ensure_thread` (an optional, `required: false` caller of
+/// `ensure_thread_index_query`) declared the scope and cached it as "ready"
+/// without ever running repair. A later `required: true` listing call then
+/// saw the scope already declared *and* the durable migration marker already
+/// complete (written by an earlier process) and returned early before
+/// reaching the reconcile step — so in the common production ordering, where
+/// a write happens before the first list in a process, self-healing never ran
+/// at all.
+#[tokio::test]
+async fn filesystem_list_threads_recovers_index_row_when_write_precedes_first_list() {
+    use ironclaw_threads::ListThreadsForScopeRequest;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-index-write-before-list", "alice");
+    let scope = scope("index-write-before-list");
+
+    // Seed durable state, including the scope's migration-complete marker,
+    // using a first process that lists before ever writing again.
+    {
+        let seeding_service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+        for id in ["projected-thread", "unprojected-thread"] {
+            seeding_service
+                .ensure_thread(EnsureThreadRequest {
+                    scope: scope.clone(),
+                    thread_id: Some(ThreadId::new(id).unwrap()),
+                    created_by_actor_id: "actor-a".into(),
+                    title: Some(id.into()),
+                    metadata_json: None,
+                })
+                .await
+                .unwrap();
+        }
+        seeding_service
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: scope.clone(),
+                limit: None,
+                cursor: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    // Damage one row's projection keys, same shape as the other recovery
+    // tests, so a fresh process has real repair work to do.
+    let index_path = thread_index_record_path_for_test(&scope, "unprojected-thread");
+    let damaged: serde_json::Value = serde_json::from_slice(
+        &scoped
+            .get(&scope.to_resource_scope(), &index_path)
+            .await
+            .unwrap()
+            .expect("ensure_thread writes a derived index row")
+            .entry
+            .body,
+    )
+    .unwrap();
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &index_path,
+            Entry::bytes(serde_json::to_vec_pretty(&damaged).unwrap()),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup rewrites the index row without projection keys");
+
+    // Fresh process, durable migration marker already complete from seeding.
+    // Critically, perform a WRITE (`ensure_thread`) before the first list —
+    // the ordering that reproduces the bug — so the optional declaration path
+    // caches the scope as "ready" before any required call ever runs. Uses a
+    // brand-new thread id, distinct from the damaged row: `ensure_thread`
+    // would otherwise refresh the damaged row's own index entry as a side
+    // effect (because the fresh process's in-memory "known row" cache is
+    // empty too), which would repair it incidentally and defeat the test.
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    restarted
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("write-before-list-thread").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("write-before-list-thread".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    wait_for_thread_index_projection_repair(scoped.as_ref(), &scope).await;
+    let listed = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    let ids: Vec<&str> = listed
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert!(
+        ids.contains(&"projected-thread"),
+        "the undamaged thread must still list; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&"unprojected-thread"),
+        "a damaged row must still be repaired and listable even when a write \
+         happens before the first list in the process; got {ids:?}"
+    );
+}
+
+/// Projection repair is background work. A blocked repair must not delay the
+/// listing that scheduled it or a listing for another scope.
+#[tokio::test]
+async fn filesystem_list_threads_reconciles_unrelated_scopes_independently() {
+    let blocked_scope = scope("index-scope-lock-blocked");
+    let unrelated_scope = scope("index-scope-lock-unrelated");
+    let backend = Arc::new(BlockingScopeReconcileBackend::new(format!(
+        "/agents/{}/",
+        blocked_scope.agent_id.as_str()
+    )));
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-index-scope-lock", "alice");
+    let seeding_service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+
+    for (scope, thread_id) in [
+        (&blocked_scope, "blocked-scope-thread"),
+        (&unrelated_scope, "unrelated-scope-thread"),
+    ] {
+        seeding_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(thread_id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(thread_id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        seeding_service
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: scope.clone(),
+                limit: None,
+                cursor: None,
+            })
+            .await
+            .expect("seed listing writes the completed migration marker");
+    }
+
+    backend.arm();
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let blocked = timeout(
+        Duration::from_secs(2),
+        restarted.list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: blocked_scope.clone(),
+            limit: None,
+            cursor: None,
+        }),
+    )
+    .await
+    .expect("listing must not wait for its background projection repair")
+    .expect("blocked scope listing succeeds");
+    assert_eq!(blocked.threads.len(), 1);
+    timeout(Duration::from_secs(5), backend.reconcile_entered.wait())
+        .await
+        .expect("the blocked scope enters its background repair scan");
+
+    let unrelated = timeout(
+        Duration::from_secs(2),
+        restarted.list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: unrelated_scope.clone(),
+            limit: None,
+            cursor: None,
+        }),
+    )
+    .await
+    .expect("unrelated scope must not wait behind another scope's repair")
+    .expect("unrelated scope listing succeeds");
+    assert_eq!(unrelated.threads.len(), 1);
+
+    backend.release_reconcile.wait().await;
+    wait_for_thread_index_projection_repair(scoped.as_ref(), &blocked_scope).await;
+    wait_for_thread_index_projection_repair(scoped.as_ref(), &unrelated_scope).await;
+}
+
+/// Reconciliation is a best-effort repair for rows that the listing projection
+/// cannot see. A transient failure while discovering those rows must not turn
+/// an otherwise-readable sidebar page into a hard listing failure.
+#[tokio::test]
+async fn filesystem_list_threads_degrades_to_projected_rows_when_reconcile_fails() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(
+        Arc::clone(&backend),
+        "tenant-index-reconcile-failure",
+        "alice",
+    );
+    let seeding_service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("index-reconcile-failure");
+
+    for id in ["projected-before-failure-a", "projected-before-failure-b"] {
+        seeding_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(id).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(id.into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+    seeding_service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("seed listing writes the completed migration marker");
+
+    let damaged_path = thread_index_record_path_for_test(&scope, "projected-before-failure-b");
+    let damaged_body = scoped
+        .get(&scope.to_resource_scope(), &damaged_path)
+        .await
+        .unwrap()
+        .expect("seeded index row exists")
+        .entry
+        .body;
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &damaged_path,
+            Entry::bytes(damaged_body),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup removes the damaged row's projection keys");
+
+    // A fresh process reaches the marker-complete repair branch. Fail its
+    // first background directory discovery; the listing itself must still
+    // return the projected rows.
+    backend.add_fault(
+        Fault::on(FilesystemOperation::ListDir)
+            .path("/thread_index")
+            .nth(1)
+            .backend("projection reconcile directory listing fails once"),
+    );
+    let restarted = FilesystemSessionThreadService::new(scoped);
+    let degraded = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("a reconcile failure must degrade to projected listing rows");
+    let degraded_ids: Vec<&str> = degraded
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert_eq!(degraded_ids.len(), 1);
+    assert!(degraded_ids.contains(&"projected-before-failure-a"));
+    assert!(!degraded_ids.contains(&"projected-before-failure-b"));
+
+    // A failed background pass must not write its durable completion marker.
+    // Once the transient fault is spent, a later list admits a retry.
+    let repaired = timeout(Duration::from_secs(5), async {
+        loop {
+            let listed = restarted
+                .list_threads_for_scope(ListThreadsForScopeRequest {
+                    scope: scope.clone(),
+                    limit: None,
+                    cursor: None,
+                })
+                .await
+                .expect("listing remains available while repair retries");
+            if listed.threads.len() == 2 {
+                break listed;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("a later listing retries the failed background repair");
+    let repaired_ids: Vec<&str> = repaired
+        .threads
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect();
+    assert_eq!(repaired_ids.len(), 2);
+    assert!(repaired_ids.contains(&"projected-before-failure-a"));
+    assert!(repaired_ids.contains(&"projected-before-failure-b"));
+}
+
+/// A current-version record can still be invisible when its entry sidecar
+/// loses the ordered keys. Repair must use the shared CAS retry loop rather
+/// than a one-shot conditional put, because a benign concurrent rewrite can
+/// race this best-effort projection repair.
+#[tokio::test]
+async fn filesystem_list_threads_retries_reconcile_projection_repair_after_cas_race() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(
+        Arc::clone(&backend),
+        "tenant-index-reconcile-cas-race",
+        "alice",
+    );
+    let scope = scope("index-reconcile-cas-race");
+    let thread_id = ThreadId::new("current-version-damaged-row").unwrap();
+    let seeding_service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    seeding_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(thread_id.clone()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("current version damaged row".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    seeding_service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("seed listing writes the completed migration marker");
+
+    let index_path = thread_index_record_path_for_test(&scope, thread_id.as_str());
+    let current_body = scoped
+        .get(&scope.to_resource_scope(), &index_path)
+        .await
+        .unwrap()
+        .expect("seeded index row exists")
+        .entry
+        .body;
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &index_path,
+            Entry::bytes(current_body),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("test setup removes current row projection keys");
+    backend.add_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .path(format!("/thread_index/{}.json", thread_id.as_str()))
+            .nth(1)
+            .version_mismatch(),
+    );
+
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("listing retries the projection repair after a CAS race");
+    wait_for_thread_index_projection_repair(scoped.as_ref(), &scope).await;
+    let listed = restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("listing observes the repaired projection after a CAS race");
+    assert_eq!(listed.threads.len(), 1);
+    assert_eq!(listed.threads[0].thread_id, thread_id);
+}
+
+/// Regression for the old live-reconcile cap: scopes larger than one backend
+/// page must still repair every hidden row. Repair runs in bounded chunks in
+/// the background and writes completion only after the entire scope succeeds.
+#[tokio::test]
+async fn filesystem_list_threads_repairs_oversized_scope_in_background() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-index-oversized", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("index-oversized");
+    let damaged_id = ThreadId::new("thread-oversized-hidden").unwrap();
+
+    for index in 0..Page::MAX_LIMIT {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: scope.clone(),
+                thread_id: Some(ThreadId::new(format!("thread-oversized-{index:04}")).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(format!("thread {index}")),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+    service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(damaged_id.clone()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("damaged oversized row".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    // Make the fresh service take its marker-complete reconcile branch instead
+    // of the full migration. Then remove the damaged row's projection keys.
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &thread_index_migration_marker_path_for_test(&scope),
+            Entry::bytes(b"thread-index-v1".to_vec()),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("seed completed thread-index migration marker");
+    let damaged_path = thread_index_record_path_for_test(&scope, damaged_id.as_str());
+    let damaged_body = scoped
+        .get(&scope.to_resource_scope(), &damaged_path)
+        .await
+        .unwrap()
+        .expect("damaged row exists")
+        .entry
+        .body;
+    scoped
+        .put(
+            &scope.to_resource_scope(),
+            &damaged_path,
+            Entry::bytes(damaged_body),
+            CasExpectation::Any,
+        )
+        .await
+        .expect("strip damaged row projection keys");
+
+    let restarted = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    restarted
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: Some(200),
+            cursor: None,
+        })
+        .await
+        .expect("listing schedules oversized repair without waiting for it");
+    wait_for_thread_index_projection_repair(scoped.as_ref(), &scope).await;
+
+    let mut listed_ids = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = restarted
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: scope.clone(),
+                limit: Some(200),
+                cursor,
+            })
+            .await
+            .expect("oversized scope remains listable after background repair");
+        listed_ids.extend(page.threads.into_iter().map(|record| record.thread_id));
+        let Some(next_cursor) = page.next_cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+
+    assert_eq!(listed_ids.len(), Page::MAX_LIMIT as usize + 1);
+    assert!(
+        listed_ids.contains(&damaged_id),
+        "the background repair must restore a damaged row beyond one backend page"
+    );
+}
+
 #[tokio::test]
 async fn filesystem_list_threads_does_not_treat_partial_source_cache_as_complete() {
     use ironclaw_threads::ListThreadsForScopeRequest;
@@ -4755,6 +5524,48 @@ fn thread_index_migration_marker_path_for_test(scope: &ThreadScope) -> ScopedPat
     .unwrap()
 }
 
+fn thread_index_projection_repair_marker_path_for_test(scope: &ThreadScope) -> ScopedPath {
+    ScopedPath::new(format!(
+        "/threads/agents/{}/projects/{}/owners/{}/index-migrations/thread-index-projection-v2.complete",
+        scope.agent_id.as_str(),
+        scope
+            .project_id
+            .as_ref()
+            .expect("test scope has project")
+            .as_str(),
+        scope
+            .owner_user_id
+            .as_ref()
+            .expect("test scope has owner")
+            .as_str()
+    ))
+    .unwrap()
+}
+
+async fn wait_for_thread_index_projection_repair<F>(
+    scoped: &ScopedFilesystem<F>,
+    scope: &ThreadScope,
+) where
+    F: RootFilesystem,
+{
+    timeout(Duration::from_secs(5), async {
+        let marker = thread_index_projection_repair_marker_path_for_test(scope);
+        loop {
+            if scoped
+                .get(&scope.to_resource_scope(), &marker)
+                .await
+                .expect("projection repair marker read succeeds")
+                .is_some()
+            {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("background thread-index projection repair completes");
+}
+
 fn transcript_index_migration_marker_path_for_test(scope: &ThreadScope) -> ScopedPath {
     ScopedPath::new(format!(
         "/threads/agents/{}/projects/{}/owners/{}/index-migrations/transcript-index-v2.complete",
@@ -4873,6 +5684,17 @@ struct QueryCountingBackend {
     thread_index_put_count: AtomicUsize,
 }
 
+/// Holds the first reconcile directory scan for one scope so the caller test
+/// can prove another scope's required listing still makes progress.
+struct BlockingScopeReconcileBackend {
+    inner: InMemoryBackend,
+    blocked_scope_path: String,
+    armed: AtomicBool,
+    blocked_once: AtomicBool,
+    reconcile_entered: Arc<Barrier>,
+    release_reconcile: Arc<Barrier>,
+}
+
 struct MigrationRaceBackend {
     inner: InMemoryBackend,
     armed: AtomicBool,
@@ -4923,6 +5745,30 @@ impl QueryCountingBackend {
 
     fn reset_thread_index_put_count(&self) {
         self.thread_index_put_count.store(0, Ordering::SeqCst);
+    }
+}
+
+impl BlockingScopeReconcileBackend {
+    fn new(blocked_scope_path: String) -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            blocked_scope_path,
+            armed: AtomicBool::new(false),
+            blocked_once: AtomicBool::new(false),
+            reconcile_entered: Arc::new(Barrier::new(2)),
+            release_reconcile: Arc::new(Barrier::new(2)),
+        }
+    }
+
+    fn arm(&self) {
+        self.armed.store(true, Ordering::SeqCst);
+    }
+
+    fn blocks_reconcile_for(&self, path: &VirtualPath) -> bool {
+        self.armed.load(Ordering::SeqCst)
+            && path.as_str().contains(&self.blocked_scope_path)
+            && path.as_str().ends_with("/thread_index")
+            && !self.blocked_once.swap(true, Ordering::SeqCst)
     }
 }
 
@@ -5087,6 +5933,76 @@ impl RootFilesystem for QueryCountingBackend {
         page: &OrderedPage,
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         self.query_count.fetch_add(1, Ordering::SeqCst);
+        self.inner.query_ordered(path, filter, page).await
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        self.inner.ensure_index(path, spec).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn begin(&self, path: &VirtualPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
+        self.inner.begin(path).await
+    }
+
+    async fn reserve_sequence(&self, path: &VirtualPath) -> Result<SeqNo, FilesystemError> {
+        self.inner.reserve_sequence(path).await
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for BlockingScopeReconcileBackend {
+    fn capabilities(&self) -> BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        if self.blocks_reconcile_for(path) {
+            self.reconcile_entered.wait().await;
+            self.release_reconcile.wait().await;
+        }
+        self.inner.list_dir(path).await
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        self.inner.query(path, filter, page).await
+    }
+
+    async fn query_ordered(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: &OrderedPage,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         self.inner.query_ordered(path, filter, page).await
     }
 

--- a/crates/substrates/ironclaw_filesystem/CONTRACT.md
+++ b/crates/substrates/ironclaw_filesystem/CONTRACT.md
@@ -5,7 +5,7 @@ There is one trait (`RootFilesystem`), one entry type (`Entry`), one mount
 table (`CompositeRootFilesystem`). Every persistence concern in the workspace
 (secrets, leases, processes, memory documents, project files, event logs,
 engine state, settings, …) lives behind a single set of ops: `put` / `get` /
-`delete` / `list_dir` / `query` / `ensure_index` / `stat` / `begin` /
+`delete` / `list_dir` / `list_dir_page` / `query` / `ensure_index` / `stat` / `begin` /
 `append` / `tail`.
 
 This supersedes the earlier "bytes mount; structured records stay typed"
@@ -187,7 +187,7 @@ boundary. The current rule is codified in
 
 ## Legacy bytes plane (transitional)
 
-`read_file` / `write_file` / `append_file` / `list_dir` / `stat` /
+`read_file` / `write_file` / `append_file` / `list_dir` / `list_dir_page` / `stat` /
 `delete` / `create_dir_all` remain on `RootFilesystem` during the
 migration window. Default impls route reads/writes through `put`/`get` so
 existing backends (and existing consumer code) continue to work without
@@ -195,6 +195,11 @@ changes. These methods will be removed entirely once
 `src/db.rs` is dissolved (task #17 of the storage rework). Do not add new
 consumers of the legacy methods — new code should call `put`/`get`/
 `query`/etc. directly.
+
+Explicit migration work that must discover entries whose indexed projection
+may be absent uses `list_dir_page` with its stable child-name continuation.
+Production backends implement that traversal with memory bounded by the page
+limit; request paths continue to use declared indexed projections.
 
 ## When you're editing this crate
 

--- a/crates/substrates/ironclaw_filesystem/Cargo.toml
+++ b/crates/substrates/ironclaw_filesystem/Cargo.toml
@@ -41,6 +41,9 @@ tokio = { version = "1", features = ["fs", "io-util", "sync", "time"] }
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 tracing = "0.1"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tempfile = "3"
 # The Postgres contract tests provision their own container when no database

--- a/crates/substrates/ironclaw_filesystem/src/cas.rs
+++ b/crates/substrates/ironclaw_filesystem/src/cas.rs
@@ -27,7 +27,9 @@
 //! 2. Run the caller's `apply` closure, which computes the next snapshot plus a
 //!    caller-defined outcome (`T`) or returns the caller's error (`E`).
 //! 3. If the snapshot is unchanged (or the caller explicitly returns a no-op),
-//!    return the outcome without writing.
+//!    return the outcome without writing. A caller that must rewrite entry
+//!    sidecars despite an unchanged decoded snapshot can explicitly request a
+//!    force write.
 //! 4. Otherwise either `put` the encoded snapshot back with the read version as
 //!    the CAS precondition (`CasExpectation::Absent` for a first write), or
 //!    conditionally delete it when the caller returns [`CasApply::delete`].
@@ -106,7 +108,7 @@ pub const FILESYSTEM_CAS_BACKOFF_MAX: Duration = Duration::from_millis(50);
 /// `snapshot` is the next snapshot to persist; `outcome` is whatever the caller
 /// wants returned from the whole `cas_update` call on success.
 ///
-/// The caller selects one of three typed mutation outcomes:
+/// The caller selects one of four typed mutation outcomes:
 ///
 /// 1. **Write** — return `CasApply::new`. When the returned snapshot equals the
 ///    existing value that `apply` received, `cas_update` skips the write as a
@@ -117,6 +119,11 @@ pub const FILESYSTEM_CAS_BACKOFF_MAX: Duration = Duration::from_millis(50);
 /// 3. **Delete** — return `CasApply::delete`. The helper conditionally deletes
 ///    the version just read, then re-runs `apply` against a fresh read to prove
 ///    the caller's postcondition across delete + recreate ABA cycles.
+/// 4. **Force write** — return `CasApply::force_write`. This bypasses only the
+///    decoded-snapshot equality fast-path, so the entry is encoded and written
+///    with the same bounded, capability-gated CAS retry behavior as a normal
+///    write. Use it when entry sidecars such as indexed projection metadata
+///    need repair even though the decoded body is already current.
 pub struct CasApply<S, T> {
     /// The new snapshot to write back. Ignored for persistence when writing is
     /// not selected (i.e., constructed via [`CasApply::no_op`] or
@@ -130,6 +137,7 @@ pub struct CasApply<S, T> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CasApplyOperation {
     Write,
+    ForceWrite,
     NoOp,
     Delete,
 }
@@ -137,15 +145,31 @@ enum CasApplyOperation {
 impl<S, T> CasApply<S, T> {
     /// Produce a [`CasApply`] that **writes** `snapshot` back to the store.
     ///
-    /// All existing callers use this constructor; its signature is unchanged.
-    /// If `snapshot` equals the value `apply` was handed (i.e. nothing
-    /// changed), `cas_update` still skips the write via the `PartialEq` fast
-    /// path — no API change needed for callers that rely on that behavior.
+    /// This is the normal write constructor. If `snapshot` equals the value
+    /// `apply` was handed (i.e. nothing changed), `cas_update` still skips the
+    /// write via the `PartialEq` fast path. Use [`CasApply::force_write`] when
+    /// an entry-sidecar repair must persist despite decoded equality.
     pub fn new(snapshot: S, outcome: T) -> Self {
         Self {
             snapshot,
             outcome,
             operation: CasApplyOperation::Write,
+        }
+    }
+
+    /// Produce a [`CasApply`] that writes `snapshot` even when it equals the
+    /// value `apply` received.
+    ///
+    /// This bypasses only `cas_update`'s decoded-snapshot equality fast-path.
+    /// The write still uses the version read by this attempt and therefore
+    /// retains the helper's bounded retries, timeout, and capability gate.
+    /// Use it for entry-sidecar repairs (for example, missing indexed
+    /// projection metadata) that are not represented in `S`.
+    pub fn force_write(snapshot: S, outcome: T) -> Self {
+        Self {
+            snapshot,
+            outcome,
+            operation: CasApplyOperation::ForceWrite,
         }
     }
 
@@ -266,6 +290,10 @@ impl<E: std::fmt::Display + std::fmt::Debug> std::error::Error for CasUpdateErro
 ///     `unchanged_snapshot` equals what `apply` was handed; `cas_update`
 ///     detects the equality via `PartialEq` and skips the write as a
 ///     convenience fast path.
+///   - Return `CasApply::force_write(snapshot, outcome)` to persist an entry
+///     despite decoded equality, such as when its indexed sidecar needs a
+///     physical rewrite. It still uses the same conditional put and retry
+///     behavior as `CasApply::new`.
 ///   - Return `CasApply::delete(snapshot, outcome)` to conditionally delete the
 ///     current version. The helper re-runs `apply` after deletion to establish
 ///     the caller-defined postcondition across delete + recreate ABA cycles.
@@ -397,7 +425,7 @@ where
         mutation_attempts += 1;
 
         match operation {
-            CasApplyOperation::Write => {
+            CasApplyOperation::Write | CasApplyOperation::ForceWrite => {
                 // Verification found that a different mutation is now needed;
                 // its outcome supersedes any earlier delete outcome.
                 drop(successful_delete_outcome.take());

--- a/crates/substrates/ironclaw_filesystem/src/cas/tests.rs
+++ b/crates/substrates/ironclaw_filesystem/src/cas/tests.rs
@@ -285,6 +285,71 @@ struct AlwaysMismatchBackend {
     put_attempts: AtomicUsize,
 }
 
+/// CAS-capable backend that simulates one competing rewrite before accepting
+/// the caller's retry. The competing rewrite preserves the decoded snapshot,
+/// so this proves a force rewrite bypasses only `cas_update`'s equality
+/// fast-path and still re-reads after a real `VersionMismatch`.
+struct OneMismatchThenSuccessBackend {
+    inner: InMemoryBackend,
+    mismatch_once: AtomicBool,
+    put_attempts: AtomicUsize,
+}
+
+impl OneMismatchThenSuccessBackend {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            mismatch_once: AtomicBool::new(false),
+            put_attempts: AtomicUsize::new(0),
+        }
+    }
+
+    fn arm_mismatch(&self) {
+        self.mismatch_once.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for OneMismatchThenSuccessBackend {
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities::in_memory_full()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        self.put_attempts.fetch_add(1, Ordering::SeqCst);
+        if self.mismatch_once.swap(false, Ordering::SeqCst) {
+            let found = self.inner.put(path, entry, CasExpectation::Any).await?;
+            let expected = match cas {
+                CasExpectation::Version(version) => Some(version),
+                CasExpectation::Absent | CasExpectation::Any => None,
+            };
+            return Err(FilesystemError::VersionMismatch {
+                path: path.clone(),
+                expected,
+                found: Some(found),
+            });
+        }
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+}
+
 impl AlwaysMismatchBackend {
     fn new() -> Self {
         Self {
@@ -457,6 +522,68 @@ async fn no_op_apply_skips_write() {
     assert_eq!(
         version_before, version_after,
         "no-op apply must not issue a write"
+    );
+}
+
+#[tokio::test]
+async fn force_write_rewrites_equal_snapshot_and_retries_one_version_mismatch() {
+    let backend = Arc::new(OneMismatchThenSuccessBackend::new());
+    let fs = Arc::new(scoped(Arc::clone(&backend)));
+    let scope = ResourceScope::system();
+
+    cas_update(
+        fs.as_ref(),
+        &scope,
+        &counter_path(),
+        decode_counter,
+        encode_counter,
+        |_: Option<Counter>| async move { Ok::<_, TestError>(CasApply::new(Counter { value: 5 }, ())) },
+    )
+    .await
+    .expect("seed counter");
+    let version_before = fs
+        .get(&scope, &counter_path())
+        .await
+        .expect("read seeded counter")
+        .expect("seeded counter exists")
+        .version;
+
+    backend.arm_mismatch();
+    let outcome = cas_update(
+        fs.as_ref(),
+        &scope,
+        &counter_path(),
+        decode_counter,
+        encode_counter,
+        |current: Option<Counter>| async move {
+            Ok::<_, TestError>(CasApply::force_write(
+                current.expect("seeded counter"),
+                "rewritten",
+            ))
+        },
+    )
+    .await
+    .expect("force rewrite retries and succeeds");
+
+    assert_eq!(outcome, "rewritten");
+    assert_eq!(
+        backend.put_attempts.load(Ordering::SeqCst),
+        3,
+        "one seed write, one mismatched rewrite, and one successful retry"
+    );
+    let stored = fs
+        .get(&scope, &counter_path())
+        .await
+        .expect("read force-rewritten counter")
+        .expect("force-rewritten counter exists");
+    assert_eq!(
+        decode_counter(&stored.entry.body).unwrap(),
+        Counter { value: 5 }
+    );
+    assert_eq!(
+        stored.version,
+        version_before.next().next(),
+        "the competing equal rewrite and force rewrite both persist"
     );
 }
 

--- a/crates/substrates/ironclaw_filesystem/src/catalog.rs
+++ b/crates/substrates/ironclaw_filesystem/src/catalog.rs
@@ -384,6 +384,18 @@ impl RootFilesystem for CompositeRootFilesystem {
         self.matching_mount(path)?.backend.list_dir(path).await
     }
 
+    async fn list_dir_page(
+        &self,
+        path: &VirtualPath,
+        after: Option<&str>,
+        max_entries: usize,
+    ) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .list_dir_page(path, after, max_entries)
+            .await
+    }
+
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         self.matching_mount(path)?.backend.stat(path).await
     }

--- a/crates/substrates/ironclaw_filesystem/src/fault.rs
+++ b/crates/substrates/ironclaw_filesystem/src/fault.rs
@@ -387,6 +387,16 @@ where
         self.inner.list_dir(path).await
     }
 
+    async fn list_dir_page(
+        &self,
+        path: &VirtualPath,
+        after: Option<&str>,
+        max_entries: usize,
+    ) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.gate(FilesystemOperation::ListDir, path)?;
+        self.inner.list_dir_page(path, after, max_entries).await
+    }
+
     async fn query(
         &self,
         path: &VirtualPath,

--- a/crates/substrates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/substrates/ironclaw_filesystem/src/in_memory.rs
@@ -228,6 +228,55 @@ impl RootFilesystem for InMemoryBackend {
         Ok(out)
     }
 
+    async fn list_dir_page(
+        &self,
+        path: &VirtualPath,
+        after: Option<&str>,
+        max_entries: usize,
+    ) -> Result<Vec<DirEntry>, FilesystemError> {
+        if max_entries == 0 {
+            return Ok(Vec::new());
+        }
+        let state = self.state.lock().await;
+        let prefix = with_trailing_slash(path.as_str());
+        let mut page = std::collections::BTreeMap::<String, FileType>::new();
+        for stored_path in state.entries.keys() {
+            let Some(suffix) = stored_path.as_str().strip_prefix(&prefix) else {
+                continue;
+            };
+            let (head, has_more) = first_segment(suffix);
+            if head.is_empty() || after.is_some_and(|cursor| head <= cursor) {
+                continue;
+            }
+            if let Some(existing) = page.get_mut(head) {
+                if has_more {
+                    *existing = FileType::Directory;
+                }
+                continue;
+            }
+            page.insert(
+                head.to_string(),
+                if has_more {
+                    FileType::Directory
+                } else {
+                    FileType::File
+                },
+            );
+            if page.len() > max_entries {
+                page.pop_last();
+            }
+        }
+        page.into_iter()
+            .map(|(name, file_type)| {
+                Ok(DirEntry {
+                    path: VirtualPath::new(join_path(path.as_str(), &name))?,
+                    name,
+                    file_type,
+                })
+            })
+            .collect()
+    }
+
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         let state = self.state.lock().await;
         if let Some(stored) = state.entries.get(path) {
@@ -1922,6 +1971,50 @@ mod tests {
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].name, "a.md");
         assert_eq!(entries[1].name, "b.md");
+    }
+
+    #[tokio::test]
+    async fn list_dir_page_uses_stable_name_keyset_without_duplicates() {
+        let fs = InMemoryBackend::new();
+        for p in [
+            "/projects/a.md",
+            "/projects/b.md",
+            "/projects/c.md",
+            "/projects/sub/nested.md",
+        ] {
+            fs.put(&vpath(p), Entry::bytes(vec![]), CasExpectation::Absent)
+                .await
+                .unwrap();
+        }
+
+        let first = fs
+            .list_dir_page(&vpath("/projects"), None, 2)
+            .await
+            .unwrap();
+        let second = fs
+            .list_dir_page(
+                &vpath("/projects"),
+                first.last().map(|entry| entry.name.as_str()),
+                2,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            first
+                .iter()
+                .map(|entry| entry.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a.md", "b.md"]
+        );
+        assert_eq!(
+            second
+                .iter()
+                .map(|entry| entry.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["c.md", "sub"]
+        );
+        assert_eq!(second[1].file_type, FileType::Directory);
     }
 
     #[tokio::test]

--- a/crates/substrates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/substrates/ironclaw_filesystem/src/libsql.rs
@@ -1238,6 +1238,80 @@ impl RootFilesystem for LibSqlRootFilesystem {
         children
     }
 
+    async fn list_dir_page(
+        &self,
+        path: &VirtualPath,
+        after: Option<&str>,
+        max_entries: usize,
+    ) -> Result<Vec<DirEntry>, FilesystemError> {
+        if max_entries == 0 {
+            return Ok(Vec::new());
+        }
+        let exact_entry = self.exact_entry(path).await?;
+        if matches!(exact_entry, Some((_, FileType::File, _))) {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ListDir,
+                reason: "not a directory".to_string(),
+            });
+        }
+        let conn = self.read_connection().await?;
+        let (prefix_lower, prefix_upper) = descendant_path_range(path);
+        let after = after.unwrap_or_default();
+        let limit = i64::try_from(max_entries.min(Page::MAX_LIMIT as usize))
+            .unwrap_or(i64::from(Page::MAX_LIMIT));
+        let mut rows = conn
+            .query(
+                "WITH direct_children AS ( \
+                     SELECT substr(substr(path, length(?1) + 1), 1, \
+                                   CASE WHEN instr(substr(path, length(?1) + 1), '/') = 0 \
+                                        THEN length(substr(path, length(?1) + 1)) \
+                                        ELSE instr(substr(path, length(?1) + 1), '/') - 1 END) AS name, \
+                            max(is_dir OR instr(substr(path, length(?1) + 1), '/') > 0) AS is_dir \
+                     FROM root_filesystem_entries \
+                     WHERE path >= ?1 AND path < ?2 \
+                     GROUP BY 1 \
+                 ) \
+                 SELECT name, is_dir FROM direct_children \
+                 WHERE name > ?3 ORDER BY name LIMIT ?4",
+                libsql::params![prefix_lower, prefix_upper, after, limit],
+            )
+            .await
+            .map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::ListDir, error)
+            })?;
+        let mut page = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ListDir, error))?
+        {
+            let name: String = row.get(0).map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::ListDir, error)
+            })?;
+            let is_dir: i64 = row.get(1).map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::ListDir, error)
+            })?;
+            page.push(DirEntry {
+                path: VirtualPath::new(format!(
+                    "{}/{}",
+                    path.as_str().trim_end_matches('/'),
+                    name
+                ))?,
+                name,
+                file_type: if is_dir != 0 {
+                    FileType::Directory
+                } else {
+                    FileType::File
+                },
+            });
+        }
+        if page.is_empty() && after.is_empty() && exact_entry.is_none() {
+            return Err(not_found(path.clone(), FilesystemOperation::ListDir));
+        }
+        Ok(page)
+    }
+
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         if let Some((len, file_type, modified)) = self.exact_entry(path).await? {
             return Ok(FileStat {

--- a/crates/substrates/ironclaw_filesystem/src/local.rs
+++ b/crates/substrates/ironclaw_filesystem/src/local.rs
@@ -646,37 +646,7 @@ async fn atomic_write_file(
         CasExpectation::Any => tokio::fs::rename(&temp, target)
             .await
             .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)),
-        CasExpectation::Absent => match tokio::fs::hard_link(&temp, target).await {
-            Ok(()) => tokio::fs::remove_file(&temp).await.map_err(|error| {
-                io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)
-            }),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                if let Err(cleanup_error) = tokio::fs::remove_file(&temp).await {
-                    tracing::debug!(
-                        error = ?cleanup_error,
-                        "best-effort cleanup of write temp file failed after CAS conflict"
-                    );
-                }
-                Err(FilesystemError::VersionMismatch {
-                    path: virtual_path.clone(),
-                    expected: None,
-                    found: Some(RecordVersion::from_backend(0)),
-                })
-            }
-            Err(error) => {
-                if let Err(cleanup_error) = tokio::fs::remove_file(&temp).await {
-                    tracing::debug!(
-                        error = ?cleanup_error,
-                        "best-effort cleanup of write temp file failed after hard-link error"
-                    );
-                }
-                Err(io_error(
-                    virtual_path.clone(),
-                    FilesystemOperation::WriteFile,
-                    error,
-                ))
-            }
-        },
+        CasExpectation::Absent => publish_absent_temp(virtual_path, &temp, target).await,
         CasExpectation::Version(_) => Err(FilesystemError::Unsupported {
             path: virtual_path.clone(),
             operation: FilesystemOperation::WriteFile,
@@ -685,6 +655,92 @@ async fn atomic_write_file(
 
     install_result?;
     sync_parent_dir(virtual_path, parent).await
+}
+
+#[cfg(not(windows))]
+async fn publish_absent_temp(
+    virtual_path: &VirtualPath,
+    temp: &Path,
+    target: &Path,
+) -> Result<(), FilesystemError> {
+    match tokio::fs::hard_link(temp, target).await {
+        Ok(()) => tokio::fs::remove_file(&temp)
+            .await
+            .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            if let Err(cleanup_error) = tokio::fs::remove_file(&temp).await {
+                tracing::debug!(
+                    error = ?cleanup_error,
+                    "best-effort cleanup of write temp file failed after CAS conflict"
+                );
+            }
+            Err(FilesystemError::VersionMismatch {
+                path: virtual_path.clone(),
+                expected: None,
+                found: Some(RecordVersion::from_backend(0)),
+            })
+        }
+        Err(error) => {
+            if let Err(cleanup_error) = tokio::fs::remove_file(&temp).await {
+                tracing::debug!(
+                    error = ?cleanup_error,
+                    "best-effort cleanup of write temp file failed after hard-link error"
+                );
+            }
+            Err(io_error(
+                virtual_path.clone(),
+                FilesystemOperation::WriteFile,
+                error,
+            ))
+        }
+    }
+}
+
+#[cfg(windows)]
+async fn publish_absent_temp(
+    virtual_path: &VirtualPath,
+    temp: &Path,
+    target: &Path,
+) -> Result<(), FilesystemError> {
+    // Windows rename is an atomic create-only publication: unlike Unix rename,
+    // it refuses to replace an existing destination. Use that native behavior
+    // instead of `CreateHardLinkW`, which can return `PermissionDenied` on
+    // hosted Windows runners even when both paths are writable and share a
+    // volume. The existence read is only error classification after rename
+    // has already failed; it never decides whether publication may proceed.
+    match tokio::fs::rename(temp, target).await {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let target_exists = tokio::fs::try_exists(target)
+                .await
+                .map_err(|inspect_error| {
+                    io_error(
+                        virtual_path.clone(),
+                        FilesystemOperation::WriteFile,
+                        inspect_error,
+                    )
+                })?;
+            if let Err(cleanup_error) = tokio::fs::remove_file(temp).await {
+                tracing::debug!(
+                    error = ?cleanup_error,
+                    "best-effort cleanup of write temp file failed after rename error"
+                );
+            }
+            if target_exists {
+                Err(FilesystemError::VersionMismatch {
+                    path: virtual_path.clone(),
+                    expected: None,
+                    found: Some(RecordVersion::from_backend(0)),
+                })
+            } else {
+                Err(io_error(
+                    virtual_path.clone(),
+                    FilesystemOperation::WriteFile,
+                    error,
+                ))
+            }
+        }
+    }
 }
 
 fn unique_temp_path(
@@ -824,9 +880,21 @@ async fn sync_parent_dir_for_operation(
     parent: &Path,
     operation: FilesystemOperation,
 ) -> Result<(), FilesystemError> {
+    #[cfg(windows)]
+    {
+        // `tokio::fs::File::open` cannot open a Windows directory without
+        // `FILE_FLAG_BACKUP_SEMANTICS`. The file contents were already
+        // flushed before the atomic rename; Windows does not expose a
+        // portable parent-directory fsync equivalent through std/tokio.
+        let _ = (virtual_path, parent, operation);
+        return Ok(());
+    }
+
+    #[cfg(not(windows))]
     let dir = tokio::fs::File::open(parent)
         .await
         .map_err(|error| io_error(virtual_path.clone(), operation, error))?;
+    #[cfg(not(windows))]
     dir.sync_all()
         .await
         .map_err(|error| io_error(virtual_path.clone(), operation, error))

--- a/crates/substrates/ironclaw_filesystem/src/local.rs
+++ b/crates/substrates/ironclaw_filesystem/src/local.rs
@@ -546,6 +546,52 @@ impl RootFilesystem for DiskFilesystem {
         Ok(entries)
     }
 
+    async fn list_dir_page(
+        &self,
+        path: &VirtualPath,
+        after: Option<&str>,
+        max_entries: usize,
+    ) -> Result<Vec<DirEntry>, FilesystemError> {
+        if max_entries == 0 {
+            return Ok(Vec::new());
+        }
+        let resolved = self
+            .resolve_existing(path, FilesystemOperation::ListDir)
+            .await?;
+        let mut read_dir = tokio::fs::read_dir(resolved)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::ListDir, error))?;
+        let mut page = std::collections::BTreeMap::<String, DirEntry>::new();
+        while let Some(entry) = read_dir
+            .next_entry()
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::ListDir, error))?
+        {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if after.is_some_and(|cursor| name.as_str() <= cursor) {
+                continue;
+            }
+            let entry_path =
+                VirtualPath::new(format!("{}/{}", path.as_str().trim_end_matches('/'), name))?;
+            let metadata = entry
+                .metadata()
+                .await
+                .map_err(|error| io_error(entry_path.clone(), FilesystemOperation::Stat, error))?;
+            page.insert(
+                name.clone(),
+                DirEntry {
+                    name,
+                    path: entry_path,
+                    file_type: file_type_from_metadata(&metadata),
+                },
+            );
+            if page.len() > max_entries {
+                page.pop_last();
+            }
+        }
+        Ok(page.into_values().collect())
+    }
+
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         let resolved = self
             .resolve_existing(path, FilesystemOperation::Stat)
@@ -727,16 +773,7 @@ async fn publish_absent_temp(
                     "best-effort cleanup of write temp file failed after rename error"
                 );
             }
-            let target_exists = tokio::fs::try_exists(target)
-                .await
-                .map_err(|inspect_error| {
-                    io_error(
-                        virtual_path.clone(),
-                        FilesystemOperation::WriteFile,
-                        inspect_error,
-                    )
-                })?;
-            if target_exists {
+            if windows_target_exists_error(&error) {
                 Err(FilesystemError::VersionMismatch {
                     path: virtual_path.clone(),
                     expected: None,
@@ -751,6 +788,15 @@ async fn publish_absent_temp(
             }
         }
     }
+}
+
+#[cfg(windows)]
+fn windows_target_exists_error(error: &std::io::Error) -> bool {
+    use windows_sys::Win32::Foundation::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS};
+
+    error
+        .raw_os_error()
+        .is_some_and(|code| code == ERROR_ALREADY_EXISTS as i32 || code == ERROR_FILE_EXISTS as i32)
 }
 
 #[cfg(windows)]
@@ -1108,6 +1154,20 @@ fn io_reason(error: std::io::Error) -> String {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_existing_target_errors_are_classified_without_a_follow_up_probe() {
+        use windows_sys::Win32::Foundation::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS};
+
+        for code in [ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS] {
+            let error = std::io::Error::from_raw_os_error(code as i32);
+            assert!(windows_target_exists_error(&error));
+        }
+        assert!(!windows_target_exists_error(
+            &std::io::Error::from_raw_os_error(5)
+        ));
+    }
 
     #[tokio::test]
     #[tracing_test::traced_test]

--- a/crates/substrates/ironclaw_filesystem/src/local.rs
+++ b/crates/substrates/ironclaw_filesystem/src/local.rs
@@ -664,9 +664,15 @@ async fn publish_absent_temp(
     target: &Path,
 ) -> Result<(), FilesystemError> {
     match tokio::fs::hard_link(temp, target).await {
-        Ok(()) => tokio::fs::remove_file(&temp)
-            .await
-            .map_err(|error| io_error(virtual_path.clone(), FilesystemOperation::WriteFile, error)),
+        Ok(()) => {
+            if let Err(cleanup_error) = tokio::fs::remove_file(temp).await {
+                tracing::debug!(
+                    error = ?cleanup_error,
+                    "best-effort cleanup of write temp file failed after publication"
+                );
+            }
+            Ok(())
+        }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             if let Err(cleanup_error) = tokio::fs::remove_file(&temp).await {
                 tracing::debug!(
@@ -702,15 +708,25 @@ async fn publish_absent_temp(
     temp: &Path,
     target: &Path,
 ) -> Result<(), FilesystemError> {
-    // Windows rename is an atomic create-only publication: unlike Unix rename,
-    // it refuses to replace an existing destination. Use that native behavior
-    // instead of `CreateHardLinkW`, which can return `PermissionDenied` on
-    // hosted Windows runners even when both paths are writable and share a
-    // volume. The existence read is only error classification after rename
-    // has already failed; it never decides whether publication may proceed.
-    match tokio::fs::rename(temp, target).await {
+    let temp_path = temp.to_path_buf();
+    let target_path = target.to_path_buf();
+    let publish =
+        tokio::task::spawn_blocking(move || move_file_absent_windows(&temp_path, &target_path))
+            .await
+            .map_err(|error| FilesystemError::Backend {
+                path: virtual_path.clone(),
+                operation: FilesystemOperation::WriteFile,
+                reason: format!("Windows create-only publication task failed: {error}"),
+            })?;
+    match publish {
         Ok(()) => Ok(()),
         Err(error) => {
+            if let Err(cleanup_error) = tokio::fs::remove_file(temp).await {
+                tracing::debug!(
+                    error = ?cleanup_error,
+                    "best-effort cleanup of write temp file failed after rename error"
+                );
+            }
             let target_exists = tokio::fs::try_exists(target)
                 .await
                 .map_err(|inspect_error| {
@@ -720,12 +736,6 @@ async fn publish_absent_temp(
                         inspect_error,
                     )
                 })?;
-            if let Err(cleanup_error) = tokio::fs::remove_file(temp).await {
-                tracing::debug!(
-                    error = ?cleanup_error,
-                    "best-effort cleanup of write temp file failed after rename error"
-                );
-            }
             if target_exists {
                 Err(FilesystemError::VersionMismatch {
                     path: virtual_path.clone(),
@@ -741,6 +751,82 @@ async fn publish_absent_temp(
             }
         }
     }
+}
+
+#[cfg(windows)]
+fn move_file_absent_windows(temp: &Path, target: &Path) -> std::io::Result<()> {
+    use windows_sys::Win32::Storage::FileSystem::{MOVEFILE_WRITE_THROUGH, MoveFileExW};
+
+    let temp = path_to_nul_terminated_wide(temp)?;
+    let target = path_to_nul_terminated_wide(target)?;
+    // SAFETY: Both pointers reference live, NUL-terminated UTF-16 buffers.
+    // Omitting MOVEFILE_REPLACE_EXISTING makes an existing target a failure,
+    // preserving CasExpectation::Absent atomically on the same volume.
+    let moved = unsafe { MoveFileExW(temp.as_ptr(), target.as_ptr(), MOVEFILE_WRITE_THROUGH) };
+    if moved == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn path_to_nul_terminated_wide(path: &Path) -> std::io::Result<Vec<u16>> {
+    use std::os::windows::ffi::OsStrExt;
+
+    let absolute = std::path::absolute(path)?;
+    let mut wide: Vec<u16> = absolute.as_os_str().encode_wide().collect();
+    if wide.contains(&0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path contains an interior NUL byte",
+        ));
+    }
+
+    normalize_windows_path_separators(&mut wide);
+    if !has_windows_namespace_prefix(&wide) {
+        wide = verbatim_windows_path(wide);
+    }
+    wide.push(0);
+    Ok(wide)
+}
+
+#[cfg(windows)]
+fn has_windows_namespace_prefix(wide: &[u16]) -> bool {
+    wide.len() >= 4
+        && is_windows_path_separator(wide[0])
+        && is_windows_path_separator(wide[1])
+        && (wide[2] == b'?' as u16 || wide[2] == b'.' as u16)
+        && is_windows_path_separator(wide[3])
+}
+
+#[cfg(windows)]
+fn normalize_windows_path_separators(wide: &mut [u16]) {
+    for code_unit in wide {
+        if *code_unit == b'/' as u16 {
+            *code_unit = b'\\' as u16;
+        }
+    }
+}
+
+#[cfg(windows)]
+fn verbatim_windows_path(wide: Vec<u16>) -> Vec<u16> {
+    if wide.len() >= 2 && is_windows_path_separator(wide[0]) && is_windows_path_separator(wide[1]) {
+        let mut prefixed: Vec<u16> = r"\\?\UNC\".encode_utf16().collect();
+        prefixed.extend_from_slice(&wide[2..]);
+        prefixed
+    } else if wide.len() >= 3 && wide[1] == b':' as u16 && is_windows_path_separator(wide[2]) {
+        let mut prefixed: Vec<u16> = r"\\?\".encode_utf16().collect();
+        prefixed.extend_from_slice(&wide);
+        prefixed
+    } else {
+        wide
+    }
+}
+
+#[cfg(windows)]
+fn is_windows_path_separator(code_unit: u16) -> bool {
+    code_unit == b'\\' as u16 || code_unit == b'/' as u16
 }
 
 fn unique_temp_path(

--- a/crates/substrates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/substrates/ironclaw_filesystem/src/postgres.rs
@@ -900,6 +900,67 @@ impl RootFilesystem for PostgresRootFilesystem {
         children
     }
 
+    async fn list_dir_page(
+        &self,
+        path: &VirtualPath,
+        after: Option<&str>,
+        max_entries: usize,
+    ) -> Result<Vec<DirEntry>, FilesystemError> {
+        if max_entries == 0 {
+            return Ok(Vec::new());
+        }
+        let client = self.client().await?;
+        let exact_entry = self.exact_entry_with_client(&client, path).await?;
+        if matches!(exact_entry, Some((_, FileType::File, _))) {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ListDir,
+                reason: "not a directory".to_string(),
+            });
+        }
+        let (prefix_lower, prefix_upper) = descendant_path_range(path);
+        let after = after.unwrap_or_default();
+        let limit = i64::try_from(max_entries.min(Page::MAX_LIMIT as usize))
+            .unwrap_or(i64::from(Page::MAX_LIMIT));
+        let rows = cached_query(
+            &client,
+            "WITH direct_children AS ( \
+                 SELECT split_part(substring(path FROM char_length($1) + 1), '/', 1) AS name, \
+                        bool_or(is_dir OR position('/' IN substring(path FROM char_length($1) + 1)) > 0) AS is_dir \
+                 FROM root_filesystem_entries \
+                 WHERE path >= $1 AND path < $2 \
+                 GROUP BY 1 \
+             ) \
+             SELECT name, is_dir FROM direct_children \
+             WHERE name > $3 ORDER BY name LIMIT $4",
+            &[&prefix_lower, &prefix_upper, &after, &limit],
+        )
+        .await
+        .map_err(|error| db_error(path.clone(), FilesystemOperation::ListDir, error))?;
+        if rows.is_empty() && after.is_empty() && exact_entry.is_none() {
+            return Err(not_found(path.clone(), FilesystemOperation::ListDir));
+        }
+        rows.into_iter()
+            .map(|row| {
+                let name: String = row.get("name");
+                let is_dir: bool = row.get("is_dir");
+                Ok(DirEntry {
+                    path: VirtualPath::new(format!(
+                        "{}/{}",
+                        path.as_str().trim_end_matches('/'),
+                        name
+                    ))?,
+                    name,
+                    file_type: if is_dir {
+                        FileType::Directory
+                    } else {
+                        FileType::File
+                    },
+                })
+            })
+            .collect()
+    }
+
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         let client = self.client().await?;
         postgres_stat_with_client(&client, path).await

--- a/crates/substrates/ironclaw_filesystem/src/root.rs
+++ b/crates/substrates/ironclaw_filesystem/src/root.rs
@@ -81,9 +81,10 @@ pub trait RootFilesystem: Send + Sync {
 
     /// Lists direct children of a canonical virtual directory.
     ///
-    /// Lightweight: returns path + type, no payload, no pagination. Use
-    /// [`query`](Self::query) when you need pagination, filtering, or the
-    /// materialized entry bodies.
+    /// Lightweight: returns path + type and no payload. Use
+    /// [`list_dir_page`](Self::list_dir_page) for bounded keyset pagination,
+    /// or [`query`](Self::query) for indexed filtering and materialized entry
+    /// bodies.
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError>;
 
     /// Lists at most `max_entries` direct children of a canonical virtual
@@ -98,6 +99,30 @@ pub trait RootFilesystem: Send + Sync {
         max_entries: usize,
     ) -> Result<Vec<DirEntry>, FilesystemError> {
         let mut entries = self.list_dir(path).await?;
+        entries.truncate(max_entries);
+        Ok(entries)
+    }
+
+    /// Lists a stable name-ordered keyset page of direct children.
+    ///
+    /// `after` is the final child name returned by the previous page. Backends
+    /// with native path ordering should override this method so memory remains
+    /// bounded by `max_entries`. The default preserves compatibility for
+    /// decorators and test doubles by filtering a materialized listing.
+    async fn list_dir_page(
+        &self,
+        path: &VirtualPath,
+        after: Option<&str>,
+        max_entries: usize,
+    ) -> Result<Vec<DirEntry>, FilesystemError> {
+        if max_entries == 0 {
+            return Ok(Vec::new());
+        }
+        let mut entries = self.list_dir(path).await?;
+        if let Some(after) = after {
+            entries.retain(|entry| entry.name.as_str() > after);
+        }
+        entries.sort_by(|left, right| left.name.cmp(&right.name));
         entries.truncate(max_entries);
         Ok(entries)
     }

--- a/crates/substrates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/substrates/ironclaw_filesystem/src/scoped.rs
@@ -650,6 +650,26 @@ where
         result
     }
 
+    pub async fn list_dir_page(
+        &self,
+        scope: &ResourceScope,
+        path: &ScopedPath,
+        after: Option<&str>,
+        max_entries: usize,
+    ) -> Result<Vec<DirEntry>, FilesystemError> {
+        let started_at = live_latency_started_at();
+        let (virtual_path, is_mount_root) =
+            self.resolve_read_root_aware(scope, path, FilesystemOperation::ListDir)?;
+        let result = empty_when_missing_root(
+            self.root
+                .list_dir_page(&virtual_path, after, max_entries)
+                .await,
+            is_mount_root,
+        );
+        trace_fs_latency("list_dir_page", path, started_at, &result, None);
+        result
+    }
+
     pub async fn stat(
         &self,
         scope: &ResourceScope,

--- a/crates/substrates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/substrates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -162,6 +162,37 @@ async fn libsql_root_filesystem_lists_direct_children_sorted_with_virtual_paths(
         ]
     );
     assert_eq!(entries[1].file_type, FileType::Directory);
+
+    let first_page = filesystem
+        .list_dir_page(
+            &VirtualPath::new("/engine/tenants/t1/users/u1").unwrap(),
+            None,
+            2,
+        )
+        .await
+        .unwrap();
+    let second_page = filesystem
+        .list_dir_page(
+            &VirtualPath::new("/engine/tenants/t1/users/u1").unwrap(),
+            first_page.last().map(|entry| entry.name.as_str()),
+            2,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        first_page
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["alpha.txt", "nested"]
+    );
+    assert_eq!(
+        second_page
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["zeta.txt"]
+    );
 }
 #[tokio::test]
 async fn libsql_root_filesystem_appends_deletes_and_creates_directories() {
@@ -2734,6 +2765,44 @@ mod postgres_tests {
 
     fn vpath(prefix: &str, leaf: &str) -> VirtualPath {
         VirtualPath::new(format!("{prefix}/{leaf}")).unwrap()
+    }
+
+    #[tokio::test]
+    async fn postgres_list_dir_page_uses_stable_name_keyset() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        for leaf in ["a.json", "b.json", "c.json", "nested/value.json"] {
+            fs.put(
+                &vpath(&prefix, leaf),
+                Entry::bytes(Vec::new()),
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+        }
+        let root = VirtualPath::new(prefix).unwrap();
+        let first = fs.list_dir_page(&root, None, 2).await.unwrap();
+        let second = fs
+            .list_dir_page(&root, first.last().map(|entry| entry.name.as_str()), 2)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            first
+                .iter()
+                .map(|entry| entry.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a.json", "b.json"]
+        );
+        assert_eq!(
+            second
+                .iter()
+                .map(|entry| entry.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["c.json", "nested"]
+        );
+        assert_eq!(second[1].file_type, FileType::Directory);
     }
 
     #[tokio::test]

--- a/crates/substrates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/substrates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -922,6 +922,38 @@ async fn local_list_dir_bounded_returns_at_most_max_entries() {
 }
 
 #[tokio::test]
+async fn local_list_dir_page_continues_after_stable_name_cursor() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    for name in ["c.txt", "a.txt", "b.txt"] {
+        std::fs::write(storage.path().join("project1").join(name), b"entry").unwrap();
+    }
+    let root = local_root_with_projects_mount(storage.path());
+    let path = VirtualPath::new("/projects/project1").unwrap();
+
+    let first = root.list_dir_page(&path, None, 2).await.unwrap();
+    let second = root
+        .list_dir_page(&path, first.last().map(|entry| entry.name.as_str()), 2)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        first
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a.txt", "b.txt"]
+    );
+    assert_eq!(
+        second
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["c.txt"]
+    );
+}
+
+#[tokio::test]
 async fn local_list_dir_bounded_propagates_read_dir_errors() {
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join("project1")).unwrap();

--- a/crates/substrates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/substrates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -308,6 +308,51 @@ async fn local_put_absent_rejects_existing_file_without_overwrite() {
 }
 
 #[tokio::test]
+async fn concurrent_local_put_absent_has_exactly_one_winner() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+
+    let mut root = DiskFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+    let root = std::sync::Arc::new(root);
+    let path = VirtualPath::new("/projects/project1/lock").unwrap();
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+    let writers = [b"first".to_vec(), b"second".to_vec()].map(|bytes| {
+        let root = std::sync::Arc::clone(&root);
+        let path = path.clone();
+        let barrier = std::sync::Arc::clone(&barrier);
+        tokio::spawn(async move {
+            barrier.wait().await;
+            root.put(&path, Entry::bytes(bytes), CasExpectation::Absent)
+                .await
+        })
+    });
+    let [first_writer, second_writer] = writers;
+    let (first, second) = tokio::join!(first_writer, second_writer);
+    let results = [first.unwrap(), second.unwrap()];
+
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, Err(FilesystemError::VersionMismatch { .. })))
+            .count(),
+        1
+    );
+    assert!(matches!(
+        std::fs::read(storage.path().join("project1/lock"))
+            .unwrap()
+            .as_slice(),
+        b"first" | b"second"
+    ));
+}
+
+#[tokio::test]
 async fn scoped_write_is_denied_on_read_only_mount() {
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join("project1")).unwrap();

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -315,6 +315,11 @@ PR_STATIC_CONTROL_PATHS = {
     ".cargo/config.toml",
     "tests/integration/coverage-exemptions.toml",
     "tests/integration/coverage-floor.toml",
+    # Release-smoke Python coverage is executed by Code Style's dedicated
+    # `Release smoke script tests` step. It drives the real
+    # `scripts/ci/smoke-release-binary.py`; no Tests (Reborn) Rust lane owns
+    # this unittest module.
+    "tests/test_smoke_release_binary.py",
     # Repo-root `scripts/` is deliberately NOT prefix-classified — the
     # `unmapped test or CI path` arm below exists to force a per-file decision.
     # These are decided:

--- a/scripts/ci/smoke-release-binary.py
+++ b/scripts/ci/smoke-release-binary.py
@@ -42,7 +42,7 @@ class SmokeFailure(RuntimeError):
 
 
 Runner = Callable[
-    [Path, tuple[str, ...], dict[str, str]], subprocess.CompletedProcess[str]
+    [Path, tuple[str, ...], dict[str, str], Path], subprocess.CompletedProcess[str]
 ]
 
 
@@ -50,6 +50,7 @@ def _run_command(
     binary: Path,
     args: tuple[str, ...],
     environment: dict[str, str],
+    working_directory: Path,
 ) -> subprocess.CompletedProcess[str]:
     try:
         return subprocess.run(
@@ -58,6 +59,7 @@ def _run_command(
             capture_output=True,
             text=True,
             env=environment,
+            cwd=working_directory,
             timeout=120,
         )
     except (OSError, subprocess.TimeoutExpired) as error:
@@ -70,9 +72,10 @@ def _checked_output(
     binary: Path,
     args: tuple[str, ...],
     environment: dict[str, str],
+    working_directory: Path,
     runner: Runner,
 ) -> str:
-    result = runner(binary, args, environment)
+    result = runner(binary, args, environment, working_directory)
     if result.returncode != 0:
         stdout = result.stdout[-4000:]
         stderr = result.stderr[-4000:]
@@ -183,26 +186,39 @@ def smoke_release_binary(binary: Path, runner: Runner = _run_command) -> set[str
     with tempfile.TemporaryDirectory(prefix="ironclaw-release-smoke-") as temp:
         root = Path(temp)
         environment = _isolated_environment(root)
+        workspace = Path(environment["IRONCLAW_REBORN_WORKSPACE_ROOT"])
 
-        version = _checked_output(binary, ("--version",), environment, runner)
+        version = _checked_output(
+            binary, ("--version",), environment, workspace, runner
+        )
         if "ironclaw" not in version.lower():
             raise SmokeFailure("--version did not identify IronClaw")
         evidence.add("version")
 
-        help_output = _checked_output(binary, ("--help",), environment, runner)
+        help_output = _checked_output(
+            binary, ("--help",), environment, workspace, runner
+        )
         for command in ("serve", "run", "extension", "profile"):
             if command not in help_output:
                 raise SmokeFailure(f"--help is missing the {command!r} command")
         evidence.add("help")
 
         profiles = _checked_output(
-            binary, ("profile", "list", "--json"), environment, runner
+            binary,
+            ("profile", "list", "--json"),
+            environment,
+            workspace,
+            runner,
         )
         _validate_profiles(profiles)
         evidence.add("profiles")
 
         extensions = _checked_output(
-            binary, ("extension", "search", "--json"), environment, runner
+            binary,
+            ("extension", "search", "--json"),
+            environment,
+            workspace,
+            runner,
         )
         _validate_bundled_extensions(extensions)
         evidence.add("bundled_extensions")
@@ -217,7 +233,11 @@ def smoke_release_binary(binary: Path, runner: Runner = _run_command) -> set[str
         migration_environment = dict(environment)
         migration_environment["IRONCLAW_REBORN_PROFILE"] = "migration-dry-run"
         migration = _checked_output(
-            binary, ("run", "--dry-run"), migration_environment, runner
+            binary,
+            ("run", "--dry-run"),
+            migration_environment,
+            workspace,
+            runner,
         )
         if "profile: migration-dry-run" not in migration:
             raise SmokeFailure(

--- a/scripts/ci/smoke-release-binary.py
+++ b/scripts/ci/smoke-release-binary.py
@@ -32,6 +32,8 @@ _PASSTHROUGH_ENV = (
     "TMP",
     "TEMP",
     "LANG",
+    "USERNAME",
+    "USERDOMAIN",
 )
 
 

--- a/scripts/ci/smoke-release-binary.py
+++ b/scripts/ci/smoke-release-binary.py
@@ -160,6 +160,7 @@ def _isolated_environment(root: Path) -> dict[str, str]:
             "HOME": str(home),
             "USERPROFILE": str(home),
             "IRONCLAW_REBORN_HOME": str(reborn_home),
+            "IRONCLAW_REBORN_WORKSPACE_ROOT": str(workspace),
             "IRONCLAW_DISABLE_OS_KEYCHAIN": "1",
             "TZ": "UTC",
             "LANG": environment.get("LANG", "C.UTF-8"),

--- a/scripts/ci/smoke-release-binary.py
+++ b/scripts/ci/smoke-release-binary.py
@@ -87,7 +87,10 @@ def _parse_json_object(output: str, label: str) -> dict[str, object]:
     try:
         value = json.loads(output)
     except json.JSONDecodeError as error:
-        raise SmokeFailure(f"{label} did not emit valid JSON: {error}") from error
+        prefix = output[:500]
+        raise SmokeFailure(
+            f"{label} did not emit valid JSON: {error}; stdout prefix: {prefix!r}"
+        ) from error
     if not isinstance(value, dict):
         raise SmokeFailure(f"{label} must emit a JSON object")
     return value

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -1171,6 +1171,7 @@ class RebornPrTestPlanTests(unittest.TestCase):
         shape as the `.claude/` gap the CHECKLIST row already records.
         """
         for path in (
+            "tests/test_smoke_release_binary.py",
             "scripts/no_panics_reborn_baseline.txt",
             "scripts/reborn-e2e-rust.sh",
             "scripts/check-version-bumps.sh",

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -212,9 +212,16 @@ fn reborn_runtime_image_can_run_the_orchestrator_healthcheck() {
         .rsplit_once(" AS runtime\n")
         .map(|(_, stage)| stage)
         .expect("Dockerfile must define a runtime stage");
+    let runtime_packages = runtime_stage
+        .split_once("install -y --no-install-recommends \\\n")
+        .and_then(|(_, packages)| packages.split_once("    && rm -rf /var/lib/apt/lists/*"))
+        .map(|(packages, _)| packages)
+        .expect("runtime stage must install its package list before apt cleanup");
 
     assert!(
-        runtime_stage.contains("curl"),
+        runtime_packages
+            .lines()
+            .any(|line| line.trim() == "curl \\"),
         "runtime image must include an HTTP client for orchestrator healthchecks"
     );
 }

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -204,6 +204,22 @@ fn reborn_runtime_image_includes_sql_debug_clients() {
 }
 
 #[test]
+fn reborn_runtime_image_can_run_the_orchestrator_healthcheck() {
+    // Earlier build stages install curl for downloads, so inspect only the
+    // shipped runtime stage used by container healthchecks.
+    let dockerfile = read_repo_file("Dockerfile");
+    let runtime_stage = dockerfile
+        .rsplit_once(" AS runtime\n")
+        .map(|(_, stage)| stage)
+        .expect("Dockerfile must define a runtime stage");
+
+    assert!(
+        runtime_stage.contains("curl"),
+        "runtime image must include an HTTP client for orchestrator healthchecks"
+    );
+}
+
+#[test]
 fn reborn_hosted_single_tenant_seed_config_contains_postgres_storage() {
     let config = read_repo_file("docker/reborn/config.hosted-single-tenant.toml");
 

--- a/tests/test_smoke_release_binary.py
+++ b/tests/test_smoke_release_binary.py
@@ -129,7 +129,12 @@ class ReleaseBinarySmokeTests(unittest.TestCase):
         workspace_root = workspace_roots.pop()
         self.assertIsNotNone(workspace_root)
         self.assertTrue(all(self.runner.workspace_roots_were_directories))
-        self.assertNotEqual(Path(workspace_root), ROOT)
+        workspace_path = Path(workspace_root).resolve()
+        repository_path = ROOT.resolve()
+        self.assertFalse(
+            workspace_path == repository_path
+            or repository_path in workspace_path.parents
+        )
         self.assertTrue(
             all("DATABASE_URL" not in environment for environment in environments)
         )

--- a/tests/test_smoke_release_binary.py
+++ b/tests/test_smoke_release_binary.py
@@ -27,6 +27,7 @@ def completed(
 class FakeRunner:
     def __init__(self) -> None:
         self.calls: list[tuple[tuple[str, ...], dict[str, str]]] = []
+        self.workspace_roots_were_directories: list[bool] = []
         self.responses = {
             ("--version",): completed("ironclaw 1.0.0\n"),
             ("--help",): completed("Commands: serve run extension profile\n"),
@@ -73,6 +74,10 @@ class FakeRunner:
         self, _binary: Path, args: tuple[str, ...], environment: dict[str, str]
     ) -> subprocess.CompletedProcess[str]:
         self.calls.append((args, environment))
+        workspace_root = environment.get("IRONCLAW_REBORN_WORKSPACE_ROOT")
+        self.workspace_roots_were_directories.append(
+            workspace_root is not None and Path(workspace_root).is_dir()
+        )
         if args == ("extension", "search", "--json"):
             database = (
                 Path(environment["IRONCLAW_REBORN_HOME"])
@@ -115,6 +120,15 @@ class ReleaseBinarySmokeTests(unittest.TestCase):
         self.assertTrue(
             all("IRONCLAW_REBORN_HOME" in environment for environment in environments)
         )
+        workspace_roots = {
+            environment.get("IRONCLAW_REBORN_WORKSPACE_ROOT")
+            for environment in environments
+        }
+        self.assertEqual(len(workspace_roots), 1)
+        workspace_root = workspace_roots.pop()
+        self.assertIsNotNone(workspace_root)
+        self.assertTrue(all(self.runner.workspace_roots_were_directories))
+        self.assertNotEqual(Path(workspace_root), ROOT)
         self.assertTrue(
             all("DATABASE_URL" not in environment for environment in environments)
         )

--- a/tests/test_smoke_release_binary.py
+++ b/tests/test_smoke_release_binary.py
@@ -8,6 +8,7 @@ import subprocess
 import tarfile
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -132,6 +133,19 @@ class ReleaseBinarySmokeTests(unittest.TestCase):
         self.assertTrue(
             all("DATABASE_URL" not in environment for environment in environments)
         )
+
+    def test_isolated_environment_preserves_windows_account_for_key_acl(self) -> None:
+        root = Path(self.temp_dir.name) / "windows-smoke"
+        root.mkdir()
+        with mock.patch.dict(
+            os.environ,
+            {"USERNAME": "runneradmin", "USERDOMAIN": "RUNNER"},
+            clear=False,
+        ):
+            environment = SMOKE._isolated_environment(root)
+
+        self.assertEqual(environment["USERNAME"], "runneradmin")
+        self.assertEqual(environment["USERDOMAIN"], "RUNNER")
 
     def test_nonzero_shipping_command_fails(self) -> None:
         self.runner.responses[("extension", "search", "--json")] = completed(

--- a/tests/test_smoke_release_binary.py
+++ b/tests/test_smoke_release_binary.py
@@ -27,7 +27,7 @@ def completed(
 
 class FakeRunner:
     def __init__(self) -> None:
-        self.calls: list[tuple[tuple[str, ...], dict[str, str]]] = []
+        self.calls: list[tuple[tuple[str, ...], dict[str, str], Path]] = []
         self.workspace_roots_were_directories: list[bool] = []
         self.responses = {
             ("--version",): completed("ironclaw 1.0.0\n"),
@@ -72,9 +72,13 @@ class FakeRunner:
         }
 
     def __call__(
-        self, _binary: Path, args: tuple[str, ...], environment: dict[str, str]
+        self,
+        _binary: Path,
+        args: tuple[str, ...],
+        environment: dict[str, str],
+        working_directory: Path,
     ) -> subprocess.CompletedProcess[str]:
-        self.calls.append((args, environment))
+        self.calls.append((args, environment, working_directory))
         workspace_root = environment.get("IRONCLAW_REBORN_WORKSPACE_ROOT")
         self.workspace_roots_were_directories.append(
             workspace_root is not None and Path(workspace_root).is_dir()
@@ -105,7 +109,7 @@ class ReleaseBinarySmokeTests(unittest.TestCase):
 
         self.assertEqual(evidence, SMOKE.REQUIRED_EVIDENCE)
         self.assertEqual(
-            [args for args, _ in self.runner.calls],
+            [args for args, _, _ in self.runner.calls],
             [
                 ("--version",),
                 ("--help",),
@@ -114,7 +118,11 @@ class ReleaseBinarySmokeTests(unittest.TestCase):
                 ("run", "--dry-run"),
             ],
         )
-        environments = [environment for _, environment in self.runner.calls]
+        environments = [environment for _, environment, _ in self.runner.calls]
+        working_directories = {
+            working_directory.resolve()
+            for _, _, working_directory in self.runner.calls
+        }
         self.assertEqual(
             environments[-1]["IRONCLAW_REBORN_PROFILE"], "migration-dry-run"
         )
@@ -130,6 +138,7 @@ class ReleaseBinarySmokeTests(unittest.TestCase):
         self.assertIsNotNone(workspace_root)
         self.assertTrue(all(self.runner.workspace_roots_were_directories))
         workspace_path = Path(workspace_root).resolve()
+        self.assertEqual(working_directories, {workspace_path})
         repository_path = ROOT.resolve()
         self.assertFalse(
             workspace_path == repository_path
@@ -187,7 +196,10 @@ class ReleaseBinarySmokeTests(unittest.TestCase):
 
     def test_successful_catalog_without_local_libsql_state_fails(self) -> None:
         def runner_without_database(
-            _binary: Path, args: tuple[str, ...], _environment: dict[str, str]
+            _binary: Path,
+            args: tuple[str, ...],
+            _environment: dict[str, str],
+            _working_directory: Path,
         ) -> subprocess.CompletedProcess[str]:
             return self.runner.responses[args]
 

--- a/tests/test_smoke_release_binary.py
+++ b/tests/test_smoke_release_binary.py
@@ -155,6 +155,15 @@ class ReleaseBinarySmokeTests(unittest.TestCase):
         with self.assertRaisesRegex(SMOKE.SmokeFailure, "exited 7"):
             SMOKE.smoke_release_binary(self.binary, self.runner)
 
+    def test_invalid_json_reports_the_captured_stdout_prefix(self) -> None:
+        with self.assertRaisesRegex(
+            SMOKE.SmokeFailure, "processed file: master-key"
+        ):
+            SMOKE._parse_json_object(
+                'processed file: master-key\n{"payload": {}}',
+                "extension search --json",
+            )
+
     def test_missing_profile_fails(self) -> None:
         self.runner.responses[("profile", "list", "--json")] = completed(
             json.dumps({"profiles": [{"name": "local-dev"}]})


### PR DESCRIPTION
## Summary

- Forward-port the independently validated 1.2 release fixes onto current `main`: Windows filesystem/release-smoke reliability, clean Windows JSON output, runtime `curl` for healthchecks, and stable `1.2.0` metadata.
- Retain the one-time thread-index projection repair needed to recover durable threads whose index row exists but has lost the projection sidecar used by sidebar listing.
- Run projection repair as bounded background migration work: at most two active repairs and 128 admitted scopes, no listing-path wait, durable completion only after the full scope succeeds, and a three-attempt per-scope budget for persistent failures.
- Repair scopes larger than 1,024 rows through stable keyset directory pages and use CAS force-write when the decoded row body is already current but its projection sidecar is damaged.
- Deliberately exclude the release-only legacy-state migration implementation and upgrade canary.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [x] Security or permissions
- [x] Dependencies

## Linked Issue

Related #7507, #7514, #7555. Replaces #7657.

## Test Strategy

User behavior: Windows release binaries preserve state and machine-readable output; create-only local filesystem writes cannot replace an existing target; runtime containers can execute HTTP healthchecks; durable threads hidden by missing index projection metadata become listable again after background repair.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: complete `ironclaw_filesystem` and `ironclaw_threads` suites, including local CAS, stable directory paging across in-memory/disk/libSQL/PostgreSQL, PostgreSQL parity/race contracts, damaged projection sidecars, transient and persistent failures, CAS races, scope independence, and a 1,025-row repair.
- Reborn integration: CLI `smoke` and `extension` targets; root Dockerfile runtime contract. The projection repair is covered at its filesystem service contract seam because it does not change product orchestration.
- Recorded fixture: Not applicable; no provider payload parsing changed.
- Browser E2E: Not applicable; no browser behavior changed.
- Backend or runtime: local filesystem publication contracts, filesystem backends including PostgreSQL/libSQL coverage, and exact final-stage Docker package assertion.
- Live canary: Not applicable; no provider integration changed. Upgrade behavior remains covered by the durable filesystem service contract.

What the tests prove: successful publication is not reported as failed when temp cleanup fails; Windows publication is create-only; release smoke commands use an isolated non-repository workspace and preserve required environment; CLI JSON stays uncontaminated; final runtime packages contain `curl`; listing stays responsive while repair runs; incomplete repairs retry up to the bounded per-scope failure budget without writing completion; damaged equal-body sidecars are physically rewritten; oversized scopes are not permanently skipped.

Commands run:
- `cargo fmt --all -- --check`
- `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` (earlier forward-port validation)
- `cargo clippy -p ironclaw_threads --all-targets --all-features -- -D warnings`
- `cargo clippy -p ironclaw_filesystem --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_threads --no-fail-fast`
- `cargo test -p ironclaw_filesystem --no-fail-fast`
- `cargo test -p ironclaw_architecture_tests --no-fail-fast`
- `cargo test -p ironclaw --test smoke --test extension`
- `cargo test -p ironclaw_integration_tests --test dockerfile_runtime_home`
- `python3.12 -m unittest tests.test_smoke_release_binary scripts.ci.test_reborn_pr_test_plan`
- `bash scripts/pre-commit-safety.sh`

Cross-compilation note: a local Windows target check is blocked on macOS before reaching this crate because the installed toolchain lacks the Windows C headers required by `ring`; GitHub Windows CI remains the platform-native verification.

## Security Impact

Windows standalone key permissions retain the existing ACL policy, and `icacls` diagnostics are captured on stderr without contaminating JSON stdout. Atomic absent-write semantics are preserved with native create-only publication. Projection repair uses the existing scoped filesystem and CAS capability boundary.

## Database Impact

No schema migration. The retained repair rewrites only existing derived thread-index entries whose listing projection sidecar is incomplete and writes a per-scope completion marker after successful read-back. Source thread records and messages are never deleted or rewritten.

## Blast Radius

Local atomic writes, Windows release-smoke execution, standalone Windows secret-key ACL invocation, thread-list projection recovery, release metadata, and the Docker runtime package set.

## Rollback Plan

Revert this PR. No schema rollback is required. If rolled back before a repair completes, the absence of its completion marker leaves the scope eligible for a later retry after restoration.

## Review Follow-Through

All inline review findings were re-audited. The projection repair is retained because it restores otherwise durable-but-invisible threads, but it no longer scans or blocks inside the listing request. Oversized scopes are repaired with bounded keyset paging instead of materializing every row; failures never write completion and persistent failures stop request-triggered rescans after three attempts; the barrier-based regression test uses bounded timeouts. Bot observations against code already present on current `main` were audited separately.

---

**Review track**: C (persistence/runtime/CI)
