### PR TITLE
refactor(runtime): centralize capability outcome processing

### DIFF
--- a/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
@@ -861,7 +861,9 @@ fn reborn_contracts_crates_carry_a_checked_size_ceiling() {
         // this test's own failure message.
         // Reviewed growth: immutable, provider-neutral output-contract DTOs
         // belong beside the turn contract consumed across loop families.
-        ("ironclaw_host_api", 20_156),
+        // 20_156 -> 20_334 (2026-08-19, #7686 restack): capability dispatch-result
+        // declarations retained beside main's provider-neutral output contracts.
+        ("ironclaw_host_api", 20_334),
         // 14_479 -> 13_949 (2026-08-07, #7157): downward re-capture after the
         // delivery-heuristic vocabulary (stored trigger delivery targets and
         // their run-profile plumbing) left this crate with the two-lane

--- a/crates/app/ironclaw_composition/src/product_capability.rs
+++ b/crates/app/ironclaw_composition/src/product_capability.rs
@@ -414,25 +414,6 @@ async fn product_resolution(
                 diagnostic,
             ))
         }
-        RuntimeCapabilityOutcome::Unknown(unknown) => {
-            let diagnostic = unknown
-                .message
-                .as_deref()
-                .map(model_diagnostic)
-                .unwrap_or_else(|| ModelFailureDiagnostic::Diagnostic {
-                    text: ModelDiagnostic::unavailable(),
-                });
-            let summary = unknown
-                .message
-                .and_then(|value| SafeSummary::new(value).ok())
-                .unwrap_or_else(SafeSummary::placeholder);
-            Ok(recoverable_failure(
-                invocation_id,
-                FailureKind::from_tag(&unknown.kind),
-                summary,
-                diagnostic,
-            ))
-        }
     }
 }
 
@@ -498,7 +479,6 @@ fn ensure_matching_capability(
         RuntimeCapabilityOutcome::ResourceBlocked(gate) => &gate.capability_id,
         RuntimeCapabilityOutcome::SpawnedProcess(process) => &process.capability_id,
         RuntimeCapabilityOutcome::Failed(failure) => &failure.capability_id,
-        RuntimeCapabilityOutcome::Unknown(unknown) => &unknown.capability_id,
     };
     if actual != requested {
         return Err(ProductSurfaceError::internal_from(
@@ -833,29 +813,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unknown_runtime_outcome_inlines_message_before_summary_fallback() {
-        let cause = "legacy runtime failed at /workspace/project/input.json";
-        let outcome =
-            RuntimeCapabilityOutcome::Unknown(ironclaw_host_runtime::RuntimeCapabilityUnknown {
-                capability_id: CapabilityId::new("demo.legacy").unwrap(),
-                kind: "legacy_failure".to_string(),
-                message: Some(cause.to_string()),
-            });
-
-        let resolution = product_resolution(
-            &empty_product_result_filesystem(),
-            &resource_scope(),
-            InvocationId::new(),
-            outcome,
-        )
-        .await
-        .expect("unknown runtime outcome remains model-recoverable");
-
-        assert_eq!(model_visible_failure_text(&resolution), cause);
-    }
-
-    #[tokio::test]
-    async fn missing_runtime_detail_uses_explicit_fallbacks() {
+    async fn missing_runtime_failure_detail_uses_explicit_fallback() {
         let failed =
             RuntimeCapabilityOutcome::Failed(ironclaw_host_runtime::RuntimeCapabilityFailure::new(
                 CapabilityId::new("demo.read").unwrap(),
@@ -873,25 +831,6 @@ mod tests {
         assert_eq!(
             model_visible_failure_text(&failed_resolution),
             "capability invocation failed"
-        );
-
-        let unknown =
-            RuntimeCapabilityOutcome::Unknown(ironclaw_host_runtime::RuntimeCapabilityUnknown {
-                capability_id: CapabilityId::new("demo.legacy").unwrap(),
-                kind: "legacy_failure".to_string(),
-                message: None,
-            });
-        let unknown_resolution = product_resolution(
-            &empty_product_result_filesystem(),
-            &resource_scope(),
-            InvocationId::new(),
-            unknown,
-        )
-        .await
-        .expect("unknown runtime outcome remains model-recoverable");
-        assert_eq!(
-            model_visible_failure_text(&unknown_resolution),
-            ModelDiagnostic::unavailable().as_str()
         );
     }
 

--- a/crates/contracts/ironclaw_host_api/src/resolution.rs
+++ b/crates/contracts/ironclaw_host_api/src/resolution.rs
@@ -1125,6 +1125,55 @@ mod tests {
         }
     }
 
+    #[test]
+    fn persisted_resolution_maps_unknown_failure_tags_and_ignores_additive_fields() {
+        let mut wire = serde_json::to_value(Resolution::Done(outcome(
+            ToolVerdict::recoverable_failure_with_diagnostic(
+                FailureKind::OperationFailed,
+                ModelFailureDiagnostic::Diagnostic {
+                    text: ModelDiagnostic::new("provider rejected the operation").unwrap(),
+                },
+            ),
+        )))
+        .unwrap();
+        let done = wire
+            .get_mut("done")
+            .and_then(serde_json::Value::as_object_mut)
+            .unwrap();
+        done.insert(
+            "future_additive_field".to_string(),
+            serde_json::json!({ "ignored": true }),
+        );
+        let verdict = done
+            .get_mut("verdict")
+            .and_then(|value| value.get_mut("recoverable_failure"))
+            .and_then(serde_json::Value::as_object_mut)
+            .unwrap();
+        verdict.insert(
+            "error_kind".to_string(),
+            serde_json::json!("future_provider_failure"),
+        );
+        verdict.insert(
+            "future_diagnostic_metadata".to_string(),
+            serde_json::json!({ "version": 2 }),
+        );
+
+        let restored: Resolution = serde_json::from_value(wire).unwrap();
+        let Resolution::Done(outcome) = restored else {
+            panic!("persisted recoverable failure must remain a done outcome");
+        };
+        assert_eq!(
+            outcome.verdict.error_kind(),
+            Some(&FailureKind::Unclassified),
+            "an unknown persisted failure tag must fail visibly without becoming success"
+        );
+        assert!(!outcome.verdict.is_success());
+        assert_eq!(
+            outcome.verdict.error_kind().map(|kind| kind.fate()),
+            Some(crate::result_meta::FailureFate::ModelVisible)
+        );
+    }
+
     /// The §5.3 acceptance table is the definition of done: every one of today's
     /// ten `CapabilityOutcome` variants maps to exactly one `Resolution` channel,
     /// with the right suspension semantics. `host_api` cannot import the turns

--- a/crates/kernel/ironclaw_capabilities/AGENTS.md
+++ b/crates/kernel/ironclaw_capabilities/AGENTS.md
@@ -14,7 +14,7 @@
 ## What This Crate Owns
 
 - The single caller-facing `CapabilityHost` authority path, currently:
-- `CapabilityHost` (`host`) and the invoke/resume/spawn flows/results: direct invoke/resume parameters, `CapabilityDispatchResult`, `CapabilitySpawnRequest`/`CapabilitySpawnResult` (`requests`); `CapabilityInvocationError`/`ResumeContextMismatchKind` (`error`).
+- `CapabilityHost` (`host`) and the invoke/resume/spawn flows/results: direct invoke/resume parameters, `CapabilitySpawnRequest`/`CapabilitySpawnResult` (`requests`); `CapabilityDispatchResult` re-exported at the crate root from `ironclaw_host_api::dispatch`; `CapabilityInvocationError`/`ResumeContextMismatchKind` (`error`).
 - The obligation seam (`obligations`): `CapabilityObligationHandler`, `CapabilityObligationRequest`/`CapabilityObligationOutcome`, abort/completion requests, `CapabilityObligationPhase`/`CapabilityObligationFailureKind`/`CapabilityObligationError`.
 - The host-private replay-payload store (`replay_payload`): `ReplayPayload`, the `ReplayPayloadStore` port, `ReplayPayloadStore`, and `ReplayPayloadStoreError`. Persists the raw replay payload a gate/auth resume re-dispatches from, keyed by `InvocationId`, behind a `ScopedFilesystem` CAS lane. Never model-visible (no `SafeSummary`) — see Guardrails below.
 - Crate-local public API, tests, and fixtures needed to prove that ownership.

--- a/crates/kernel/ironclaw_capabilities/AGENTS.md
+++ b/crates/kernel/ironclaw_capabilities/AGENTS.md
@@ -14,7 +14,7 @@
 ## What This Crate Owns
 
 - The single caller-facing `CapabilityHost` authority path, currently:
-- `CapabilityHost` (`host`) and the invoke/resume/spawn flows/results: direct invoke/resume parameters, `CapabilityInvocationResult`, `CapabilitySpawnRequest`/`CapabilitySpawnResult` (`requests`); `CapabilityInvocationError`/`ResumeContextMismatchKind` (`error`).
+- `CapabilityHost` (`host`) and the invoke/resume/spawn flows/results: direct invoke/resume parameters, `CapabilityDispatchResult`, `CapabilitySpawnRequest`/`CapabilitySpawnResult` (`requests`); `CapabilityInvocationError`/`ResumeContextMismatchKind` (`error`).
 - The obligation seam (`obligations`): `CapabilityObligationHandler`, `CapabilityObligationRequest`/`CapabilityObligationOutcome`, abort/completion requests, `CapabilityObligationPhase`/`CapabilityObligationFailureKind`/`CapabilityObligationError`.
 - The host-private replay-payload store (`replay_payload`): `ReplayPayload`, the `ReplayPayloadStore` port, `ReplayPayloadStore`, and `ReplayPayloadStoreError`. Persists the raw replay payload a gate/auth resume re-dispatches from, keyed by `InvocationId`, behind a `ScopedFilesystem` CAS lane. Never model-visible (no `SafeSummary`) — see Guardrails below.
 - Crate-local public API, tests, and fixtures needed to prove that ownership.

--- a/crates/kernel/ironclaw_capabilities/src/host/approval_resume.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/approval_resume.rs
@@ -7,7 +7,7 @@
 use ironclaw_approvals::{ApprovalStatus, ApprovalStoreError};
 use ironclaw_host_api::{
     decision::DenyReason,
-    dispatch::CapabilityDispatcher,
+    dispatch::{CapabilityDispatchResult, CapabilityDispatcher},
     ids::{ApprovalRequestId, CapabilityId},
     resource::ResourceEstimate,
     scope::ExecutionContext,
@@ -18,12 +18,12 @@ use super::{
     ApprovalResumeInput, BlockedResumeKind, CapabilityHost, PendingClaimAfterAuth,
     ResumedDispatchParams, ResumedLeaseState,
 };
+use crate::CapabilityInvocationError;
 use crate::helpers::{
     CapabilityActionKind, approval_not_approved_error_kind, fail_invocation_if_configured,
     invocation_fingerprint_for_kind, matching_approval_lease, resume_context_mismatch_kind,
     validate_approval_request_matches_invocation,
 };
-use crate::{CapabilityInvocationError, CapabilityInvocationResult};
 
 impl<'a, D> CapabilityHost<'a, D>
 where
@@ -36,7 +36,7 @@ where
         capability_id: CapabilityId,
         estimate: ResourceEstimate,
         input: serde_json::Value,
-    ) -> Result<CapabilityInvocationResult, CapabilityInvocationError> {
+    ) -> Result<CapabilityDispatchResult, CapabilityInvocationError> {
         let request = ApprovalResumeInput {
             context,
             approval_request_id,

--- a/crates/kernel/ironclaw_capabilities/src/host/auth_resume.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/auth_resume.rs
@@ -8,7 +8,7 @@
 use ironclaw_approvals::{ApprovalStatus, ApprovalStoreError};
 use ironclaw_host_api::{
     decision::DenyReason,
-    dispatch::CapabilityDispatcher,
+    dispatch::{CapabilityDispatchResult, CapabilityDispatcher},
     ids::{ApprovalRequestId, CapabilityId},
     resource::ResourceEstimate,
     scope::ExecutionContext,
@@ -19,6 +19,7 @@ use tracing::{debug, warn};
 use super::{
     AuthResumeInput, BlockedResumeKind, CapabilityHost, ResumedDispatchParams, ResumedLeaseState,
 };
+use crate::CapabilityInvocationError;
 use crate::helpers::{
     CapabilityActionKind, approval_not_approved_error_kind, capability_lease_error_kind,
     claim_error_may_be_concurrent_resume, fail_invocation_if_configured,
@@ -26,7 +27,6 @@ use crate::helpers::{
     matching_claimed_approval_lease_for_auth_resume, resume_context_mismatch_kind,
     validate_approval_request_matches_invocation,
 };
-use crate::{CapabilityInvocationError, CapabilityInvocationResult};
 
 impl<'a, D> CapabilityHost<'a, D>
 where
@@ -47,7 +47,7 @@ where
         estimate: ResourceEstimate,
         input: serde_json::Value,
         approval_request_id: Option<ApprovalRequestId>,
-    ) -> Result<CapabilityInvocationResult, CapabilityInvocationError> {
+    ) -> Result<CapabilityDispatchResult, CapabilityInvocationError> {
         let request = AuthResumeInput {
             context,
             capability_id,

--- a/crates/kernel/ironclaw_capabilities/src/host/invoke.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/invoke.rs
@@ -2,11 +2,14 @@
 //!
 //! Owns the caller-facing entry point only: it hands the decision to
 //! [`super::authorize`], then dispatches, completes obligations, and maps the
-//! fold back to a [`CapabilityInvocationResult`]. It never decides policy.
+//! fold back to a [`CapabilityDispatchResult`]. It never decides policy.
 
 use ironclaw_host_api::{
-    authorized::AuthorizeResult, dispatch::CapabilityDispatcher, ids::CapabilityId,
-    resource::ResourceEstimate, scope::ExecutionContext,
+    authorized::AuthorizeResult,
+    dispatch::{CapabilityDispatchResult, CapabilityDispatcher},
+    ids::CapabilityId,
+    resource::ResourceEstimate,
+    scope::ExecutionContext,
 };
 use tracing::debug;
 
@@ -20,10 +23,7 @@ use crate::helpers::{
     apply_invocation_state_transition_if_configured, complete_invocation_after_side_effect,
     fail_invocation_if_configured,
 };
-use crate::{
-    CapabilityInvocationError, CapabilityInvocationResult, CapabilityObligationOutcome,
-    CapabilityObligationPhase,
-};
+use crate::{CapabilityInvocationError, CapabilityObligationOutcome, CapabilityObligationPhase};
 
 impl<'a, D> CapabilityHost<'a, D>
 where
@@ -44,7 +44,7 @@ where
         capability_id: CapabilityId,
         estimate: ResourceEstimate,
         input: serde_json::Value,
-    ) -> Result<CapabilityInvocationResult, CapabilityInvocationError> {
+    ) -> Result<CapabilityDispatchResult, CapabilityInvocationError> {
         let request = InvocationInput {
             context,
             capability_id,
@@ -209,6 +209,6 @@ where
         }
 
         debug!("capability invocation completed");
-        Ok(CapabilityInvocationResult { dispatch })
+        Ok(dispatch)
     }
 }

--- a/crates/kernel/ironclaw_capabilities/src/host/resume_support.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/resume_support.rs
@@ -10,7 +10,7 @@ use ironclaw_authorization::{CapabilityLease, CapabilityLeaseStorePort};
 use ironclaw_host_api::{
     authorized::AuthorizeResult,
     decision::Decision,
-    dispatch::CapabilityDispatcher,
+    dispatch::{CapabilityDispatchResult, CapabilityDispatcher},
     ids::{CapabilityId, DenyRef, GateRef},
     resolution::{Blocked, GateWaypoint},
     scope::ExecutionContext,
@@ -33,10 +33,7 @@ use crate::helpers::{
     fail_invocation_if_configured, invocation_state_error_kind,
 };
 use crate::ports::PolicyAction;
-use crate::{
-    CapabilityInvocationError, CapabilityInvocationResult, CapabilityObligationOutcome,
-    CapabilityObligationPhase,
-};
+use crate::{CapabilityInvocationError, CapabilityObligationOutcome, CapabilityObligationPhase};
 
 impl<'a, D> CapabilityHost<'a, D>
 where
@@ -311,7 +308,7 @@ where
     pub(super) async fn dispatch_resumed_capability(
         &self,
         params: ResumedDispatchParams<'_>,
-    ) -> Result<CapabilityInvocationResult, CapabilityInvocationError> {
+    ) -> Result<CapabilityDispatchResult, CapabilityInvocationError> {
         // Pre-dispatch authority fold (trust-aware authorization + Decision
         // mapping) extracted to `authorize_resumed`, mirroring `authorize()`.
         // The claim-before-dispatch ordering the resume paths depend on stays in
@@ -587,6 +584,6 @@ where
             "dispatch",
         )
         .await;
-        Ok(CapabilityInvocationResult { dispatch })
+        Ok(dispatch)
     }
 }

--- a/crates/kernel/ironclaw_capabilities/src/lib.rs
+++ b/crates/kernel/ironclaw_capabilities/src/lib.rs
@@ -45,4 +45,4 @@ pub use registry::{CapabilityDispatchRegistry, CapabilityRegistrationError};
 pub use replay_payload::{
     ReplayPayload, ReplayPayloadStore, ReplayPayloadStoreError, ReplayPayloadStorePort,
 };
-pub use requests::{CapabilityInvocationResult, CapabilitySpawnRequest, CapabilitySpawnResult};
+pub use requests::{CapabilitySpawnRequest, CapabilitySpawnResult};

--- a/crates/kernel/ironclaw_capabilities/src/requests.rs
+++ b/crates/kernel/ironclaw_capabilities/src/requests.rs
@@ -1,4 +1,3 @@
-use ironclaw_host_api::dispatch::CapabilityDispatchResult;
 use ironclaw_processes::ProcessRecord;
 
 /// Caller-facing capability spawn request.
@@ -8,12 +7,6 @@ pub struct CapabilitySpawnRequest {
     pub capability_id: ironclaw_host_api::ids::CapabilityId,
     pub estimate: ironclaw_host_api::resource::ResourceEstimate,
     pub input: serde_json::Value,
-}
-
-/// Caller-facing capability invocation result.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CapabilityInvocationResult {
-    pub dispatch: CapabilityDispatchResult,
 }
 
 /// Caller-facing capability spawn result.

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
@@ -91,7 +91,7 @@ async fn auth_resume_json_accepts_blocked_auth_run_and_dispatches() {
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(result.output, json!({"ok": true}));
     assert!(dispatcher.call_count() > 0);
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, ProcessInvocationStatus::Completed);
@@ -460,7 +460,7 @@ async fn auth_resume_json_with_approval_request_id_claims_active_lease_and_dispa
         .unwrap();
 
     assert_eq!(
-        result.dispatch.output,
+        result.output,
         json!({"ok": true}),
         "auth_resume with original invocation_id must complete dispatch"
     );
@@ -765,7 +765,7 @@ async fn auth_resume_json_without_approval_request_id_skips_lease_path_and_dispa
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(result.output, json!({"ok": true}));
     assert!(dispatcher.call_count() > 0);
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, ProcessInvocationStatus::Completed);
@@ -947,7 +947,7 @@ async fn auth_resume_after_real_approval_bounce_reuses_claimed_lease() {
         });
 
     assert_eq!(
-        auth_result.dispatch.output,
+        auth_result.output,
         json!({"ok": true}),
         "(b) auth_resume_json must dispatch successfully"
     );

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_contract.rs
@@ -97,7 +97,7 @@ async fn capability_host_authorized_dispatch_uses_neutral_dispatch_port() {
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(result.output, json!({"ok": true}));
     let recorded = dispatcher.last_request().unwrap();
     assert_eq!(recorded.invocation.capability, capability_id());
     assert_eq!(recorded.invocation.scope, scope);

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
@@ -51,7 +51,7 @@ async fn capability_host_invokes_through_runtime_dispatcher_and_completes_run() 
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"via":"runtime-dispatcher"}));
+    assert_eq!(result.output, json!({"via":"runtime-dispatcher"}));
     let recorded = adapter.take_request();
     assert_eq!(recorded.capability_id, capability_id());
     assert_eq!(recorded.scope, scope);
@@ -149,7 +149,7 @@ async fn capability_host_blocks_then_resumes_approved_dispatch_through_runtime_d
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"approved":true}));
+    assert_eq!(result.output, json!({"approved":true}));
     assert_eq!(adapter.request_count(), 1);
     let recorded = adapter.take_request();
     assert_eq!(recorded.scope, scope);

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_github_comment_approval_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_github_comment_approval_contract.rs
@@ -84,7 +84,7 @@ async fn capability_host_resumes_approved_github_comment_issue_and_dispatches_on
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(result.output, json!({"ok": true}));
     assert_eq!(fixture.dispatcher.call_count(), 1);
     let request = fixture.dispatcher.last_request().unwrap();
     assert_eq!(

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_invocation_state_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_invocation_state_contract.rs
@@ -624,7 +624,7 @@ async fn capability_host_returns_dispatch_result_when_run_completion_fails_after
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(result.output, json!({"ok": true}));
     assert!(dispatcher.call_count() > 0);
 }
 
