### PR TITLE
perf(threads): fold message lookup indexes into message rows

### DIFF
--- a/crates/domains/ironclaw_threads/README.md
+++ b/crates/domains/ironclaw_threads/README.md
@@ -62,6 +62,8 @@ dumping ground.
 - Context-window limits count the effective model-visible transcript, not
   hidden durable rows. Truncated windows report the exact last omitted
   sequence and kind so loop policy can react without guessing.
+- Exact message lookups by run, tool result, provider call, and first user are
+  indexed projections on the message row; they do not create sibling records.
 - Backend-neutral by construction: persistence is `ScopedFilesystem` only;
   backend choice happens in composition (`.claude/rules/database.md`).
 

--- a/crates/domains/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service.rs
@@ -280,7 +280,7 @@ where
         })?;
         let mut entry = Entry::bytes(body).with_content_type(ContentType::json());
         entry.kind = Some(kind);
-        Ok(entry
+        let entry = entry
             .with_indexed(
                 fs_index_key("thread_id")?,
                 IndexValue::Text(record.thread_id.to_string()),
@@ -304,7 +304,8 @@ where
             .with_indexed(
                 fs_index_key("message_status")?,
                 IndexValue::Text(serde_enum_index_value(&record.status)?),
-            ))
+            );
+        message_lookup_index::with_message_lookup_projections(entry, record)
     }
 
     fn summary_entry(record: &SummaryArtifact) -> Result<Entry, SessionThreadError> {
@@ -486,44 +487,6 @@ where
         Ok(Some((record, versioned.version)))
     }
 
