### PR TITLE
fix(auth): support origin-scoped hosted MCP OAuth

### DIFF
--- a/crates/domains/ironclaw_auth/src/engine/admission.rs
+++ b/crates/domains/ironclaw_auth/src/engine/admission.rs
@@ -56,7 +56,8 @@ impl ProtectedResourceMetadataFetch {
 /// that mediated egress may fetch after the resource document is validated.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuthorizationServerMetadataFetch {
-    resource: ProtectedResourceMetadataFetch,
+    resource: HttpsEndpoint,
+    protected_resource_metadata_url: HttpsEndpoint,
     issuer: HttpsEndpoint,
     metadata_url: HttpsEndpoint,
 }
@@ -71,8 +72,36 @@ impl AuthorizationServerMetadataFetch {
     }
 }
 
+/// Match an admitted OAuth resource to its hosted-MCP transport endpoint.
+///
+/// RFC 9728 binds these values exactly. A small set of deployed MCP servers
+/// instead scopes the conventional `/mcp` transport to the queryless origin
+/// root. Accept only that one vendor-neutral compatibility shape; broader
+/// parent paths or query-bearing endpoints could widen a token audience.
+pub fn oauth_resource_matches_hosted_mcp_endpoint(
+    endpoint: &HttpsEndpoint,
+    resource: &HttpsEndpoint,
+) -> bool {
+    let exact_match = endpoint == resource;
+    let resource_text = resource.as_str();
+    let (Ok(endpoint), Ok(resource)) = (
+        url::Url::parse(endpoint.as_str()),
+        url::Url::parse(resource.as_str()),
+    ) else {
+        return false;
+    };
+    let canonical_origin_resource = endpoint.origin().ascii_serialization();
+    exact_match
+        || (endpoint.origin() == resource.origin()
+            && endpoint.path() == "/mcp"
+            && endpoint.query().is_none()
+            && resource.path() == "/"
+            && resource.query().is_none()
+            && resource_text == canonical_origin_resource)
+}
+
 /// An operator-managed client profile. It is usable only for its exact
-/// canonical resource and issuer, and carries handles rather than secrets.
+/// admitted OAuth resource and issuer, and carries handles rather than secrets.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdmissionClientProfile {
     pub id: String,
@@ -215,13 +244,16 @@ where
     }
 
     /// Validate the fetched RFC 9728 document and produce the only issuer
-    /// metadata URL that may be fetched next.
+    /// metadata URL that may be fetched next. Resource identity is exact apart
+    /// from the bounded conventional `/mcp`-to-origin compatibility shape.
     pub fn preflight_authorization_server(
         resource: ProtectedResourceMetadataFetch,
         metadata: &ProtectedResourceAdmissionMetadata,
     ) -> Result<AuthorizationServerMetadataFetch, AuthProductError> {
-        if metadata.resource.as_str() != resource.canonical_resource.as_str()
-            || metadata.authorization_servers.len() != 1
+        if !oauth_resource_matches_hosted_mcp_endpoint(
+            &resource.canonical_resource,
+            &metadata.resource,
+        ) || metadata.authorization_servers.len() != 1
         {
             return Err(AuthProductError::MalformedConfig);
         }
@@ -233,7 +265,8 @@ where
             malformed_config_from_host_api_error("authorization_server_metadata_url", error)
         })?;
         Ok(AuthorizationServerMetadataFetch {
-            resource,
+            resource: metadata.resource.clone(),
+            protected_resource_metadata_url: resource.metadata_url,
             issuer,
             metadata_url,
         })