@@ -731,7 +731,7 @@ async fn capability_host_resumes_approved_invocation_and_consumes_matching_lease
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(result.output, json!({"ok": true}));
     assert_eq!(
         dispatcher
             .last_request()
@@ -809,7 +809,7 @@ async fn capability_host_returns_dispatch_result_when_run_completion_fails_after
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(result.output, json!({"ok": true}));
 }
 
 #[tokio::test]
@@ -1051,7 +1051,7 @@ async fn capability_host_returns_dispatch_result_when_lease_consume_fails_after_
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(result.output, json!({"ok": true}));
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, ProcessInvocationStatus::Completed);
     let claimed = leases.get(&scope, lease.grant.id).await.unwrap();

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_persistent_approval_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_persistent_approval_contract.rs
@@ -112,7 +112,7 @@ async fn persistent_grant_flips_to_allow_and_dispatches_without_gate() {
         .await
         .expect("persistent grant must authorize dispatch without an approval gate");
 
-    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(result.output, json!({"ok": true}));
     assert!(
         dispatcher.has_request(),
         "kernel must dispatch once the persistent grant is adopted"

--- a/crates/kernel/ironclaw_capabilities/tests/capability_obligation_handler_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_obligation_handler_contract.rs
@@ -52,7 +52,7 @@ async fn capability_host_uses_obligation_handler_before_dispatch() {
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(result.output, json!({"ok": true}));
     assert!(dispatcher.call_count() > 0);
     assert_eq!(
         handler.records(),
@@ -198,7 +198,7 @@ async fn capability_host_completes_post_dispatch_obligations_before_returning() 
         .await
         .unwrap();
 
-    assert_eq!(result.dispatch.output, json!({"token": "[REDACTED]"}));
+    assert_eq!(result.output, json!({"token": "[REDACTED]"}));
 }
 
 #[tokio::test]

--- a/crates/kernel/ironclaw_host_runtime/src/capability_response_processor.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/capability_response_processor.rs
@@ -1,0 +1,156 @@
+//! Canonical mapping from inline capability-host responses to runtime outcomes.
+//!
+//! Fresh invocation, approval resume, and auth resume all cross this seam. The
+//! processor owns response interpretation only; authorization, dispatch,
+//! obligation settlement, and durable/model projection remain with their
+//! existing owners.
+
+use ironclaw_capabilities::CapabilityInvocationError;
+use ironclaw_extension_registry::ExtensionRegistry;
+use ironclaw_host_api::{
+    dispatch::CapabilityDispatchResult,
+    ids::{CapabilityId, InvocationId},
+    resource::ResourceScope,
+    result_meta::FailureKind,
+};
+
+use crate::production::{
+    DefaultHostRuntime, auth_required_outcome, capability_is_standard_write, failure_from,
+};
+use crate::{
+    HostRuntimeError, RuntimeApprovalGate, RuntimeBlockedReason, RuntimeCapabilityCompleted,
+    RuntimeCapabilityFailure, RuntimeCapabilityOutcome,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InlineInvocationMode {
+    Fresh,
+    ApprovalResume,
+    AuthResume,
+}
+
+pub(super) struct CapabilityResponseContext<'a> {
+    pub registry: &'a ExtensionRegistry,
+    pub capability_id: CapabilityId,
+    pub scope: &'a ResourceScope,
+    pub invocation_id: InvocationId,
+    pub mode: InlineInvocationMode,
+}
+
+pub(super) async fn process_capability_response(
+    runtime: &DefaultHostRuntime,
+    context: CapabilityResponseContext<'_>,
+    response: Result<CapabilityDispatchResult, CapabilityInvocationError>,
+) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+    match response {
+        Ok(dispatch) => Ok(completed_or_output_violation_outcome(
+            dispatch,
+            context.capability_id,
+            context.registry,
+        )),
+        Err(CapabilityInvocationError::AuthorizationRequiresAuth {
+            capability,
+            required_secrets,
+            credential_requirements,
+        }) => Ok(auth_required_outcome(
+            capability,
+            required_secrets,
+            credential_requirements,
+        )),
+        Err(CapabilityInvocationError::AuthorizationRequiresApproval { capability }) => {
+            match context.mode {
+                InlineInvocationMode::Fresh => match runtime
+                    .lookup_approval_request_id(context.scope, context.invocation_id)
+                    .await
+                {
+                    Ok(Some(approval_request_id)) => Ok(
+                        RuntimeCapabilityOutcome::ApprovalRequired(RuntimeApprovalGate {
+                            approval_request_id,
+                            capability_id: capability,
+                            reason: RuntimeBlockedReason::ApprovalRequired,
+                        }),
+                    ),
+                    Ok(None) => Ok(RuntimeCapabilityOutcome::Failed(
+                        RuntimeCapabilityFailure::new(
+                            capability,
+                            FailureKind::Authorization,
+                            Some(
+                                "approval required but no approval request was persisted"
+                                    .to_string(),
+                            ),
+                        ),
+                    )),
+                    Err(host_error) => {
+                        tracing::warn!(
+                            capability_id = %capability,
+                            error = %host_error,
+                            "approval request lookup failed; surfacing as host runtime unavailability"
+                        );
+                        Err(host_error)
+                    }
+                },
+                // A resume must never start a second approval loop. Surface a
+                // failed resume if the capability kernel asks for approval again.
+                InlineInvocationMode::ApprovalResume | InlineInvocationMode::AuthResume => {
+                    Ok(RuntimeCapabilityOutcome::Failed(failed_response(
+                        CapabilityInvocationError::AuthorizationRequiresApproval { capability },
+                        context.registry,
+                        context.capability_id,
+                    )))
+                }
+            }
+        }
+        Err(error) => {
+            let should_fail_dispatch_run = context.mode == InlineInvocationMode::Fresh
+                && matches!(error, CapabilityInvocationError::Dispatch { .. });
+            let failure = failed_response(error, context.registry, context.capability_id);
+            if should_fail_dispatch_run {
+                runtime
+                    .fail_dispatch_run(&failure, context.scope, context.invocation_id)
+                    .await;
+            }
+            Ok(RuntimeCapabilityOutcome::Failed(failure))
+        }
+    }
+}
+
+fn failed_response(
+    error: CapabilityInvocationError,
+    registry: &ExtensionRegistry,
+    capability_id: CapabilityId,
+) -> RuntimeCapabilityFailure {
+    let is_standard_write = capability_is_standard_write(registry, &capability_id);
+    failure_from(error, capability_id).with_is_standard_write(is_standard_write)
+}
+
+fn completed_or_output_violation_outcome(
+    dispatch: CapabilityDispatchResult,
+    capability_id: CapabilityId,
+    registry: &ExtensionRegistry,
+) -> RuntimeCapabilityOutcome {
+    let standard_op = registry
+        .get_capability(&capability_id)
+        .and_then(|descriptor| descriptor.standard_op);
+    let completed = RuntimeCapabilityCompleted {
+        capability_id: capability_id.clone(),
+        output: dispatch.output,
+        display_preview: dispatch.display_preview,
+        usage: dispatch.usage,
+    };
+
+    if let Some(op) = standard_op
+        && let Some(issues) =
+            crate::standard_op_output::standard_op_output_violations(op, &completed.output)
+    {
+        return RuntimeCapabilityOutcome::Failed(RuntimeCapabilityFailure::new(
+            capability_id,
+            FailureKind::InvalidResult,
+            Some(format!(
+                "standard op output failed validation: {}",
+                issues.join("; ")
+            )),
+        ));
+    }
+
+    RuntimeCapabilityOutcome::Completed(Box::new(completed))
+}

--- a/crates/kernel/ironclaw_host_runtime/src/capability_response_processor.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/capability_response_processor.rs
@@ -81,6 +81,10 @@ pub(super) async fn process_capability_response(
                         ),
                     )),
                     Err(host_error) => {
+                        // Surface persistence outages as Unavailable rather than
+                        // pretending the approval was never persisted; otherwise a
+                        // transient run-state failure looks indistinguishable from
+                        // the (separately bug-prone) cap-host-skipped-persist path.
                         tracing::warn!(
                             capability_id = %capability,
                             error = %host_error,
@@ -123,6 +127,25 @@ fn failed_response(
     failure_from(error, capability_id).with_is_standard_write(is_standard_write)
 }
 
+/// Single choke point for every path that turns a successful capability
+/// dispatch into a `Completed` outcome. [`process_capability_response`] above
+/// has exactly three callers — `invoke_capability` (Fresh), `resume_capability`
+/// (ApprovalResume), and `auth_resume_capability` (AuthResume), the only
+/// resume paths that can complete a capability rather than suspend or fail it
+/// — and all three route their successful-dispatch case through this function
+/// instead of constructing `Completed` themselves, so the standard-op output
+/// check cannot be skipped on one entry path while covered on another (see
+/// `.claude/rules/review-discipline.md`).
+///
+/// A capability bound to a standard messaging op (`descriptor.standard_op`)
+/// has its dispatch output checked against that op's canonical output schema
+/// before `Completed` is allowed to stick. A violation becomes a
+/// model-visible `Failed` outcome instead, using the same
+/// [`FailureKind::InvalidResult`] kind wasm `InvalidResult` dispatch
+/// errors already produce, so the model can retry or report rather than the
+/// run completing with a shape no downstream consumer validated. Bespoke
+/// capabilities (`standard_op: None`) and an unknown capability id
+/// (descriptor lookup miss — already errors elsewhere) are returned untouched.
 fn completed_or_output_violation_outcome(
     dispatch: CapabilityDispatchResult,
     capability_id: CapabilityId,

--- a/crates/kernel/ironclaw_host_runtime/src/lib.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/lib.rs
@@ -42,6 +42,7 @@ use std::{collections::BTreeMap, env, fmt};
 use thiserror::Error;
 
 mod capability_catalog;
+mod capability_response_processor;
 mod document_output;
 mod egress;
 mod extension_contracts;
@@ -504,17 +505,6 @@ impl PartialEq for RuntimeCapabilityFailure {
     }
 }
 
-/// Explicit fallback for outcome categories that the loop adapter cannot handle
-/// yet. New first-class outcome variants should be added to
-/// [`RuntimeCapabilityOutcome`] and exhaustively mapped by consumers instead of
-/// being hidden behind wildcard matches.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RuntimeCapabilityUnknown {
-    pub capability_id: CapabilityId,
-    pub kind: String,
-    pub message: Option<String>,
-}
-
 /// Outcomes returned by capability invocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeCapabilityOutcome {
@@ -524,7 +514,6 @@ pub enum RuntimeCapabilityOutcome {
     ResourceBlocked(RuntimeResourceGate),
     SpawnedProcess(RuntimeProcessHandle),
     Failed(RuntimeCapabilityFailure),
-    Unknown(RuntimeCapabilityUnknown),
 }
 
 impl RuntimeCapabilityOutcome {
@@ -536,7 +525,6 @@ impl RuntimeCapabilityOutcome {
             Self::ResourceBlocked(_) => "resource_blocked",
             Self::SpawnedProcess(_) => "spawned_process",
             Self::Failed(_) => "failed",
-            Self::Unknown(_) => "unknown",
         }
     }
 }

