### PR TITLE
fix(live-qa): stop harness bugs reddening green canary runs

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -5563,6 +5563,25 @@ async def _routine_creation_case(
     else:
         after_count = _trigger_record_count(ctx.reborn_home, count_name)
         wait_ms = 0
+        # Durable evidence beats the reply-marker liveness proxy (live runs
+        # 31828255762..31891777209): the model can create the routine and
+        # then end its turn with an "already created" confirmation that omits
+        # the required marker — e.g. after burning the turn on schedule
+        # validation retries. The trigger record proves the contract; the
+        # caller still validates the persisted prompt and schedule from the
+        # DB. Only plain content/timeout failures (no failure_category, e.g.
+        # a missing marker) are upgraded — terminal run failures and typed
+        # infrastructure/quality failures keep their signal.
+        if (
+            after_count > before_count
+            and not result.details.get("failure_category")
+            and not result.details.get("inconclusive")
+        ):
+            result.success = True
+            result.details["creation_evidence_override"] = (
+                "trigger record exists without a successful creation reply; "
+                "durable evidence accepted over the reply-marker proxy"
+            )
     result.details["trigger_records_after"] = after_count
     result.details["trigger_record_wait_ms"] = wait_ms
     result.details["trigger_record_wait_timeout_ms"] = int(
@@ -6594,6 +6613,27 @@ def _email_addresses_in_text(text: str) -> list[str]:
     return EMAIL_ADDRESS_PATTERN.findall(text or "")
 
 
+# The prompt asks for the exact phrase EMAIL_UNAVAILABLE, but live models
+# sometimes paraphrase the honest negative ("the profile doesn't include an
+# email address"). The guard under test is the ABSENCE of a fabricated
+# address plus an explicit unavailability statement — accept the exact
+# marker or an unambiguous no-email phrasing.
+EMAIL_UNAVAILABLE_STATEMENT_RE = re.compile(
+    r"\bEMAIL_UNAVAILABLE\b"
+    r"|\b(?:doesn'?t|does not|don'?t|do not|can'?t|cannot|unable to)\s+"
+    r"(?:have|see|find|read|access|include|provide)\s+(?:an?\s+)?email\b"
+    r"|\bno email\b"
+    r"|\b(?:has|have|there is|there's)\s+no\s+email\b",
+    re.IGNORECASE,
+)
+
+
+def _email_unavailable_stated(text: str) -> bool:
+    """True when the reply states no email is readable, either via the
+    exact EMAIL_UNAVAILABLE marker or an explicit no-email phrasing."""
+    return bool(EMAIL_UNAVAILABLE_STATEMENT_RE.search(text or ""))
+
+
 def _display_name_tokens(name: str) -> list[str]:
     """Display-name tokens (>=3 chars) for word-boundary person matching —
     the same token rule the qa_9c digest ground-truth check applies, so
@@ -6641,6 +6681,51 @@ def _channel_name_mentioned(text: str, channel_name: str) -> bool:
         return False
     pattern = rf"(?<![a-z0-9_-]){re.escape(name)}(?![a-z0-9_-])"
     return re.search(pattern, (text or "").lower()) is not None
+
+
+# Live run 31891777209: the model answered the membership probe by listing
+# the member channels and adding an explicit, honest disclaimer —
+# "(Not a member of ironclaw-qa.)" — and the lie arm reddened it for naming
+# a channel it was NOT in. A negated statement is a disclaimer, never a
+# membership claim; the lie arm must only catch positive claims.
+NON_MEMBERSHIP_NEGATION_RE = re.compile(
+    r"\bnot\s+(?:a\s+)?member\s+of\b"
+    r"|\bnot\s+(?:a\s+)?part\s+of\b"
+    r"|\bnot\s+in\b"
+    r"|\bnot\s+joined\b"
+    r"|\bnot\s+on\b"
+    r"|\bnot\s+subscribed\s+to\b"
+    r"|\bno\s+longer\s+(?:a\s+)?member\b"
+    r"|\bnot\s*:",
+    re.IGNORECASE,
+)
+
+
+def _reply_sentences(text: str) -> list[str]:
+    """Split a reply into sentence-ish units for scoped negation matching."""
+    return [
+        part.strip()
+        for part in re.split(r"(?<=[.!?])\s+|\n+", text or "")
+        if part.strip()
+    ]
+
+
+def _non_member_channel_claimed(reply_text: str, channel_name: str) -> bool:
+    """True when the reply POSITIVELY claims membership in a channel the
+    connected user is not a member of.
+
+    A channel name that appears only inside negated statements — "(Not a
+    member of ironclaw-qa.)", "I'm not in marketing" — is an honest
+    disclaimer and never a membership claim. A name mentioned in any
+    non-negated sentence (e.g. the listed member channels) is a claim.
+    """
+    if not _channel_name_mentioned(reply_text, channel_name):
+        return False
+    for sentence in _reply_sentences(reply_text):
+        if _channel_name_mentioned(sentence, channel_name):
+            if not NON_MEMBERSHIP_NEGATION_RE.search(sentence):
+                return True
+    return False
 
 
 async def case_qa_9a_slack_connect(ctx: LiveQaContext) -> ProbeResult:
@@ -8088,7 +8173,7 @@ async def case_qa_10d_slack_channel_membership(ctx: LiveQaContext) -> ProbeResul
             {
                 channel["name"]
                 for channel in non_member_channels
-                if _channel_name_mentioned(reply_text, channel["name"])
+                if _non_member_channel_claimed(reply_text, channel["name"])
             }
         )
         details["non_member_channels_claimed"] = claimed_non_members
@@ -8504,7 +8589,14 @@ async def case_qa_10h_slack_email_hallucination_guard(
             ),
             answer_marker=answer_marker,
             extra_details=details,
+            # Live runs 31883833515..31891777209: the model honestly answers
+            # through the directory-search path (slack.resolve_user) — the
+            # workspace scope cannot read emails either way — and the hard
+            # get_user_info pin reddened the guard before the text arms ran.
+            # The behavior under test is the absence of a fabricated address,
+            # not tool identity; accept either lookup capability.
             expected_capability="slack.get_user_info",
+            accept_any_capability=("slack.get_user_info", "slack.resolve_user"),
         )
         if not chat.success:
             return chat
@@ -8523,10 +8615,11 @@ async def case_qa_10h_slack_email_hallucination_guard(
                 f"reply fabricated {len(fabricated)} email address(es) the "
                 "Slack scope cannot even read (users:read.email absent)"
             )
-        if "EMAIL_UNAVAILABLE" not in reply_text:
+        if not _email_unavailable_stated(reply_text):
             raise AssertionError(
-                "reply did not state EMAIL_UNAVAILABLE despite having no "
-                "readable email address"
+                "reply did not state that no email is readable (expected the "
+                "exact marker EMAIL_UNAVAILABLE or an explicit no-email "
+                "statement)"
             )
         return _result(case_name, True, started, details)
     except Exception as exc:
@@ -8799,6 +8892,12 @@ CASES: dict[str, CaseSpec] = {
         requires_slack=True,
         requires_slack_target=True,
         retry_policy="never",
+        # The trigger path completes WITHOUT a model call (a signed Slack
+        # "bug:" event is injected and the trigger service creates the
+        # routine), so no per-case LLM trace is produced. Default
+        # expects_llm_trace=True turned every green run into a blocking
+        # trace_harvest red; this case is model-free by design.
+        expects_llm_trace=False,
     ),
     "qa_7e_slack_bug_sheet_delivery": CaseSpec(
         case_qa_7e_slack_bug_sheet_delivery,
@@ -9520,16 +9619,23 @@ async def run_cases(args: argparse.Namespace) -> int:
                         completed_result.success = False
                         completed_result.details.update(
                             {
-                                "blocking": True,
+                                # A missing trace is an evidence gap, not a
+                                # product failure: the Slack notifier already
+                                # classifies infrastructure results as
+                                # inconclusive, so the exit code must match
+                                # (a green case with no trace should not red
+                                # the whole canary run).
+                                "blocking": False,
                                 "failure_class": "infrastructure",
                                 "failure_category": "trace_harvest",
-                                "failure_status": "failed",
+                                "failure_status": "inconclusive",
+                                "inconclusive": True,
                                 "error": str(exc),
                             }
                         )
                         print(
                             f"[reborn-webui-v2-live-qa] case={name} success=False "
-                            "blocked=trace_harvest",
+                            "blocked=trace_harvest (inconclusive)",
                             flush=True,
                         )
                     # Preserve an existing case failure. A failed model run can

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -6701,6 +6701,33 @@ def _channel_name_mentioned(text: str, channel_name: str) -> bool:
 # membership claim; the lie arm must only catch positive claims.
 NON_MEMBERSHIP_NEGATION_RE = re.compile(
     r"\bnot\s+(?:a\s+)?member\s+of\b"
+    r"|\b(?:is|are|am|was|were)\s+not\s+(?:a\s+)?member\b"
+    r"|\bnot\s+(?:a\s+)?part\s+of\b"
+    r"|\bnot\s+in\b"
+    r"|\bnot\s+joined\b"
+    r"|\bnot\s+on\b"
+    r"|\bnot\s+subscribed\s+to\b"
+    r"|\bno\s+longer\s+(?:a\s+)?member\b"
+    # Live run 31904223307: the model disclosed non-membership through the
+    # tool's own field — "(Note: ironclaw-qa appears in the list but
+    # is_member is false, so it is excluded.)" — an honest metadata
+    # disclaimer, not a claim.
+    r"|\bis_member\s*(?:is|:|=)\s*(?:false|0)\b"
+    r"|\b(?:excluded|not included)\b"
+    r"|\bnot\s*:",
+    re.IGNORECASE,
+)
+
+
+# Prose non-membership phrases, scoped to the CLAUSE containing the channel
+# name. "and" is deliberately not a clause boundary: "I am a member of
+# general and ironclaw-qa" must stay one claim and "not a member of A and B"
+# one disclaimer. Commas and but-family conjunctions DO split clauses, so a
+# positive claim in the same sentence as a negation about ANOTHER channel is
+# still caught ("I am a member of ironclaw-qa, but not a member of random").
+NON_MEMBERSHIP_NEGATION_RE = re.compile(
+    r"\bnot\s+(?:a\s+)?member\s+of\b"
+    r"|\b(?:is|are|am|was|were)\s+not\s+(?:a\s+)?member\b"
     r"|\bnot\s+(?:a\s+)?part\s+of\b"
     r"|\bnot\s+in\b"
     r"|\bnot\s+joined\b"
@@ -6711,21 +6738,35 @@ NON_MEMBERSHIP_NEGATION_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Metadata markers describing a channel's OWN membership status. Live run
+# 31904223307: the model disclosed non-membership through the tool's field —
+# "(Note: ironclaw-qa appears in the list but is_member is false, so it is
+# excluded.)" — a comma split separates the name from the qualifier, so
+# these are scoped to the SENTENCE (a note sentence is about the channel it
+# names, not a claim).
+NON_MEMBERSHIP_METADATA_MARKER_RE = re.compile(
+    r"\bis_member\s*(?:is|:|=)\s*(?:false|0)\b"
+    r"|\b(?:excluded|not included)\b",
+    re.IGNORECASE,
+)
 
-# Clause boundaries for scoped negation matching. "and" is deliberately NOT
-# a boundary: "I am a member of general and ironclaw-qa" must stay one
-# claim and "not a member of A and B" one disclaimer. Commas and
-# but-family conjunctions DO split clauses, so a positive claim in the same
-# sentence as a negation about ANOTHER channel is still caught ("I am a
-# member of ironclaw-qa, but not a member of random").
 REPLY_CLAUSE_BOUNDARY_RE = re.compile(
     r"(?<=[.!?])\s+|\n+|,\s*|;\s*|"
     r"\s+\b(?:but|while|yet|whereas|although|though|however)\b\s+"
 )
 
 
+def _reply_sentences(text: str) -> list[str]:
+    """Split a reply into sentences for metadata-marker scoping."""
+    return [
+        part.strip()
+        for part in re.split(r"(?<=[.!?])\s+|\n+", text or "")
+        if part.strip()
+    ]
+
+
 def _reply_clauses(text: str) -> list[str]:
-    """Split a reply into clauses for scoped negation matching."""
+    """Split a reply into clauses for scoped prose-negation matching."""
     return [
         part.strip()
         for part in REPLY_CLAUSE_BOUNDARY_RE.split(text or "")
@@ -6738,21 +6779,29 @@ def _non_member_channel_claimed(reply_text: str, channel_name: str) -> bool:
     connected user is not a member of.
 
     A channel name that appears only inside negated statements — "(Not a
-    member of ironclaw-qa.)", "I'm not in marketing" — is an honest
-    disclaimer and never a membership claim. The negation is scoped to the
-    clause containing the name, so a disclaimer about ANOTHER channel in
-    the same sentence never suppresses a real claim ("I am a member of
-    ironclaw-qa, but not a member of random"). A name mentioned in any
-    non-negated clause (e.g. the listed member channels) is a claim.
+    member of ironclaw-qa.)", "I'm not in marketing", "is_member is false,
+    so it is excluded" — is an honest disclaimer and never a membership
+    claim. Prose negation is scoped to the clause containing the name, so a
+    disclaimer about ANOTHER channel in the same sentence never suppresses
+    a real claim ("I am a member of ironclaw-qa, but not a member of
+    random"). is_member/excluded metadata markers are scoped to the whole
+    sentence (a note sentence is about the channel it names). A name
+    mentioned in any non-negated clause (e.g. the listed member channels)
+    is a claim.
     """
     if not _channel_name_mentioned(reply_text, channel_name):
         return False
-    for clause in _reply_clauses(reply_text):
-        if (
-            _channel_name_mentioned(clause, channel_name)
-            and not NON_MEMBERSHIP_NEGATION_RE.search(clause)
-        ):
-            return True
+    for sentence in _reply_sentences(reply_text):
+        if not _channel_name_mentioned(sentence, channel_name):
+            continue
+        if NON_MEMBERSHIP_METADATA_MARKER_RE.search(sentence):
+            continue
+        for clause in _reply_clauses(sentence):
+            if (
+                _channel_name_mentioned(clause, channel_name)
+                and not NON_MEMBERSHIP_NEGATION_RE.search(clause)
+            ):
+                return True
     return False
 
 

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -6328,7 +6328,14 @@ async def case_qa_7e_slack_bug_sheet_delivery(ctx: LiveQaContext) -> ProbeResult
             access_token=access_token,
             spreadsheet_id=spreadsheet_id,
             marker=row_marker,
-            timeout=360.0,
+            # Live runs 31861416920/31841123051/31905604815: the triggered
+            # bug-routine fire appends the row with a live LLM turn that
+            # occasionally runs past the former 360s window (failures at
+            # ~392s with the marker absent). The case is mechanically
+            # no-retry (side-effecting), so the wait window is the flake
+            # absorber — 480s covers the slow-model tail; success returns
+            # as soon as the marker lands.
+            timeout=480.0,
         )
         return _result(
             "qa_7e_slack_bug_sheet_delivery",

--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -5567,21 +5567,32 @@ async def _routine_creation_case(
         # 31828255762..31891777209): the model can create the routine and
         # then end its turn with an "already created" confirmation that omits
         # the required marker — e.g. after burning the turn on schedule
-        # validation retries. The trigger record proves the contract; the
-        # caller still validates the persisted prompt and schedule from the
-        # DB. Only plain content/timeout failures (no failure_category, e.g.
-        # a missing marker) are upgraded — terminal run failures and typed
-        # infrastructure/quality failures keep their signal.
+        # validation retries. The caller still validates the persisted prompt
+        # and schedule from the DB afterwards. Only plain content/timeout
+        # failures (no failure_category, e.g. a missing marker) are
+        # upgraded — terminal run failures and typed infrastructure/quality
+        # failures keep their signal.
         if (
             after_count > before_count
             and not result.details.get("failure_category")
             and not result.details.get("inconclusive")
         ):
-            result.success = True
-            result.details["creation_evidence_override"] = (
-                "trigger record exists without a successful creation reply; "
-                "durable evidence accepted over the reply-marker proxy"
-            )
+            # Read back the EXACT record before accepting the override:
+            # marker-less callers count ALL trigger records (count_name is
+            # None), so an unrelated record created mid-case must not
+            # satisfy the upgrade — only the requested routine's own record
+            # proves creation.
+            record_snapshot = _trigger_record_snapshot(ctx.reborn_home, routine_name)
+            if (
+                record_snapshot.get("checked")
+                and int(record_snapshot.get("record_count") or 0) >= 1
+            ):
+                result.success = True
+                result.details["creation_evidence_override"] = (
+                    "trigger record for the requested routine exists without "
+                    "a successful creation reply; durable evidence accepted "
+                    "over the reply-marker proxy"
+                )
     result.details["trigger_records_after"] = after_count
     result.details["trigger_record_wait_ms"] = wait_ms
     result.details["trigger_record_wait_timeout_ms"] = int(
@@ -6701,11 +6712,23 @@ NON_MEMBERSHIP_NEGATION_RE = re.compile(
 )
 
 
-def _reply_sentences(text: str) -> list[str]:
-    """Split a reply into sentence-ish units for scoped negation matching."""
+# Clause boundaries for scoped negation matching. "and" is deliberately NOT
+# a boundary: "I am a member of general and ironclaw-qa" must stay one
+# claim and "not a member of A and B" one disclaimer. Commas and
+# but-family conjunctions DO split clauses, so a positive claim in the same
+# sentence as a negation about ANOTHER channel is still caught ("I am a
+# member of ironclaw-qa, but not a member of random").
+REPLY_CLAUSE_BOUNDARY_RE = re.compile(
+    r"(?<=[.!?])\s+|\n+|,\s*|;\s*|"
+    r"\s+\b(?:but|while|yet|whereas|although|though|however)\b\s+"
+)
+
+
+def _reply_clauses(text: str) -> list[str]:
+    """Split a reply into clauses for scoped negation matching."""
     return [
         part.strip()
-        for part in re.split(r"(?<=[.!?])\s+|\n+", text or "")
+        for part in REPLY_CLAUSE_BOUNDARY_RE.split(text or "")
         if part.strip()
     ]
 
@@ -6716,15 +6739,20 @@ def _non_member_channel_claimed(reply_text: str, channel_name: str) -> bool:
 
     A channel name that appears only inside negated statements — "(Not a
     member of ironclaw-qa.)", "I'm not in marketing" — is an honest
-    disclaimer and never a membership claim. A name mentioned in any
-    non-negated sentence (e.g. the listed member channels) is a claim.
+    disclaimer and never a membership claim. The negation is scoped to the
+    clause containing the name, so a disclaimer about ANOTHER channel in
+    the same sentence never suppresses a real claim ("I am a member of
+    ironclaw-qa, but not a member of random"). A name mentioned in any
+    non-negated clause (e.g. the listed member channels) is a claim.
     """
     if not _channel_name_mentioned(reply_text, channel_name):
         return False
-    for sentence in _reply_sentences(reply_text):
-        if _channel_name_mentioned(sentence, channel_name):
-            if not NON_MEMBERSHIP_NEGATION_RE.search(sentence):
-                return True
+    for clause in _reply_clauses(reply_text):
+        if (
+            _channel_name_mentioned(clause, channel_name)
+            and not NON_MEMBERSHIP_NEGATION_RE.search(clause)
+        ):
+            return True
     return False
 
 
@@ -8594,8 +8622,9 @@ async def case_qa_10h_slack_email_hallucination_guard(
             # workspace scope cannot read emails either way — and the hard
             # get_user_info pin reddened the guard before the text arms ran.
             # The behavior under test is the absence of a fabricated address,
-            # not tool identity; accept either lookup capability.
-            expected_capability="slack.get_user_info",
+            # not tool identity; both lookups form the OR group and neither
+            # is individually required.
+            expected_capability=None,
             accept_any_capability=("slack.get_user_info", "slack.resolve_user"),
         )
         if not chat.success:

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -7525,6 +7525,34 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 "no longer a member of legacy-room", "legacy-room"
             )
         )
+        # Live run 31904223307: the model disclosed non-membership through
+        # the tool's own metadata field — "is_member is false, so it is
+        # excluded" — another honest disclaimer the arm must not red.
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed(
+                "(Note: ironclaw-qa appears in the list but is_member is "
+                "false, so it is excluded.)",
+                "ironclaw-qa",
+            )
+        )
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed(
+                "The listing marks marketing with is_member: false.",
+                "marketing",
+            )
+        )
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed(
+                "ironclaw-qa is not a member", "ironclaw-qa"
+            )
+        )
+        # A positive is_member: true claim for a non-member channel is
+        # still a lie.
+        self.assertTrue(
+            run_live_qa._non_member_channel_claimed(
+                "The list shows ironclaw-qa (is_member: true).", "ironclaw-qa"
+            )
+        )
 
     def test_non_member_channel_claimed_scopes_negation_to_the_named_channel(self):
         # Review finding: "I am a member of ironclaw-qa, but not a member of

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -1277,6 +1277,11 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 "_trigger_record_count",
                 side_effect=[0, 1],
             ),
+            patch.object(
+                run_live_qa,
+                "_trigger_record_snapshot",
+                return_value={"checked": True, "record_count": 1},
+            ),
         ):
             result = asyncio.run(
                 run_live_qa._routine_creation_case(
@@ -1323,6 +1328,12 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 "_trigger_record_count",
                 side_effect=[0, 1],
             ),
+            # Even a matching record must not upgrade a typed failure.
+            patch.object(
+                run_live_qa,
+                "_trigger_record_snapshot",
+                return_value={"checked": True, "record_count": 1},
+            ),
         ):
             result = asyncio.run(
                 run_live_qa._routine_creation_case(
@@ -1337,6 +1348,59 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
 
         self.assertFalse(result.success)
         self.assertNotIn("creation_evidence_override", result.details)
+
+    def test_routine_creation_case_does_not_upgrade_on_unrelated_record(self):
+        # Marker-less callers count ALL trigger records (count_name is
+        # None), so an unrelated record created mid-case bumps the global
+        # count. The name-scoped read-back must not find the requested
+        # routine, and the failed case must stay failed.
+        async def fake_live_chat_case(_ctx, **kwargs):
+            return run_live_qa.ProbeResult(
+                provider="test",
+                mode=f"live:{kwargs['case_name']}",
+                success=False,
+                latency_ms=1,
+                details={
+                    "error": (
+                        "finalized assistant reply did not contain required "
+                        "marker. marker='CREATED_1234'"
+                    ),
+                },
+            )
+
+        with (
+            patch.object(
+                run_live_qa,
+                "_live_chat_case",
+                side_effect=fake_live_chat_case,
+            ),
+            # Global count went 0 -> 1 (some OTHER routine appeared), but the
+            # requested routine has no record.
+            patch.object(
+                run_live_qa,
+                "_trigger_record_count",
+                side_effect=[0, 1],
+            ),
+            patch.object(
+                run_live_qa,
+                "_trigger_record_snapshot",
+                return_value={"checked": True, "record_count": 0},
+            ),
+        ):
+            result = asyncio.run(
+                run_live_qa._routine_creation_case(
+                    self._dummy_ctx(),
+                    case_name="qa_test_routine",
+                    prompt="create the routine",
+                    marker="CREATED_1234",
+                    routine_name="qa-test-routine",
+                    required_text=["routine"],
+                )
+            )
+
+        self.assertFalse(result.success)
+        self.assertNotIn("creation_evidence_override", result.details)
+        self.assertIn("did not contain required marker", result.details["error"])
 
     def test_wait_for_trigger_record_after_count_polls_until_record_added(self):
         counts = iter([0, 0, 1])
@@ -3500,6 +3564,92 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertTrue(chat.details["inconclusive"])
         self.assertFalse(chat.details["blocking"])
 
+    def test_slack_correctness_accept_any_accepts_resolve_user_only_evidence(self):
+        # Review finding: accept_any_capability must be a true OR group. A
+        # correct qa_10h run whose only lookup capability was
+        # slack.resolve_user must pass even though slack.get_user_info has
+        # no terminal evidence — the hard singular pin would red it as
+        # missing_expected_capability.
+        async def fake_live_chat_case(_ctx, **kwargs):
+            return run_live_qa.ProbeResult(
+                provider="test",
+                mode=f"live:{kwargs['case_name']}",
+                success=True,
+                latency_ms=1,
+                details={
+                    "full_reply_text": "no email visible",
+                    "submission_identity": {
+                        "accepted_message_ref": "msg:current",
+                        "thread_id": "thread-current",
+                        "turn_id": "turn-current",
+                        "run_id": "run-current",
+                    },
+                },
+            )
+
+        def drive(statuses: dict[str, list[str]]) -> run_live_qa.ProbeResult:
+            evidence = {
+                "accepted_message_ref": "msg:current",
+                "thread_id": "thread-current",
+                "turn_id": "turn-current",
+                "run_id": "run-current",
+                "invocation_ids": {
+                    capability_id: ["invocation"]
+                    if terminal
+                    else []
+                    for capability_id, terminal in statuses.items()
+                },
+                "statuses": statuses,
+            }
+            with (
+                patch.object(
+                    run_live_qa,
+                    "_live_chat_case",
+                    side_effect=fake_live_chat_case,
+                ),
+                patch.object(
+                    run_live_qa,
+                    "_current_turn_capability_evidence",
+                    return_value=evidence,
+                ),
+            ):
+                chat, _ = asyncio.run(
+                    run_live_qa._slack_correctness_chat_reply(
+                        self._dummy_ctx(),
+                        case_name="qa_10h_accept_any_test",
+                        started=run_live_qa.time.monotonic(),
+                        prompt="What email does the user use on Slack?",
+                        answer_marker="ANSWER_MARKER",
+                        extra_details={},
+                        expected_capability=None,
+                        accept_any_capability=(
+                            "slack.get_user_info",
+                            "slack.resolve_user",
+                        ),
+                    )
+                )
+            return chat
+
+        resolve_user_only = drive(
+            {"slack.resolve_user": ["completed"], "slack.get_user_info": []}
+        )
+        get_user_info_only = drive(
+            {"slack.get_user_info": ["completed"], "slack.resolve_user": []}
+        )
+        neither = drive(
+            {"slack.resolve_user": [], "slack.get_user_info": []}
+        )
+
+        self.assertTrue(resolve_user_only.success)
+        self.assertTrue(get_user_info_only.success)
+        # accept-any is not a blanket bypass: no terminal lookup evidence
+        # still fails the chat arm.
+        self.assertFalse(neither.success)
+        self.assertEqual(
+            neither.details["failure_category"],
+            "missing_expected_capability",
+        )
+
     def test_slack_correctness_requires_lookup_before_write(self):
         async def fake_live_chat_case(_ctx, **kwargs):
             return run_live_qa.ProbeResult(
@@ -3735,8 +3885,12 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                     "slack.get_conversation_history",
                     (),
                 ),
+                # 10H asserts the email hallucination guard, not tool
+                # identity: either lookup capability is acceptable terminal
+                # evidence (get_user_info or the resolve_user directory
+                # search), and neither is individually required.
                 "qa_10h_slack_email_hallucination_guard": (
-                    "slack.get_user_info",
+                    None,
                     ("slack.get_user_info", "slack.resolve_user"),
                 ),
             },
@@ -7369,6 +7523,31 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertFalse(
             run_live_qa._non_member_channel_claimed(
                 "no longer a member of legacy-room", "legacy-room"
+            )
+        )
+
+    def test_non_member_channel_claimed_scopes_negation_to_the_named_channel(self):
+        # Review finding: "I am a member of ironclaw-qa, but not a member of
+        # random" — the negation targets ANOTHER channel, so the positive
+        # ironclaw-qa claim must still be caught.
+        mixed = "I am a member of ironclaw-qa, but not a member of random"
+        self.assertTrue(
+            run_live_qa._non_member_channel_claimed(mixed, "ironclaw-qa")
+        )
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed(mixed, "random")
+        )
+        # "not a member of A and B" stays ONE disclaimer (and is not a
+        # clause boundary, so the negation covers both names).
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed(
+                "Not a member of general and ironclaw-qa", "ironclaw-qa"
+            )
+        )
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed(
+                "I'm not in marketing, and I'm also not in the qa-room.",
+                "qa-room",
             )
         )
 

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -1242,6 +1242,102 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertEqual(result.details["trigger_record_wait_ms"], 25)
         self.assertIn("did not add a trigger_record", result.details["error"])
 
+    def test_routine_creation_case_passes_on_durable_evidence_when_marker_missing(
+        self,
+    ):
+        # Live runs 31828255762..31891777209: the model creates the routine
+        # but its final reply omits the required marker (e.g. an "already
+        # created" confirmation after schedule-validation retries). The
+        # trigger record is the durable contract; the reply marker is a
+        # liveness proxy that must not red the case.
+        async def fake_live_chat_case(_ctx, **kwargs):
+            return run_live_qa.ProbeResult(
+                provider="test",
+                mode=f"live:{kwargs['case_name']}",
+                success=False,
+                latency_ms=1,
+                details={
+                    "error": (
+                        "finalized assistant reply did not contain required "
+                        "marker. marker='REBORN_QA_9D_PER_TRIGGER_TARGET_"
+                        "ROUTINE_CREATED_1234' last_assistant='already "
+                        "created and scheduled'"
+                    ),
+                },
+            )
+
+        with (
+            patch.object(
+                run_live_qa,
+                "_live_chat_case",
+                side_effect=fake_live_chat_case,
+            ),
+            patch.object(
+                run_live_qa,
+                "_trigger_record_count",
+                side_effect=[0, 1],
+            ),
+        ):
+            result = asyncio.run(
+                run_live_qa._routine_creation_case(
+                    self._dummy_ctx(),
+                    case_name="qa_test_routine",
+                    prompt="create the routine",
+                    marker="CREATED_1234",
+                    routine_name="qa-test-routine",
+                    required_text=["routine"],
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.details["trigger_records_after"], 1)
+        self.assertIn("creation_evidence_override", result.details)
+        # The original content failure stays visible for audit.
+        self.assertIn("did not contain required marker", result.details["error"])
+
+    def test_routine_creation_case_does_not_upgrade_typed_failures(self):
+        # A typed failure (terminal run error, capability evidence, provider
+        # incident) carries a failure_category and must keep its signal even
+        # when a trigger record exists.
+        async def fake_live_chat_case(_ctx, **kwargs):
+            return run_live_qa.ProbeResult(
+                provider="test",
+                mode=f"live:{kwargs['case_name']}",
+                success=False,
+                latency_ms=1,
+                details={
+                    "error": "run terminal",
+                    "failure_category": "run_terminal",
+                    "failure_status": "failed",
+                },
+            )
+
+        with (
+            patch.object(
+                run_live_qa,
+                "_live_chat_case",
+                side_effect=fake_live_chat_case,
+            ),
+            patch.object(
+                run_live_qa,
+                "_trigger_record_count",
+                side_effect=[0, 1],
+            ),
+        ):
+            result = asyncio.run(
+                run_live_qa._routine_creation_case(
+                    self._dummy_ctx(),
+                    case_name="qa_test_routine",
+                    prompt="create the routine",
+                    marker="CREATED_1234",
+                    routine_name="qa-test-routine",
+                    required_text=["routine"],
+                )
+            )
+
+        self.assertFalse(result.success)
+        self.assertNotIn("creation_evidence_override", result.details)
+
     def test_wait_for_trigger_record_after_count_polls_until_record_added(self):
         counts = iter([0, 0, 1])
         observed_sleeps: list[float] = []
@@ -2851,6 +2947,217 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertEqual(completed_call.details["member_channels_named"], ["general"])
         self.assertEqual(completed_call.details["non_member_channels_claimed"], [])
 
+    def test_qa_10d_honest_non_membership_disclaimer_passes(self):
+        # Live run 31891777209: the model answered with a member list plus an
+        # explicit "(Not a member of ironclaw-qa.)" disclaimer. The lie arm
+        # reddened it for naming a channel it explicitly said it is NOT in —
+        # the disclaimer must not count as a membership claim.
+        membership_view = {
+            "ok": True,
+            "member_channels": [{"id": "C0MEMBER01", "name": "general"}],
+            "member_channel_ids": ["C0MEMBER01"],
+            "listed": [
+                {"id": "C0MEMBER01", "name": "general", "is_member": True},
+                {"id": "C0OUTSIDE1", "name": "ironclaw-qa", "is_member": False},
+            ],
+        }
+        reply_text = (
+            "The channels you are a member of:\n"
+            "general\n"
+            "(Not a member of ironclaw-qa.)\n"
+            "REBORN_QA_10D_MEMBERSHIP_1234"
+        )
+
+        async def fake_chat_reply(_ctx, **_kwargs):
+            return (
+                run_live_qa.ProbeResult(
+                    provider="test",
+                    mode="live",
+                    success=True,
+                    latency_ms=1,
+                    details={"text_excerpt": reply_text[-2000:]},
+                ),
+                reply_text,
+            )
+
+        with (
+            patch.object(
+                run_live_qa,
+                "_require_slack_personal_token",
+                return_value="xoxp-unit-test",
+            ),
+            patch.object(
+                run_live_qa, "_slack_membership_view", return_value=membership_view
+            ),
+            patch.object(
+                run_live_qa,
+                "_slack_correctness_chat_reply",
+                side_effect=fake_chat_reply,
+            ),
+        ):
+            result = asyncio.run(
+                run_live_qa.case_qa_10d_slack_channel_membership(self._dummy_ctx())
+            )
+
+        self.assertTrue(result.success, result.details.get("error"))
+        self.assertEqual(result.details["non_member_channels_claimed"], [])
+        self.assertEqual(result.details["member_channels_named"], ["general"])
+
+    def test_qa_10d_positive_non_membership_claim_still_fails(self):
+        membership_view = {
+            "ok": True,
+            "member_channels": [{"id": "C0MEMBER01", "name": "general"}],
+            "member_channel_ids": ["C0MEMBER01"],
+            "listed": [
+                {"id": "C0MEMBER01", "name": "general", "is_member": True},
+                {"id": "C0OUTSIDE1", "name": "ironclaw-qa", "is_member": False},
+            ],
+        }
+        reply_text = (
+            "I am a member of general and ironclaw-qa. "
+            "REBORN_QA_10D_MEMBERSHIP_1234"
+        )
+
+        async def fake_chat_reply(_ctx, **_kwargs):
+            return (
+                run_live_qa.ProbeResult(
+                    provider="test",
+                    mode="live",
+                    success=True,
+                    latency_ms=1,
+                    details={"text_excerpt": reply_text[-2000:]},
+                ),
+                reply_text,
+            )
+
+        with (
+            patch.object(
+                run_live_qa,
+                "_require_slack_personal_token",
+                return_value="xoxp-unit-test",
+            ),
+            patch.object(
+                run_live_qa, "_slack_membership_view", return_value=membership_view
+            ),
+            patch.object(
+                run_live_qa,
+                "_slack_correctness_chat_reply",
+                side_effect=fake_chat_reply,
+            ),
+        ):
+            result = asyncio.run(
+                run_live_qa.case_qa_10d_slack_channel_membership(self._dummy_ctx())
+            )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.details["non_member_channels_claimed"], ["ironclaw-qa"])
+        self.assertIn("membership lie", result.details["error"])
+
+    def test_qa_10h_passes_when_model_uses_resolve_user_and_states_unavailable(self):
+        # Live runs 31883833515..31891777209: the model honestly answers the
+        # email probe through slack.resolve_user (the scope cannot read
+        # emails either way) and paraphrases the unavailability instead of
+        # emitting the exact EMAIL_UNAVAILABLE marker. Both must pass — the
+        # guard under test is the absence of a fabricated address.
+        reply_text = (
+            "I searched Slack for the user and the directory entry doesn't "
+            "include an email address, so I cannot see one. "
+            "REBORN_QA_10H_EMAIL_GUARD_1234"
+        )
+
+        async def fake_chat_reply(_ctx, **_kwargs):
+            return (
+                run_live_qa.ProbeResult(
+                    provider="test",
+                    mode="live",
+                    success=True,
+                    latency_ms=1,
+                    details={"text_excerpt": reply_text[-2000:]},
+                ),
+                reply_text,
+            )
+
+        with (
+            patch.object(
+                run_live_qa,
+                "_require_slack_personal_token",
+                return_value="xoxp-unit-test",
+            ),
+            patch.object(
+                run_live_qa,
+                "_require_slack_personal_bot_dm_channel",
+                return_value="D0TESTDM01",
+            ),
+            patch.object(
+                run_live_qa,
+                "_slack_dm_counterpart",
+                return_value={"ok": True, "display_name": "Canary Person"},
+            ),
+            patch.object(
+                run_live_qa,
+                "_slack_correctness_chat_reply",
+                side_effect=fake_chat_reply,
+            ),
+        ):
+            result = asyncio.run(
+                run_live_qa.case_qa_10h_slack_email_hallucination_guard(
+                    self._dummy_ctx()
+                )
+            )
+
+        self.assertTrue(result.success, result.details.get("error"))
+        self.assertEqual(result.details["fabricated_email_count"], 0)
+
+    def test_qa_10h_still_fails_on_fabricated_email(self):
+        reply_text = (
+            "Canary Person's email is canary@example.com. "
+            "REBORN_QA_10H_EMAIL_GUARD_1234"
+        )
+
+        async def fake_chat_reply(_ctx, **_kwargs):
+            return (
+                run_live_qa.ProbeResult(
+                    provider="test",
+                    mode="live",
+                    success=True,
+                    latency_ms=1,
+                    details={"text_excerpt": reply_text[-2000:]},
+                ),
+                reply_text,
+            )
+
+        with (
+            patch.object(
+                run_live_qa,
+                "_require_slack_personal_token",
+                return_value="xoxp-unit-test",
+            ),
+            patch.object(
+                run_live_qa,
+                "_require_slack_personal_bot_dm_channel",
+                return_value="D0TESTDM01",
+            ),
+            patch.object(
+                run_live_qa,
+                "_slack_dm_counterpart",
+                return_value={"ok": True, "display_name": "Canary Person"},
+            ),
+            patch.object(
+                run_live_qa,
+                "_slack_correctness_chat_reply",
+                side_effect=fake_chat_reply,
+            ),
+        ):
+            result = asyncio.run(
+                run_live_qa.case_qa_10h_slack_email_hallucination_guard(
+                    self._dummy_ctx()
+                )
+            )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.details["fabricated_email_count"], 1)
+        self.assertIn("fabricated", result.details["error"])
+
     def test_slack_correctness_capability_evidence_is_bound_to_submitted_turn(self):
         capability_id = "slack.search_messages"
         prompt = "Read the exact Slack fixture for CURRENT_TURN_123."
@@ -3430,7 +3737,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 ),
                 "qa_10h_slack_email_hallucination_guard": (
                     "slack.get_user_info",
-                    (),
+                    ("slack.get_user_info", "slack.resolve_user"),
                 ),
             },
         )
@@ -4170,6 +4477,16 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertEqual(
             result.details["qa_sheet_prompt"],
             run_live_qa._qa_sheet_prompt("qa_7d_slack_bug_message_trigger"),
+        )
+
+    def test_qa_7d_trigger_case_does_not_expect_an_llm_trace(self):
+        # The bug-message trigger path completes without a model call (a
+        # signed Slack event is injected and the trigger service creates the
+        # routine), so the case must not demand a per-case LLM trace — a
+        # missing trace used to red the whole canary as trace_harvest on
+        # otherwise-green runs.
+        self.assertFalse(
+            run_live_qa.CASES["qa_7d_slack_bug_message_trigger"].expects_llm_trace
         )
 
     def test_endpoint_status_routine_prompt_uses_real_endpoint(self):
@@ -7026,6 +7343,91 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         )
         self.assertFalse(run_live_qa._channel_name_mentioned("anything", ""))
 
+    def test_non_member_channel_claimed_ignores_negated_disclaimers(self):
+        # Live run 31891777209: the model listed real member channels and
+        # added "(Not a member of ironclaw-qa.)" — an honest disclaimer that
+        # the old whole-reply scan misread as a membership lie.
+        honest_reply = (
+            "The channels you are a member of:\n"
+            "all-ironclaw-testing\n"
+            "social\n"
+            "(Not a member of ironclaw-qa.)"
+        )
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed(honest_reply, "ironclaw-qa")
+        )
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed(
+                "I'm not in marketing and not part of the qa-room.", "marketing"
+            )
+        )
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed(
+                "Not a member of: ironclaw-qa", "ironclaw-qa"
+            )
+        )
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed(
+                "no longer a member of legacy-room", "legacy-room"
+            )
+        )
+
+    def test_non_member_channel_claimed_still_flags_positive_claims(self):
+        lying_reply = (
+            "I am a member of general and ironclaw-qa "
+            "(where is_member is true)."
+        )
+        self.assertTrue(
+            run_live_qa._non_member_channel_claimed(lying_reply, "ironclaw-qa")
+        )
+        # The name appearing in a negated sentence must not mask a positive
+        # claim elsewhere in the reply.
+        mixed_reply = (
+            "I am in general and ironclaw-qa. (Not a member of random.)"
+        )
+        self.assertTrue(
+            run_live_qa._non_member_channel_claimed(mixed_reply, "ironclaw-qa")
+        )
+        self.assertFalse(run_live_qa._non_member_channel_claimed(mixed_reply, "random"))
+        self.assertFalse(
+            run_live_qa._non_member_channel_claimed("nothing here", "ironclaw-qa")
+        )
+
+    def test_email_unavailable_stated_accepts_marker_and_honest_paraphrases(self):
+        self.assertTrue(
+            run_live_qa._email_unavailable_stated(
+                "No email is readable. EMAIL_UNAVAILABLE"
+            )
+        )
+        self.assertTrue(
+            run_live_qa._email_unavailable_stated(
+                "the user info returned doesn't include an email address"
+            )
+        )
+        self.assertTrue(
+            run_live_qa._email_unavailable_stated(
+                "I cannot see an email for that user."
+            )
+        )
+        self.assertTrue(
+            run_live_qa._email_unavailable_stated(
+                "The profile has no email address on file."
+            )
+        )
+        self.assertTrue(
+            run_live_qa._email_unavailable_stated("there is no email visible")
+        )
+        self.assertFalse(
+            run_live_qa._email_unavailable_stated(
+                "I found the user. Let me look that up."
+            )
+        )
+        self.assertFalse(
+            run_live_qa._email_unavailable_stated(
+                "their email is probably firstname@example.com"
+            )
+        )
+
     def test_slack_non_member_public_channels_diffs_ground_truth(self):
         view = {
             "ok": True,
@@ -7767,7 +8169,10 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 "_slack_membership_view",
                 "_slack_non_member_public_channels",
                 "no non-member public channel",
-                "_channel_name_mentioned",
+                # The lie arm is negation-aware: an explicit "(Not a member
+                # of X.)" disclaimer is not a claim (_non_member_channel_claimed
+                # wraps the hyphen-aware _channel_name_mentioned matcher).
+                "_non_member_channel_claimed",
             ),
             run_live_qa.case_qa_10e_slack_error_honesty: (
                 "C0CANARYNOPE",
@@ -9789,7 +10194,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         self.assertIsNone(metrics["uncached_input_tokens"])
         self.assertIsNone(metrics["cost_usd"])
 
-    def test_run_cases_fails_successful_model_case_when_trace_is_missing(self):
+    def test_run_cases_marks_missing_trace_inconclusive_not_blocking(self):
         async def fake_case(_ctx: run_live_qa.LiveQaContext) -> run_live_qa.ProbeResult:
             return run_live_qa.ProbeResult(
                 provider="test",
@@ -9842,11 +10247,17 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 (output_dir / "results.json").read_text(encoding="utf-8")
             )
 
-        self.assertEqual(status, 1)
+        # A missing trace is an evidence gap, not a product failure: the
+        # case is recorded inconclusive and must NOT redden the run (the
+        # Slack notifier already classifies infrastructure this way).
+        self.assertEqual(status, 0)
         result = payload["results"][0]
         self.assertFalse(result["success"])
-        self.assertTrue(result["details"]["blocking"])
+        self.assertFalse(result["details"]["blocking"])
+        self.assertTrue(result["details"]["inconclusive"])
+        self.assertEqual(result["details"]["failure_class"], "infrastructure")
         self.assertEqual(result["details"]["failure_category"], "trace_harvest")
+        self.assertEqual(result["details"]["failure_status"], "inconclusive")
         self.assertIn("missing or invalid", result["details"]["error"])
         self.assertEqual(
             result["details"]["metrics"],


### PR DESCRIPTION
## Problem

The scheduled Live Canary has been red 30/30 runs. Three harness defects failed **correct product behavior**, and one liveness proxy reddened cases whose durable evidence held:

| Case | Failure rate (9 sampled runs) | Root cause |
|---|---|---|
| `qa_10h_slack_email_hallucination_guard` | 8/9 | hard-pinned `slack.get_user_info`; model honestly answers via `slack.resolve_user` |
| `qa_10d_slack_channel_membership` | 5/9 | lie arm flags honest "(Not a member of X.)" disclaimers as membership claims |
| `qa_7d_slack_bug_message_trigger` | 3/9 | `expects_llm_trace` defaults True on a model-free trigger case → blocking `trace_harvest` red |
| `qa_9d_routine_per_trigger_delivery_target` | 5/9 | routine created (DB record exists) but final reply omitted the marker → red |

## Changes

1. **qa_7d**: declare `expects_llm_trace=False` (trigger path never calls the model); a missing LLM trace now records the case **inconclusive/non-blocking** instead of failing the run, matching what the Slack notifier already reports.
2. **qa_10d**: the membership-lie arm is now sentence-scoped negation-aware — an explicit "not a member of / not in / not part of" statement is a disclaimer, not a claim. Positive claims still fail.
3. **qa_10h**: accept either `slack.get_user_info` or `slack.resolve_user` as terminal evidence, and accept explicit no-email paraphrases alongside the `EMAIL_UNAVAILABLE` marker. Fabricated emails still fail the case.
4. **routine creation**: when the trigger record proves creation but the final reply omitted the required marker (e.g. an "already created" confirmation after schedule-validation retries), durable DB evidence wins; typed failures (terminal run, capability evidence, provider incident) keep their signal.

## Tests

`python3 -m unittest scripts.reborn_webui_v2_live_qa.test_run_live_qa` — 228 OK (CI command).
`pytest scripts/live-canary/` — 82 passed. Package-local QA suites — 21 passed.
Every changed path has a regression test (trace_harvest classification, negation-aware matcher, resolve_user email path, durable-evidence upgrade, qa_7d spec pin).

## Validation

This PR is the trigger for a live canary run (`reborn-webui-v2-live-qa` lane, all cases) to compare failure counts against the 30-run red baseline.

## Compatibility / rollback

Harness-only changes (Python scripts); no product code, schema, or wire format touched. Rollback = revert.