-    async fn write_message_lookup_indexes(
-        &self,
-        scope: &ThreadScope,
-        thread_id: &ThreadId,
-        message: &ThreadMessageRecord,
-    ) -> Result<(), SessionThreadError> {
-        MessageLookupIndexStore::new(self.filesystem.as_ref())
-            .write_for_message(scope, thread_id, message)
-            .await
-    }
-
-    async fn write_message_lookup_indexes_best_effort(
-        &self,
-        scope: &ThreadScope,
-        thread_id: &ThreadId,
-        message: &ThreadMessageRecord,
-        context: &'static str,
-    ) {
-        if let Err(error) = self
-            .write_message_lookup_indexes(scope, thread_id, message)
-            .await
-        {
-            // The source message is already durable. Lookup projection failure
-            // is observable as a missing exact lookup; requests never repair it
-            // by scanning the transcript.
-            tracing::debug!(
-                ?error,
-                ?scope,
-                thread_id = %thread_id.as_str(),
-                message_id = %message.message_id,
-                kind = ?message.kind,
-                status = ?message.status,
-                context = context,
-                "message lookup projection write failed; exact lookup remains unavailable",
-            );
-        }
-    }
-
     async fn write_new_message(
         &self,
         scope: &ThreadScope,
@@ -545,20 +508,6 @@ where
                 {
                     txn.rollback().await;
                     return Err(absent_put_error(error, description, &path));
-                }
-                for (lookup_path, lookup_entry, expectation) in
-                    MessageLookupIndexStore::<F>::entries_for_message(scope, thread_id, message)?
-                {
-                    let virtual_path = self.filesystem.resolve(&resource_scope, &lookup_path)?;
-                    if matches!(expectation, CasExpectation::Absent)
-                        && txn.get(&virtual_path).await?.is_some()
-                    {
-                        continue;
-                    }
-                    if let Err(error) = txn.put(&virtual_path, lookup_entry, expectation).await {
-                        txn.rollback().await;
-                        return Err(absent_put_error(error, "message lookup", &lookup_path));
-                    }
                 }
                 txn.commit().await?;
                 self.invalidate_one_shot_context_window(scope, thread_id);
@@ -582,15 +531,6 @@ where
         let thread_virtual_path = self.filesystem.resolve(&resource_scope, &thread_path)?;
         let message_path = message_record_path(scope, thread_id, message.message_id)?;
         let message_virtual_path = self.filesystem.resolve(&resource_scope, &message_path)?;
-        let lookup_entries =
-            MessageLookupIndexStore::<F>::entries_for_message(scope, thread_id, message)?
-                .into_iter()
-                .map(|(path, entry, expectation)| {
-                    self.filesystem
-                        .resolve(&resource_scope, &path)
-                        .map(|virtual_path| (path, virtual_path, entry, expectation))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
         let idempotency_record = idempotency_record
             .map(|(path, entry)| {
                 self.filesystem
@@ -688,18 +628,6 @@ where
                 txn.rollback().await;
                 return Err(absent_put_error(error, "message", &message_path));
             }
-            for (lookup_path, virtual_path, entry, expectation) in &lookup_entries {
-                if matches!(expectation, CasExpectation::Absent)
-                    && txn.get(virtual_path).await?.is_some()
-                {
-                    continue;
-                }
-                if let Err(error) = txn.put(virtual_path, entry.clone(), *expectation).await {
-                    txn.rollback().await;
-                    return Err(absent_put_error(error, "message lookup", lookup_path));
-                }
-            }
-
             match txn.commit().await {
                 Ok(()) => return Ok(TransactionalMessageWrite::Written),
                 // Optimistic-concurrency conflict on the thread record: another
@@ -1463,13 +1391,6 @@ where
             .await
             {
                 Ok(()) => {
-                    self.write_message_lookup_indexes_best_effort(
-                        scope,
-                        thread_id,
-                        &message,
-                        "message update",
-                    )
-                    .await;
                     self.invalidate_one_shot_context_window(scope, thread_id);
                     return Ok(message);
                 }
@@ -2023,15 +1944,7 @@ where
                 .put(&resource_scope, &path, entry, CasExpectation::Absent)
                 .await
             {
-                Ok(_) => {
-                    self.write_message_lookup_indexes_best_effort(
-                        &request.scope,
-                        &thread_id,
-                        row,
-                        "prepared context seed",
-                    )
-                    .await;
-                }
+                Ok(_) => {}
                 // A crashed prior attempt already landed this row; its stored
                 // sequence stays authoritative (the reservation above only
                 // burned a counter slot, which is harmless).
@@ -2665,16 +2578,7 @@ where
         )
         .await
         {
-            Ok(()) => {
-                self.write_message_lookup_indexes_best_effort(
-                    &request.scope,
-                    &request.thread_id,
-                    &message,
-                    "capability display preview",
-                )
-                .await;
-                Ok(message)
-            }
+            Ok(()) => Ok(message),
             Err(PutError::VersionMismatch) => self
                 .read_message_versioned(&request.scope, &request.thread_id, message_id)
                 .await?
@@ -3685,13 +3589,15 @@ fn fs_index_name(raw: &str) -> Result<IndexName, SessionThreadError> {
 /// Every ordered-index spec this crate queries, all declared together at the
 /// `/threads` alias root. Each leads with its partition key, so one
 /// declaration above the per-thread paths serves every thread on the mount.
-fn root_index_specs() -> Result<[IndexSpec; 4], SessionThreadError> {
-    Ok([
+fn root_index_specs() -> Result<Vec<IndexSpec>, SessionThreadError> {
+    let mut indexes = vec![
         message_sequence_index_spec()?,
         message_kind_status_index_spec()?,
         summary_index_spec()?,
         thread_index::thread_activity_index_spec()?,
-    ])
+    ];
+    indexes.extend(message_lookup_index::lookup_index_specs()?);
+    Ok(indexes)
 }
 
 fn summary_index_spec() -> Result<IndexSpec, SessionThreadError> {

--- a/crates/domains/ironclaw_threads/src/filesystem_service/message_lookup_index.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/message_lookup_index.rs
@@ -1,4 +1,7 @@
-use ironclaw_filesystem::{CasExpectation, ContentType, Entry, RootFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::{
+    Entry, Filter, IndexKind, IndexSpec, IndexValue, OrderedPage, RootFilesystem, ScopedFilesystem,
+    SortDirection,
+};
 use ironclaw_host_api::{
     ids::{InvocationId, ThreadId},
     path::ScopedPath,
@@ -12,7 +15,8 @@ use crate::{
 };
 
 use super::{
-    PutError, deserialize, put_with_cas, scoped_path, serialize_pretty, thread_root_string,
+    deserialize, fs_index_key, fs_index_name, messages_root, scoped_path, serialize_pretty,
+    thread_root_string,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,168 +40,24 @@ where
         Self { filesystem }
     }
 
-    pub(super) async fn write_for_message(
-        &self,
-        scope: &ThreadScope,
-        thread_id: &ThreadId,
-        message: &ThreadMessageRecord,
-    ) -> Result<(), SessionThreadError> {
-        if message.kind == MessageKind::Assistant
-            && let Some(turn_run_id) = message.turn_run_id.as_deref()
-        {
-            self.write(
-                scope,
-                &assistant_run_index_path(scope, thread_id, turn_run_id)?,
-                thread_id,
-                message.message_id,
-            )
-            .await?;
-        }
-        if message.kind == MessageKind::ToolResultReference
-            && let (Some(turn_run_id), Some(result_ref)) = (
-                message.turn_run_id.as_deref(),
-                message.tool_result_ref.as_deref(),
-            )
-        {
-            self.write(
-                scope,
-                &tool_result_index_path(scope, thread_id, turn_run_id, result_ref)?,
-                thread_id,
-                message.message_id,
-            )
-            .await?;
-            if let Some(provider_call_id) = message
-                .tool_result_provider_call
-                .as_ref()
-                .map(|provider_call| provider_call.provider_call_id.as_str())
-            {
-                self.write(
-                    scope,
-                    &tool_result_provider_call_index_path(
-                        scope,
-                        thread_id,
-                        turn_run_id,
-                        result_ref,
-                        provider_call_id,
-                    )?,
-                    thread_id,
-                    message.message_id,
-                )
-                .await?;
-            }
-        }
-        if message.kind == MessageKind::User {
-            self.write_if_absent(
-                scope,
-                &first_user_index_path(scope, thread_id)?,
-                thread_id,
-                message.message_id,
-            )
-            .await?;
-        }
-        if message.kind == MessageKind::CapabilityDisplayPreview
-            && let (Some(turn_run_id), Some(invocation_id)) = (
-                message.turn_run_id.as_deref(),
-                CapabilityDisplayPreviewEnvelope::invocation_id_from_json(
-                    message.content.as_deref(),
-                )
-                .map_err(SessionThreadError::Serialization)?,
-            )
-        {
-            self.write(
-                scope,
-                &capability_preview_index_path(scope, thread_id, turn_run_id, invocation_id)?,
-                thread_id,
-                message.message_id,
-            )
-            .await?;
-        }
-        Ok(())
-    }
-
-    pub(super) fn entries_for_message(
-        scope: &ThreadScope,
-        thread_id: &ThreadId,
-        message: &ThreadMessageRecord,
-    ) -> Result<Vec<(ScopedPath, Entry, CasExpectation)>, SessionThreadError> {
-        let mut entries = Vec::new();
-        let mut push = |path: ScopedPath, expectation: CasExpectation| {
-            let record = MessageLookupIndexRecord {
-                thread_id: thread_id.clone(),
-                message_id: message.message_id,
-            };
-            let body = serialize_pretty(&record)?;
-            entries.push((
-                path,
-                Entry::bytes(body).with_content_type(ContentType::json()),
-                expectation,
-            ));
-            Ok::<(), SessionThreadError>(())
-        };
-        if message.kind == MessageKind::Assistant
-            && let Some(turn_run_id) = message.turn_run_id.as_deref()
-        {
-            push(
-                assistant_run_index_path(scope, thread_id, turn_run_id)?,
-                CasExpectation::Any,
-            )?;
-        }
-        if message.kind == MessageKind::ToolResultReference
-            && let (Some(turn_run_id), Some(result_ref)) = (
-                message.turn_run_id.as_deref(),
-                message.tool_result_ref.as_deref(),
-            )
-        {
-            push(
-                tool_result_index_path(scope, thread_id, turn_run_id, result_ref)?,
-                CasExpectation::Any,
-            )?;
-            if let Some(provider_call_id) = message
-                .tool_result_provider_call
-                .as_ref()
-                .map(|provider_call| provider_call.provider_call_id.as_str())
-            {
-                push(
-                    tool_result_provider_call_index_path(
-                        scope,
-                        thread_id,
-                        turn_run_id,
-                        result_ref,
-                        provider_call_id,
-                    )?,
-                    CasExpectation::Any,
-                )?;
-            }
-        }
-        if message.kind == MessageKind::User {
-            push(
-                first_user_index_path(scope, thread_id)?,
-                CasExpectation::Absent,
-            )?;
-        }
-        if message.kind == MessageKind::CapabilityDisplayPreview
-            && let (Some(turn_run_id), Some(invocation_id)) = (
-                message.turn_run_id.as_deref(),
-                CapabilityDisplayPreviewEnvelope::invocation_id_from_json(
-                    message.content.as_deref(),
-                )
-                .map_err(SessionThreadError::Serialization)?,
-            )
-        {
-            push(
-                capability_preview_index_path(scope, thread_id, turn_run_id, invocation_id)?,
-                CasExpectation::Any,
-            )?;
-        }
-        Ok(entries)
-    }
-
     pub(super) async fn read_first_user(
         &self,
         scope: &ThreadScope,
         thread_id: &ThreadId,
     ) -> Result<Option<ThreadMessageId>, SessionThreadError> {
-        self.read(scope, thread_id, &first_user_index_path(scope, thread_id)?)
+        if let Some(message_id) = self
+            .query_message_id(
+                scope,
+                thread_id,
+                first_user_index_spec()?,
+                vec![("lookup_first_user", IndexValue::Bool(true))],
+                SortDirection::Ascending,
+            )
+            .await?
+        {
+            return Ok(Some(message_id));
+        }
+        self.read_legacy(scope, thread_id, &first_user_index_path(scope, thread_id)?)
             .await
     }
 
@@ -208,7 +68,28 @@ where
         turn_run_id: &str,
         invocation_id: InvocationId,
     ) -> Result<Option<ThreadMessageId>, SessionThreadError> {
-        self.read(
+        if let Some(message_id) = self
+            .query_message_id(
+                scope,
+                thread_id,
+                capability_preview_index_spec()?,
+                vec![
+                    (
+                        "lookup_capability_run_id",
+                        IndexValue::Text(turn_run_id.to_string()),
+                    ),
+                    (
+                        "lookup_invocation_id",
+                        IndexValue::Text(invocation_id.to_string()),
+                    ),
+                ],
+                SortDirection::Descending,
+            )
+            .await?
+        {
+            return Ok(Some(message_id));
+        }
+        self.read_legacy(
             scope,
             thread_id,
             &capability_preview_index_path(scope, thread_id, turn_run_id, invocation_id)?,
@@ -222,8 +103,27 @@ where
         thread_id: &ThreadId,
         turn_run_id: &str,
     ) -> Result<Option<ThreadMessageId>, SessionThreadError> {
-        let path = assistant_run_index_path(scope, thread_id, turn_run_id)?;
-        self.read(scope, thread_id, &path).await
+        if let Some(message_id) = self
+            .query_message_id(
+                scope,
+                thread_id,
+                assistant_run_index_spec()?,
+                vec![(
+                    "lookup_assistant_run_id",
+                    IndexValue::Text(turn_run_id.to_string()),
+                )],
+                SortDirection::Descending,
+            )
+            .await?
+        {
+            return Ok(Some(message_id));
+        }
+        self.read_legacy(
+            scope,
+            thread_id,
+            &assistant_run_index_path(scope, thread_id, turn_run_id)?,
+        )
+        .await
     }
 
     pub(super) async fn read_tool_result(
@@ -233,8 +133,33 @@ where
         turn_run_id: &str,
         result_ref: &str,
     ) -> Result<Option<ThreadMessageId>, SessionThreadError> {
-        let path = tool_result_index_path(scope, thread_id, turn_run_id, result_ref)?;
-        self.read(scope, thread_id, &path).await
+        if let Some(message_id) = self
+            .query_message_id(
+                scope,
+                thread_id,
+                tool_result_index_spec()?,
+                vec![
+                    (
+                        "lookup_tool_result_run_id",
+                        IndexValue::Text(turn_run_id.to_string()),
+                    ),
+                    (
+                        "lookup_tool_result_ref",
+                        IndexValue::Text(result_ref.to_string()),
+                    ),
+                ],
+                SortDirection::Descending,
+            )
+            .await?
+        {
+            return Ok(Some(message_id));
+        }
+        self.read_legacy(
+            scope,
+            thread_id,
+            &tool_result_index_path(scope, thread_id, turn_run_id, result_ref)?,
+        )
+        .await
     }
 
     pub(super) async fn read_tool_result_provider_call(
@@ -245,17 +170,88 @@ where
         result_ref: &str,
         provider_call_id: &str,
     ) -> Result<Option<ThreadMessageId>, SessionThreadError> {
-        let path = tool_result_provider_call_index_path(
+        if let Some(message_id) = self
+            .query_message_id(
+                scope,
+                thread_id,
+                tool_result_provider_call_index_spec()?,
+                vec![
+                    (
+                        "lookup_tool_result_run_id",
+                        IndexValue::Text(turn_run_id.to_string()),
+                    ),
+                    (
+                        "lookup_tool_result_ref",
+                        IndexValue::Text(result_ref.to_string()),
+                    ),
+                    (
+                        "lookup_provider_call_id",
+                        IndexValue::Text(provider_call_id.to_string()),
+                    ),
+                ],
+                SortDirection::Descending,
+            )
+            .await?
+        {
+            return Ok(Some(message_id));
+        }
+        self.read_legacy(
             scope,
             thread_id,
-            turn_run_id,
-            result_ref,
-            provider_call_id,
-        )?;
-        self.read(scope, thread_id, &path).await
+            &tool_result_provider_call_index_path(
+                scope,
+                thread_id,
+                turn_run_id,
+                result_ref,
+                provider_call_id,
+            )?,
+        )
+        .await
     }
 
-    async fn read(
+    async fn query_message_id(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        index: IndexSpec,
+        lookup_filters: Vec<(&str, IndexValue)>,
+        direction: SortDirection,
+    ) -> Result<Option<ThreadMessageId>, SessionThreadError> {
+        let mut filters = Vec::with_capacity(lookup_filters.len() + 1);
+        filters.push(Filter::Eq {
+            key: fs_index_key("thread_id")?,
+            value: IndexValue::Text(thread_id.to_string()),
+        });
+        for (key, value) in lookup_filters {
+            filters.push(Filter::Eq {
+                key: fs_index_key(key)?,
+                value,
+            });
+        }
+        let page = OrderedPage::new(
+            index.name,
+            fs_index_key("sequence")?,
+            fs_index_key("message_id")?,
+            direction,
+            1,
+        );
+        self.filesystem
+            .query_ordered(
+                &scope.to_resource_scope(),
+                &messages_root(scope, thread_id)?,
+                &Filter::And(filters),
+                &page,
+            )
+            .await?
+            .into_iter()
+            .next()
+            .map(|row| {
+                deserialize::<ThreadMessageRecord>(&row.entry.body).map(|row| row.message_id)
+            })
+            .transpose()
+    }
+
+    async fn read_legacy(
         &self,
         scope: &ThreadScope,
         thread_id: &ThreadId,
@@ -274,63 +270,124 @@ where
         }
         Ok(Some(record.message_id))
     }
+}
 
-    async fn write(
-        &self,
-        scope: &ThreadScope,
-        path: &ScopedPath,
-        thread_id: &ThreadId,
-        message_id: ThreadMessageId,
-    ) -> Result<(), SessionThreadError> {
-        let record = MessageLookupIndexRecord {
-            thread_id: thread_id.clone(),
-            message_id,
-        };
-        let body = serialize_pretty(&record)?;
-        let entry = Entry::bytes(body).with_content_type(ContentType::json());
-        put_with_cas(
-            self.filesystem,
-            &scope.to_resource_scope(),
-            path,
-            entry,
-            CasExpectation::Any,
-        )
-        .await
-        .map_err(|error| match error {
-            PutError::VersionMismatch => SessionThreadError::Backend(format!(
-                "filesystem CAS Any rejected message lookup index at {}",
-                path.as_str()
-            )),
-            PutError::Other(error) => error,
-        })
+pub(super) fn with_message_lookup_projections(
+    mut entry: Entry,
+    message: &ThreadMessageRecord,
+) -> Result<Entry, SessionThreadError> {
+    if message.kind == MessageKind::Assistant
+        && let Some(turn_run_id) = message.turn_run_id.as_deref()
+    {
+        entry.indexed.insert(
+            fs_index_key("lookup_assistant_run_id")?,
+            IndexValue::Text(turn_run_id.to_string()),
+        );
     }
-
-    async fn write_if_absent(
-        &self,
-        scope: &ThreadScope,
-        path: &ScopedPath,
-        thread_id: &ThreadId,
-        message_id: ThreadMessageId,
-    ) -> Result<(), SessionThreadError> {
-        let record = MessageLookupIndexRecord {
-            thread_id: thread_id.clone(),
-            message_id,
-        };
-        let body = serialize_pretty(&record)?;
-        let entry = Entry::bytes(body).with_content_type(ContentType::json());
-        match put_with_cas(
-            self.filesystem,
-            &scope.to_resource_scope(),
-            path,
-            entry,
-            CasExpectation::Absent,
+    if message.kind == MessageKind::ToolResultReference
+        && let (Some(turn_run_id), Some(result_ref)) = (
+            message.turn_run_id.as_deref(),
+            message.tool_result_ref.as_deref(),
         )
-        .await
+    {
+        entry.indexed.insert(
+            fs_index_key("lookup_tool_result_run_id")?,
+            IndexValue::Text(turn_run_id.to_string()),
+        );
+        entry.indexed.insert(
+            fs_index_key("lookup_tool_result_ref")?,
+            IndexValue::Text(result_ref.to_string()),
+        );
+        if let Some(provider_call_id) = message
+            .tool_result_provider_call
+            .as_ref()
+            .map(|provider_call| provider_call.provider_call_id.as_str())
         {
-            Ok(()) | Err(PutError::VersionMismatch) => Ok(()),
-            Err(PutError::Other(error)) => Err(error),
+            entry.indexed.insert(
+                fs_index_key("lookup_provider_call_id")?,
+                IndexValue::Text(provider_call_id.to_string()),
+            );
         }
     }
+    if message.kind == MessageKind::User {
+        entry
+            .indexed
+            .insert(fs_index_key("lookup_first_user")?, IndexValue::Bool(true));
+    }
+    if message.kind == MessageKind::CapabilityDisplayPreview
+        && let (Some(turn_run_id), Some(invocation_id)) = (
+            message.turn_run_id.as_deref(),
+            CapabilityDisplayPreviewEnvelope::invocation_id_from_json(message.content.as_deref())
+                .map_err(SessionThreadError::Serialization)?,
+        )
+    {
+        entry.indexed.insert(
+            fs_index_key("lookup_capability_run_id")?,
+            IndexValue::Text(turn_run_id.to_string()),
+        );
+        entry.indexed.insert(
+            fs_index_key("lookup_invocation_id")?,
+            IndexValue::Text(invocation_id.to_string()),
+        );
+    }
+    Ok(entry)
+}
+
+pub(super) fn lookup_index_specs() -> Result<[IndexSpec; 5], SessionThreadError> {
+    Ok([
+        assistant_run_index_spec()?,
+        tool_result_index_spec()?,
+        tool_result_provider_call_index_spec()?,
+        first_user_index_spec()?,
+        capability_preview_index_spec()?,
+    ])
+}
+
+fn assistant_run_index_spec() -> Result<IndexSpec, SessionThreadError> {
+    lookup_index_spec(
+        "thread_message_assistant_run_v1",
+        &["lookup_assistant_run_id"],
+    )
+}
+
+fn tool_result_index_spec() -> Result<IndexSpec, SessionThreadError> {
+    lookup_index_spec(
+        "thread_message_tool_result_v1",
+        &["lookup_tool_result_run_id", "lookup_tool_result_ref"],
+    )
+}
+
+fn tool_result_provider_call_index_spec() -> Result<IndexSpec, SessionThreadError> {
+    lookup_index_spec(
+        "thread_message_tool_result_provider_call_v1",
+        &[
+            "lookup_tool_result_run_id",
+            "lookup_tool_result_ref",
+            "lookup_provider_call_id",
+        ],
+    )
+}
+
+fn first_user_index_spec() -> Result<IndexSpec, SessionThreadError> {
+    lookup_index_spec("thread_message_first_user_v1", &["lookup_first_user"])
+}
+
+fn capability_preview_index_spec() -> Result<IndexSpec, SessionThreadError> {
+    lookup_index_spec(
+        "thread_message_capability_preview_v1",
+        &["lookup_capability_run_id", "lookup_invocation_id"],
+    )
+}
+
+fn lookup_index_spec(name: &str, lookup_keys: &[&str]) -> Result<IndexSpec, SessionThreadError> {
+    let mut keys = Vec::with_capacity(lookup_keys.len() + 3);
+    keys.push(fs_index_key("thread_id")?);
+    for key in lookup_keys {
+        keys.push(fs_index_key(key)?);
+    }
+    keys.push(fs_index_key("sequence")?);
+    keys.push(fs_index_key("message_id")?);
+    Ok(IndexSpec::new(fs_index_name(name)?, keys, IndexKind::Exact))
 }
 
 fn first_user_index_path(

--- a/crates/domains/ironclaw_threads/src/filesystem_service/transcript_migration.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service/transcript_migration.rs
@@ -91,10 +91,7 @@ where
                         break;
                     }
                     let received = rows.len();
-                    match self
-                        .migrate_transcript_page(scope, &thread_id, messages, rows)
-                        .await?
-                    {
+                    match self.migrate_transcript_page(scope, messages, rows).await? {
                         TranscriptPageOutcome::Committed => {
                             conflict_attempts = 0;
                             migrated = migrated.saturating_add(received);
@@ -136,7 +133,6 @@ where
     async fn migrate_transcript_page(
         &self,
         scope: &ThreadScope,
-        thread_id: &ThreadId,
         messages: bool,
         rows: Vec<ironclaw_filesystem::VersionedEntry>,
     ) -> Result<TranscriptPageOutcome, SessionThreadError> {
@@ -182,40 +178,6 @@ where
             }
             let entry = if messages {
                 let record = deserialize::<ThreadMessageRecord>(&row.entry.body)?;
-                for (lookup_path, lookup_entry, expectation) in
-                    crate::filesystem_service::message_lookup_index::MessageLookupIndexStore::<F>::entries_for_message(
-                        scope,
-                        thread_id,
-                        &record,
-                    )?
-                {
-                    let virtual_path = self
-                        .filesystem
-                        .resolve(&scope.to_resource_scope(), &lookup_path)?;
-                    if matches!(expectation, CasExpectation::Absent) {
-                        // This read can lose the same writer race as the
-                        // writes below (BackendBusy under contention on both
-                        // SQL backends); classify it the same way or the
-                        // bounded-retry contract has a hole.
-                        match txn.get(&virtual_path).await {
-                            Ok(Some(_)) => continue,
-                            Ok(None) => {}
-                            Err(error) if transcript_migration_conflict(&error) => {
-                                txn.rollback().await;
-                                return Ok(TranscriptPageOutcome::Conflict(error));
-                            }
-                            Err(error) => return Err(error.into()),
-                        }
-                    }
-                    match txn.put(&virtual_path, lookup_entry, expectation).await {
-                        Ok(_) => {}
-                        Err(error) if transcript_migration_conflict(&error) => {
-                            txn.rollback().await;
-                            return Ok(TranscriptPageOutcome::Conflict(error));
-                        }
-                        Err(error) => return Err(error.into()),
-                    }
-                }
                 // Refresh the projection, keep the stored body. Rebuilding the
                 // entry from `record` would round-trip the row through the
                 // current struct, so any field a newer binary wrote and this
@@ -271,7 +233,7 @@ where
             .put(
                 &scope.to_resource_scope(),
                 &marker,
-                Entry::bytes(b"transcript-index-v1".to_vec()),
+                Entry::bytes(b"transcript-index-v2".to_vec()),
                 CasExpectation::Any,
             )
             .await?;
@@ -293,7 +255,7 @@ fn transcript_index_migration_marker_path(
     scope: &ThreadScope,
 ) -> Result<ScopedPath, SessionThreadError> {
     scoped_path(&format!(
-        "{}/index-migrations/transcript-index-v1.complete",
+        "{}/index-migrations/transcript-index-v2.complete",
         scope_axes_string(scope)
     ))
 }

--- a/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/domains/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -904,7 +904,7 @@ async fn filesystem_delete_thread_removes_inbound_idempotency_records() {
 #[tokio::test]
 async fn filesystem_finalized_assistant_lookup_by_run_uses_persisted_message() {
     let backend = Arc::new(InMemoryBackend::new());
-    let scoped = scoped_threads_fs_at(backend, "tenant-finalized-by-run", "alice");
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-finalized-by-run", "alice");
     let service = FilesystemSessionThreadService::new(scoped);
     let scope = scope("finalized-by-run");
     let thread = service
@@ -949,7 +949,7 @@ async fn filesystem_finalized_assistant_lookup_by_run_uses_persisted_message() {
 
     let finalized = service
         .finalized_assistant_message_by_run(FinalizedAssistantMessageByRunRequest {
-            scope,
+            scope: scope.clone(),
             thread_id: thread.thread_id,
             turn_run_id: "run-finalized-lookup".into(),
         })
@@ -959,6 +959,21 @@ async fn filesystem_finalized_assistant_lookup_by_run_uses_persisted_message() {
     assert_eq!(finalized.message_id, draft.message_id);
     assert_eq!(finalized.status, MessageStatus::Finalized);
     assert_eq!(finalized.content.as_deref(), Some("final"));
+
+    let stored_rows = backend
+        .query(
+            &VirtualPath::new("/tenants/tenant-finalized-by-run/users/alice/threads").unwrap(),
+            &Filter::All,
+            Page::new(0, Page::MAX_LIMIT),
+        )
+        .await
+        .unwrap();
+    assert!(
+        stored_rows
+            .iter()
+            .all(|row| !row.path.as_str().contains("/indexes/")),
+        "message lookup must not amplify one message row into sibling index entries"
+    );
 }
 
 #[tokio::test]
@@ -1438,8 +1453,8 @@ async fn filesystem_redacts_append_only_finalized_assistant_message() {
 }
 
 #[tokio::test]
-async fn filesystem_lookup_index_write_failure_rolls_back_source_message() {
-    let backend = Arc::new(lookup_index_write_failure_backend());
+async fn filesystem_message_row_write_failure_rejects_source_message() {
+    let backend = Arc::new(message_row_write_failure_backend());
     let scoped = scoped_threads_fs_at(backend, "tenant-lookup-index-failure", "alice");
     let service = FilesystemSessionThreadService::new(scoped);
     let scope = scope("lookup-index-failure");
@@ -1461,7 +1476,7 @@ async fn filesystem_lookup_index_write_failure_rolls_back_source_message() {
             content: MessageContent::text("draft"),
         })
         .await
-        .expect_err("required lookup projection failure must reject the atomic append");
+        .expect_err("message-row projection failure must reject the append");
 
     let history = service
         .list_thread_history(ThreadHistoryRequest {
@@ -2853,9 +2868,8 @@ async fn filesystem_thread_create_declares_indexes_once_per_mount() {
     create("ddl-000").await;
     let after_first = backend.count(FilesystemOperation::EnsureIndex);
     assert_eq!(
-        after_first, 4,
-        "a mount's first thread declares exactly the four root specs \
-         (message sequence, message kind/status, summary, thread activity)"
+        after_first, 9,
+        "a mount's first thread declares four transcript specs and five message lookup specs"
     );
 
     for index in 1..5 {
@@ -3196,7 +3210,7 @@ async fn filesystem_transcript_migration_retries_writer_admission_contention() {
     let marker = backend
         .recorded_paths(FilesystemOperation::WriteFile)
         .into_iter()
-        .find(|path| path.as_str().contains("transcript-index-v1.complete"))
+        .find(|path| path.as_str().contains("transcript-index-v2.complete"))
         .expect("seeding wrote the transcript migration marker");
     backend.delete(&marker).await.unwrap();
 
@@ -3255,7 +3269,7 @@ async fn filesystem_transcript_migration_retries_a_lost_cas_race() {
     let marker = backend
         .recorded_paths(FilesystemOperation::WriteFile)
         .into_iter()
-        .find(|path| path.as_str().contains("transcript-index-v1.complete"))
+        .find(|path| path.as_str().contains("transcript-index-v2.complete"))
         .expect("seeding wrote the transcript migration marker");
     backend.delete(&marker).await.unwrap();
 
@@ -3279,7 +3293,7 @@ async fn filesystem_transcript_migration_retries_a_lost_cas_race() {
     let marker_writes = backend
         .recorded_paths(FilesystemOperation::WriteFile)
         .into_iter()
-        .filter(|path| path.as_str().contains("transcript-index-v1.complete"))
+        .filter(|path| path.as_str().contains("transcript-index-v2.complete"))
         .count();
     assert_eq!(
         marker_writes, 2,
@@ -3318,7 +3332,7 @@ async fn filesystem_transcript_migration_conflict_retries_are_bounded() {
     let marker = backend
         .recorded_paths(FilesystemOperation::WriteFile)
         .into_iter()
-        .find(|path| path.as_str().contains("transcript-index-v1.complete"))
+        .find(|path| path.as_str().contains("transcript-index-v2.complete"))
         .expect("seeding wrote the transcript migration marker");
     backend.delete(&marker).await.unwrap();
 
@@ -4532,7 +4546,7 @@ fn thread_index_migration_marker_path_for_test(scope: &ThreadScope) -> ScopedPat
 
 fn transcript_index_migration_marker_path_for_test(scope: &ThreadScope) -> ScopedPath {
     ScopedPath::new(format!(
-        "/threads/agents/{}/projects/{}/owners/{}/index-migrations/transcript-index-v1.complete",
+        "/threads/agents/{}/projects/{}/owners/{}/index-migrations/transcript-index-v2.complete",
         scope.agent_id.as_str(),
         scope
             .project_id
@@ -4614,29 +4628,19 @@ where
     Arc::new(ScopedFilesystem::with_fixed_view(backend, mounts))
 }
 
-/// Real thread store backend that fails every write to a message lookup-index
-/// row (`/indexes/assistant-runs/…`, `/indexes/tool-results/…`) so the store
-/// runs its genuine "lookup-index backfill is best-effort, fall back to a
-/// transcript scan" path. Folds the former hand-rolled
-/// `LookupIndexWriteFailureBackend` onto `FaultInjecting` — two path-scoped
-/// `WriteFile` faults, one per lookup-index family.
-fn lookup_index_write_failure_backend() -> FaultInjecting<InMemoryBackend> {
-    FaultInjecting::new(InMemoryBackend::new())
-        .with_fault(
-            Fault::on(FilesystemOperation::WriteFile)
-                .path("/indexes/assistant-runs/")
-                .backend("lookup index writes disabled by contract test"),
-        )
-        .with_fault(
-            Fault::on(FilesystemOperation::WriteFile)
-                .path("/indexes/tool-results/")
-                .backend("lookup index writes disabled by contract test"),
-        )
+/// Real thread store backend that fails message-row writes. Lookup projections
+/// share that row, so projection failure cannot leave a source message without
+/// its exact-lookup keys.
+fn message_row_write_failure_backend() -> FaultInjecting<InMemoryBackend> {
+    FaultInjecting::new(InMemoryBackend::new()).with_fault(
+        Fault::on(FilesystemOperation::WriteFile)
+            .path("/messages/")
+            .backend("message row writes disabled by contract test"),
+    )
 }
 
-/// As [`lookup_index_write_failure_backend`], but fails every lookup-index
-/// *read* so the store must fall back to a transcript scan. Folds the former
-/// hand-rolled `LookupIndexReadFailureBackend`.
+/// Fails every legacy lookup-index read so a missing message-row projection
+/// cannot silently degrade into a transcript scan.
 fn lookup_index_read_failure_backend() -> FaultInjecting<InMemoryBackend> {
     FaultInjecting::new(InMemoryBackend::new())
         .with_fault(

--- a/crates/substrates/ironclaw_filesystem/CONTRACT.md
+++ b/crates/substrates/ironclaw_filesystem/CONTRACT.md
@@ -136,8 +136,9 @@ boundary. The current rule is codified in
      without native sequence reservation; `reserve_sequence` itself is now
      row-native), `apply_message_update`, `append_capability_display_preview`,
      `create_summary_artifact`, and the
-     message-row and lookup-projection writers through a local `put_with_cas`
-     retry loop (only `ensure_thread` was migrated onto `cas_update`). These
+     message-row writer through a local `put_with_cas` retry loop (lookup keys
+     are indexed projections on that same row; only `ensure_thread` was
+     migrated onto `cas_update`). These
      loops are already lock-free (no per-path mutex),
      so they are not the convoy hazard `cas_update` was introduced to fix;
      migration to `cas_update`'s fail-closed semantics is a deferred

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -251,7 +251,7 @@ One thread, whole real turn. Grouped by what the user experiences.
 **Durability, storage & restart**
 | Behavior | Evidence |
 |---|---|
-| Behavior is identical on in-memory and libSQL storage | `backend_matrix.rs` |
+| Behavior is identical on in-memory, libSQL, and PostgreSQL storage; message exact lookups avoid sibling entry rows on both durable databases | `backend_matrix.rs` |
 | Installed extensions survive a fresh store reopen | `durable.rs` |
 | Secrets survive a genuine on-disk reopen | `secrets.rs` |
 | Outbound preferences survive a process-level reopen | `outbound_store_durability.rs` |

--- a/tests/integration/backend_matrix.rs
+++ b/tests/integration/backend_matrix.rs
@@ -16,6 +16,16 @@ mod reborn_support;
 #[path = "../support/mod.rs"]
 mod support;
 
+use ironclaw_filesystem::{Filter, Page, RootFilesystem};
+use ironclaw_host_api::{
+    ids::{CapabilityId, ProviderToolName},
+    path::VirtualPath,
+};
+use ironclaw_threads::{
+    AppendToolResultReferenceRequest, FinalizedAssistantMessageByRunRequest,
+    ListThreadsForScopeRequest, ProviderToolCallReferenceEnvelope, SessionThreadService,
+    ToolResultSafeSummary, UpdateToolResultReferenceRequest,
+};
 use reborn_support::builder::{RebornIntegrationHarness, StorageMode};
 use reborn_support::reply::RebornScriptedReply;
 use rstest::rstest;
@@ -43,6 +53,171 @@ async fn backend_parity_replies_to_greeting(#[case] storage: StorageMode) {
         .assert_reply_contains("Hello! How can I help?")
         .await
         .expect("reply finalized in thread history");
+}
+
+/// Message hot-path parity: exact lookups resolve the same source message on
+/// each production database backend without materializing sibling entry rows.
+#[rstest]
+#[case(StorageMode::LibSql)]
+#[case(StorageMode::Postgres)]
+#[tokio::test]
+async fn message_lookup_indexes_share_the_message_row(#[case] storage: StorageMode) {
+    let harness = RebornIntegrationHarness::test_default()
+        .storage(storage)
+        .script([RebornScriptedReply::text("indexed reply")])
+        .build()
+        .await
+        .expect("harness builds");
+    let run_id = harness
+        .submit_turn("first user message")
+        .await
+        .expect("turn completes");
+    let service = harness
+        .thread_service_for_test()
+        .expect("thread service is available");
+    let scope = harness.thread_harness.scope.clone();
+    let thread_id = harness.binding.thread_id.clone();
+
+    let assistant = service
+        .finalized_assistant_message_by_run(FinalizedAssistantMessageByRunRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+            turn_run_id: run_id.to_string(),
+        })
+        .await
+        .expect("assistant lookup by run succeeds")
+        .expect("assistant lookup finds the finalized row");
+    assert_eq!(assistant.content.as_deref(), Some("indexed reply"));
+
+    let listed = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: None,
+            cursor: None,
+        })
+        .await
+        .expect("first-user lookup derives the title");
+    assert_eq!(
+        listed.threads[0].title.as_deref(),
+        Some("first user message")
+    );
+
+    let generic = service
+        .append_tool_result_reference(tool_result_request(
+            &scope,
+            &thread_id,
+            run_id.to_string(),
+            "result:generic",
+            None,
+        ))
+        .await
+        .expect("generic tool result is appended");
+    let generic_replay = service
+        .append_tool_result_reference(tool_result_request(
+            &scope,
+            &thread_id,
+            run_id.to_string(),
+            "result:generic",
+            None,
+        ))
+        .await
+        .expect("generic tool-result lookup deduplicates the replay");
+    assert_eq!(generic_replay.message_id, generic.message_id);
+
+    let provider_call = provider_call_reference("call-1");
+    let provider = service
+        .append_tool_result_reference(tool_result_request(
+            &scope,
+            &thread_id,
+            run_id.to_string(),
+            "result:provider",
+            Some(provider_call.clone()),
+        ))
+        .await
+        .expect("provider-call tool result is appended");
+    let provider_replay = service
+        .append_tool_result_reference(tool_result_request(
+            &scope,
+            &thread_id,
+            run_id.to_string(),
+            "result:provider",
+            Some(provider_call),
+        ))
+        .await
+        .expect("provider-call lookup deduplicates the replay");
+    assert_eq!(provider_replay.message_id, provider.message_id);
+    let updated = service
+        .update_tool_result_reference(UpdateToolResultReferenceRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+            turn_run_id: run_id.to_string(),
+            result_ref: "result:provider".to_string(),
+            provider_call_id: Some("call-1".to_string()),
+            safe_summary: ToolResultSafeSummary::new("provider result updated")
+                .expect("valid summary"),
+        })
+        .await
+        .expect("provider-call lookup targets the exact row");
+    assert_eq!(updated.message_id, provider.message_id);
+
+    let owner = scope
+        .owner_user_id
+        .as_ref()
+        .expect("integration thread scope has an owner");
+    let rows = harness
+        ._shared
+        .composite
+        .query(
+            &VirtualPath::new(format!(
+                "/tenants/{}/users/{}/threads",
+                scope.tenant_id.as_str(),
+                owner.as_str()
+            ))
+            .expect("valid threads root"),
+            &Filter::All,
+            Page::new(0, Page::MAX_LIMIT),
+        )
+        .await
+        .expect("database entry rows can be inspected");
+    assert!(
+        rows.iter()
+            .all(|row| !row.path.as_str().contains("/indexes/")),
+        "message lookup must not write sibling entry rows"
+    );
+}
+
+fn tool_result_request(
+    scope: &ironclaw_threads::ThreadScope,
+    thread_id: &ironclaw_host_api::ids::ThreadId,
+    turn_run_id: String,
+    result_ref: &str,
+    provider_call: Option<ProviderToolCallReferenceEnvelope>,
+) -> AppendToolResultReferenceRequest {
+    AppendToolResultReferenceRequest {
+        scope: scope.clone(),
+        thread_id: thread_id.clone(),
+        turn_run_id,
+        result_ref: result_ref.to_string(),
+        safe_summary: ToolResultSafeSummary::new("tool result").expect("valid summary"),
+        provider_call,
+        model_observation: None,
+    }
+}
+
+fn provider_call_reference(call_id: &str) -> ProviderToolCallReferenceEnvelope {
+    ProviderToolCallReferenceEnvelope {
+        provider_id: "test-provider".to_string(),
+        provider_model_id: "test-model".to_string(),
+        provider_turn_id: "provider-turn".to_string(),
+        provider_call_id: call_id.to_string(),
+        provider_tool_name: ProviderToolName::new("builtin__result_read")
+            .expect("valid provider tool name"),
+        capability_id: CapabilityId::new("builtin.result_read").expect("valid capability id"),
+        arguments: serde_json::json!({"offset": 0}),
+        response_reasoning: None,
+        reasoning: None,
+        signature: None,
+    }
 }
 
 /// Persistence correctness (design §3.8): the reply must survive to the

--- a/tests/integration/changed-coverage-exemptions.toml
+++ b/tests/integration/changed-coverage-exemptions.toml
@@ -1207,11 +1207,10 @@ review_after = "2026-11-02"
 [[exemption]]
 path = "crates/domains/ironclaw_threads/src/filesystem_service/transcript_migration.rs"
 lines = [
-  39, 62, 63, 103, 104, 159, 168, 169, 170, 171,
-  173, 178, 190, 202, 203, 204, 205, 207, 212, 213,
-  214, 216, 221, 222, 233, 238, 239, 241, 273, 274, 275,
+  39, 62, 63, 100, 101, 155, 164, 165, 166, 167,
+  169, 174, 183, 184, 195, 200, 201, 203, 235, 236, 237,
 ]
-branch_lines = [62, 101, 156, 169, 175, 183, 203, 212, 229, 238, 267]
+branch_lines = [62, 98, 152, 165, 171, 179, 191, 200, 229]
 owner = "@nearai/reborn"
 reason = "Contract tests deterministically cover writer-admission BackendBusy, VersionMismatch page retry, bounded exhaustion, successful message/summary rebuild, and durable marker read-back. Residuals are alternate failure sites inside the same bounded state machine, malformed legacy records, disappearing rows, and non-durable marker/backend failures not separately selectable through FaultInjecting."
 issue = "https://github.com/nearai/ironclaw/issues/6974"


### PR DESCRIPTION
## Summary

- Store exact message lookup keys as indexed projections on the message entry instead of writing 1-3 sibling entry rows per message.
- Preserve exact lookup behavior for assistant runs, tool results, provider calls, first-user titles, and capability previews, with legacy sibling-row fallback for existing data.
- Add a v2 transcript projection migration and durable-backend coverage that asserts lookups resolve while no new `/indexes/` entry rows are written.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #7605
Related #7591

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` (focused owning-crate clippy passed; full-workspace clippy was not run)
- [ ] `cargo build` (not run separately; test and clippy builds succeeded)
- [x] Relevant tests pass: `cargo test -p ironclaw_threads`; libSQL backend matrix lookup case
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (not applicable: `ironclaw_threads` has no applicable integration feature; the shared root backend matrix is used)
- [ ] Manual testing: Not applicable; behavior is exercised through filesystem contracts and the production-wired integration harness.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review (not run)

## Test Strategy

User behavior: Existing exact message lookups return the same source rows while each newly persisted message uses one filesystem entry row instead of additional lookup siblings.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Extended `filesystem_session_thread_contract` to assert lookup behavior and absence of sibling `/indexes/` rows; updated atomic write, index declaration, and v2 migration expectations.
- Reborn integration: Added one shared libSQL/PostgreSQL matrix case covering assistant-run, generic tool-result, provider-call, and first-user lookup behavior plus physical entry-row inspection.
- Recorded fixture: Not applicable: no external or nondeterministic boundary.
- Browser E2E: Not applicable: storage-only behavior with no browser surface.
- Backend or runtime: libSQL passed. PostgreSQL test compiles but could not execute locally because no Docker daemon was reachable at `/var/run/docker.sock`.
- Live canary: Not applicable: no external provider or deployed integration.

What the tests prove: New messages remain exactly addressable through every existing lookup key, replay/update calls target the original row, first-user title derivation is unchanged, and fresh durable writes do not materialize lookup sibling entries.

Commands run:

- `cargo test -p ironclaw_threads` — passed (266 tests across unit/contract suites)
- `cargo test -p ironclaw_integration_tests --test reborn_integration_backend_matrix 'message_lookup_indexes_share_the_message_row::case_1' -- --exact --nocapture` — passed (libSQL)
- `cargo test -p ironclaw_integration_tests --test reborn_integration_backend_matrix 'message_lookup_indexes_share_the_message_row::case_2' -- --exact --nocapture` — blocked before test execution; Docker socket unavailable
- `cargo clippy -p ironclaw_threads --all-targets --all-features -- -D warnings` — passed
- `cargo test -p ironclaw_architecture_tests` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check origin/main...HEAD` — passed

## Security Impact

None. This does not change authorization, secrets, network access, tool execution, or sandbox policy.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: Not applicable; no public trust-bearing types changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable; no prompt path changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. The existing SHA-256 legacy lookup-path hash is retained only for compatibility reads.
- [x] New/changed status, exit, policy, runtime, or error variants: Not applicable; none changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. No serde fields changed; the v2 indexed-projection migration is covered by filesystem contract tests.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. New ordered exact lookups are bounded to one row; migration retains its existing bounded page/retry behavior.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). Not applicable; error variants and classification are unchanged.
- [x] Sandbox/native/host names accurately describe trust boundary. Not applicable; no runtime lane changed.

## Database Impact

No SQL schema migration. This adds five RootFilesystem exact index specs and moves lookup keys into each message entry's indexed projection for both libSQL and PostgreSQL. Existing scopes receive a one-time `transcript-index-v2` projection rebuild. Legacy sibling rows are retained and remain readable; new messages stop writing them. libSQL parity passed locally; PostgreSQL execution remains to be confirmed in Docker-enabled CI/review.

## Blast Radius

Scoped to `ironclaw_threads` filesystem-backed message persistence, transcript projection migration, and exact lookup callers. A projection/index mismatch could affect assistant finalization replay, tool-result deduplication/update, capability-preview convergence, or sidebar title derivation. In-memory service behavior and public contracts are unchanged.

## Rollback Plan

Revert this commit to restore sibling-index writes. Messages created while this version is active will not have legacy sibling rows, so a binary rollback must first rehydrate those rows from the retained message records or use a forward fix; no message bodies are deleted by this change.

## Review Follow-Through

The PostgreSQL matrix leg should be confirmed by Docker-enabled CI. Reviewer judgment is especially useful on the five exact index key layouts and the one-time v2 projection migration.

---

**Review track**: C (database persistence/index behavior)