--- a/crates/kernel/ironclaw_host_runtime/src/lib.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/lib.rs
@@ -529,6 +529,18 @@ impl RuntimeCapabilityOutcome {
     }
 }
 
+// `RuntimeCapabilityOutcome` is an in-process host-runtime return value, never
+// a wire type: it carries capability output `serde_json::Value`s alongside
+// internal gate/failure state, and nothing downstream is entitled to
+// serialize or deserialize it directly (projections and transports build
+// their own typed wire shapes from it). Pin that with a compile-time check so
+// an incidental `#[derive(Serialize)]`/`#[derive(Deserialize)]` added later
+// fails the build instead of silently opening a serialization surface.
+static_assertions::assert_not_impl_any!(
+    RuntimeCapabilityOutcome: serde::Serialize,
+    serde::de::DeserializeOwned
+);
+
 /// Stable reasons for capability suspension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RuntimeBlockedReason {

--- a/crates/kernel/ironclaw_host_runtime/src/production.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/production.rs
@@ -439,7 +439,7 @@ impl HostRuntime for DefaultHostRuntime {
                 );
                 tracing::debug!(
                     capability_id = %capability_id,
-                    error_kind = failure_kind_from(&error).as_str(),
+                    error_kind = failure_kind_from(error).as_str(),
                     "capability invocation failed"
                 );
             }
