### PR TITLE
fix(runtime): close heartbeat review gaps

### DIFF
--- a/crates/app/ironclaw_composition/src/factory/tests.rs
+++ b/crates/app/ironclaw_composition/src/factory/tests.rs
@@ -1706,6 +1706,7 @@ async fn postgres_process_journal_writes_are_visible_over_the_data_plane_and_sur
         .expect("journal claim")
         .pop()
         .expect("claimed process");
+    let claimed_cursor = claim.state.journal_cursor;
     assert_eq!(read_back.process_id, process_id);
 
     let held_a = pools.data_plane.get().await.expect("data-plane checkout a");
@@ -1719,7 +1720,10 @@ async fn postgres_process_journal_writes_are_visible_over_the_data_plane_and_sur
         .await
         .expect("the journal heartbeat must not queue behind an exhausted data-plane pool");
     let _ = (held_a, held_b);
-    assert!(heartbeat.0 > 0, "heartbeat advances the journal cursor");
+    assert_eq!(
+        heartbeat, claimed_cursor,
+        "heartbeat preserves the claimed journal cursor"
+    );
 }
 
 /// Start a Postgres testcontainer, or skip (return `None`) when

--- a/crates/app/ironclaw_composition/src/runtime_input.rs
+++ b/crates/app/ironclaw_composition/src/runtime_input.rs
@@ -70,7 +70,7 @@ impl Default for RebornRuntimeIdentity {
     }
 }
 
