### PR TITLE
chore: remove retired IronLoop network settings

### DIFF
--- a/.ironloop/config.yaml
+++ b/.ironloop/config.yaml
@@ -1,10 +1,8 @@
 version: 1
 
-implementer:
-  network_access: true
+implementer: {}
 
 reviewer:
-  network_access: true
   auto_review:
     enabled: true
     max_runs: 10
@@ -12,10 +10,8 @@ reviewer:
     user_update: false
 
 resolver:
-  network_access: true
   auto_resolve:
     enabled: true
     max_runs: 10
 
-tester:
-  network_access: true
+tester: {}


### PR DESCRIPTION
## Summary

- remove obsolete `network_access` fields from the trusted IronLoop repository configuration
- retain the existing Implement, Tester, automatic Review, and automatic Resolve behavior

## Validation

- `git diff --check`
- configuration follows IronLoop v1 role schema