@@ -576,7 +576,7 @@ impl HostRuntime for DefaultHostRuntime {
         if let Err(error) = &response {
             tracing::debug!(
                 capability_id = %capability_id,
-                error_kind = failure_kind_from(&error).as_str(),
+                error_kind = failure_kind_from(error).as_str(),
                 "capability resume failed"
             );
         }
@@ -630,7 +630,7 @@ impl HostRuntime for DefaultHostRuntime {
         if let Err(error) = &response {
             tracing::debug!(
                 capability_id = %capability_id,
-                error_kind = failure_kind_from(&error).as_str(),
+                error_kind = failure_kind_from(error).as_str(),
                 "capability auth-resume failed"
             );
         }

--- a/crates/kernel/ironclaw_host_runtime/src/production.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/production.rs
@@ -24,8 +24,8 @@ use ironclaw_approvals::{
 };
 use ironclaw_authorization::{CapabilityLeaseStorePort, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_capabilities::{
-    CapabilityHost, CapabilityInvocationError, CapabilityInvocationResult,
-    CapabilityObligationHandler, CapabilitySpawnRequest, CapabilitySpawnResult,
+    CapabilityHost, CapabilityInvocationError, CapabilityObligationHandler, CapabilitySpawnRequest,
+    CapabilitySpawnResult,
 };
 use ironclaw_extension_registry::{ExtensionRegistry, SharedExtensionRegistry};
 use ironclaw_filesystem::RootFilesystem;
@@ -51,6 +51,10 @@ use ironclaw_processes::{
 use ironclaw_sandbox::{SandboxProcessPlan, ValidatedSandboxProcessPlan};
 use ironclaw_secrets::SecretStorePort;
 use ironclaw_trust::{HostTrustPolicy, TrustPolicy};
+
+use crate::capability_response_processor::{
+    CapabilityResponseContext, InlineInvocationMode, process_capability_response,
+};
 
 fn trace_capability_latency_ok(
     operation: &'static str,
@@ -101,12 +105,11 @@ fn trace_capability_latency_error<E: ?Sized>(
 use crate::{
     BuiltinObligationHandler, BuiltinObligationServices, CancelRuntimeWorkOutcome,
     CancelRuntimeWorkRequest, CapabilitySurfaceVersion, HostRuntime, HostRuntimeError,
-    HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalGate, RuntimeApprovalResume,
-    RuntimeAuthGate, RuntimeAuthResume, RuntimeBackendHealth, RuntimeBlockedReason,
-    RuntimeCapabilityCompleted, RuntimeCapabilityFailure, RuntimeCapabilityOutcome, RuntimeGateId,
-    RuntimeInvocation, RuntimeStatusRequest, RuntimeWorkId, RuntimeWorkSummary,
-    VisibleCapabilityRequest, VisibleCapabilitySurface, obligations::secret_owner_scope,
-    surface::CapabilityCatalog,
+    HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalResume, RuntimeAuthGate,
+    RuntimeAuthResume, RuntimeBackendHealth, RuntimeBlockedReason, RuntimeCapabilityFailure,
+    RuntimeCapabilityOutcome, RuntimeGateId, RuntimeInvocation, RuntimeStatusRequest,
+    RuntimeWorkId, RuntimeWorkSummary, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    obligations::secret_owner_scope, surface::CapabilityCatalog,
 };
 
 /// Default production wiring for [`HostRuntime`].
@@ -407,35 +410,24 @@ impl HostRuntime for DefaultHostRuntime {
         // run inside the capability kernel's `authorize()` fold (§5.2.7/§5.3.2),
         // reading `HostPolicyFacts` (impl'd by this runtime). A missing credential
         // surfaces as `CapabilityInvocationError::AuthorizationRequiresAuth`, which
-        // `translate_invocation_error` maps back to `auth_required_outcome` (same
-        // gate id, same fields). The kernel orders credential-before-approval and
-        // adopts the first persistent grant that flips the decision to Allow.
+        // the response processor maps back to `auth_required_outcome` (same gate
+        // id, same fields). The kernel orders credential-before-approval and adopts
+        // the first persistent grant that flips the decision to Allow.
 
         let host = self.capability_host(&registry);
 
         let dispatch_started_at = live_latency_started_at();
-        match host
+        let response = host
             .invoke_json(context, capability_id.clone(), estimate, input)
-            .await
-        {
-            Ok(result) => {
+            .await;
+        match &response {
+            Ok(_) => {
                 trace_capability_latency_ok(
                     "capability_host_invoke_json",
                     &capability_id,
                     &scope,
                     dispatch_started_at,
                 );
-                trace_capability_latency_ok(
-                    "invoke_capability",
-                    &capability_id,
-                    &scope,
-                    total_started_at,
-                );
-                Ok(completed_or_output_violation_outcome(
-                    result,
-                    capability_id,
-                    &registry,
-                ))
             }
             Err(error) => {
                 trace_capability_latency_error(
@@ -450,33 +442,36 @@ impl HostRuntime for DefaultHostRuntime {
                     error_kind = failure_kind_from(&error).as_str(),
                     "capability invocation failed"
                 );
-                let translated = self
-                    .translate_invocation_error(
-                        &registry,
-                        error,
-                        capability_id.clone(),
-                        scope.clone(),
-                        invocation_id,
-                    )
-                    .await;
-                match &translated {
-                    Ok(_) => trace_capability_latency_ok(
-                        "invoke_capability",
-                        &capability_id,
-                        &scope,
-                        total_started_at,
-                    ),
-                    Err(error) => trace_capability_latency_error(
-                        "invoke_capability",
-                        &capability_id,
-                        &scope,
-                        total_started_at,
-                        error,
-                    ),
-                }
-                translated
             }
         }
+        let processed = process_capability_response(
+            self,
+            CapabilityResponseContext {
+                registry: &registry,
+                capability_id: capability_id.clone(),
+                scope: &scope,
+                invocation_id,
+                mode: InlineInvocationMode::Fresh,
+            },
+            response,
+        )
+        .await;
+        match &processed {
+            Ok(_) => trace_capability_latency_ok(
+                "invoke_capability",
+                &capability_id,
+                &scope,
+                total_started_at,
+            ),
+            Err(error) => trace_capability_latency_error(
+                "invoke_capability",
+                &capability_id,
+                &scope,
+                total_started_at,
+                error,
+            ),
+        }
+        processed
     }
 
     async fn spawn_capability(
@@ -534,12 +529,16 @@ impl HostRuntime for DefaultHostRuntime {
                     error_kind = failure_kind_from(&error).as_str(),
                     "capability spawn failed"
                 );
-                self.translate_invocation_error(
-                    &registry,
-                    error,
-                    capability_id,
-                    scope,
-                    invocation_id,
+                process_capability_response(
+                    self,
+                    CapabilityResponseContext {
+                        registry: &registry,
+                        capability_id,
+                        scope: &scope,
+                        invocation_id,
+                        mode: InlineInvocationMode::Fresh,
+                    },
+                    Err(error),
                 )
                 .await
             }
@@ -562,8 +561,10 @@ impl HostRuntime for DefaultHostRuntime {
         // which fails the blocked run on a trust rejection (replacing the former
         // host_runtime pre-authorization + `context.trust` stamp).
         let registry = self.registry.snapshot();
+        let scope = context.resource_scope.clone();
+        let invocation_id = context.invocation_id;
         let host = self.capability_host(&registry);
-        match host
+        let response = host
             .resume_json(
                 context,
                 approval_request_id,
@@ -571,43 +572,26 @@ impl HostRuntime for DefaultHostRuntime {
                 estimate,
                 input,
             )
-            .await
-        {
-            Ok(result) => Ok(completed_or_output_violation_outcome(
-                result,
-                capability_id,
-                &registry,
-            )),
-            // Resume must not start a second approval loop: if the lower layer ever returns
-            // AuthorizationRequiresApproval here, surface it as a failed resume instead of
-            // translating it back into RuntimeCapabilityOutcome::ApprovalRequired.
-            Err(error) => {
-                tracing::debug!(
-                    capability_id = %capability_id,
-                    error_kind = failure_kind_from(&error).as_str(),
-                    "capability resume failed"
-                );
-                match error {
-                    CapabilityInvocationError::AuthorizationRequiresAuth {
-                        capability,
-                        required_secrets,
-                        credential_requirements,
-                    } => Ok(auth_required_outcome(
-                        capability,
-                        required_secrets,
-                        credential_requirements,
-                    )),
-                    other => {
-                        let is_standard_write =
-                            capability_is_standard_write(&registry, &capability_id);
-                        Ok(RuntimeCapabilityOutcome::Failed(
-                            failure_from(other, capability_id)
-                                .with_is_standard_write(is_standard_write),
-                        ))
-                    }
-                }
-            }
+            .await;
+        if let Err(error) = &response {
+            tracing::debug!(
+                capability_id = %capability_id,
+                error_kind = failure_kind_from(&error).as_str(),
+                "capability resume failed"
+            );
         }
+        process_capability_response(
+            self,
+            CapabilityResponseContext {
+                registry: &registry,
+                capability_id,
+                scope: &scope,
+                invocation_id,
+                mode: InlineInvocationMode::ApprovalResume,
+            },
+            response,
+        )
+        .await
     }
 
     async fn auth_resume_capability(
@@ -631,8 +615,10 @@ impl HostRuntime for DefaultHostRuntime {
         // replacing the former host_runtime pre-authorization + `context.trust`
         // stamp.
         let registry = self.registry.snapshot();
+        let scope = context.resource_scope.clone();
+        let invocation_id = context.invocation_id;
         let host = self.capability_host(&registry);
-        match host
+        let response = host
             .auth_resume_json(
                 context,
                 capability_id.clone(),
@@ -640,40 +626,26 @@ impl HostRuntime for DefaultHostRuntime {
                 input,
                 approval_request_id,
             )
-            .await
-        {
-            Ok(result) => Ok(completed_or_output_violation_outcome(
-                result,
-                capability_id,
-                &registry,
-            )),
-            Err(error) => {
-                tracing::debug!(
-                    capability_id = %capability_id,
-                    error_kind = failure_kind_from(&error).as_str(),
-                    "capability auth-resume failed"
-                );
-                match error {
-                    CapabilityInvocationError::AuthorizationRequiresAuth {
-                        capability,
-                        required_secrets,
-                        credential_requirements,
-                    } => Ok(auth_required_outcome(
-                        capability,
-                        required_secrets,
-                        credential_requirements,
-                    )),
-                    other => {
-                        let is_standard_write =
-                            capability_is_standard_write(&registry, &capability_id);
-                        Ok(RuntimeCapabilityOutcome::Failed(
-                            failure_from(other, capability_id)
-                                .with_is_standard_write(is_standard_write),
-                        ))
-                    }
-                }
-            }
+            .await;
+        if let Err(error) = &response {
+            tracing::debug!(
+                capability_id = %capability_id,
+                error_kind = failure_kind_from(&error).as_str(),
+                "capability auth-resume failed"
+            );
         }
+        process_capability_response(
+            self,
+            CapabilityResponseContext {
+                registry: &registry,
+                capability_id,
+                scope: &scope,
+                invocation_id,
+                mode: InlineInvocationMode::AuthResume,
+            },
+            response,
+        )
+        .await
     }
 
     async fn decline_auth_capability(
@@ -1025,73 +997,7 @@ impl DefaultHostRuntime {
         ))))
     }
 
-    async fn translate_invocation_error(
-        &self,
-        registry: &ExtensionRegistry,
-        error: CapabilityInvocationError,
-        capability_id: CapabilityId,
-        scope: ResourceScope,
-        invocation_id: InvocationId,
-    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
-        match error {
-            CapabilityInvocationError::AuthorizationRequiresApproval { capability } => {
-                match self.lookup_approval_request_id(&scope, invocation_id).await {
-                    Ok(Some(approval_request_id)) => Ok(
-                        RuntimeCapabilityOutcome::ApprovalRequired(RuntimeApprovalGate {
-                            approval_request_id,
-                            capability_id: capability,
-                            reason: RuntimeBlockedReason::ApprovalRequired,
-                        }),
-                    ),
-                    Ok(None) => Ok(RuntimeCapabilityOutcome::Failed(
-                        RuntimeCapabilityFailure::new(
-                            capability,
-                            FailureKind::Authorization,
-                            Some(
-                                "approval required but no approval request was persisted"
-                                    .to_string(),
-                            ),
-                        ),
-                    )),
-                    Err(host_error) => {
-                        // Surface persistence outages as Unavailable rather than
-                        // pretending the approval was never persisted; otherwise a
-                        // transient run-state failure looks indistinguishable from
-                        // the (separately bug-prone) cap-host-skipped-persist path.
-                        tracing::warn!(
-                            capability_id = %capability,
-                            error = %host_error,
-                            "approval request lookup failed; surfacing as host runtime unavailability"
-                        );
-                        Err(host_error)
-                    }
-                }
-            }
-            CapabilityInvocationError::AuthorizationRequiresAuth {
-                capability,
-                required_secrets,
-                credential_requirements,
-            } => Ok(auth_required_outcome(
-                capability,
-                required_secrets,
-                credential_requirements,
-            )),
-            other => {
-                let should_fail_dispatch_run =
-                    matches!(other, CapabilityInvocationError::Dispatch { .. });
-                let is_standard_write = capability_is_standard_write(registry, &capability_id);
-                let failure =
-                    failure_from(other, capability_id).with_is_standard_write(is_standard_write);
-                if should_fail_dispatch_run {
-                    self.fail_dispatch_run(&failure, &scope, invocation_id)
-                        .await;
-                }
-                Ok(RuntimeCapabilityOutcome::Failed(failure))
-            }
-        }
-    }
-
-    async fn fail_dispatch_run(
+    pub(super) async fn fail_dispatch_run(
         &self,
         failure: &RuntimeCapabilityFailure,
         scope: &ResourceScope,
@@ -1114,7 +1020,7 @@ impl DefaultHostRuntime {
         }
     }
 
-    async fn lookup_approval_request_id(
+    pub(super) async fn lookup_approval_request_id(
         &self,
         scope: &ResourceScope,
         invocation_id: InvocationId,
@@ -1374,64 +1280,6 @@ fn runtime_kind_rank(runtime: RuntimeKind) -> u8 {
     }
 }
 
-fn completed_outcome_from(
-    result: CapabilityInvocationResult,
-    capability_id: CapabilityId,
-) -> RuntimeCapabilityCompleted {
-    RuntimeCapabilityCompleted {
-        capability_id,
-        output: result.dispatch.output,
-        display_preview: result.dispatch.display_preview,
-        usage: result.dispatch.usage,
-    }
-}
-
-/// Single choke point for every path that turns a successful capability
-/// dispatch into a `Completed` outcome. `completed_outcome_from` above has
-/// exactly three callers — `invoke_capability`, `resume_capability`, and
-/// `auth_resume_capability` (the only resume paths that can complete a
-/// capability rather than suspend or fail it) — and all three call this
-/// function instead so the standard-op output check cannot be skipped on one
-/// entry path while covered on another (see `.claude/rules/review-discipline.md`).
-///
-/// A capability bound to a standard messaging op (`descriptor.standard_op`)
-/// has its dispatch output checked against that op's canonical output schema
-/// before `Completed` is allowed to stick. A violation becomes a
-/// model-visible `Failed` outcome instead, using the same
-/// [`FailureKind::InvalidResult`] kind wasm `InvalidResult` dispatch
-/// errors already produce (`failure_kind_from` /
-/// `RuntimeDispatchErrorKind::InvalidResult` below), so the model can retry
-/// or report rather than the run completing with a shape no downstream
-/// consumer validated. Bespoke capabilities (`standard_op: None`) and an
-/// unknown capability id (descriptor lookup miss — already errors elsewhere)
-/// are returned untouched.
-fn completed_or_output_violation_outcome(
-    result: CapabilityInvocationResult,
-    capability_id: CapabilityId,
-    registry: &ExtensionRegistry,
-) -> RuntimeCapabilityOutcome {
-    let standard_op = registry
-        .get_capability(&capability_id)
-        .and_then(|descriptor| descriptor.standard_op);
-    let completed = completed_outcome_from(result, capability_id.clone());
-
-    if let Some(op) = standard_op
-        && let Some(issues) =
-            crate::standard_op_output::standard_op_output_violations(op, &completed.output)
-    {
-        return RuntimeCapabilityOutcome::Failed(RuntimeCapabilityFailure::new(
-            capability_id,
-            FailureKind::InvalidResult,
-            Some(format!(
-                "standard op output failed validation: {}",
-                issues.join("; ")
-            )),
-        ));
-    }
-
-    RuntimeCapabilityOutcome::Completed(Box::new(completed))
-}
-
 /// Whether `capability_id` resolves (in `registry`) to a capability bound to
 /// a standard messaging WRITE op. Mirrors
 /// [`completed_or_output_violation_outcome`]'s own descriptor lookup just
@@ -1441,7 +1289,7 @@ fn completed_or_output_violation_outcome(
 /// point already resolves for output validation, at the failure-construction
 /// call sites instead of the success-completion one. An unknown capability id
 /// (descriptor lookup miss) resolves to `false`, same as a bespoke tool.
-fn capability_is_standard_write(
+pub(super) fn capability_is_standard_write(
     registry: &ExtensionRegistry,
     capability_id: &CapabilityId,
 ) -> bool {
@@ -1509,7 +1357,7 @@ pub(crate) fn capability_credential_requirements(
     (required_secrets, credential_requirements)
 }
 
-fn auth_required_outcome(
+pub(super) fn auth_required_outcome(
     capability_id: CapabilityId,
     required_secrets: Vec<SecretHandle>,
     credential_requirements: Vec<ironclaw_host_api::decision::RuntimeCredentialAuthRequirement>,
@@ -1731,7 +1579,7 @@ fn model_visible_cause_scrubber() -> &'static ironclaw_safety::LeakDetector {
     &DETECTOR
 }
 
-fn failure_from(
+pub(super) fn failure_from(
     error: CapabilityInvocationError,
     capability_id: CapabilityId,
 ) -> RuntimeCapabilityFailure {
@@ -3121,10 +2969,8 @@ output_schema_ref = "schemas/w1fixture/bespoke.output.v1.json"
     }
 
     /// End-to-end proof (the actual regression this wave fixes), composed
-    /// exactly as the five `other =>` call sites in this file now are
-    /// (`translate_invocation_error`, `resume_capability`,
-    /// `auth_resume_capability`, `decline_auth_capability`,
-    /// `resume_spawn_capability`): resolve `is_standard_write` from a REAL
+    /// exactly as the central response processor and the remaining spawn/decline
+    /// paths do: resolve `is_standard_write` from a REAL
     /// registry built by parsing [`W1_STANDARD_OP_MIX_MANIFEST`], thread it
     /// through `failure_from(..).with_is_standard_write(..)`, and read
     /// `.disposition()`. A Dispatch error whose kind maps to a retryable

--- a/crates/kernel/ironclaw_host_runtime/src/production.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/production.rs
@@ -561,6 +561,13 @@ impl HostRuntime for DefaultHostRuntime {
         // which fails the blocked run on a trust rejection (replacing the former
         // host_runtime pre-authorization + `context.trust` stamp).
         let registry = self.registry.snapshot();
+        // `context` is moved into `resume_json` below, so `resource_scope` must be
+        // cloned out first. `process_capability_response` doesn't read
+        // `context.scope` on the `ApprovalResume` path this PR sends here —
+        // `fail_dispatch_run` is Fresh-gated — but a stacked PR un-gates
+        // `fail_dispatch_run` for resumes too, which reads it again. Left
+        // unconditional rather than threading an `Option`/mode-gated clone that a
+        // near-term rebase would just undo.
         let scope = context.resource_scope.clone();
         let invocation_id = context.invocation_id;
         let host = self.capability_host(&registry);
@@ -615,6 +622,12 @@ impl HostRuntime for DefaultHostRuntime {
         // replacing the former host_runtime pre-authorization + `context.trust`
         // stamp.
         let registry = self.registry.snapshot();
+        // Same clone-before-move as `resume_capability` above: `context` is
+        // consumed by `auth_resume_json`, and `process_capability_response`
+        // doesn't read `context.scope` on the `AuthResume` path this PR sends
+        // here (`fail_dispatch_run` is Fresh-gated) — a stacked PR un-gates it
+        // for resumes and reads it again, so this is left unconditional rather
+        // than churned twice.
         let scope = context.resource_scope.clone();
         let invocation_id = context.invocation_id;
         let host = self.capability_host(&registry);
@@ -1282,8 +1295,8 @@ fn runtime_kind_rank(runtime: RuntimeKind) -> u8 {
 
 /// Whether `capability_id` resolves (in `registry`) to a capability bound to
 /// a standard messaging WRITE op. Mirrors
-/// [`completed_or_output_violation_outcome`]'s own descriptor lookup just
-/// above (same registry, same `descriptor.standard_op` field) — the retry
+/// [`crate::capability_response_processor::completed_or_output_violation_outcome`]'s
+/// own descriptor lookup (same registry, same `descriptor.standard_op` field) — the retry
 /// carve-out policy (pre-merge amendment W1,
 /// [`crate::capability_failure_disposition`]) needs the same fact that choke
 /// point already resolves for output validation, at the failure-construction

--- a/crates/kernel/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -17,8 +17,8 @@ use ironclaw_approvals::{
     ApprovalRecord, ApprovalRequestStorePort, ApprovalResolver, ApprovalStoreError, LeaseApproval,
 };
 use ironclaw_authorization::{
-    GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer,
-    in_memory_backed_capability_lease_store,
+    CapabilityLeaseStatus, CapabilityLeaseStorePort, GrantAuthorizer,
+    TrustAwareCapabilityDispatchAuthorizer, in_memory_backed_capability_lease_store,
 };
 use ironclaw_extension_registry::{
     ExtensionManifest, ExtensionManifestRecord, ExtensionPackage, ExtensionRegistry,
@@ -649,7 +649,7 @@ async fn default_runtime_approval_resume_completes_and_consumes_grant() {
         other => panic!("expected ApprovalRequired outcome, got {:?}", other),
     };
 
-    ApprovalResolver::new(approval_requests.as_ref(), leases.as_ref())
+    let lease = ApprovalResolver::new(approval_requests.as_ref(), leases.as_ref())
         .approve_dispatch(
             &scope,
             gate.approval_request_id,
@@ -687,6 +687,16 @@ async fn default_runtime_approval_resume_completes_and_consumes_grant() {
         other => panic!("expected Completed resume outcome, got {:?}", other),
     }
     assert_eq!(dispatcher.call_count(), 1);
+
+    // The name promises the grant is consumed by the resumed dispatch, not
+    // just that the outcome is `Completed` — assert the lease itself flips
+    // to `Consumed` so a regression that leaves the grant re-usable (or
+    // reverts to re-authorizing from a stale `Active` lease) fails here.
+    let consumed_lease = leases
+        .get(&scope, lease.grant.id)
+        .await
+        .expect("lease still present after resume");
+    assert_eq!(consumed_lease.status, CapabilityLeaseStatus::Consumed);
 }
 
 #[tokio::test]

--- a/crates/kernel/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -13,7 +13,9 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::Utc;
-use ironclaw_approvals::{ApprovalRecord, ApprovalRequestStorePort, ApprovalStoreError};
+use ironclaw_approvals::{
+    ApprovalRecord, ApprovalRequestStorePort, ApprovalResolver, ApprovalStoreError, LeaseApproval,
+};
 use ironclaw_authorization::{
     GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer,
     in_memory_backed_capability_lease_store,
@@ -35,7 +37,7 @@ use ironclaw_host_api::{
         CapabilityDescriptor, CapabilityGrant, CapabilitySet, EffectKind, GrantConstraints,
     },
     decision::{Decision, DenyReason, Obligations},
-    dispatch::CapabilityDispatchResult,
+    dispatch::{CapabilityDispatchResult, DispatchError},
     host_port::HostPortCatalog,
     ids::{
         ApprovalRequestId, CapabilityGrantId, CapabilityId, ExtensionId, InvocationId, PackageId,
@@ -56,7 +58,8 @@ use ironclaw_host_runtime::{
 };
 use ironclaw_processes::{
     ProcessCancellationRegistry, ProcessInvocationError, ProcessInvocationRecord,
-    ProcessInvocationStart, ProcessInvocationStatePort, ProcessInvocationStore,
+    ProcessInvocationStart, ProcessInvocationStatePort, ProcessInvocationStatus,
+    ProcessInvocationStore,
     ProcessJournalStore, ProcessResultStore, ProcessResultStorePort, ProcessServices, ProcessStart,
     ProcessStatus, capability_process_record, submit_capability_process,
 };
@@ -425,6 +428,499 @@ async fn default_runtime_surfaces_authorization_failure_when_authorizer_denies()
     }
     // Deny must short-circuit before dispatch runs.
     assert_eq!(dispatcher.call_count(), 0);
+}
+
+// The four tests below extend caller-level coverage of
+// `crate::capability_response_processor::process_capability_response` — the
+// centralized mapping fresh invoke, approval resume, and auth resume all cross
+// (plan: docs/internal/reborn/extension-runtime/capability-response-normalization-plan.md
+// §11 PR 1 step 1). They drive `DefaultHostRuntime`'s public entry points, not
+// the processor directly.
+
+#[tokio::test]
+async fn default_runtime_fresh_dispatch_error_becomes_failed_and_fails_run_state() {
+    // Fresh-invocation pin for the processor's `CapabilityInvocationError::Dispatch`
+    // arm: a dispatcher failure distinct from AuthRequired/RequireApproval must
+    // surface as `Failed`, and the processor's `fail_dispatch_run` side effect
+    // must transition the already-started run-state record to `Failed`.
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(TestDispatcher::responding(|_, _| {
+        Err(DispatchError::UnknownProvider {
+            capability: capability_id(),
+            provider: extension_id(),
+        })
+    }));
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let run_state = Arc::new(ironclaw_processes::in_memory_backed_process_invocation_state_store());
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        local_test_runtime_policy(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()))
+    .with_invocation_state(run_state.clone());
+
+    let context = execution_context_with_dispatch_grant();
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let request = (
+        context,
+        capability_id(),
+        ResourceEstimate::default(),
+        json!({"message": "hello"}),
+    );
+
+    let outcome = runtime.invoke_capability(request).await.unwrap();
+
+    match outcome {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::Failed(failure) => {
+            assert_eq!(failure.capability_id, capability_id());
+            assert_eq!(failure.kind, FailureKind::UnknownProvider);
+        }
+        other => panic!("expected Failed outcome, got {:?}", other),
+    }
+    assert_eq!(dispatcher.call_count(), 1);
+    let record = run_state
+        .get(&scope, invocation_id)
+        .await
+        .unwrap()
+        .expect("run record persisted before dispatch");
+    assert_eq!(
+        record.status,
+        ProcessInvocationStatus::Failed,
+        "a Dispatch error on fresh invocation must fail the started run-state record"
+    );
+}
+
+#[tokio::test]
+async fn default_runtime_fresh_auth_required_gate_is_stable_across_calls() {
+    // Fresh-invocation pin for the processor's `AuthorizationRequiresAuth` arm:
+    // two independent fresh invocations that hit the same auth requirement must
+    // resolve to the same stable `RuntimeGateId`, since the gate id is derived
+    // deterministically from capability + secrets + credential requirements
+    // (production.rs::stable_auth_gate_id), not from invocation identity.
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(TestDispatcher::auth_required());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        local_test_runtime_policy(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()));
+
+    let first = runtime
+        .invoke_capability((
+            execution_context_with_dispatch_grant(),
+            capability_id(),
+            ResourceEstimate::default(),
+            json!({"n": 1}),
+        ))
+        .await
+        .unwrap();
+    let second = runtime
+        .invoke_capability((
+            execution_context_with_dispatch_grant(),
+            capability_id(),
+            ResourceEstimate::default(),
+            json!({"n": 2}),
+        ))
+        .await
+        .unwrap();
+
+    let ironclaw_host_runtime::RuntimeCapabilityOutcome::AuthRequired(first_gate) = first else {
+        panic!("expected AuthRequired outcome, got {:?}", first);
+    };
+    let ironclaw_host_runtime::RuntimeCapabilityOutcome::AuthRequired(second_gate) = second else {
+        panic!("expected AuthRequired outcome, got {:?}", second);
+    };
+    assert_eq!(first_gate.capability_id, capability_id());
+    assert_eq!(first_gate.gate_id, second_gate.gate_id);
+    assert_eq!(dispatcher.call_count(), 2);
+}
+
+#[tokio::test]
+async fn default_runtime_approval_resume_completes_and_consumes_grant() {
+    // Approval-resume success: an approved gate resumed through
+    // `resume_capability` re-authorizes with the injected lease grant and
+    // completes, driving the processor's `Ok(dispatch)` arm under
+    // `InlineInvocationMode::ApprovalResume`.
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
+        Arc::new(ApprovalThenGrantAuthorizer);
+    let run_state = Arc::new(ironclaw_processes::in_memory_backed_process_invocation_state_store());
+    let approval_requests = Arc::new(ironclaw_approvals::in_memory_backed_approval_request_store());
+    let leases = Arc::new(in_memory_backed_capability_lease_store());
+
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        local_test_runtime_policy(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()))
+    .with_invocation_state(run_state.clone())
+    .with_approval_requests(approval_requests.clone())
+    .with_capability_leases(leases.clone());
+
+    let context = execution_context_without_grants();
+    let scope = context.resource_scope.clone();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "hello"});
+
+    let gate = match runtime
+        .invoke_capability((
+            context.clone(),
+            capability_id(),
+            estimate.clone(),
+            input.clone(),
+        ))
+        .await
+        .unwrap()
+    {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::ApprovalRequired(gate) => gate,
+        other => panic!("expected ApprovalRequired outcome, got {:?}", other),
+    };
+
+    ApprovalResolver::new(approval_requests.as_ref(), leases.as_ref())
+        .approve_dispatch(
+            &scope,
+            gate.approval_request_id,
+            LeaseApproval {
+                issued_by: Principal::HostRuntime,
+                constraints: GrantConstraints {
+                    allowed_effects: vec![EffectKind::DispatchCapability],
+                    mounts: MountView::default(),
+                    network: NetworkPolicy::default(),
+                    secrets: Vec::new(),
+                    resource_ceiling: None,
+                    expires_at: None,
+                    max_invocations: Some(1),
+                },
+            },
+        )
+        .await
+        .expect("approve dispatch");
+
+    let outcome = runtime
+        .resume_capability((
+            context,
+            gate.approval_request_id,
+            capability_id(),
+            estimate,
+            input,
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::Completed(completed) => {
+            assert_eq!(completed.capability_id, capability_id());
+        }
+        other => panic!("expected Completed resume outcome, got {:?}", other),
+    }
+    assert_eq!(dispatcher.call_count(), 1);
+}
+
+#[tokio::test]
+async fn default_runtime_approval_resume_repeated_approval_requirement_fails_without_reopening_gate()
+ {
+    // Pins the processor's `ApprovalResume` arm for `AuthorizationRequiresApproval`:
+    // when the resumed authorization decision requires approval again (rather
+    // than completing), the processor must surface a `Failed` outcome instead of
+    // opening a second approval loop (see the "resume must never start a second
+    // approval loop" comment in capability_response_processor.rs).
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
+        Arc::new(AlwaysRequireApprovalAuthorizer);
+    let run_state = Arc::new(ironclaw_processes::in_memory_backed_process_invocation_state_store());
+    let approval_requests = Arc::new(ironclaw_approvals::in_memory_backed_approval_request_store());
+    let leases = Arc::new(in_memory_backed_capability_lease_store());
+
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        local_test_runtime_policy(),
+    )
+    .with_invocation_state(run_state.clone())
+    .with_approval_requests(approval_requests.clone())
+    .with_capability_leases(leases.clone());
+
+    let context = execution_context_without_grants();
+    let scope = context.resource_scope.clone();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "hello"});
+
+    let gate = match runtime
+        .invoke_capability((
+            context.clone(),
+            capability_id(),
+            estimate.clone(),
+            input.clone(),
+        ))
+        .await
+        .unwrap()
+    {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::ApprovalRequired(gate) => gate,
+        other => panic!("expected ApprovalRequired outcome, got {:?}", other),
+    };
+
+    ApprovalResolver::new(approval_requests.as_ref(), leases.as_ref())
+        .approve_dispatch(
+            &scope,
+            gate.approval_request_id,
+            LeaseApproval {
+                issued_by: Principal::HostRuntime,
+                constraints: GrantConstraints {
+                    allowed_effects: vec![EffectKind::DispatchCapability],
+                    mounts: MountView::default(),
+                    network: NetworkPolicy::default(),
+                    secrets: Vec::new(),
+                    resource_ceiling: None,
+                    expires_at: None,
+                    max_invocations: Some(1),
+                },
+            },
+        )
+        .await
+        .expect("approve dispatch");
+
+    let outcome = runtime
+        .resume_capability((
+            context,
+            gate.approval_request_id,
+            capability_id(),
+            estimate,
+            input,
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::Failed(failure) => {
+            assert_eq!(failure.capability_id, capability_id());
+            assert_eq!(failure.kind, FailureKind::Authorization);
+        }
+        other => panic!(
+            "expected Failed outcome (no second approval loop), got {:?}",
+            other
+        ),
+    }
+    // The authorizer requiring approval again must never re-dispatch.
+    assert_eq!(dispatcher.call_count(), 0);
+}
+
+#[tokio::test]
+async fn default_runtime_auth_resume_completes_blocked_auth_run() {
+    // Auth-resume success (approval_request_id = None): a run parked in
+    // `BlockedAuth` that resumes with an authorized grant completes, driving the
+    // processor's `Ok(dispatch)` arm under `InlineInvocationMode::AuthResume`.
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let run_state = Arc::new(ironclaw_processes::in_memory_backed_process_invocation_state_store());
+
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        local_test_runtime_policy(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()))
+    .with_invocation_state(run_state.clone());
+
+    let context = execution_context_with_dispatch_grant();
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    run_state
+        .start(ProcessInvocationStart {
+            invocation_id,
+            capability_id: capability_id(),
+            scope: scope.clone(),
+            authenticated_actor_user_id: None,
+        })
+        .await
+        .expect("seed running invocation");
+    run_state
+        .block_auth(&scope, invocation_id, "AuthRequired".to_string())
+        .await
+        .expect("park invocation in BlockedAuth");
+
+    let outcome = runtime
+        .auth_resume_capability((
+            context,
+            capability_id(),
+            ResourceEstimate::default(),
+            json!({"message": "hello"}),
+            None,
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::Completed(completed) => {
+            assert_eq!(completed.capability_id, capability_id());
+        }
+        other => panic!("expected Completed auth-resume outcome, got {:?}", other),
+    }
+    assert_eq!(dispatcher.call_count(), 1);
+    let record = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(record.status, ProcessInvocationStatus::Completed);
+}
+
+#[tokio::test]
+async fn default_runtime_auth_resume_repeated_auth_requirement_reuses_stable_gate_id() {
+    // Pins the processor's `AuthorizationRequiresAuth` arm on auth-resume: a
+    // BlockedAuth run resumed against a dispatcher that still needs the same
+    // credential surfaces `AuthRequired` again with the *same* stable gate id a
+    // fresh invocation for the identical capability/requirements would have
+    // produced — the gate id is a deterministic function of capability +
+    // secrets + credential requirements, not invocation or mode identity.
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(TestDispatcher::auth_required());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let run_state = Arc::new(ironclaw_processes::in_memory_backed_process_invocation_state_store());
+
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        local_test_runtime_policy(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()))
+    .with_invocation_state(run_state.clone());
+
+    // A fresh invocation against the same always-auth-required dispatcher
+    // establishes the baseline gate id.
+    let fresh_gate = match runtime
+        .invoke_capability((
+            execution_context_with_dispatch_grant(),
+            capability_id(),
+            ResourceEstimate::default(),
+            json!({"n": 1}),
+        ))
+        .await
+        .unwrap()
+    {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::AuthRequired(gate) => gate,
+        other => panic!("expected AuthRequired outcome, got {:?}", other),
+    };
+
+    let context = execution_context_with_dispatch_grant();
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    run_state
+        .start(ProcessInvocationStart {
+            invocation_id,
+            capability_id: capability_id(),
+            scope: scope.clone(),
+            authenticated_actor_user_id: None,
+        })
+        .await
+        .expect("seed running invocation");
+    run_state
+        .block_auth(&scope, invocation_id, "AuthRequired".to_string())
+        .await
+        .expect("park invocation in BlockedAuth");
+
+    let outcome = runtime
+        .auth_resume_capability((
+            context,
+            capability_id(),
+            ResourceEstimate::default(),
+            json!({"n": 1}),
+            None,
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::AuthRequired(resumed_gate) => {
+            assert_eq!(resumed_gate.capability_id, capability_id());
+            assert_eq!(resumed_gate.gate_id, fresh_gate.gate_id);
+        }
+        other => panic!(
+            "expected AuthRequired outcome (no second approval loop), got {:?}",
+            other
+        ),
+    }
+}
+
+struct ApprovalThenGrantAuthorizer;
+
+#[async_trait]
+impl TrustAwareCapabilityDispatchAuthorizer for ApprovalThenGrantAuthorizer {
+    async fn authorize_dispatch_with_trust(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        trust_decision: &TrustDecision,
+    ) -> Decision {
+        if context.grants.grants.is_empty() {
+            Decision::RequireApproval {
+                request: ApprovalRequest {
+                    id: ApprovalRequestId::new(),
+                    correlation_id: context.correlation_id,
+                    requested_by: Principal::Extension(context.extension_id.clone()),
+                    action: Box::new(Action::Dispatch {
+                        capability: descriptor.id.clone(),
+                        estimated_resources: estimate.clone(),
+                    }),
+                    invocation_fingerprint: None,
+                    reason: "approval required".to_string(),
+                    reusable_scope: None,
+                },
+            }
+        } else {
+            GrantAuthorizer
+                .authorize_dispatch_with_trust(context, descriptor, estimate, trust_decision)
+                .await
+        }
+    }
+}
+
+/// Always requires approval, ignoring any grant injected by the resume
+/// preamble — pins that a resume decision landing back on
+/// `AuthorizationRequiresApproval` fails the resume instead of reopening a
+/// second approval loop.
+struct AlwaysRequireApprovalAuthorizer;
+
+#[async_trait]
+impl TrustAwareCapabilityDispatchAuthorizer for AlwaysRequireApprovalAuthorizer {
+    async fn authorize_dispatch_with_trust(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        _trust_decision: &TrustDecision,
+    ) -> Decision {
+        Decision::RequireApproval {
+            request: ApprovalRequest {
+                id: ApprovalRequestId::new(),
+                correlation_id: context.correlation_id,
+                requested_by: Principal::Extension(context.extension_id.clone()),
+                action: Box::new(Action::Dispatch {
+                    capability: descriptor.id.clone(),
+                    estimated_resources: estimate.clone(),
+                }),
+                invocation_fingerprint: None,
+                reason: "approval required".to_string(),
+                reusable_scope: None,
+            },
+        }
+    }
 }
 
 #[tokio::test]
@@ -1711,6 +2207,24 @@ fn execution_context_with_dispatch_grant() -> ExecutionContext {
         RuntimeKind::Wasm,
         TrustClass::UserTrusted,
         grants,
+        MountView::default(),
+    )
+    .unwrap();
+    context.run_id = Some(RunId::new());
+    context
+}
+
+/// A context with no pre-existing dispatch grant — the approval/auth resume
+/// tests use this so the initial dispatch requires approval instead of
+/// bypassing it, mirroring `execution_context_without_grants` in
+/// `host_runtime_persistent_approvals_contract.rs`.
+fn execution_context_without_grants() -> ExecutionContext {
+    let mut context = ExecutionContext::local_default(
+        UserId::new("user").unwrap(),
+        ExtensionId::new("caller").unwrap(),
+        RuntimeKind::Wasm,
+        TrustClass::UserTrusted,
+        CapabilitySet::default(),
         MountView::default(),
     )
     .unwrap();

--- a/crates/kernel/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -59,9 +59,9 @@ use ironclaw_host_runtime::{
 use ironclaw_processes::{
     ProcessCancellationRegistry, ProcessInvocationError, ProcessInvocationRecord,
     ProcessInvocationStart, ProcessInvocationStatePort, ProcessInvocationStatus,
-    ProcessInvocationStore,
-    ProcessJournalStore, ProcessResultStore, ProcessResultStorePort, ProcessServices, ProcessStart,
-    ProcessStatus, capability_process_record, submit_capability_process,
+    ProcessInvocationStore, ProcessJournalStore, ProcessResultStore, ProcessResultStorePort,
+    ProcessServices, ProcessStart, ProcessStatus, capability_process_record,
+    submit_capability_process,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -493,10 +493,9 @@ async fn default_runtime_surfaces_authorization_failure_when_authorizer_denies()
 
 // The four tests below extend caller-level coverage of
 // `crate::capability_response_processor::process_capability_response` — the
-// centralized mapping fresh invoke, approval resume, and auth resume all cross
-// (plan: docs/internal/reborn/extension-runtime/capability-response-normalization-plan.md
-// §11 PR 1 step 1). They drive `DefaultHostRuntime`'s public entry points, not
-// the processor directly.
+// centralized mapping fresh invoke, approval resume, and auth resume all cross.
+// They drive `DefaultHostRuntime`'s public entry points, not the processor
+// directly, so a regression here pins the seam as callers actually exercise it.
 
 #[tokio::test]
 async fn default_runtime_fresh_dispatch_error_becomes_failed_and_fails_run_state() {

--- a/crates/kernel/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -346,6 +346,67 @@ async fn default_runtime_propagates_unavailable_when_run_state_lookup_fails_duri
 }
 
 #[tokio::test]
+async fn default_runtime_fresh_approval_without_persisted_request_fails_authorization() {
+    // Regression: the response processor's Fresh-mode `AuthorizationRequiresApproval`
+    // arm reads the approval request id back through `lookup_approval_request_id`
+    // rather than trusting the capability kernel's in-band signal alone. If that
+    // read-back finds no persisted record — even though the capability host's own
+    // write succeeded — the invocation must fail as a model-visible authorization
+    // failure instead of fabricating an `ApprovalRequired` gate the caller could
+    // never resolve.
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(ApprovalAuthorizer);
+    let inner_run_state =
+        Arc::new(ironclaw_processes::in_memory_backed_process_invocation_state_store());
+    let run_state: Arc<dyn ProcessInvocationStatePort> = Arc::new(InvisibleApprovalRunStateStore {
+        inner: inner_run_state.clone(),
+    });
+    let approval_requests = Arc::new(ironclaw_approvals::in_memory_backed_approval_request_store());
+    let leases: Arc<dyn ironclaw_authorization::CapabilityLeaseStorePort> =
+        Arc::new(in_memory_backed_capability_lease_store());
+
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher,
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        local_test_runtime_policy(),
+    )
+    .with_invocation_state(run_state)
+    .with_approval_requests(approval_requests)
+    .with_capability_leases(leases);
+
+    let context = execution_context_with_dispatch_grant();
+    let request = (
+        context,
+        capability_id(),
+        ResourceEstimate::default(),
+        json!({"message": "hello"}),
+    );
+
+    let outcome = runtime
+        .invoke_capability(request)
+        .await
+        .expect("missing persisted approval must surface as a Failed outcome, not a host error");
+
+    match outcome {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::Failed(failure) => {
+            assert_eq!(failure.kind, FailureKind::Authorization);
+            let message = failure.message.as_deref().unwrap_or_default();
+            assert!(
+                message.contains("no approval request was persisted"),
+                "unexpected message: {message}"
+            );
+        }
+        other => panic!(
+            "expected Failed outcome with no approval gate, got {:?}",
+            other
+        ),
+    }
+}
+
+#[tokio::test]
 async fn default_runtime_returns_failed_for_unknown_capability() {
     let registry = Arc::new(ExtensionRegistry::new());
     let dispatcher = Arc::new(TestDispatcher::ok(dispatch_result()));
@@ -1803,6 +1864,82 @@ impl ProcessInvocationStatePort for FailingGetRunStateStore {
         Err(ProcessInvocationError::Backend(
             "simulated read failure: /tmp/runstate.db connection refused".to_string(),
         ))
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ProcessInvocationRecord>, ProcessInvocationError> {
+        self.inner.records_for_scope(scope).await
+    }
+}
+
+/// Wraps an [`ironclaw_processes::ProcessInvocationStateStore<ironclaw_filesystem::InMemoryBackend>`]
+/// but always answers `get` with `Ok(None)`, even after `start`/`block_approval`
+/// writes have succeeded against the inner store. Simulates a read-your-write
+/// gap between the capability host's approval-block write and the host
+/// runtime's own approval-lookup read, so the response processor's
+/// `AuthorizationRequiresApproval` arm sees no persisted record despite the
+/// kernel having required approval.
+struct InvisibleApprovalRunStateStore {
+    inner:
+        Arc<ironclaw_processes::ProcessInvocationStateStore<ironclaw_filesystem::InMemoryBackend>>,
+}
+
+#[async_trait]
+impl ProcessInvocationStatePort for InvisibleApprovalRunStateStore {
+    async fn start(
+        &self,
+        start: ProcessInvocationStart,
+    ) -> Result<ProcessInvocationRecord, ProcessInvocationError> {
+        self.inner.start(start).await
+    }
+
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<ProcessInvocationRecord, ProcessInvocationError> {
+        self.inner
+            .block_approval(scope, invocation_id, approval)
+            .await
+    }
+
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<ProcessInvocationRecord, ProcessInvocationError> {
+        self.inner
+            .block_auth(scope, invocation_id, error_kind)
+            .await
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<ProcessInvocationRecord, ProcessInvocationError> {
+        self.inner.complete(scope, invocation_id).await
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<ProcessInvocationRecord, ProcessInvocationError> {
+        self.inner.fail(scope, invocation_id, error_kind).await
+    }
+
+    async fn get(
+        &self,
+        _scope: &ResourceScope,
+        _invocation_id: InvocationId,
+    ) -> Result<Option<ProcessInvocationRecord>, ProcessInvocationError> {
+        Ok(None)
     }
 
     async fn records_for_scope(

--- a/crates/loop/ironclaw_loop_host/src/capability_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/capability_port.rs
@@ -3647,21 +3647,6 @@ async fn runtime_outcome_to_loop(
             }
             GatedResolution::bare(class.into_resolution())
         }
-        RuntimeCapabilityOutcome::Unknown(unknown) => {
-            let detail = unknown
-                .message
-                .as_deref()
-                .and_then(model_visible_diagnostic_text)
-                .unwrap_or_else(|| ModelDiagnostic::unavailable().into_inner());
-            GatedResolution::bare(resolution::failed(
-                FailureKind::from_tag(&unknown.kind),
-                runtime_safe_summary(
-                    unknown.message,
-                    "capability invocation returned an unknown outcome",
-                ),
-                CapabilityFailureDetail::Diagnostic { text: detail },
-            ))
-        }
     })
 }
 
@@ -3725,16 +3710,6 @@ fn runtime_terminal_milestone(
                 // so the live per-tool UI card shows the real reason, not just
                 // the bare error kind.
                 safe_summary,
-            })
-        }
-        RuntimeCapabilityOutcome::Unknown(unknown) => {
-            Some(LoopHostMilestoneKind::CapabilityFailed {
-                activity_id,
-                capability_id: unknown.capability_id.clone(),
-                provider: Some(provider),
-                runtime: Some(runtime),
-                reason_kind: FailureKind::from_tag(&unknown.kind),
-                safe_summary: None,
             })
         }
         RuntimeCapabilityOutcome::ApprovalRequired(_)
@@ -3950,7 +3925,6 @@ fn ensure_runtime_outcome_matches(
         RuntimeCapabilityOutcome::ResourceBlocked(gate) => &gate.capability_id,
         RuntimeCapabilityOutcome::SpawnedProcess(process) => &process.capability_id,
         RuntimeCapabilityOutcome::Failed(failure) => &failure.capability_id,
-        RuntimeCapabilityOutcome::Unknown(unknown) => &unknown.capability_id,
     };
     if actual != expected {
         return Err(AgentLoopHostError::new(
@@ -4168,7 +4142,7 @@ mod tests {
     use ironclaw_host_runtime::{
         CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest, CapabilitySurfaceVersion,
         HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalResume, RuntimeCapabilityCompleted,
-        RuntimeCapabilityFailure, RuntimeCapabilityUnknown, RuntimeInvocation,
+        RuntimeCapabilityFailure, RuntimeInvocation,
         RuntimeStatusRequest, SurfaceKind, VisibleCapability, VisibleCapabilityAccess,
         VisibleCapabilitySurface,
     };

--- a/crates/loop/ironclaw_loop_host/src/capability_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/capability_port.rs
@@ -4142,9 +4142,8 @@ mod tests {
     use ironclaw_host_runtime::{
         CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest, CapabilitySurfaceVersion,
         HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalResume, RuntimeCapabilityCompleted,
-        RuntimeCapabilityFailure, RuntimeInvocation,
-        RuntimeStatusRequest, SurfaceKind, VisibleCapability, VisibleCapabilityAccess,
-        VisibleCapabilitySurface,
+        RuntimeCapabilityFailure, RuntimeInvocation, RuntimeStatusRequest, SurfaceKind,
+        VisibleCapability, VisibleCapabilityAccess, VisibleCapabilitySurface,
     };
     use ironclaw_loop_contracts::{
         InMemoryRunProfileResolver, LoopDriverId, RunProfileResolutionRequest, RunProfileResolver,

--- a/crates/loop/ironclaw_loop_host/src/capability_port/tests/runtime_capability.rs
+++ b/crates/loop/ironclaw_loop_host/src/capability_port/tests/runtime_capability.rs
@@ -517,7 +517,7 @@ async fn runtime_capability_terminal_milestone_failure_is_retryable_without_rewr
 }
 
 #[tokio::test]
-async fn runtime_capability_failed_and_unknown_outcomes_emit_failure_milestones() {
+async fn runtime_capability_failed_outcome_emits_failure_milestones() {
     let cases = [
         (
             RuntimeCapabilityOutcome::Failed(RuntimeCapabilityFailure::new(
@@ -547,29 +547,6 @@ async fn runtime_capability_failed_and_unknown_outcomes_emit_failure_milestones(
             )),
             FailureKind::InputEncode,
             Some(RuntimeDispatchErrorKind::InputEncode.human_summary()),
-            true,
-        ),
-        (
-            RuntimeCapabilityOutcome::Unknown(RuntimeCapabilityUnknown {
-                capability_id: CapabilityId::new("demo.echo").expect("valid capability id"),
-                kind: "custom_failure".to_string(),
-                message: Some("custom failure".to_string()),
-            }),
-            // Unrecognized legacy open-set tag: the closed vocabulary's
-            // total `from_tag` fallback lands on the non-retryable
-            // `Unclassified` sink.
-            FailureKind::Unclassified,
-            None,
-            false,
-        ),
-        (
-            RuntimeCapabilityOutcome::Unknown(RuntimeCapabilityUnknown {
-                capability_id: CapabilityId::new("demo.echo").expect("valid capability id"),
-                kind: "custom_failure".to_string(),
-                message: None,
-            }),
-            FailureKind::from_tag("custom_failure"),
-            None,
             true,
         ),
     ];

--- a/crates/loop/ironclaw_loop_host/src/capability_port/tests/runtime_lifecycle_tests.rs
+++ b/crates/loop/ironclaw_loop_host/src/capability_port/tests/runtime_lifecycle_tests.rs
@@ -21,9 +21,8 @@ use ironclaw_host_runtime::{
     CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest, HostRuntime, HostRuntimeError,
     HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalGate, RuntimeApprovalResume,
     RuntimeAuthGate, RuntimeAuthResume, RuntimeBlockedReason, RuntimeCapabilityCompleted,
-    RuntimeCapabilityFailure, RuntimeCapabilityOutcome, RuntimeCapabilityUnknown, RuntimeGateId,
-    RuntimeInvocation, RuntimeProcessHandle, RuntimeResourceGate, RuntimeStatusRequest,
-    VisibleCapabilitySurface,
+    RuntimeCapabilityFailure, RuntimeCapabilityOutcome, RuntimeGateId, RuntimeInvocation,
+    RuntimeProcessHandle, RuntimeResourceGate, RuntimeStatusRequest, VisibleCapabilitySurface,
 };
 use ironclaw_loop_contracts::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityApprovalResume, CapabilityAuthResume,
@@ -402,72 +401,54 @@ async fn runtime_capability_batch_continues_after_runtime_failure_outcome() {
 }
 
 #[tokio::test]
-async fn runtime_capability_failed_and_unknown_outcomes_emit_failure_milestones() {
-    let cases = [
-        (
-            RuntimeCapabilityOutcome::Failed(RuntimeCapabilityFailure::new(
-                CapabilityId::new("demo.echo").expect("valid capability id"),
-                FailureKind::InputEncode,
-                Some("invalid input".to_string()),
-            )),
-            FailureKind::InputEncode,
-        ),
-        (
-            RuntimeCapabilityOutcome::Unknown(RuntimeCapabilityUnknown {
-                capability_id: CapabilityId::new("demo.echo").expect("valid capability id"),
-                kind: "custom_failure".to_string(),
-                message: Some("custom failure".to_string()),
-            }),
-            // Unrecognized legacy open-set tag: the closed vocabulary's total
-            // `from_tag` fallback lands on the non-retryable `Unclassified`
-            // sink.
-            FailureKind::Unclassified,
-        ),
-    ];
-
-    for (outcome, expected_kind) in cases {
-        let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
-        let provider_id = ExtensionId::new("demo").expect("valid provider id");
-        let milestone_sink =
-            Arc::new(ironclaw_loop_contracts::InMemoryLoopHostMilestoneSink::default());
-        let port = runtime_capability_port(
-            &capability_id,
-            &provider_id,
-            Arc::new(QueuedHostRuntime::new(
-                vec![visible_capability(
+async fn runtime_capability_failed_outcome_emits_failure_milestone() {
+    let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
+    let provider_id = ExtensionId::new("demo").expect("valid provider id");
+    let milestone_sink =
+        Arc::new(ironclaw_loop_contracts::InMemoryLoopHostMilestoneSink::default());
+    let port = runtime_capability_port(
+        &capability_id,
+        &provider_id,
+        Arc::new(QueuedHostRuntime::new(
+            vec![visible_capability(
+                capability_id.clone(),
+                provider_id.clone(),
+            )],
+            vec![Ok(RuntimeCapabilityOutcome::Failed(
+                RuntimeCapabilityFailure::new(
                     capability_id.clone(),
-                    provider_id.clone(),
-                )],
-                vec![Ok(outcome)],
-            )),
-            Arc::new(RecordingResultWriter::default()),
-            milestone_sink.clone(),
-            "thread-runtime-capability-failure-milestone",
-        )
-        .await;
+                    FailureKind::InputEncode,
+                    Some("invalid input".to_string()),
+                ),
+            ))],
+        )),
+        Arc::new(RecordingResultWriter::default()),
+        milestone_sink.clone(),
+        "thread-runtime-capability-failure-milestone",
+    )
+    .await;
 
-        let outcome = invoke_visible_runtime_capability(&port)
-            .await
-            .expect("runtime failure outcome maps to loop outcome");
+    let outcome = invoke_visible_runtime_capability(&port)
+        .await
+        .expect("runtime failure outcome maps to loop outcome");
 
-        assert!(matches!(
-            &outcome,
-            Resolution::Done(o) if o.verdict.error_kind().is_some()
-        ));
-        let milestones = milestone_sink.milestones();
-        assert_eq!(milestones.len(), 2);
-        assert!(matches!(
-            &milestones[1].kind,
-            ironclaw_loop_contracts::LoopHostMilestoneKind::CapabilityFailed {
-                activity_id: _,
-                capability_id: actual,
-                provider: Some(provider),
-                runtime: Some(RuntimeKind::FirstParty),
-                reason_kind,
-                ..
-            } if actual == &capability_id && provider == &provider_id && reason_kind == &expected_kind
-        ));
-    }
+    assert!(matches!(
+        &outcome,
+        Resolution::Done(o) if o.verdict.error_kind().is_some()
+    ));
+    let milestones = milestone_sink.milestones();
+    assert_eq!(milestones.len(), 2);
+    assert!(matches!(
+        &milestones[1].kind,
+        ironclaw_loop_contracts::LoopHostMilestoneKind::CapabilityFailed {
+            activity_id: _,
+            capability_id: actual,
+            provider: Some(provider),
+            runtime: Some(RuntimeKind::FirstParty),
+            reason_kind: FailureKind::InputEncode,
+            ..
+        } if actual == &capability_id && provider == &provider_id
+    ));
 }
 
 #[tokio::test]
@@ -957,65 +938,6 @@ async fn host_runtime_default_auth_decline_fails_closed_as_unavailable() {
         .expect_err("runtime without durable decline support must fail closed");
 
     assert!(matches!(error, HostRuntimeError::Unavailable { .. }));
-}
-
-/// The unified `FailureKind` vocabulary is closed and `from_tag` is total, so
-/// a wild/unsafe unknown-outcome tag no longer aborts the run with an internal
-/// "could not be represented" host error — it lands in the non-retryable
-/// `Unclassified` sink, emits the failure milestone, and returns a
-/// model-visible failed resolution.
-#[tokio::test]
-async fn runtime_capability_unknown_outcome_with_wild_kind_maps_to_unclassified_failure() {
-    let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
-    let provider_id = ExtensionId::new("demo").expect("valid provider id");
-    let milestone_sink =
-        Arc::new(ironclaw_loop_contracts::InMemoryLoopHostMilestoneSink::default());
-    let port = runtime_capability_port(
-        &capability_id,
-        &provider_id,
-        Arc::new(QueuedHostRuntime::new(
-            vec![visible_capability(
-                capability_id.clone(),
-                provider_id.clone(),
-            )],
-            vec![Ok(RuntimeCapabilityOutcome::Unknown(
-                RuntimeCapabilityUnknown {
-                    capability_id: capability_id.clone(),
-                    kind: "invalid kind with spaces".to_string(),
-                    message: Some("bad kind".to_string()),
-                },
-            ))],
-        )),
-        Arc::new(RecordingResultWriter::default()),
-        milestone_sink.clone(),
-        "thread-runtime-capability-invalid-unknown-kind",
-    )
-    .await;
-
-    let outcome = invoke_visible_runtime_capability(&port)
-        .await
-        .expect("wild unknown-outcome kind becomes a model-visible failure");
-
-    assert!(matches!(
-        &outcome,
-        Resolution::Done(o)
-            if o.verdict.error_kind() == Some(&FailureKind::Unclassified)
-    ));
-    let milestones = milestone_sink.milestones();
-    assert_eq!(milestones.len(), 2);
-    assert!(matches!(
-        &milestones[1].kind,
-        ironclaw_loop_contracts::LoopHostMilestoneKind::CapabilityFailed {
-            activity_id: _,
-            capability_id: actual,
-            provider: Some(provider),
-            runtime: Some(RuntimeKind::FirstParty),
-            reason_kind,
-            ..
-        } if actual == &capability_id
-            && provider == &provider_id
-            && reason_kind == &FailureKind::Unclassified
-    ));
 }
 
 #[tokio::test]

--- a/tests/reborn_qa_recorded_behavior.rs
+++ b/tests/reborn_qa_recorded_behavior.rs
@@ -1311,9 +1311,14 @@ async fn replay_routine_phrase_fires(case: &QaPhrase, cron_fragment: &str) {
         }
     }
 
-    // Read the fired run's persisted reply while the runtime is still up; the
-    // assertion happens after the clearer fire-progress asserts below.
-    let fired_reply = fired_routine_finalized_reply(&runtime, &tenant_id, trigger_id).await;
+    // Fire acceptance sets the trigger status before the scheduled turn has
+    // necessarily persisted its final reply. Observe that user-visible result
+    // within the same bounded deadline instead of racing turn finalization.
+    let mut fired_reply = fired_routine_finalized_reply(&runtime, &tenant_id, trigger_id).await;
+    while fired_reply.is_none() && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        fired_reply = fired_routine_finalized_reply(&runtime, &tenant_id, trigger_id).await;
+    }
 
     runtime.shutdown().await.expect("runtime shutdown");
 


### PR DESCRIPTION
## Summary

PR 1 of the capability-response-normalization plan (#7627). Behavior-preserving centralization: fresh invocation, approval resume, and auth resume now produce `RuntimeCapabilityOutcome` through one concrete `capability_response_processor` in `ironclaw_host_runtime`, replacing the scattered conversion helpers (`completed_outcome_from`, `translate_invocation_error`, resume-specific matches).

Per layer:

- **kernel/ironclaw_host_runtime** — new `capability_response_processor.rs` with `CapabilityResponseContext` + `InlineInvocationMode { Fresh, ApprovalResume, AuthResume }`; `production.rs` slims to routing; compile-time pin that `RuntimeCapabilityOutcome` never derives Serde.
- **kernel/ironclaw_capabilities** — deletes the single-field `CapabilityInvocationResult { dispatch }` wrapper; invoke/approval-resume/auth-resume return `CapabilityDispatchResult` directly.
- **contracts/ironclaw_host_api** — persisted-resolution compatibility test: legacy open-set failure tags load as bounded `Unclassified`, unknown additive fields ignored, cannot become success.
- **loop/ironclaw_loop_host, app/ironclaw_composition** — remove `RuntimeCapabilityOutcome::Unknown` match arms and synthetic tests; the variant had no production producer and no persistence role (enum is in-memory only, never serialized).

No outcome semantics change. Follow-ups in the plan: PR 2 (ProviderDiagnostic + protocol decoders, branch `fix/7627-provider-response-normalization` stacked on this), PR 3 (WASM WIT), PR 4 (product projection).

## Test Strategy

- **Integration:** `cargo test -p ironclaw_integration_tests --test reborn_integration_auth_gate` — 18/18 pass; drives submit-turn → dispatch → auth gate through the new processor path.
- **Crate:** `host_runtime_contract.rs` extended with 6 caller-level tests through `DefaultHostRuntime` public entry points pinning all three inline modes (dispatch failure → Failed + run-state fail, stable auth-gate ids across repeats, approval resume cannot reopen a gate). `cargo test -p ironclaw_host_runtime`: 485 passed; the 2 `trace_commons` failures reproduce identically on base ee1062d01 (sandbox network egress, unrelated files).
- **Architecture:** `cargo test -p ironclaw_architecture_tests` — all green.
- **E2E:** Not applicable: pure internal refactor, no user-visible behavior change; integration tier covers the wired path.

Clippy `-D warnings` clean on changed crates; fmt clean.

## Compatibility / rollback

In-memory contracts only; no persisted schema, config, or wire change. Revert is a clean single-commit-range rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)