-pub(crate) const DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+pub(crate) const DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 pub(crate) const DEFAULT_TURN_RUNNER_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 // The fire-time access contract lives in `ironclaw_triggers` (CHECKLIST WS6):
@@ -711,6 +711,13 @@ impl RebornRuntimeInput {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn turn_runner_default_uses_fifteen_second_heartbeat() {
+        assert_eq!(
+            TurnRunnerSettings::default().heartbeat_interval,
+            Duration::from_secs(15)
+        );
+    }
 
     #[test]
     fn from_build_input_preserves_configured_ironhub_manifest_url() {

--- a/crates/kernel/ironclaw_processes/tests/legacy_migration_backend_contract.rs
+++ b/crates/kernel/ironclaw_processes/tests/legacy_migration_backend_contract.rs
@@ -39,7 +39,10 @@ async fn heartbeat_persistence_is_durable_on_libsql() {
 
 #[tokio::test]
 async fn heartbeat_persistence_is_durable_on_postgres() {
-    let Some(backend) = postgres_backend().await else {
+    let Some(backend) = postgres_backend()
+        .await
+        .expect("configure process heartbeat PostgreSQL backend")
+    else {
         eprintln!(
             "skipping process heartbeat Postgres contract: \
              IRONCLAW_FILESYSTEM_POSTGRES_URL / DATABASE_URL unavailable"
@@ -210,7 +213,10 @@ async fn deployed_legacy_layouts_import_on_libsql() {
 
 #[tokio::test]
 async fn deployed_legacy_layouts_import_on_postgres() {
-    let Some(backend) = postgres_backend().await else {
+    let Some(backend) = postgres_backend()
+        .await
+        .expect("configure process migration PostgreSQL backend")
+    else {
         eprintln!(
             "skipping process legacy-migration Postgres contract: \
              IRONCLAW_FILESYSTEM_POSTGRES_URL / DATABASE_URL unavailable"
@@ -390,20 +396,30 @@ where
         .expect("seed durable fixture");
 }
 
-async fn postgres_backend() -> Option<PostgresRootFilesystem> {
-    if std::env::var("IRONCLAW_SKIP_POSTGRES_TESTS").is_ok() {
-        return None;
+async fn postgres_backend() -> Result<Option<PostgresRootFilesystem>, String> {
+    if std::env::var_os("IRONCLAW_SKIP_POSTGRES_TESTS").is_some() {
+        return Ok(None);
     }
-    let url = std::env::var("IRONCLAW_FILESYSTEM_POSTGRES_URL")
-        .or_else(|_| std::env::var("DATABASE_URL"))
-        .ok()?;
-    let config = url.parse::<tokio_postgres::Config>().ok()?;
+    let Some(url) = std::env::var_os("IRONCLAW_FILESYSTEM_POSTGRES_URL")
+        .or_else(|| std::env::var_os("DATABASE_URL"))
+    else {
+        return Ok(None);
+    };
+    let url = url
+        .into_string()
+        .map_err(|_| "PostgreSQL URL is not valid UTF-8".to_string())?;
+    let config = url
+        .parse::<tokio_postgres::Config>()
+        .map_err(|error| format!("parse PostgreSQL URL: {error}"))?;
     let manager = deadpool_postgres::Manager::new(config, tokio_postgres::NoTls);
     let pool = deadpool_postgres::Pool::builder(manager)
         .max_size(4)
         .build()
-        .ok()?;
+        .map_err(|error| format!("build PostgreSQL pool: {error}"))?;
     let backend = PostgresRootFilesystem::new(pool);
-    backend.run_migrations().await.ok()?;
-    Some(backend)
+    backend
+        .run_migrations()
+        .await
+        .map_err(|error| format!("run PostgreSQL migrations: {error}"))?;
+    Ok(Some(backend))
 }


### PR DESCRIPTION
## Summary

- Fail configured PostgreSQL heartbeat and migration tests when URL parsing, pool construction, or migrations fail; only missing configuration or the explicit skip flag may skip.
- Align configless composition with the shipped 15-second turn-runner heartbeat default introduced by #7628.
- Assert that a successful heartbeat preserves the claimed process journal cursor.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Follow-up to #7628. Related to #7593 and #7599.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_processes`; focused composition default and cursor tests; `cargo test -p ironclaw_architecture_tests`
- [x] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed: not applicable because `ironclaw_processes` has no integration feature; its durable backend contract test passed for libSQL and skip behavior, and a configured invalid PostgreSQL URL failed loudly as required.
- [x] Manual testing: reproduced the configured invalid-URL test silently passing before the fix, then verified it fails with `parse PostgreSQL URL: invalid connection string` after the fix.
- [x] If a coding agent was used and supports it, review comments were audited before implementation.

## Test Strategy

User behavior:

Configless runtimes now use the same 15-second heartbeat interval as generated and shipped configuration. Test infrastructure no longer reports green when a configured PostgreSQL backend cannot initialize.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: added the `TurnRunnerSettings` default assertion; strengthened the PostgreSQL pool-isolation cursor assertion; preserved durable backend conformance coverage.
- Reborn integration: Not applicable; no whole-turn behavior changed.
- Recorded fixture: Not applicable; no model request or response behavior changed.
- Browser E2E: Not applicable; no browser-visible behavior changed.
- Backend or runtime: libSQL durable-backend contract passed; missing PostgreSQL configuration still skips; configured invalid PostgreSQL now fails loudly; focused composition default and cursor tests passed.
- Live canary: Not applicable; no live model or provider behavior changed.

What the tests prove:

The configless composition heartbeat is 15 seconds, heartbeat writes preserve the claimed journal cursor, durable libSQL behavior remains valid, and configured PostgreSQL setup failures cannot become green skips.

Commands run:

- `cargo test -p ironclaw_processes`
- `cargo test -p ironclaw_processes --test legacy_migration_backend_contract`
- `IRONCLAW_FILESYSTEM_POSTGRES_URL=not-a-postgres-url cargo test -p ironclaw_processes --test legacy_migration_backend_contract heartbeat_persistence_is_durable_on_postgres -- --exact` (expected failure after the fix)
- `cargo test -p ironclaw_composition runtime_input::tests::turn_runner_default_uses_fifteen_second_heartbeat -- --exact`
- `cargo test -p ironclaw_composition factory::tests::postgres_process_journal_writes_are_visible_over_the_data_plane_and_survive_pool_exhaustion -- --exact`
- `cargo clippy -p ironclaw_processes --tests -- -D warnings`
- `cargo clippy -p ironclaw_composition --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_architecture_tests`
- `cargo fmt --all -- --check`

The full `ironclaw_composition` suite encountered a stack overflow in the unchanged `runtime::tests::the_model_runs_a_skills_script_from_the_workdir_the_body_advertises` test. The remaining suite reached 542 passing tests before one timing-sensitive projection test failed; that projection test passed on exact rerun.

## Security Impact

None. No permissions, network access, secrets, file access, tool execution, or sandbox policy changed.

## Reborn Trust-Boundary Checklist

N/A: this change adjusts test error propagation, a composition-owned runtime setting, and assertions. It adds no public types, untrusted-content paths, hashes, statuses, serialization fields, queues, error variants, or runtime boundary names.

## Database Impact

No schema or migration changes. PostgreSQL test setup now propagates configured URL, pool-build, and migration failures. LibSQL and production persistence behavior are unchanged.

## Blast Radius

- Configless composition changes from a 5-second to a 15-second turn-runner heartbeat.
- Worker-death observation can therefore occur up to 10 seconds later, within the existing 90-second lease TTL.
- Generated and shipped configurations already use 15 seconds, so deployed configured profiles do not change.

## Rollback Plan

Revert this PR. That restores the 5-second configless composition default, the prior PostgreSQL test skip behavior, and the weaker cursor assertion. No data migration is required.

## Review Follow-Through

Addresses the remaining findings from #7628 after that PR merged and its head branch was deleted:

- CodeRabbit thread `discussion_r3787508476`: configured PostgreSQL errors no longer collapse into skips.
- Pierre Le Guen review `pullrequestreview-4941639498`: composition default aligned and stale cursor assertion corrected.
- The unused import blocker was already fixed by `0bb1a37c93` before #7628 merged.

---

**Review track**: C (runtime/database test behavior)
