### PR TITLE
perf(threads): coalesce thread index touches

### DIFF
--- a/crates/domains/ironclaw_threads/Cargo.toml
+++ b/crates/domains/ironclaw_threads/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
 thiserror = "2"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["rt", "sync", "time"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }
 

--- a/crates/domains/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service.rs
@@ -183,7 +183,7 @@ where
     F: RootFilesystem,
 {
     filesystem: Arc<ScopedFilesystem<F>>,
-    known_thread_index_rows: Mutex<HashSet<String>>,
+    known_thread_index_rows: Arc<Mutex<HashSet<String>>>,
     ready_thread_index_scopes: Mutex<HashSet<String>>,
     /// Mounts whose `/threads`-root index specs are already declared, keyed by
     /// `tenant:user` — the pair the alias resolves through. Keeps thread create
@@ -216,7 +216,7 @@ where
     pub fn new(filesystem: Arc<ScopedFilesystem<F>>) -> Self {
         Self {
             filesystem,
-            known_thread_index_rows: Mutex::new(HashSet::new()),
+            known_thread_index_rows: Arc::new(Mutex::new(HashSet::new())),
             ready_thread_index_scopes: Mutex::new(HashSet::new()),
             ready_index_mounts: Mutex::new(HashSet::new()),
             thread_index_declaration_lock: tokio::sync::Mutex::new(()),

--- a/crates/domains/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service.rs
@@ -40,6 +40,7 @@ mod transcript_migration;
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -110,6 +111,10 @@ const TITLE_DERIVATION_READ_CONCURRENCY: usize = 8;
 /// One-shot first-turn context windows are a hot-path handoff from inbound
 /// accept to prompt construction; keep the cache bounded if a turn never runs.
 const ONE_SHOT_CONTEXT_WINDOW_CACHE_MAX_ENTRIES: usize = 4096;
+/// Activity projection writes are advisory and bursty. Keep the default short
+/// enough for sidebar freshness while collapsing the message/draft/finalize
+/// writes produced by a typical turn.
+const DEFAULT_THREAD_INDEX_TOUCH_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
 
 struct MaterializedMessageRange {
     thread: StoredThreadRecord,
@@ -185,6 +190,8 @@ where
     /// off the index-DDL path after a mount's first thread.
     ready_index_mounts: Mutex<HashSet<(TenantId, UserId)>>,
     thread_index_declaration_lock: tokio::sync::Mutex<()>,
+    thread_index_touch_state: Arc<thread_index::ThreadIndexTouchState>,
+    thread_index_touch_flush_interval: Duration,
     one_shot_context_windows: Mutex<HashMap<String, ContextWindow>>,
 }
 
@@ -213,8 +220,19 @@ where
             ready_thread_index_scopes: Mutex::new(HashSet::new()),
             ready_index_mounts: Mutex::new(HashSet::new()),
             thread_index_declaration_lock: tokio::sync::Mutex::new(()),
+            thread_index_touch_state: Arc::new(thread_index::ThreadIndexTouchState::default()),
+            thread_index_touch_flush_interval: DEFAULT_THREAD_INDEX_TOUCH_FLUSH_INTERVAL,
             one_shot_context_windows: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Configure how frequently one service instance may rewrite a thread's
+    /// activity projection. Production uses the short default; tests and
+    /// specialized compositions may tune the trade-off between write volume
+    /// and sidebar freshness.
+    pub fn with_thread_index_touch_flush_interval(mut self, interval: Duration) -> Self {
+        self.thread_index_touch_flush_interval = interval;
+        self
     }
 
     pub fn clear_thread_index_cache_for_scope(&self, _scope: &ThreadScope) {}
@@ -1381,7 +1399,10 @@ where
         scope: &ThreadScope,
         thread_id: &ThreadId,
         updated_at: DateTime<Utc>,
-    ) -> Result<(), SessionThreadError> {
+    ) -> Result<(), SessionThreadError>
+    where
+        F: 'static,
+    {
         self.touch_thread_index_updated_at(scope, thread_id, updated_at)
             .await
     }
@@ -1398,7 +1419,9 @@ where
         scope: &ThreadScope,
         thread_id: &ThreadId,
         updated_at: DateTime<Utc>,
-    ) {
+    ) where
+        F: 'static,
+    {
         if let Err(error) = self
             .touch_thread_updated_at(scope, thread_id, updated_at)
             .await
@@ -1615,7 +1638,7 @@ where
 #[async_trait]
 impl<F> SessionThreadService for FilesystemSessionThreadService<F>
 where
-    F: RootFilesystem,
+    F: RootFilesystem + 'static,
 {
     async fn ensure_thread(
         &self,

--- a/crates/domains/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -245,11 +245,8 @@ where
     }
 
     fn mark_thread_index_known(&self, scope: &ThreadScope, thread_id: &ThreadId) {
-        if let Ok(mut known) = self.known_thread_index_rows.lock() {
-            let key = thread_index_record_cache_key(scope, thread_id);
-            known.insert(key.clone());
-            evict_entry_over_limit(&mut known, THREAD_INDEX_KNOWN_ROW_MAX, &key);
-        }
+        let key = thread_index_record_cache_key(scope, thread_id);
+        mark_thread_index_known_key(&self.known_thread_index_rows, &key);
     }
 
     pub(super) fn is_thread_index_known(&self, scope: &ThreadScope, thread_id: &ThreadId) -> bool {
@@ -416,8 +413,16 @@ where
             Ok(state) => state,
             Err(_) => return ThreadIndexTouchAction::FlushNow(touch),
         };
-        evict_thread_index_touch_state_over_limit(&mut state, key);
+        if state.len() >= THREAD_INDEX_TOUCH_STATE_MAX && !state.contains_key(key) {
+            return ThreadIndexTouchAction::FlushNow(touch);
+        }
         let entry = state.entry(key.to_string()).or_default();
+        if touch.derived_title.is_some() {
+            // A derived title copies user text. Persist it synchronously so a
+            // later redaction can never race a buffered copy back into view.
+            entry.last_flushed_at = Some(now);
+            return ThreadIndexTouchAction::FlushNow(touch);
+        }
         let can_flush_now = entry
             .last_flushed_at
             .is_none_or(|last| now.duration_since(last) >= self.thread_index_touch_flush_interval);
@@ -439,6 +444,7 @@ where
             tokio::spawn(flush_thread_index_touch_loop(
                 Arc::clone(&self.filesystem),
                 Arc::clone(&self.thread_index_touch_state),
+                Arc::clone(&self.known_thread_index_rows),
                 key.to_string(),
                 self.thread_index_touch_flush_interval,
                 delay,
@@ -481,12 +487,12 @@ where
                 let thread_id = thread_id_for_retry.clone();
                 let resource_scope = resource_scope.clone();
                 async move {
-                    let mut index = match current {
+                    let (mut index, mut changed) = match current {
                         Some(index) => {
                             if index.record.scope != scope || index.record.thread_id != thread_id {
                                 return Err(SessionThreadError::ThreadScopeMismatch { thread_id });
                             }
-                            index
+                            (index, false)
                         }
                         None => {
                             let source_path = super::thread_record_path(&scope, &thread_id)?;
@@ -505,10 +511,9 @@ where
                                 return Err(SessionThreadError::ThreadScopeMismatch { thread_id });
                             }
                             stored.record.updated_at = Some(updated_at);
-                            Self::thread_index_record(&stored)
+                            (Self::thread_index_record(&stored), true)
                         }
                     };
-                    let mut changed = false;
                     if index
                         .record
                         .updated_at
@@ -783,26 +788,18 @@ fn merge_pending_thread_index_touch(
     }
 }
 
-fn evict_thread_index_touch_state_over_limit(
-    state: &mut HashMap<String, ThreadIndexTouchEntry>,
-    keep: &str,
-) {
-    if state.len() < THREAD_INDEX_TOUCH_STATE_MAX || state.contains_key(keep) {
-        return;
-    }
-    let victim = state
-        .iter()
-        .filter(|(_, entry)| entry.pending.is_none() && !entry.worker_running)
-        .min_by_key(|(_, entry)| entry.last_flushed_at)
-        .map(|(key, _)| key.clone());
-    if let Some(victim) = victim {
-        state.remove(&victim);
+fn mark_thread_index_known_key(known_rows: &Mutex<HashSet<String>>, key: &str) {
+    if let Ok(mut known) = known_rows.lock() {
+        let key = key.to_string();
+        known.insert(key.clone());
+        evict_entry_over_limit(&mut known, THREAD_INDEX_KNOWN_ROW_MAX, &key);
     }
 }
 
 async fn flush_thread_index_touch_loop<F>(
     filesystem: Arc<ScopedFilesystem<F>>,
     state: Arc<ThreadIndexTouchState>,
+    known_rows: Arc<Mutex<HashSet<String>>>,
     key: String,
     flush_interval: Duration,
     mut delay: Duration,
@@ -827,17 +824,29 @@ async fn flush_thread_index_touch_loop<F>(
             touch
         };
 
-        if let Err(error) = FilesystemSessionThreadService::<F>::write_thread_index_touch(
+        match FilesystemSessionThreadService::<F>::write_thread_index_touch(
             filesystem.as_ref(),
             &touch,
         )
         .await
         {
-            tracing::debug!(
-                ?error,
-                thread_id = %touch.thread_id.as_str(),
-                "coalesced thread recency touch failed",
-            );
+            Ok(true) => mark_thread_index_known_key(&known_rows, &key),
+            Ok(false) => {}
+            Err(error) => {
+                tracing::debug!(
+                    ?error,
+                    thread_id = %touch.thread_id.as_str(),
+                    "coalesced thread recency touch failed",
+                );
+                let mut entries = match state.entries.lock() {
+                    Ok(entries) => entries,
+                    Err(_) => return,
+                };
+                let Some(entry) = entries.get_mut(&key) else {
+                    return;
+                };
+                merge_pending_thread_index_touch(&mut entry.pending, touch);
+            }
         }
 
         let has_pending = match state.entries.lock() {
@@ -995,7 +1004,10 @@ mod tests {
     };
 
     use super::super::thread_record_path;
-    use super::{ThreadIndexFlags, ThreadIndexRecord};
+    use super::{
+        PendingThreadIndexTouch, THREAD_INDEX_TOUCH_STATE_MAX, ThreadIndexFlags, ThreadIndexRecord,
+        ThreadIndexTouchAction, ThreadIndexTouchEntry,
+    };
 
     #[test]
     fn merge_thread_index_records_prefers_present_source_fields() {
@@ -1164,6 +1176,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn filesystem_thread_index_touch_recreates_a_missing_projection_row() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let scoped = scoped_threads_fs_at(backend, "tenant-missing-projection-touch", "alice");
+        let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+        let request_scope = scope("missing-projection-touch");
+        let thread_id = ThreadId::new("thread-missing-projection-touch").unwrap();
+        let created = service
+            .ensure_thread(EnsureThreadRequest {
+                scope: request_scope.clone(),
+                thread_id: Some(thread_id.clone()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some("projection source".into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        scoped
+            .delete(
+                &request_scope.to_resource_scope(),
+                &super::thread_index_record_path(&request_scope, &thread_id).unwrap(),
+            )
+            .await
+            .expect("test setup removes only the projection row");
+        let touched_at =
+            created.updated_at.expect("creation timestamp") + chrono::Duration::seconds(1);
+
+        service
+            .touch_thread_index_updated_at(&request_scope, &thread_id, touched_at)
+            .await
+            .unwrap();
+
+        let recreated = service
+            .read_thread_index_record(&request_scope, &thread_id)
+            .await
+            .unwrap()
+            .expect("touch recreates the missing projection from its source");
+        assert_eq!(recreated.record.updated_at, Some(touched_at));
+    }
+    #[tokio::test]
     async fn filesystem_thread_index_recreate_does_not_reuse_stale_metadata() {
         let backend = Arc::new(InMemoryBackend::new());
         let scoped = scoped_threads_fs_at(backend, "tenant-stale-index", "alice");
@@ -1220,6 +1271,83 @@ mod tests {
         assert_eq!(
             recreated.metadata_json.as_deref(),
             Some("{\"recreated\":true}")
+        );
+    }
+
+    #[tokio::test]
+    async fn derived_title_touch_is_never_buffered() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let scoped = scoped_threads_fs_at(backend, "tenant-derived-title-touch", "alice");
+        let service = FilesystemSessionThreadService::new(scoped);
+        let request_scope = scope("derived-title-touch");
+        let thread_id = ThreadId::new("thread-derived-title-touch").unwrap();
+        let key = "derived-title-touch";
+        let first = service.buffer_thread_index_touch(
+            key,
+            PendingThreadIndexTouch {
+                scope: request_scope.clone(),
+                thread_id: thread_id.clone(),
+                updated_at: chrono::Utc::now(),
+                derived_title: None,
+            },
+        );
+        assert!(matches!(first, ThreadIndexTouchAction::FlushNow(_)));
+
+        let title_touch = service.buffer_thread_index_touch(
+            key,
+            PendingThreadIndexTouch {
+                scope: request_scope,
+                thread_id,
+                updated_at: chrono::Utc::now(),
+                derived_title: Some("private sidebar text".into()),
+            },
+        );
+
+        assert!(
+            matches!(title_touch, ThreadIndexTouchAction::FlushNow(_)),
+            "user text must persist synchronously so later redaction cannot race a buffered copy"
+        );
+    }
+    #[test]
+    fn thread_index_touch_state_flushes_directly_when_all_entries_are_active() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let scoped = scoped_threads_fs_at(backend, "tenant-touch-cap", "alice");
+        let service = FilesystemSessionThreadService::new(scoped);
+        {
+            let mut entries = match service.thread_index_touch_state.entries.lock() {
+                Ok(entries) => entries,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            for index in 0..THREAD_INDEX_TOUCH_STATE_MAX {
+                entries.insert(
+                    format!("active-{index}"),
+                    ThreadIndexTouchEntry {
+                        worker_running: true,
+                        ..ThreadIndexTouchEntry::default()
+                    },
+                );
+            }
+        }
+        let request_scope = scope("touch-cap");
+        let thread_id = ThreadId::new("thread-touch-cap").unwrap();
+        let action = service.buffer_thread_index_touch(
+            "new-touch-over-cap",
+            PendingThreadIndexTouch {
+                scope: request_scope,
+                thread_id,
+                updated_at: chrono::Utc::now(),
+                derived_title: None,
+            },
+        );
+
+        assert!(matches!(action, ThreadIndexTouchAction::FlushNow(_)));
+        let retained = match service.thread_index_touch_state.entries.lock() {
+            Ok(entries) => entries.len(),
+            Err(poisoned) => poisoned.into_inner().len(),
+        };
+        assert_eq!(
+            retained, THREAD_INDEX_TOUCH_STATE_MAX,
+            "active touch state must stay within its hard cap"
         );
     }
 }

--- a/crates/domains/ironclaw_threads/src/filesystem_service/thread_index.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/thread_index.rs
@@ -1,10 +1,14 @@
-use std::collections::HashSet;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use chrono::{DateTime, Utc};
 use ironclaw_filesystem::{
     CasApply, CasExpectation, ContentType, Entry, FileType, Filter, IndexKey, IndexKind, IndexName,
     IndexSpec, IndexValue, OrderedPage, OrderedQueryCursor, Page, RecordKind, RootFilesystem,
-    SortDirection, cas_update,
+    ScopedFilesystem, SortDirection, cas_update,
 };
 use ironclaw_host_api::{ids::ThreadId, path::ScopedPath};
 use serde::{Deserialize, Serialize};
@@ -22,6 +26,7 @@ const THREAD_SCOPE_INDEX_KEY: &str = "scope_key";
 const THREAD_ACTIVITY_SORT_KEY: &str = "activity_sort";
 const THREAD_ID_INDEX_KEY: &str = "thread_id";
 const THREAD_INDEX_KNOWN_ROW_MAX: usize = 100_000;
+const THREAD_INDEX_TOUCH_STATE_MAX: usize = 100_000;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) struct ThreadIndexRecord {
@@ -43,6 +48,31 @@ struct ThreadIndexFlags {
     title_present: bool,
     metadata_present: bool,
     goal_present: bool,
+}
+
+#[derive(Debug, Clone)]
+struct PendingThreadIndexTouch {
+    scope: ThreadScope,
+    thread_id: ThreadId,
+    updated_at: DateTime<Utc>,
+    derived_title: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct ThreadIndexTouchEntry {
+    last_flushed_at: Option<Instant>,
+    pending: Option<PendingThreadIndexTouch>,
+    worker_running: bool,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct ThreadIndexTouchState {
+    entries: Mutex<HashMap<String, ThreadIndexTouchEntry>>,
+}
+
+enum ThreadIndexTouchAction {
+    FlushNow(PendingThreadIndexTouch),
+    Buffered,
 }
 
 impl<F> FilesystemSessionThreadService<F>
@@ -183,8 +213,12 @@ where
     }
 
     pub(super) fn forget_thread_index_row(&self, scope: &ThreadScope, thread_id: &ThreadId) {
+        let key = thread_index_record_cache_key(scope, thread_id);
         if let Ok(mut known) = self.known_thread_index_rows.lock() {
-            known.remove(&thread_index_record_cache_key(scope, thread_id));
+            known.remove(&key);
+        }
+        if let Ok(mut state) = self.thread_index_touch_state.entries.lock() {
+            state.remove(&key);
         }
     }
 
@@ -324,7 +358,10 @@ where
         scope: &ThreadScope,
         thread_id: &ThreadId,
         updated_at: DateTime<Utc>,
-    ) -> Result<(), SessionThreadError> {
+    ) -> Result<(), SessionThreadError>
+    where
+        F: 'static,
+    {
         self.touch_thread_index_updated_at_with_derived_title(scope, thread_id, updated_at, None)
             .await
     }
@@ -339,15 +376,102 @@ where
         thread_id: &ThreadId,
         updated_at: DateTime<Utc>,
         derived_title: Option<String>,
-    ) -> Result<(), SessionThreadError> {
+    ) -> Result<(), SessionThreadError>
+    where
+        F: 'static,
+    {
         self.ensure_thread_index_query(scope, false).await?;
+        let touch = PendingThreadIndexTouch {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+            updated_at,
+            derived_title,
+        };
+        let key = thread_index_record_cache_key(scope, thread_id);
+        let ThreadIndexTouchAction::FlushNow(touch) = self.buffer_thread_index_touch(&key, touch)
+        else {
+            return Ok(());
+        };
+        match Self::write_thread_index_touch(self.filesystem.as_ref(), &touch).await {
+            Ok(true) => self.mark_thread_index_known(scope, thread_id),
+            Ok(false) => {}
+            Err(error) => {
+                self.release_failed_thread_index_touch(&key);
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    fn buffer_thread_index_touch(
+        &self,
+        key: &str,
+        touch: PendingThreadIndexTouch,
+    ) -> ThreadIndexTouchAction
+    where
+        F: 'static,
+    {
+        let now = Instant::now();
+        let mut state = match self.thread_index_touch_state.entries.lock() {
+            Ok(state) => state,
+            Err(_) => return ThreadIndexTouchAction::FlushNow(touch),
+        };
+        evict_thread_index_touch_state_over_limit(&mut state, key);
+        let entry = state.entry(key.to_string()).or_default();
+        let can_flush_now = entry
+            .last_flushed_at
+            .is_none_or(|last| now.duration_since(last) >= self.thread_index_touch_flush_interval);
+        if can_flush_now && !entry.worker_running {
+            entry.last_flushed_at = Some(now);
+            return ThreadIndexTouchAction::FlushNow(touch);
+        }
+
+        merge_pending_thread_index_touch(&mut entry.pending, touch);
+        if !entry.worker_running {
+            entry.worker_running = true;
+            let delay = entry
+                .last_flushed_at
+                .map(|last| {
+                    self.thread_index_touch_flush_interval
+                        .saturating_sub(now.duration_since(last))
+                })
+                .unwrap_or(self.thread_index_touch_flush_interval);
+            tokio::spawn(flush_thread_index_touch_loop(
+                Arc::clone(&self.filesystem),
+                Arc::clone(&self.thread_index_touch_state),
+                key.to_string(),
+                self.thread_index_touch_flush_interval,
+                delay,
+            ));
+        }
+        ThreadIndexTouchAction::Buffered
+    }
+
+    fn release_failed_thread_index_touch(&self, key: &str) {
+        if let Ok(mut state) = self.thread_index_touch_state.entries.lock()
+            && let Some(entry) = state.get_mut(key)
+        {
+            entry.last_flushed_at = None;
+            if entry.pending.is_none() && !entry.worker_running {
+                state.remove(key);
+            }
+        }
+    }
+
+    async fn write_thread_index_touch(
+        filesystem: &ScopedFilesystem<F>,
+        touch: &PendingThreadIndexTouch,
+    ) -> Result<bool, SessionThreadError> {
+        let scope = &touch.scope;
+        let thread_id = &touch.thread_id;
         let path = thread_index_record_path(scope, thread_id)?;
         let resource_scope = scope.to_resource_scope();
         let scope_for_retry = scope.clone();
         let thread_id_for_retry = thread_id.clone();
-        let derived_title = &derived_title;
+        let updated_at = touch.updated_at;
+        let derived_title = &touch.derived_title;
         let row_known = cas_update(
-            self.filesystem.as_ref(),
+            filesystem,
             &resource_scope,
             &path,
             |bytes: &[u8]| deserialize::<ThreadIndexRecord>(bytes),
@@ -355,6 +479,7 @@ where
             |current: Option<ThreadIndexRecord>| {
                 let scope = scope_for_retry.clone();
                 let thread_id = thread_id_for_retry.clone();
+                let resource_scope = resource_scope.clone();
                 async move {
                     let mut index = match current {
                         Some(index) => {
@@ -364,21 +489,40 @@ where
                             index
                         }
                         None => {
-                            let Some((mut stored, _)) =
-                                self.read_thread_versioned(&scope, &thread_id).await?
+                            let source_path = super::thread_record_path(&scope, &thread_id)?;
+                            let Some(versioned) =
+                                filesystem.get(&resource_scope, &source_path).await?
                             else {
                                 return Ok(CasApply::no_op(
                                     no_op_thread_index_record(scope, thread_id),
                                     false,
                                 ));
                             };
+                            let mut stored =
+                                deserialize::<StoredThreadRecord>(&versioned.entry.body)?;
+                            if stored.record.scope != scope || stored.record.thread_id != thread_id
+                            {
+                                return Err(SessionThreadError::ThreadScopeMismatch { thread_id });
+                            }
                             stored.record.updated_at = Some(updated_at);
                             Self::thread_index_record(&stored)
                         }
                     };
-                    index.record.updated_at = Some(updated_at);
+                    let mut changed = false;
+                    if index
+                        .record
+                        .updated_at
+                        .is_none_or(|current| current < updated_at)
+                    {
+                        index.record.updated_at = Some(updated_at);
+                        changed = true;
+                    }
                     if index.record.title.is_none() && index.derived_title.is_none() {
                         index.derived_title = derived_title.as_ref().cloned();
+                        changed |= index.derived_title.is_some();
+                    }
+                    if !changed {
+                        return Ok(CasApply::no_op(index, true));
                     }
                     Ok(CasApply::new(index, true))
                 }
@@ -386,10 +530,7 @@ where
         )
         .await
         .map_err(map_cas_error)?;
-        if row_known {
-            self.mark_thread_index_known(scope, thread_id);
-        }
-        Ok(())
+        Ok(row_known)
     }
 
     /// Drop the cached sidebar label for a thread.
@@ -622,6 +763,101 @@ where
             }
         }
         Ok(stored.record)
+    }
+}
+
+fn merge_pending_thread_index_touch(
+    pending: &mut Option<PendingThreadIndexTouch>,
+    incoming: PendingThreadIndexTouch,
+) {
+    match pending {
+        Some(current) => {
+            if incoming.updated_at > current.updated_at {
+                current.updated_at = incoming.updated_at;
+            }
+            if current.derived_title.is_none() {
+                current.derived_title = incoming.derived_title;
+            }
+        }
+        None => *pending = Some(incoming),
+    }
+}
+
+fn evict_thread_index_touch_state_over_limit(
+    state: &mut HashMap<String, ThreadIndexTouchEntry>,
+    keep: &str,
+) {
+    if state.len() < THREAD_INDEX_TOUCH_STATE_MAX || state.contains_key(keep) {
+        return;
+    }
+    let victim = state
+        .iter()
+        .filter(|(_, entry)| entry.pending.is_none() && !entry.worker_running)
+        .min_by_key(|(_, entry)| entry.last_flushed_at)
+        .map(|(key, _)| key.clone());
+    if let Some(victim) = victim {
+        state.remove(&victim);
+    }
+}
+
+async fn flush_thread_index_touch_loop<F>(
+    filesystem: Arc<ScopedFilesystem<F>>,
+    state: Arc<ThreadIndexTouchState>,
+    key: String,
+    flush_interval: Duration,
+    mut delay: Duration,
+) where
+    F: RootFilesystem + 'static,
+{
+    loop {
+        tokio::time::sleep(delay).await;
+        let touch = {
+            let mut entries = match state.entries.lock() {
+                Ok(entries) => entries,
+                Err(_) => return,
+            };
+            let Some(entry) = entries.get_mut(&key) else {
+                return;
+            };
+            let Some(touch) = entry.pending.take() else {
+                entry.worker_running = false;
+                return;
+            };
+            entry.last_flushed_at = Some(Instant::now());
+            touch
+        };
+
+        if let Err(error) = FilesystemSessionThreadService::<F>::write_thread_index_touch(
+            filesystem.as_ref(),
+            &touch,
+        )
+        .await
+        {
+            tracing::debug!(
+                ?error,
+                thread_id = %touch.thread_id.as_str(),
+                "coalesced thread recency touch failed",
+            );
+        }
+
+        let has_pending = match state.entries.lock() {
+            Ok(mut entries) => {
+                let Some(entry) = entries.get_mut(&key) else {
+                    return;
+                };
+                if entry.pending.is_none() {
+                    entry.worker_running = false;
+                    false
+                } else {
+                    true
+                }
+            }
+            Err(_) => return,
+        };
+        if !has_pending {
+            return;
+        }
+        delay = flush_interval;
     }
 }
 
@@ -881,6 +1117,49 @@ mod tests {
                 .iter()
                 .any(|record| record.thread_id == thread_id),
             "a no-op touch for a missing row must not suppress index creation after recreate"
+        );
+    }
+
+    #[tokio::test]
+    async fn filesystem_thread_index_touch_is_monotonic_across_service_instances() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let scoped = scoped_threads_fs_at(backend, "tenant-monotonic-touch", "alice");
+        let service_a = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+        let service_b = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+        let request_scope = scope("monotonic-touch");
+        let thread_id = ThreadId::new("thread-monotonic-touch").unwrap();
+        let created = service_a
+            .ensure_thread(EnsureThreadRequest {
+                scope: request_scope.clone(),
+                thread_id: Some(thread_id.clone()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some("monotonic".into()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        let created_at = created.updated_at.expect("thread creation timestamp");
+        let newer = created_at + chrono::Duration::seconds(20);
+        let stale = created_at + chrono::Duration::seconds(10);
+
+        service_a
+            .touch_thread_index_updated_at(&request_scope, &thread_id, newer)
+            .await
+            .unwrap();
+        service_b
+            .touch_thread_index_updated_at(&request_scope, &thread_id, stale)
+            .await
+            .unwrap();
+
+        let index = service_b
+            .read_thread_index_record(&request_scope, &thread_id)
+            .await
+            .unwrap()
+            .expect("thread index exists");
+        assert_eq!(
+            index.record.updated_at,
+            Some(newer),
+            "a stale worker touch must not move sidebar activity backward"
         );
     }
 

--- a/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -3852,7 +3852,8 @@ async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
 
     let backend = Arc::new(InMemoryBackend::new());
     let scoped = scoped_threads_fs_at(backend, "tenant-activity-fs", "alice");
-    let service = FilesystemSessionThreadService::new(scoped);
+    let service = FilesystemSessionThreadService::new(scoped)
+        .with_thread_index_touch_flush_interval(std::time::Duration::from_millis(20));
     let scope_a = scope("activity");
 
     // Create "older" first, then "newer" — newer has the later
@@ -3980,6 +3981,11 @@ async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
         .await
         .unwrap();
 
+    // This touch follows earlier activity on the same thread inside the
+    // coalescing window. Wait for the configured trailing flush before
+    // asserting the cross-thread sidebar order.
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
     let final_list = service
         .list_threads_for_scope(ListThreadsForScopeRequest {
             scope: scope_a,
@@ -3995,6 +4001,115 @@ async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
         .collect();
     // Recency wins over transcript length.
     assert_eq!(final_ids, ["t-older", "t-newer"]);
+}
+
+/// Regression for #7596: the message/draft/finalize path used to rewrite the
+/// complete thread-index row once at every activity call site. A single turn
+/// should coalesce that burst while still making the finalized thread lead the
+/// activity-sorted sidebar.
+#[tokio::test]
+async fn filesystem_thread_activity_burst_coalesces_index_touches_and_orders_after_finalize() {
+    let backend = Arc::new(QueryCountingBackend::new());
+    let scoped = scoped_threads_fs_at(
+        Arc::clone(&backend),
+        "tenant-coalesced-index-touch",
+        "alice",
+    );
+    let service = FilesystemSessionThreadService::new(scoped)
+        .with_thread_index_touch_flush_interval(std::time::Duration::from_millis(50));
+    let request_scope = scope("coalesced-index-touch");
+
+    let older = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: request_scope.clone(),
+            thread_id: Some(ThreadId::new("thread-coalesced-older").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("older".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: request_scope.clone(),
+            thread_id: older.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: Some("binding-coalesced-touch".into()),
+            reply_target_binding_id: None,
+            external_event_id: Some("event-coalesced-touch".into()),
+            content: MessageContent::text("start the turn"),
+        })
+        .await
+        .unwrap();
+    let draft = service
+        .append_assistant_draft(AppendAssistantDraftRequest {
+            scope: request_scope.clone(),
+            thread_id: older.thread_id.clone(),
+            turn_run_id: "run-coalesced-touch".into(),
+            content: MessageContent::text("working"),
+        })
+        .await
+        .unwrap();
+    wait_until_after(draft.updated_at.expect("draft activity stamp")).await;
+    let newer = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: request_scope.clone(),
+            thread_id: Some(ThreadId::new("thread-coalesced-newer").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("newer".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    wait_until_after(newer.updated_at.expect("newer creation stamp")).await;
+    backend.reset_thread_index_put_count();
+
+    service
+        .update_assistant_draft(UpdateAssistantDraftRequest {
+            scope: request_scope.clone(),
+            thread_id: older.thread_id.clone(),
+            message_id: draft.message_id,
+            content: MessageContent::text("still working"),
+        })
+        .await
+        .unwrap();
+    service
+        .finalize_assistant_message(
+            &request_scope,
+            &older.thread_id,
+            draft.message_id,
+            MessageContent::text("done"),
+        )
+        .await
+        .unwrap();
+
+    let listed = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            let listed = service
+                .list_threads_for_scope(ListThreadsForScopeRequest {
+                    scope: request_scope.clone(),
+                    limit: None,
+                    cursor: None,
+                })
+                .await
+                .unwrap();
+            if listed.threads[0].thread_id == older.thread_id {
+                break listed;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("finalized activity reaches the sidebar after the flush interval");
+    let burst_puts = backend.thread_index_put_count();
+    assert!(
+        burst_puts <= 1,
+        "one turn must write the thread-index touch at most once per flush interval; saw {burst_puts} writes"
+    );
+    assert_eq!(
+        listed.threads[0].thread_id, older.thread_id,
+        "the finalized thread must lead the activity-sorted sidebar"
+    );
 }
 
 #[tokio::test]
@@ -4655,6 +4770,7 @@ struct QueryCountingBackend {
     inner: InMemoryBackend,
     query_count: AtomicUsize,
     get_count: AtomicUsize,
+    thread_index_put_count: AtomicUsize,
 }
 
 struct MigrationRaceBackend {
@@ -4689,6 +4805,7 @@ impl QueryCountingBackend {
             inner: InMemoryBackend::new(),
             query_count: AtomicUsize::new(0),
             get_count: AtomicUsize::new(0),
+            thread_index_put_count: AtomicUsize::new(0),
         }
     }
 
@@ -4698,6 +4815,14 @@ impl QueryCountingBackend {
 
     fn get_count(&self) -> usize {
         self.get_count.load(Ordering::SeqCst)
+    }
+
+    fn thread_index_put_count(&self) -> usize {
+        self.thread_index_put_count.load(Ordering::SeqCst)
+    }
+
+    fn reset_thread_index_put_count(&self) {
+        self.thread_index_put_count.store(0, Ordering::SeqCst);
     }
 }
 
@@ -4830,6 +4955,9 @@ impl RootFilesystem for QueryCountingBackend {
         entry: Entry,
         cas: CasExpectation,
     ) -> Result<RecordVersion, FilesystemError> {
+        if path.as_str().contains("/thread_index/") {
+            self.thread_index_put_count.fetch_add(1, Ordering::SeqCst);
+        }
         self.inner.put(path, entry, cas).await
     }
 

--- a/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -3982,18 +3982,26 @@ async fn filesystem_list_threads_orders_by_last_activity_not_creation() {
         .unwrap();
 
     // This touch follows earlier activity on the same thread inside the
-    // coalescing window. Wait for the configured trailing flush before
-    // asserting the cross-thread sidebar order.
-    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
-
-    let final_list = service
-        .list_threads_for_scope(ListThreadsForScopeRequest {
-            scope: scope_a,
-            limit: None,
-            cursor: None,
-        })
-        .await
-        .unwrap();
+    // coalescing window. Poll until the detached trailing flush makes the
+    // expected cross-thread order observable.
+    let final_list = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            let listed = service
+                .list_threads_for_scope(ListThreadsForScopeRequest {
+                    scope: scope_a.clone(),
+                    limit: None,
+                    cursor: None,
+                })
+                .await
+                .unwrap();
+            if listed.threads[0].thread_id.as_str() == "t-older" {
+                break listed;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("the trailing touch reaches the sidebar after the flush interval");
     let final_ids: Vec<&str> = final_list
         .threads
         .iter()
@@ -4016,7 +4024,7 @@ async fn filesystem_thread_activity_burst_coalesces_index_touches_and_orders_aft
         "alice",
     );
     let service = FilesystemSessionThreadService::new(scoped)
-        .with_thread_index_touch_flush_interval(std::time::Duration::from_millis(50));
+        .with_thread_index_touch_flush_interval(std::time::Duration::from_millis(500));
     let request_scope = scope("coalesced-index-touch");
 
     let older = service
@@ -4083,7 +4091,7 @@ async fn filesystem_thread_activity_burst_coalesces_index_touches_and_orders_aft
         .await
         .unwrap();
 
-    let listed = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+    let listed = tokio::time::timeout(std::time::Duration::from_secs(2), async {
         loop {
             let listed = service
                 .list_threads_for_scope(ListThreadsForScopeRequest {
@@ -4110,6 +4118,94 @@ async fn filesystem_thread_activity_burst_coalesces_index_touches_and_orders_aft
         listed.threads[0].thread_id, older.thread_id,
         "the finalized thread must lead the activity-sorted sidebar"
     );
+}
+
+#[tokio::test]
+async fn filesystem_failed_deferred_thread_index_touch_is_retried() {
+    let backend = Arc::new(FaultInjecting::new(InMemoryBackend::new()));
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-deferred-index-retry", "alice");
+    let service = FilesystemSessionThreadService::new(scoped)
+        .with_thread_index_touch_flush_interval(std::time::Duration::from_secs(1));
+    let request_scope = scope("deferred-index-retry");
+    let older = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: request_scope.clone(),
+            thread_id: Some(ThreadId::new("thread-deferred-retry-older").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("older".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: request_scope.clone(),
+            thread_id: older.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: Some("binding-deferred-index-retry".into()),
+            reply_target_binding_id: None,
+            external_event_id: Some("event-deferred-index-retry".into()),
+            content: MessageContent::text("start activity tracking"),
+        })
+        .await
+        .unwrap();
+    let draft = service
+        .append_assistant_draft(AppendAssistantDraftRequest {
+            scope: request_scope.clone(),
+            thread_id: older.thread_id.clone(),
+            turn_run_id: "run-deferred-index-retry".into(),
+            content: MessageContent::text("working"),
+        })
+        .await
+        .unwrap();
+    wait_until_after(draft.updated_at.expect("draft activity stamp")).await;
+    let newer = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: request_scope.clone(),
+            thread_id: Some(ThreadId::new("thread-deferred-retry-newer").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: Some("newer".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    wait_until_after(newer.updated_at.expect("newer creation stamp")).await;
+    backend.add_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .path("/thread_index/")
+            .nth(1)
+            .backend("deferred thread-index write fails once"),
+    );
+
+    service
+        .update_assistant_draft(UpdateAssistantDraftRequest {
+            scope: request_scope.clone(),
+            thread_id: older.thread_id.clone(),
+            message_id: draft.message_id,
+            content: MessageContent::text("newest activity"),
+        })
+        .await
+        .unwrap();
+
+    let listed = tokio::time::timeout(std::time::Duration::from_secs(4), async {
+        loop {
+            let listed = service
+                .list_threads_for_scope(ListThreadsForScopeRequest {
+                    scope: request_scope.clone(),
+                    limit: None,
+                    cursor: None,
+                })
+                .await
+                .unwrap();
+            if listed.threads[0].thread_id == older.thread_id {
+                break listed;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("the failed deferred touch is retried");
+    assert_eq!(listed.threads[0].thread_id, older.thread_id);
 }
 
 #[tokio::test]

--- a/tests/integration/support/session_thread.rs
+++ b/tests/integration/support/session_thread.rs
@@ -45,7 +45,7 @@ where
     root_prefix: String,
 }
 
-impl<F: RootFilesystem> RebornThreadHarness<F> {
+impl<F: RootFilesystem + 'static> RebornThreadHarness<F> {
     pub fn reopened(&self) -> Result<Self, RebornThreadHarnessError> {
         let scoped = scoped_threads_fs_at(&self.root_prefix, Arc::clone(&self.backend))?;
         let service = Arc::new(FilesystemSessionThreadService::new(scoped));


### PR DESCRIPTION
## Summary

- coalesce bursty per-thread activity touches into bounded thread-index writes
- flush the newest pending timestamp after the configured interval so finalized threads regain sidebar priority
- preserve multi-worker correctness with monotonic CAS updates and cover write counts plus stale-worker ordering

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #7596

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_threads`; `cargo test -p ironclaw_architecture_tests`
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (the root `integration` feature is empty — the flag is per-crate)
- [ ] Manual testing: Not applicable; deterministic filesystem contract coverage exercises the production service path.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional lint: `cargo clippy -p ironclaw_threads --all-targets --all-features -- -D warnings`.

## Test Strategy

User behavior: Bursty activity performs at most one thread-index touch write per configured flush interval, and a finalized thread returns to the top of the activity-sorted sidebar after the trailing flush.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Added a two-service monotonic timestamp test and a filesystem service contract that counts thread-index writes through inbound, draft, update, finalize, and sidebar listing.
- Reborn integration: Not applicable: the changed contract is fully owned and observable through `ironclaw_threads`.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: Not applicable: sidebar transport or rendering did not change.
- Backend or runtime: Not applicable: the store remains backend-neutral over `ScopedFilesystem`; no backend-specific behavior or schema changed.
- Live canary: Not applicable: no external provider behavior changed.

What the tests prove: Activity bursts are coalesced, the newest finalized activity reaches sidebar ordering after the configured interval, missing-row touches remain safe, and stale worker timestamps cannot move activity backward.

Commands run:
- `cargo test -p ironclaw_threads`
- `cargo clippy -p ironclaw_threads --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_architecture_tests`
- `cargo fmt --check`
- `git diff --check`

## Security Impact

None.

## Reborn Trust-Boundary Checklist

N/A: this changes only advisory thread-list projection write batching. It adds no public trust-bearing types, untrusted inputs, status variants, credentials, network calls, or runtime lanes. The new per-thread state map is bounded and timestamp updates remain monotonic under multi-worker CAS contention.

## Database Impact

None. No migrations or schema changes; persistence remains behind the existing `ScopedFilesystem` contract.

## Blast Radius

Limited to filesystem-backed thread activity projection timestamps. Transcript writes and substantive thread-index writes are unchanged. A process crash may lose only a trailing advisory touch inside the default 250 ms window; the leading touch remains durable.

## Rollback Plan

Revert this commit to restore synchronous per-activity index touches. No data migration or compatibility step is required.

## Review Follow-Through

Reviewer judgment is requested on the default 250 ms freshness/write-volume trade-off. No known follow-up is required.

---

**Review track**: B