@@ -244,11 +277,7 @@ where
         request: OAuthRecipeAdmissionRequest,
     ) -> Result<ResolvedVendorAuthRecipe, AuthProductError> {
         let issuer = request.authorization_server_fetch.issuer.as_str();
-        let canonical_resource = request
-            .authorization_server_fetch
-            .resource
-            .canonical_resource
-            .as_str();
+        let admitted_resource = request.authorization_server_fetch.resource.as_str();
         let expected_as_metadata = request.authorization_server_fetch.metadata_url.as_str();
         if request.authorization_server_metadata.issuer.as_str() != issuer {
             return Err(AuthProductError::MalformedConfig);
@@ -275,7 +304,7 @@ where
                     .resolve(&profile_id)
                     .await
                     .ok_or(AuthProductError::MalformedConfig)?;
-                if profile.resource.as_str() != canonical_resource
+                if profile.resource.as_str() != admitted_resource
                     || profile.issuer.as_str() != issuer
                 {
                     return Err(AuthProductError::MalformedConfig);
@@ -333,9 +362,11 @@ where
         Ok(ResolvedVendorAuthRecipe {
             vendor: request.vendor,
             recipe: VendorAuthRecipe::Oauth2Code(Box::new(recipe)),
-            token_exchange_resource: Some(canonical_resource.to_string()),
+            token_exchange_resource: Some(admitted_resource.to_string()),
             protected_resource_metadata_url: Some(
-                request.authorization_server_fetch.resource.metadata_url,
+                request
+                    .authorization_server_fetch
+                    .protected_resource_metadata_url,
             ),
         })
     }
@@ -678,6 +709,115 @@ mod tests {
         assert!(
             OAuthRecipeAdmission::<Profiles>::preflight_authorization_server(fetch, &metadata)
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn hosted_mcp_resource_compatibility_is_limited_to_origin_scoped_mcp() {
+        let cases = [
+            (
+                "https://mcp.example.test/mcp",
+                "https://mcp.example.test/mcp",
+                true,
+            ),
+            (
+                "https://mcp.example.test/mcp",
+                "https://mcp.example.test",
+                true,
+            ),
+            (
+                "https://mcp.example.test/mcp",
+                "https://mcp.example.test/",
+                false,
+            ),
+            (
+                "https://mcp.example.test/mcp?tenant=one",
+                "https://mcp.example.test",
+                false,
+            ),
+            (
+                "https://mcp.example.test/team/mcp",
+                "https://mcp.example.test",
+                false,
+            ),
+            (
+                "https://mcp.example.test/mcp",
+                "https://mcp.example.test/team",
+                false,
+            ),
+            (
+                "https://mcp.example.test/mcp",
+                "https://other.example.test",
+                false,
+            ),
+            (
+                "https://mcp.example.test:8443/mcp",
+                "https://mcp.example.test",
+                false,
+            ),
+            (
+                "https://mcp.example.test/mcp",
+                "https://mcp.example.test?tenant=one",
+                false,
+            ),
+            (
+                "https://mcp.example.test/mcp",
+                "https://mcp.example.test/tenant/..",
+                false,
+            ),
+            (
+                "https://mcp.example.test/mcp",
+                "https://mcp.example.test/%2e",
+                false,
+            ),
+        ];
+
+        for (endpoint, resource, expected) in cases {
+            assert_eq!(
+                oauth_resource_matches_hosted_mcp_endpoint(&https(endpoint), &https(resource)),
+                expected,
+                "endpoint={endpoint}, resource={resource}"
+            );
+        }
+        assert!(
+            HttpsEndpoint::new("http://mcp.example.test/mcp").is_err(),
+            "non-HTTPS inputs cannot cross the typed matcher boundary"
+        );
+    }
+
+    #[tokio::test]
+    async fn origin_scoped_mcp_resource_is_preserved_as_the_token_resource() {
+        let challenge = McpAuthChallenge {
+            status: 401,
+            www_authenticate_metadata: vec![
+                McpAuthMetadataLocation::new(
+                    "https://mcp.example.test/.well-known/oauth-protected-resource",
+                )
+                .unwrap(),
+            ],
+            protected_resource_metadata: vec![],
+        };
+        let fetch = OAuthRecipeAdmission::<Profiles>::preflight_protected_resource(
+            "https://mcp.example.test/mcp",
+            &challenge,
+        )
+        .unwrap();
+        let metadata = ProtectedResourceAdmissionMetadata {
+            resource: https("https://mcp.example.test"),
+            authorization_servers: vec![https("https://auth.example.test")],
+        };
+        let authorization_server_fetch =
+            OAuthRecipeAdmission::<Profiles>::preflight_authorization_server(fetch, &metadata)
+                .expect("the conventional origin-scoped MCP resource admits");
+        let mut request = request();
+        request.authorization_server_fetch = authorization_server_fetch;
+
+        let admitted = admit(request)
+            .await
+            .expect("origin-scoped MCP resource produces an OAuth recipe");
+        assert_eq!(
+            admitted.token_exchange_resource.as_deref(),
+            Some("https://mcp.example.test")
         );
     }
     #[tokio::test]
@@ -1078,6 +1218,55 @@ mod tests {
             .admit(r)
             .await
             .unwrap();
+        let VendorAuthRecipe::Oauth2Code(recipe) = resolved.recipe else {
+            panic!("oauth recipe")
+        };
+        assert_eq!(
+            recipe.client_credentials.unwrap().client_id_handle.as_str(),
+            "client-id"
+        );
+    }
+
+    #[tokio::test]
+    async fn origin_scoped_resource_with_matching_client_profile_admits_handles() {
+        let challenge = McpAuthChallenge {
+            status: 401,
+            www_authenticate_metadata: vec![
+                McpAuthMetadataLocation::new(
+                    "https://mcp.example.test/.well-known/oauth-protected-resource",
+                )
+                .unwrap(),
+            ],
+            protected_resource_metadata: vec![],
+        };
+        let fetch = OAuthRecipeAdmission::<Profiles>::preflight_protected_resource(
+            "https://mcp.example.test/mcp",
+            &challenge,
+        )
+        .unwrap();
+        let metadata = ProtectedResourceAdmissionMetadata {
+            resource: https("https://mcp.example.test"),
+            authorization_servers: vec![https("https://auth.example.test")],
+        };
+        let mut request = request();
+        request.authorization_server_fetch =
+            OAuthRecipeAdmission::<Profiles>::preflight_authorization_server(fetch, &metadata)
+                .expect("origin-scoped resource admits");
+        request.client_profile_id = Some("known".into());
+        let profile = AdmissionClientProfile {
+            id: "known".into(),
+            resource: https("https://mcp.example.test"),
+            issuer: https("https://auth.example.test"),
+            credentials: RecipeClientCredentials {
+                client_id_handle: ironclaw_host_api::ids::SecretHandle::new("client-id").unwrap(),
+                client_secret_handle: None,
+            },
+        };
+
+        let resolved = OAuthRecipeAdmission::new(Profiles(Some(profile)))
+            .admit(request)
+            .await
+            .expect("profile bound to the admitted origin resource is accepted");
         let VendorAuthRecipe::Oauth2Code(recipe) = resolved.recipe else {
             panic!("oauth recipe")
         };

--- a/crates/domains/ironclaw_auth/src/engine/mod.rs
+++ b/crates/domains/ironclaw_auth/src/engine/mod.rs
@@ -87,8 +87,10 @@ pub use dcr::DCR_CLIENT_HANDLE_PREFIX;
 /// One vendor's recipe, resolved from active extensions or bundled manifests.
 ///
 /// `token_exchange_resource` is the RFC 8707 resource indicator sent with
-/// token requests — for hosted-MCP vendors this is the manifest's
-/// `[mcp].server` URL, i.e. still manifest data, never engine code.
+/// token requests. For hosted-MCP vendors it is the resource admitted from
+/// RFC 9728 metadata: normally the manifest's `[mcp].server` URL, with the
+/// bounded conventional `/mcp`-to-origin compatibility shape admitted by the
+/// auth policy. It remains manifest-derived data, never engine code.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedVendorAuthRecipe {
     pub vendor: String,

--- a/crates/domains/ironclaw_auth/src/lib.rs
+++ b/crates/domains/ironclaw_auth/src/lib.rs
@@ -58,7 +58,7 @@ pub use engine::admission::{
     AdmissionClientProfile, AuthorizationServerAdmissionMetadata, AuthorizationServerMetadataFetch,
     EmptyOAuthClientProfileRegistry, OAuthClientProfileRegistry, OAuthRecipeAdmission,
     OAuthRecipeAdmissionRequest, ProtectedResourceAdmissionMetadata,
-    ProtectedResourceMetadataFetch,
+    ProtectedResourceMetadataFetch, oauth_resource_matches_hosted_mcp_endpoint,
 };
 pub use engine::keepalive;
 pub use engine::keepalive::{

--- a/crates/domains/ironclaw_auth/tests/auth_engine_contract.rs
+++ b/crates/domains/ironclaw_auth/tests/auth_engine_contract.rs
@@ -1365,7 +1365,7 @@ async fn dcr_requires_advertised_protected_resource_metadata() {
 #[tokio::test]
 async fn dcr_uses_the_admitted_non_well_known_protected_resource_metadata_url() {
     let mut recipe = manifest_recipe("notion-mcp", "notion");
-    recipe.token_exchange_resource = Some("https://mcp.example.test/mcp".to_string());
+    recipe.token_exchange_resource = Some("https://mcp.example.test".to_string());
     recipe.protected_resource_metadata_url = Some(
         HttpsEndpoint::new("https://mcp.example.test/admitted-metadata".to_string())
             .expect("admitted metadata URL"),
@@ -1375,7 +1375,7 @@ async fn dcr_uses_the_admitted_non_well_known_protected_resource_metadata_url() 
         "https://mcp.example.test/admitted-metadata",
         200,
         serde_json::json!({
-            "resource": "https://mcp.example.test/mcp",
+            "resource": "https://mcp.example.test",
             "authorization_servers": ["https://auth.example.test"]
         }),
     );
@@ -1395,12 +1395,13 @@ async fn dcr_uses_the_admitted_non_well_known_protected_resource_metadata_url() 
         serde_json::json!({ "client_id": "admitted-metadata-dcr-client" }),
     );
 
+    let scope = test_scope();
     harness
         .engine
         .prepare_oauth_flow(PrepareOAuthFlowRequest {
             vendor: "notion".to_string(),
             requester_extension: None,
-            scope: test_scope(),
+            scope: scope.clone(),
             flow_id: AuthFlowId::new(),
             account_label: CredentialAccountLabel::new("account").expect("account label"),
             requested_scopes: Vec::new(),
@@ -1422,6 +1423,65 @@ async fn dcr_uses_the_admitted_non_well_known_protected_resource_metadata_url() 
             .requests_for("https://mcp.example.test/.well-known/oauth-protected-resource/mcp")
             .is_empty(),
         "DCR must not reconstruct a different metadata URL from the resource"
+    );
+
+    harness.server.script(
+        "https://auth.example.test/token",
+        200,
+        serde_json::json!({
+            "access_token": "origin-resource-access",
+            "refresh_token": "origin-resource-refresh",
+            "expires_in": 3600
+        }),
+    );
+    let exchange = harness
+        .engine
+        .exchange_callback(
+            exchange_context(&scope),
+            callback_request("notion", Vec::new()),
+        )
+        .await
+        .expect("the admitted origin resource survives through token exchange");
+    let token_requests = harness
+        .server
+        .requests_for("https://auth.example.test/token");
+    let token_request = &token_requests[0];
+    assert_eq!(
+        token_request.form().get("resource").map(String::as_str),
+        Some("https://mcp.example.test"),
+        "token exchange uses the admitted origin resource, not the transport path"
+    );
+
+    harness.server.script(
+        "https://auth.example.test/token",
+        200,
+        serde_json::json!({
+            "access_token": "refreshed-origin-resource-access",
+            "refresh_token": "refreshed-origin-resource-refresh",
+            "expires_in": 3600
+        }),
+    );
+    harness
+        .engine
+        .refresh_token(OAuthProviderRefreshRequest {
+            provider: AuthProviderId::new("notion").expect("provider id"),
+            scope,
+            account_id: exchange.account_id.unwrap_or_else(CredentialAccountId::new),
+            refresh_secret: exchange
+                .refresh_secret
+                .expect("token exchange stores the refresh token"),
+            scopes: exchange.scopes,
+        })
+        .await
+        .expect("refresh preserves the admitted origin resource");
+    let token_requests = harness
+        .server
+        .requests_for("https://auth.example.test/token");
+    assert_eq!(token_requests.len(), 2);
+    assert_eq!(
+        token_requests[1].form().get("resource").map(String::as_str),
+        Some("https://mcp.example.test"),
+        "refresh uses the admitted origin resource, not the transport path"
     );
 }
 

--- a/crates/extensions/ironclaw_extension_host/src/hosted_mcp_manifest.rs
+++ b/crates/extensions/ironclaw_extension_host/src/hosted_mcp_manifest.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use ironclaw_extension_contracts::hosted_mcp::HostedMcpAuthSelection;
+use ironclaw_extension_contracts::{hosted_mcp::HostedMcpAuthSelection, recipe::HttpsEndpoint};
 use ironclaw_extension_registry::{
     ExtensionManifestRecord, ExtensionPackage, ManifestSource, PackageDefinitionRetention,
     PackageRootBinding,
@@ -140,6 +140,24 @@ pub(crate) fn oauth_admission_error(
     }
 }
 
+fn oauth_resource_validation_error(
+    error: ironclaw_host_api::error::HostApiError,
+) -> ProductOperationFailure {
+    let (error_kind, error_reason) = match error {
+        ironclaw_host_api::error::HostApiError::InvalidId { kind, reason, .. } => (kind, reason),
+        _ => (
+            "host_api_validation",
+            "unexpected host API validation error".to_string(),
+        ),
+    };
+    tracing::debug!(
+        error_kind,
+        error_reason,
+        "hosted MCP OAuth resource was invalid"
+    );
+    oauth_admission_error(ironclaw_auth::AuthProductError::MalformedConfig)
+}
+
 pub(crate) fn metadata_network_policy(url: &str) -> Result<NetworkPolicy, ProductOperationFailure> {
     let parsed = url::Url::parse(url)
         .map_err(|_| oauth_admission_error(ironclaw_auth::AuthProductError::MalformedConfig))?;
@@ -169,7 +187,18 @@ pub(crate) fn manifest_with_admitted_oauth(
     endpoint: &hosted_mcp_admission::CanonicalHostedMcpEndpoint,
     admitted: ironclaw_auth::ResolvedVendorAuthRecipe,
 ) -> Result<ExtensionManifestRecord, ProductOperationFailure> {
-    if admitted.token_exchange_resource.as_deref() != Some(endpoint.as_str()) {
+    let endpoint_resource =
+        HttpsEndpoint::new(endpoint.as_str()).map_err(oauth_resource_validation_error)?;
+    let oauth_resource = admitted
+        .token_exchange_resource
+        .as_deref()
+        .ok_or_else(|| oauth_admission_error(ironclaw_auth::AuthProductError::MalformedConfig))?;
+    let oauth_resource =
+        HttpsEndpoint::new(oauth_resource).map_err(oauth_resource_validation_error)?;
+    if !ironclaw_auth::oauth_resource_matches_hosted_mcp_endpoint(
+        &endpoint_resource,
+        &oauth_resource,
+    ) {
         return Err(oauth_admission_error(
             ironclaw_auth::AuthProductError::MalformedConfig,
         ));
@@ -210,6 +239,7 @@ pub(crate) fn manifest_with_admitted_oauth(
         vendor,
         setup,
         recipe: Some(admitted.recipe),
+        oauth_resource: Some(oauth_resource),
         protected_resource_metadata_url: admitted.protected_resource_metadata_url,
     }];
     let mcp = resolved

--- a/crates/extensions/ironclaw_extension_host/src/recipes.rs
+++ b/crates/extensions/ironclaw_extension_host/src/recipes.rs
@@ -40,7 +40,7 @@ pub fn unified_vendor_recipes<'a>(
     let mut unified: BTreeMap<String, (String, ResolvedVendorAuthRecipe)> = BTreeMap::new();
     for manifest in manifests {
         let extension_id = manifest.id.as_str().to_string();
-        let resource = manifest.mcp.as_ref().map(|mcp| mcp.server.clone());
+        let mcp_resource = manifest.mcp.as_ref().map(|mcp| mcp.server.clone());
         for surface in &manifest.auth {
             let Some(recipe) = &surface.recipe else {
                 // v2 manifests synthesize auth surfaces without recipes; they
@@ -48,6 +48,11 @@ pub fn unified_vendor_recipes<'a>(
                 continue;
             };
             let vendor = surface.vendor.as_str().to_string();
+            let resource = surface
+                .oauth_resource
+                .as_ref()
+                .map(|resource| resource.as_str().to_string())
+                .or_else(|| mcp_resource.clone());
             match unified.get_mut(&vendor) {
                 None => {
                     unified.insert(
@@ -246,6 +251,7 @@ mod tests {
                 vendor: ironclaw_host_api::ids::VendorId::new(vendor).expect("vendor id"),
                 setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
                 recipe: Some(recipe),
+                oauth_resource: None,
                 protected_resource_metadata_url: None,
             }],
             host_apis: Vec::new(),
@@ -284,6 +290,41 @@ mod tests {
         assert_eq!(error.vendor, "vendorco");
         assert_eq!(error.first_extension, "mail-ext");
         assert_eq!(error.second_extension, "docs-ext");
+    }
+
+    #[test]
+    fn legacy_manifest_without_oauth_resource_falls_back_to_mcp_server() {
+        let mut manifest = manifest_with_recipe(
+            "mcp-ext",
+            "mcp-vendor",
+            oauth_recipe(&[], "https://auth.example/token"),
+        );
+        manifest.mcp = Some(ironclaw_extension_registry::ResolvedMcpDeclaration {
+            server: "https://mcp.example/mcp".to_string(),
+            namespace: "mcp-ext".to_string(),
+            max_tools: 16,
+            default_permission: ironclaw_host_api::capability::PermissionMode::Deny,
+            effects: Vec::new(),
+            credential_handles: Vec::new(),
+            dynamic_input_schemas: Default::default(),
+            registration_auth:
+                ironclaw_extension_contracts::hosted_mcp::HostedMcpAuthSelection::OAuth {
+                    client_profile_id: None,
+                },
+        });
+        let legacy_wire = serde_json::to_value(&manifest).expect("legacy manifest serializes");
+        assert!(
+            legacy_wire["auth"][0].get("oauth_resource").is_none(),
+            "the compatibility fixture must exercise the pre-field wire shape"
+        );
+        let restored: ResolvedExtensionManifest =
+            serde_json::from_value(legacy_wire).expect("legacy manifest remains readable");
+
+        let recipes = unified_vendor_recipes([&restored]).expect("legacy recipe resolves");
+        assert_eq!(
+            recipes[0].token_exchange_resource.as_deref(),
+            Some("https://mcp.example/mcp")
+        );
     }
 
     #[test]

--- a/crates/extensions/ironclaw_extension_host/src/recipes.rs
+++ b/crates/extensions/ironclaw_extension_host/src/recipes.rs
@@ -6,8 +6,9 @@
 //!
 //! Shared vendors (overview §3.2): every extension using a vendor embeds the
 //! recipe; recipes for one vendor must be identical except scope and
-//! presentation metadata, the scope ceiling is the union across extensions,
-//! and an incompatible pair is a conflict.
+//! presentation metadata, OAuth resource bindings must match exactly, the
+//! scope ceiling is the union across extensions, and an incompatible pair is
+//! a conflict.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
@@ -22,8 +23,8 @@ use ironclaw_host_api::ids::{ExtensionId, UserId};
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error(
     "extensions `{first_extension}` and `{second_extension}` declare incompatible \
-     [auth.{vendor}] recipes (recipes for a shared vendor must be identical except \
-     scope and presentation metadata)"
+     [auth.{vendor}] recipes or OAuth resource bindings (shared-vendor recipes must be \
+     identical except scope and presentation metadata, and OAuth bindings must match)"
 )]
 pub struct VendorRecipeConflict {
     pub vendor: String,
@@ -33,7 +34,9 @@ pub struct VendorRecipeConflict {
 
 /// Unify the vendor recipes declared across `manifests` (overview §3.2):
 /// Recipes that differ only in scope or presentation metadata merge with a
-/// scope-ceiling union; anything else conflicts.
+/// scope-ceiling union. OAuth recipes must also carry identical effective
+/// resource and protected-resource metadata bindings; these fields are not
+/// meaningful for API-key recipes. Anything else conflicts.
 pub fn unified_vendor_recipes<'a>(
     manifests: impl IntoIterator<Item = &'a ResolvedExtensionManifest>,
 ) -> Result<Vec<ResolvedVendorAuthRecipe>, VendorRecipeConflict> {
@@ -53,25 +56,30 @@ pub fn unified_vendor_recipes<'a>(
                 .as_ref()
                 .map(|resource| resource.as_str().to_string())
                 .or_else(|| mcp_resource.clone());
+            let incoming = ResolvedVendorAuthRecipe {
+                vendor: vendor.clone(),
+                recipe: recipe.clone(),
+                token_exchange_resource: resource,
+                protected_resource_metadata_url: surface.protected_resource_metadata_url.clone(),
+            };
             match unified.get_mut(&vendor) {
                 None => {
-                    unified.insert(
-                        vendor.clone(),
-                        (
-                            extension_id.clone(),
-                            ResolvedVendorAuthRecipe {
-                                vendor,
-                                recipe: recipe.clone(),
-                                token_exchange_resource: resource.clone(),
-                                protected_resource_metadata_url: surface
-                                    .protected_resource_metadata_url
-                                    .clone(),
-                            },
-                        ),
-                    );
+                    unified.insert(vendor.clone(), (extension_id.clone(), incoming));
                 }
                 Some((first_extension, existing)) => {
-                    if !existing.recipe.compatible_for_shared_vendor(recipe) {
+                    let oauth_bindings_match = match (&existing.recipe, &incoming.recipe) {
+                        (VendorAuthRecipe::Oauth2Code(_), VendorAuthRecipe::Oauth2Code(_)) => {
+                            existing.token_exchange_resource == incoming.token_exchange_resource
+                                && existing.protected_resource_metadata_url
+                                    == incoming.protected_resource_metadata_url
+                        }
+                        _ => true,
+                    };
+                    if !existing
+                        .recipe
+                        .compatible_for_shared_vendor(&incoming.recipe)
+                        || !oauth_bindings_match
+                    {
                         return Err(VendorRecipeConflict {
                             vendor,
                             first_extension: first_extension.clone(),
@@ -81,20 +89,13 @@ pub fn unified_vendor_recipes<'a>(
                     if let (
                         VendorAuthRecipe::Oauth2Code(unified_recipe),
                         VendorAuthRecipe::Oauth2Code(incoming),
-                    ) = (&mut existing.recipe, recipe)
+                    ) = (&mut existing.recipe, &incoming.recipe)
                     {
                         for scope in &incoming.scopes {
                             if !unified_recipe.scopes.contains(scope) {
                                 unified_recipe.scopes.push(scope.clone());
                             }
                         }
-                    }
-                    if existing.token_exchange_resource.is_none() {
-                        existing.token_exchange_resource = resource.clone();
-                    }
-                    if existing.protected_resource_metadata_url.is_none() {
-                        existing.protected_resource_metadata_url =
-                            surface.protected_resource_metadata_url.clone();
                     }
                 }
             }

--- a/crates/extensions/ironclaw_extension_registry/src/resolved.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/resolved.rs
@@ -155,6 +155,11 @@ pub struct ResolvedAuthSurface {
     /// `None` for v2 manifests (no recipe vocabulary); required in v3.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recipe: Option<VendorAuthRecipe>,
+    /// OAuth resource admitted from protected-resource metadata for a
+    /// user-registered MCP. Older and static manifests omit this and derive
+    /// the resource from the MCP server endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth_resource: Option<ironclaw_extension_contracts::recipe::HttpsEndpoint>,
     /// Exact RFC 9728 document admitted while preparing a user-registered
     /// OAuth MCP. This stays with the recipe so later DCR uses the advertised
     /// location rather than guessing a well-known resource path.
@@ -215,6 +220,7 @@ impl ResolvedExtensionManifest {
                     vendor: provider,
                     setup,
                     recipe: None,
+                    oauth_resource: None,
                     protected_resource_metadata_url: None,
                 }),
                 _ => None,

--- a/crates/extensions/ironclaw_extension_registry/src/v3.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/v3.rs
@@ -705,6 +705,7 @@ pub(crate) fn parse_v3(
                 vendor,
                 setup,
                 recipe: Some(recipe),
+                oauth_resource: None,
                 protected_resource_metadata_url: None,
             }
         })

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -190,7 +190,7 @@ One thread, whole real turn. Grouped by what the user experiences.
 | Shell commands dispatch through the real path without spawning an OS process | `process_port.rs` |
 | A sandbox-profile shell turn executes as an unprivileged user in a real Docker worker and keeps its workspace across calls | `reborn_sandbox_shell_turn.rs` |
 | MCP tools work over a real loopback HTTP MCP server | `mcp.rs` |
-| User-registered and bundled hosted MCP servers register, authenticate, project active, restore, and invoke | `hosted_mcp_registration.rs` |
+| User-registered and bundled hosted MCP servers register, admit exact or narrowly compatible origin-scoped OAuth resources, authenticate, project active, restore, and invoke | `hosted_mcp_registration.rs` |
 | Web search/fetch runs the real Exa MCP handshake | `web_access.rs` |
 | Outbound HTTP crosses the real security pipeline (network policy + leak scan) | `real_egress_pipeline.rs` |
 | Tools marked host-internal are never advertised to the model, and calls to them are rejected | `extension_visibility.rs`, `surface_disclosure.rs` |

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -210,7 +210,7 @@ One thread, whole real turn. Grouped by what the user experiences.
 **Auth** (`tests/integration/auth/`)
 | Behavior | Evidence |
 |---|---|
-| A full OAuth connect → callback → stored account round trip | `auth/oauth_connect.rs` |
+| A full OAuth connect → callback → stored account round trip; conflicting shared-vendor OAuth resource or metadata bindings fail resolution closed | `auth/oauth_connect.rs` |
 | Abandoning the OAuth popup, late callbacks, and retrying cleanly | `auth/oauth_popup_journeys.rs` |
 | Idle credentials get refreshed by the background sweep | `auth/oauth_refresh.rs` |
 | A missing credential parks a sign-in gate; denying it ends the run cleanly | `auth/auth_gate.rs` |

--- a/tests/integration/auth/oauth_connect.rs
+++ b/tests/integration/auth/oauth_connect.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 
 use chrono::{Duration, Utc};
 use common::{authorized_callback_request, hex64, new_flow_request, test_scope};
-use ironclaw_auth::AuthProviderClient;
 use ironclaw_auth::{
     AuthErrorCode, AuthFlowId, AuthProductScope, AuthProviderId, AuthSurface,
     AuthorizationCodeHash, CredentialAccountLabel, CredentialAccountListRequest,
@@ -28,6 +27,7 @@ use ironclaw_auth::{
     OAuthProviderExchangeContext, OpaqueStateHash, PkceVerifierHash, PkceVerifierSecret,
     PrepareOAuthFlowRequest, ProviderScope,
 };
+use ironclaw_auth::{AuthProviderClient, AuthRecipeResolver};
 use ironclaw_composition::test_support::{
     ScriptedOAuthTokenEgress, build_oauth_product_auth_for_test,
 };
@@ -344,6 +344,53 @@ async fn one_google_authorization_satisfies_every_installed_google_extension() {
     );
 }
 
+/// Shared-vendor scope union is safe only when every OAuth binding names the
+/// same protected resource and metadata document. Otherwise a resolver request
+/// for one extension could inherit another extension's binding and send its
+/// `resource` in DCR and token requests.
+#[tokio::test]
+async fn installed_resolver_rejects_conflicting_shared_vendor_oauth_bindings() {
+    let cases = [
+        (
+            "resource",
+            ("https://resource-a.example", None),
+            ("https://resource-b.example", None),
+        ),
+        (
+            "metadata URL",
+            (
+                "https://resource.example",
+                Some("https://resource.example/metadata-a"),
+            ),
+            (
+                "https://resource.example",
+                Some("https://resource.example/metadata-b"),
+            ),
+        ),
+    ];
+
+    for (conflict, gmail_binding, drive_binding) in cases {
+        let store = installed_store_from_records(vec![
+            manifest_record_with_oauth_binding("gmail", gmail_binding),
+            manifest_record_with_oauth_binding("google-drive", drive_binding),
+        ])
+        .await;
+        let resolver = ironclaw_extension_host::InstalledManifestAuthRecipeResolver::new(store);
+        let caller = UserId::new("shared-vendor-binding-user").expect("caller user");
+
+        for requester in ["gmail", "google-drive"] {
+            let requester = ExtensionId::new(requester).expect("requester extension");
+            assert!(
+                resolver
+                    .resolve(Some(&requester), Some(&caller), "google")
+                    .await
+                    .is_none(),
+                "a differing OAuth {conflict} must fail shared-vendor resolution closed for {requester}"
+            );
+        }
+    }
+}
+
 /// Registration is tenant-wide; installation is per user. The scope ceiling
 /// must follow the INSTALL, so one user's consent screen never carries scopes
 /// for an extension a DIFFERENT user installed (#7078).
@@ -653,6 +700,18 @@ async fn installed_store_for_users(packages: &[(&str, &str)]) -> Arc<ExtensionIn
 /// inventory `InstalledManifestAuthRecipeResolver` unions vendor recipes over.
 /// Same construction as `oauth_popup_journeys.rs`.
 async fn installed_store(packages: &[&str]) -> Arc<ExtensionInstallationStore> {
+    installed_store_from_records(
+        packages
+            .iter()
+            .map(|package| bundled_manifest_record(package))
+            .collect(),
+    )
+    .await
+}
+
+async fn installed_store_from_records(
+    records: Vec<ExtensionManifestRecord>,
+) -> Arc<ExtensionInstallationStore> {
     let store = ExtensionInstallationStore::load_at(
         Arc::new(InMemoryBackend::new()),
         VirtualPath::new("/system/extensions/.installations/oauth-connect")
@@ -663,14 +722,13 @@ async fn installed_store(packages: &[&str]) -> Arc<ExtensionInstallationStore> {
     )
     .await
     .expect("filesystem installation store");
-    for package in packages {
-        let record = bundled_manifest_record(package);
+    for record in records {
         let extension_id = record.extension_id().clone();
         store
             .upsert_manifest_and_installation(
                 record,
                 ExtensionInstallation::new(
-                    ExtensionInstallationId::new(format!("itest-{package}"))
+                    ExtensionInstallationId::new(format!("itest-{extension_id}"))
                         .expect("installation id"),
                     extension_id.clone(),
                     ExtensionManifestRef::new(extension_id, None),
@@ -684,6 +742,35 @@ async fn installed_store(packages: &[&str]) -> Arc<ExtensionInstallationStore> {
             .expect("persist install");
     }
     Arc::new(store)
+}
+
+fn manifest_record_with_oauth_binding(
+    package: &str,
+    binding: (&str, Option<&str>),
+) -> ExtensionManifestRecord {
+    let manifest = bundled_manifest_record(package);
+    let mut resolved = manifest.resolved().clone();
+    let auth = resolved
+        .auth
+        .iter_mut()
+        .find(|surface| surface.vendor.as_str() == "google")
+        .expect("bundled Google extension declares auth");
+    auth.oauth_resource = Some(
+        ironclaw_extension_contracts::recipe::HttpsEndpoint::new(binding.0.to_string())
+            .expect("OAuth resource"),
+    );
+    auth.protected_resource_metadata_url = binding.1.map(|url| {
+        ironclaw_extension_contracts::recipe::HttpsEndpoint::new(url.to_string())
+            .expect("protected-resource metadata URL")
+    });
+    ExtensionManifestRecord::from_resolved(
+        manifest.raw_toml(),
+        manifest.manifest().source,
+        resolved,
+        manifest.manifest_hash().cloned(),
+    )
+    .expect("modified resolved manifest remains valid")
+    .with_definition_retention(manifest.definition_retention())
 }
 
 /// Parse a real bundled package manifest the way the installation store does.

--- a/tests/integration/hosted_mcp_registration.rs
+++ b/tests/integration/hosted_mcp_registration.rs
@@ -18,13 +18,13 @@ use ironclaw_assistant::{
 };
 use ironclaw_auth::{
     AdmissionClientProfile, AuthContinuationRef, AuthProductError, AuthProductScope,
-    AuthProviderClient, AuthProviderId, AuthSurface, AuthorizationCodeHash, CredentialAccountLabel,
-    OAuthAuthorizationCode, OAuthAuthorizationUrl, OAuthClientProfileRegistry,
-    OAuthProviderCallbackRequest, OAuthProviderExchange, OAuthProviderExchangeContext,
-    OAuthProviderRefresh, OAuthProviderRefreshRequest, OpaqueStateHash, PkceVerifierHash,
-    PkceVerifierSecret, ProviderScope, RebornManualTokenSetupRequest,
-    RebornManualTokenSubmitRequest, RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest,
-    RebornOAuthStartFlowRequest,
+    AuthProviderClient, AuthProviderId, AuthRecipeResolver, AuthSurface, AuthorizationCodeHash,
+    CredentialAccountLabel, OAuthAuthorizationCode, OAuthAuthorizationUrl,
+    OAuthClientProfileRegistry, OAuthProviderCallbackRequest, OAuthProviderExchange,
+    OAuthProviderExchangeContext, OAuthProviderRefresh, OAuthProviderRefreshRequest,
+    OpaqueStateHash, PkceVerifierHash, PkceVerifierSecret, ProviderScope,
+    RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest, RebornOAuthCallbackOutcome,
+    RebornOAuthCallbackRequest, RebornOAuthStartFlowRequest,
 };
 use ironclaw_extension_contracts::hosted_mcp::{
     HostedMcpAuthSelection, HostedMcpEndpoint, RegisterHostedMcpRequest,
@@ -33,6 +33,7 @@ use ironclaw_extension_contracts::lifecycle_id::LifecyclePackageId;
 use ironclaw_extension_contracts::recipe::{
     HttpsEndpoint, RecipeClientCredentials, VendorAuthRecipe,
 };
+use ironclaw_extension_host::InstalledManifestAuthRecipeResolver;
 use ironclaw_extension_manager::lifecycle_test_support::{
     build_lifecycle_test_services, build_lifecycle_test_services_with_auth_provider,
     build_lifecycle_test_services_with_oauth_client_profiles, invoke_with_standalone_approval,
@@ -2262,6 +2263,161 @@ async fn oauth_registration_discovers_standard_metadata_then_hands_off_to_generi
     assert!(server.requests().iter().any(|request| {
         request.rpc_method.as_deref() == Some("tools/call") && request.authorization_matches
     }));
+}
+
+#[tokio::test]
+async fn oauth_registration_accepts_origin_scoped_resource_and_hands_off_to_auth_setup() {
+    let server = HostedMcpRegistrationServer::start(
+        HostedMcpAuthPolicy::OAuth {
+            access_token: "oauth-token".to_string(),
+        },
+        vec![HostedMcpTool::read_only("search", json!("ok"))],
+    )
+    .await;
+    server.script_protected_resource_response(ScriptedMetadataResponse::new(
+        axum::http::StatusCode::OK,
+        serde_json::to_vec(&json!({
+            "resource": "https://mcp.example.test",
+            "authorization_servers": ["https://auth.example.test"],
+            "bearer_methods_supported": ["header"]
+        }))
+        .expect("origin-scoped protected-resource metadata serializes"),
+    ));
+    let services = build_lifecycle_test_services(
+        "hosted-mcp-oauth-origin-resource",
+        Some(Arc::new(HostedMcpRegistrationNetworkEgress::for_server(
+            &server,
+        ))),
+        false,
+    )
+    .await;
+    let scope = webui_gate_resource_scope_for_owner("hosted-mcp-oauth-origin-resource");
+
+    let registration = services
+        .lifecycle_service
+        .execute(
+            lifecycle_product_context(scope.clone()),
+            LifecycleProductAction::ExtensionRegisterHostedMcp {
+                request: registration_request(HostedMcpAuthSelection::OAuth {
+                    client_profile_id: None,
+                }),
+            },
+        )
+        .await
+        .expect("origin-scoped OAuth metadata admits the hosted MCP definition");
+    assert_eq!(
+        registration.phase,
+        ironclaw_extension_contracts::state::InstallationState::Installed
+    );
+    assert!(registration.blockers.is_empty());
+
+    let setup_needed = install_fixture(&services, scope.clone()).await;
+    let provider = credential_provider_from_response(&setup_needed);
+    assert!(setup_needed.blockers.iter().any(|blocker| matches!(
+        blocker,
+        ironclaw_product_contracts::package_lifecycle::LifecycleReadinessBlocker::Credential { .. }
+    )));
+    assert!(
+        services
+            .extension_management
+            .active_model_visible_capabilities()
+            .await
+            .expect("active capability projection")
+            .is_empty(),
+        "origin-scoped OAuth publishes no tools before browser authorization"
+    );
+
+    let restored = rebuild_lifecycle_test_services_with_auth_provider(
+        &services,
+        "hosted-mcp-oauth-origin-resource",
+        Some(Arc::new(HostedMcpRegistrationNetworkEgress::for_server(
+            &server,
+        ))),
+        false,
+        Arc::new(ironclaw_auth::UnavailableAuthProviderClient),
+    )
+    .await;
+    let resolver = InstalledManifestAuthRecipeResolver::new(
+        restored.extension_management.installation_store_for_test(),
+    );
+    let extension_id = ExtensionId::new("mcp-fixture").expect("test extension id");
+    let resolved = resolver
+        .resolve(Some(&extension_id), Some(&scope.user_id), provider.as_str())
+        .await
+        .expect("installed hosted MCP retains its admitted OAuth recipe");
+    assert_eq!(
+        resolved.token_exchange_resource.as_deref(),
+        Some("https://mcp.example.test"),
+        "the installed manifest must retain the admitted origin resource for browser OAuth"
+    );
+}
+
+#[tokio::test]
+async fn oauth_registration_rejects_origin_scope_near_misses_without_persistence() {
+    let cases = [
+        ("query-root", "https://mcp.example.test?tenant=one"),
+        ("sibling-path", "https://mcp.example.test/team"),
+        ("cross-origin", "https://other.example.test"),
+        ("changed-port", "https://mcp.example.test:8443"),
+        ("dot-segment", "https://mcp.example.test/tenant/.."),
+        ("encoded-dot-segment", "https://mcp.example.test/%2e"),
+    ];
+
+    for (case, resource) in cases {
+        let server = HostedMcpRegistrationServer::start(
+            HostedMcpAuthPolicy::OAuth {
+                access_token: "oauth-token".to_string(),
+            },
+            vec![HostedMcpTool::read_only("search", json!("ok"))],
+        )
+        .await;
+        server.script_protected_resource_response(ScriptedMetadataResponse::new(
+            axum::http::StatusCode::OK,
+            serde_json::to_vec(&json!({
+                "resource": resource,
+                "authorization_servers": ["https://auth.example.test"]
+            }))
+            .expect("near-miss protected-resource metadata serializes"),
+        ));
+        let user_id = format!("hosted-mcp-oauth-origin-near-miss-{case}");
+        let services = build_lifecycle_test_services(
+            &user_id,
+            Some(Arc::new(HostedMcpRegistrationNetworkEgress::for_server(
+                &server,
+            ))),
+            false,
+        )
+        .await;
+        let error = services
+            .lifecycle_service
+            .execute(
+                lifecycle_product_context(webui_gate_resource_scope_for_owner(&user_id)),
+                LifecycleProductAction::ExtensionRegisterHostedMcp {
+                    request: registration_request(HostedMcpAuthSelection::OAuth {
+                        client_profile_id: None,
+                    }),
+                },
+            )
+            .await
+            .expect_err("an origin-scope near miss must fail registration");
+        assert_eq!(
+            error.kind,
+            ProductSurfaceErrorKind::Validation,
+            "case={case}"
+        );
+        assert!(
+            services
+                .extension_management
+                .installation_store_for_test()
+                .get_registered_package_definition(
+                    &ExtensionId::new("mcp-fixture").expect("extension id")
+                )
+                .await
+                .expect("registered definition readback")
+                .is_none(),
+            "case={case} must not persist a hosted MCP definition"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- admit the narrowly bounded hosted-MCP OAuth shape used by MKT1: an HTTPS `/mcp` endpoint whose RFC 9728 resource is the same canonical bare origin
- preserve the admitted OAuth resource and metadata URL through resolved-manifest persistence, DCR, token exchange, and refresh
- keep exact resource matching as the default and reject query, sibling-path, cross-origin, changed-port, trailing-slash, and dot-segment aliases

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

None — reported from the IronClaw vs Hermes custom-MCP OAuth experience.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `ironclaw_auth`, hosted-MCP registration integration, extension registry/host suites, architecture tests
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (not applicable: no database-backed crate feature changed)
- [x] Manual testing: probed MKT1's live endpoint and OAuth metadata chain; confirmed it advertises `resource=https://mcp.mkt1.co` for `https://mcp.mkt1.co/mcp`
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: A custom MCP with MKT1-shaped metadata registers, survives a fresh restore, retains its admitted resource, and reaches the existing credential/browser OAuth setup path.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [ ] Side effect
- [x] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: compatibility matrix; typed client-profile admission; DCR, token exchange, and refresh resource propagation; legacy manifest fallback
- Reborn integration: registration success, durable restore/readback, credential blocker, and production caller-level rejection matrix with no persistence
- Recorded fixture: Not applicable: the hermetic hosted-MCP server scripts the exact metadata documents
- Browser E2E: Not applicable: no frontend behavior changed; the integration journey verifies handoff to the existing browser-auth blocker
- Backend or runtime: Not applicable: no storage backend or runtime-lane implementation changed
- Live canary: live metadata probe only; no user OAuth grant was performed

What the tests prove:
- the exception admits only the canonical bare same-origin resource for a queryless HTTPS `/mcp` endpoint
- near misses fail before definition persistence or tool publication
- the admitted origin survives persistence, DCR, token exchange, and refresh
- older manifests without the new optional field continue deriving the exact MCP server resource

Commands run:
- `cargo test -p ironclaw_auth`
- `cargo test -p ironclaw_extension_registry -p ironclaw_extension_host`
- `cargo test -p ironclaw_integration_tests --test reborn_integration_hosted_mcp_registration`
- `cargo clippy -p ironclaw_auth -p ironclaw_extension_registry -p ironclaw_extension_host --tests -- -D warnings`
- `cargo test -p ironclaw_architecture_tests`
- `cargo fmt --all -- --check`

## Security Impact

Intentional, narrow OAuth audience compatibility concession. Exact RFC 9728 matching remains the default. The exception requires typed HTTPS endpoints, requested path exactly `/mcp`, no query, the same effective origin and port, and metadata resource equal to the canonical bare origin. Query-bearing, sibling-path, cross-origin, changed-port, trailing-slash, and normalization aliases fail closed.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: only typed `HttpsEndpoint` values cross the exported matcher; auth admission owns policy and the extension host reuses it
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. N/A: no prompt path changed
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. N/A: no hashes changed
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. No variants added; callers continue receiving sanitized `MalformedConfig`
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. `oauth_resource` is optional; legacy fallback is regression-tested
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. N/A: none changed
- [x] Driver/operator-visible errors have stable class semantics. Validation remains a stable non-retryable malformed-config failure with sanitized diagnostics
- [x] Sandbox/native/host names accurately describe trust boundary. No runtime naming changed

## Database Impact

None. The resolved-manifest JSON gains an optional field with a tested legacy fallback; no migration or backend-specific behavior changes.

## Blast Radius

Hosted-MCP OAuth metadata admission and resolved auth-recipe persistence/resolution. Static OAuth extensions and exact-resource hosted MCPs keep their existing path. A shared-vendor recipe continues using the existing unification rules.

## Rollback Plan

Revert this commit. That restores strict RFC 9728 equality and safely makes MKT1-shaped registrations fail before browser OAuth again. Persisted manifests remain readable because the new field is optional and older readers ignore unknown resolved-manifest fields; no database rollback is required.

## Review Follow-Through

Eight specialist review lanes and a thermo-nuclear maintainability pass were run. Findings around persisted-resource loss, refresh propagation, strong typing, canonicalization aliases, error diagnostics, and compatibility coverage were addressed. No blocking findings remain.

---

**Review track**: C
