### PR TITLE
fix(slack): address multi-agent review findings on #7682

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4241,6 +4241,7 @@ dependencies = [
  "ironclaw_trust",
  "ironclaw_turns",
  "lru",
+ "percent-encoding",
  "proptest",
  "rand 0.10.2",
  "rust_decimal",

--- a/crates/app/ironclaw_composition/src/extension_host_assembly.rs
+++ b/crates/app/ironclaw_composition/src/extension_host_assembly.rs
@@ -41,6 +41,25 @@ use ironclaw_product_contracts::delivery::ChannelDeliveryResolver;
 /// rather than advertising an unreachable loopback URL into a channel.
 const CONNECT_LINK_BASE_URL_ENV: &str = "IRONCLAW_REBORN_WEBUI_BASE_URL";
 
+/// Interpret `IRONCLAW_REBORN_WEBUI_BASE_URL` exactly as the OAuth path does
+/// (`ironclaw_cli::commands::serve_sso`'s `non_empty_env` + `normalize_base_url`):
+/// trim whitespace, strip trailing slashes, and treat a value that is empty
+/// afterwards as unset. Without the blank filter, `IRONCLAW_REBORN_WEBUI_BASE_URL=`
+/// in a deployment's `.env` resolves to `Some("")` and the notice advertises the
+/// relative path `/chat?connect=<extension>` into a customer conversation. The OAuth
+/// consumer *fails startup* on a blank value; this consumer has a working
+/// link-free fallback, so it ships dark instead — the two agree on what the
+/// variable means, and differ only in what an unusable value costs.
+fn connect_link_base_url_from_env() -> Option<String> {
+    let raw = std::env::var(CONNECT_LINK_BASE_URL_ENV).ok()?; // silent-ok: optional public-origin env read; unset keeps the notice link-free
+    normalize_connect_link_base_url(&raw)
+}
+
+fn normalize_connect_link_base_url(raw: &str) -> Option<String> {
+    let normalized = raw.trim().trim_end_matches('/');
+    (!normalized.is_empty()).then(|| normalized.to_string())
+}
+
 pub(crate) struct BackendExtensionHostAssemblyInput {
     pub(crate) binder: ExtensionLaneToolBinder,
     pub(crate) native_factories: Vec<Arc<dyn ironclaw_extension_host::NativeExtensionFactory>>,
@@ -587,7 +606,7 @@ pub(crate) fn start_channel_host(
         dm_targets: Some(Arc::clone(dm_targets)),
         channel_pairing: channel_pairing.clone(),
         admin_users,
-        connect_link_base_url: std::env::var(CONNECT_LINK_BASE_URL_ENV).ok(),
+        connect_link_base_url: connect_link_base_url_from_env(),
     });
     StartedChannelHost {
         assembly,
@@ -693,4 +712,30 @@ pub(crate) fn start_channel_host_from_stores(
 ) -> Option<Arc<ironclaw_extension_host::channel_host::GenericChannelHostAssembly>> {
     let source = channel_host_source(services)?;
     Some(start_channel_host(&source, wiring).assembly)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_connect_link_base_url;
+
+    /// #7682: a blank or whitespace-only `IRONCLAW_REBORN_WEBUI_BASE_URL`
+    /// (`IRONCLAW_REBORN_WEBUI_BASE_URL=` in a deployment `.env`) must resolve
+    /// to `None`, not `Some("")` — the latter appends the relative link
+    /// "Or connect directly: /chat?connect=<extension>" to a notice posted into a
+    /// customer conversation. Normalization matches the OAuth consumer's.
+    #[test]
+    fn connect_link_base_url_normalization_matches_the_oauth_consumer() {
+        assert_eq!(normalize_connect_link_base_url(""), None);
+        assert_eq!(normalize_connect_link_base_url("   "), None);
+        assert_eq!(normalize_connect_link_base_url("/"), None);
+        assert_eq!(normalize_connect_link_base_url(" / "), None);
+        assert_eq!(
+            normalize_connect_link_base_url(" https://app.example.com/ "),
+            Some("https://app.example.com".to_string())
+        );
+        assert_eq!(
+            normalize_connect_link_base_url("https://app.example.com"),
+            Some("https://app.example.com".to_string())
+        );
+    }
 }

--- a/crates/extensions/ironclaw_extension_host/Cargo.toml
+++ b/crates/extensions/ironclaw_extension_host/Cargo.toml
@@ -70,6 +70,9 @@ axum = { version = "0.8" }
 fs4 = "1.1"
 futures = "0.3"
 lru = { version = "0.18" }
+# Query-value escaping for the connect link appended to a channel's
+# `connect_required` notice (extension ids come from durable records).
+percent-encoding = "2"
 rand = "0.10"
 rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }
 secrecy = "0.10"

--- a/crates/extensions/ironclaw_extension_host/src/channel_host.rs
+++ b/crates/extensions/ironclaw_extension_host/src/channel_host.rs
@@ -67,6 +67,17 @@ use crate::extension_ingress::{
 use ironclaw_extension_host::ChannelConfigService;
 use ironclaw_product_contracts::admin_users::AdminUserService;
 
+/// Characters that must be escaped when an extension id is interpolated into
+/// the `connect` query value. Extension ids arrive as raw strings from durable
+/// installation and deployment-binding records, so the id is encoded rather
+/// than trusted to be URL-safe: a `&`, `#`, or space in an id would otherwise
+/// truncate or re-target the link the notice advertises.
+const CONNECT_QUERY_VALUE: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
 /// The channel's `connect_required` copy, with a one-click connect link
 /// appended when the strategy is OAuth and the deployment configured a public
 /// web origin (#7681). `/chat?connect=<extension>` is an authenticated route,
@@ -81,6 +92,8 @@ fn connect_required_notice(
     match base_url {
         Some(base) if connection.strategy == ChannelConnectionStrategy::OAuth => {
             let base = base.trim_end_matches('/');
+            let extension_id =
+                percent_encoding::utf8_percent_encode(extension_id, CONNECT_QUERY_VALUE);
             format!("{text} Or connect directly: {base}/chat?connect={extension_id}")
         }
         _ => text.clone(),
@@ -1271,6 +1284,78 @@ mod tests {
             }
             other => panic!("expected a shared-secret-header mint, got {other:?}"),
         }
+    }
+
+    fn connection_descriptor(strategy: ChannelConnectionStrategy) -> ChannelConnectionDescriptor {
+        ChannelConnectionDescriptor {
+            provider: ironclaw_host_api::ids::VendorId::new("vendorx").expect("vendor id"),
+            strategy,
+            instructions: "connect".to_string(),
+            input_placeholder: String::new(),
+            submit_label: "Connect".to_string(),
+            error_message: "failed".to_string(),
+            notices: ironclaw_extension_contracts::channel::ChannelConnectionNotices {
+                connect_required: "Connect your account.".to_string(),
+                paired: "paired".to_string(),
+                already_paired_same_user: "already".to_string(),
+                already_bound_to_other_user: "other".to_string(),
+                expired_or_unknown: "expired".to_string(),
+            },
+            connection_success_message: "connected".to_string(),
+            deep_link_template: None,
+            inbound_code_prefixes: Vec::new(),
+        }
+    }
+
+    /// #7681: the one-click link is appended only for an OAuth-strategy channel
+    /// on a deployment that configured a public web origin. Every other
+    /// combination must return the manifest copy verbatim — a relative or
+    /// vendor-mismatched link would be posted into a customer conversation.
+    #[test]
+    fn connect_notice_appends_the_link_only_for_oauth_with_a_base_url() {
+        let oauth = connection_descriptor(ChannelConnectionStrategy::OAuth);
+
+        assert_eq!(
+            connect_required_notice(&oauth, "slack", Some("https://app.example.com")),
+            "Connect your account. Or connect directly: https://app.example.com/chat?connect=slack"
+        );
+        // A trailing slash on the configured origin must not produce `//chat`.
+        assert_eq!(
+            connect_required_notice(&oauth, "slack", Some("https://app.example.com/")),
+            "Connect your account. Or connect directly: https://app.example.com/chat?connect=slack"
+        );
+        // Unset origin ships dark: the notice stays link-free rather than
+        // advertising an unreachable relative path.
+        assert_eq!(
+            connect_required_notice(&oauth, "slack", None),
+            oauth.notices.connect_required
+        );
+        // A non-OAuth strategy carries its own deep link, so no link leaks
+        // into its copy even when an origin IS configured.
+        for strategy in [
+            ChannelConnectionStrategy::DeviceLink,
+            ChannelConnectionStrategy::WebGeneratedCode,
+            ChannelConnectionStrategy::AdminManagedChannels,
+        ] {
+            let other = connection_descriptor(strategy);
+            assert_eq!(
+                connect_required_notice(&other, "slack", Some("https://app.example.com")),
+                other.notices.connect_required,
+                "{strategy:?} must return the manifest copy verbatim"
+            );
+        }
+    }
+
+    /// The extension id comes from a durable record, so it is percent-encoded:
+    /// an unescaped `&` would truncate the query and re-target the link.
+    #[test]
+    fn connect_notice_percent_encodes_the_extension_id() {
+        let oauth = connection_descriptor(ChannelConnectionStrategy::OAuth);
+        assert_eq!(
+            connect_required_notice(&oauth, "sl ack&evil=1", Some("https://app.example.com")),
+            "Connect your account. Or connect directly: \
+             https://app.example.com/chat?connect=sl%20ack%26evil%3D1"
+        );
     }
 
     #[test]

--- a/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
+++ b/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
@@ -443,6 +443,10 @@ struct HarnessOptions {
     actor_role: AdminUserRole,
     /// Optional connection-strategy override for migration boundary tests.
     connection_strategy: Option<ChannelConnectionStrategy>,
+    /// The deployment's public web origin, as composition resolves it from
+    /// `IRONCLAW_REBORN_WEBUI_BASE_URL`. `None` (the default) keeps the
+    /// connect notice link-free.
+    connect_link_base_url: Option<String>,
 }
 
 impl HarnessOptions {
@@ -455,6 +459,7 @@ impl HarnessOptions {
             foreign_scope_approvals: false,
             actor_role: AdminUserRole::Member,
             connection_strategy: None,
+            connect_link_base_url: None,
         }
     }
 }
@@ -484,6 +489,12 @@ async fn build_harness_with_manifest_commands(
 ) -> Harness {
     let mut options = HarnessOptions::new(mode);
     options.manifest_commands = Some(commands);
+    build_harness_with_options(options).await
+}
+
+async fn build_harness_with_connect_link_base_url(mode: TurnMode, base_url: &str) -> Harness {
+    let mut options = HarnessOptions::new(mode);
+    options.connect_link_base_url = Some(base_url.to_string());
     build_harness_with_options(options).await
 }
 
@@ -685,7 +696,7 @@ async fn build_harness_with_options(options: HarnessOptions) -> Harness {
         dm_targets: Some(Arc::clone(&dm_targets)),
         channel_pairing: None,
         admin_users: Arc::new(FakeAdminUsers::seeded(USER, options.actor_role)),
-        connect_link_base_url: None,
+        connect_link_base_url: options.connect_link_base_url.clone(),
     };
     let assembly = GenericChannelHostAssembly::start(deps);
     let command_executions = Arc::new(RecordingCommandExecutionSurface::new(model_preferences));
@@ -2527,15 +2538,18 @@ async fn slack_top_level_mention_roots_a_thread_and_replies_in_it() {
     );
 }
 
-/// Added with the run-acts-as-invoker ruling (#7377): an UNPAIRED user's
-/// channel mention executes NO run. The fixed `connect_required` notice is
-/// posted into the conversation through the same anchored placement replies
-/// use (threaded on the pinged message's ts), and a repeat mention in that
-/// same thread inside the throttle window posts nothing more — presence
-/// admits the conversation, pairing gates the run, and the nudge addresses
-/// the one unpaired sender rather than the room.
+/// Added with the run-acts-as-invoker ruling (#7377), delivery inverted by
+/// #7681: an UNPAIRED user's channel mention executes NO run. The fixed
+/// `connect_required` notice reaches only that sender, so it rides
+/// `chat.postEphemeral` at CHANNEL level and is deliberately un-threaded —
+/// Slack renders an ephemeral message inside a thread only when that thread is
+/// already active, and a top-level mention self-roots its own, so threading it
+/// makes Slack answer `ok` and show nothing (verified live). A repeat mention
+/// in that same conversation inside the throttle window posts nothing more —
+/// presence admits the conversation, pairing gates the run, and the nudge
+/// addresses the one unpaired sender rather than the room.
 #[tokio::test]
-async fn slack_unpaired_mention_gets_a_threaded_pairing_notice() {
+async fn slack_unpaired_mention_gets_an_ephemeral_pairing_notice() {
     let harness = build_harness(TurnMode::Complete {
         assistant_text: "never produced".into(),
     })
@@ -2596,6 +2610,53 @@ async fn slack_unpaired_mention_gets_a_threaded_pairing_notice() {
     );
 }
 
+/// #7681/#7682, through the production assembly: on a deployment that
+/// configured a public web origin, the SAME ephemeral nudge carries the
+/// one-click connect link. This is the caller-path proof that composition's
+/// `connect_link_base_url` reaches the notice the vendor actually receives —
+/// the unit test over `connect_required_notice` cannot show that. A trailing
+/// slash on the configured origin must not produce `//chat`.
+#[tokio::test]
+async fn slack_unpaired_mention_nudge_carries_the_connect_link_when_an_origin_is_configured() {
+    let harness = build_harness_with_connect_link_base_url(
+        TurnMode::Complete {
+            assistant_text: "never produced".into(),
+        },
+        "https://app.example.com/",
+    )
+    .await;
+
+    let response = harness.post_event(UNPAIRED_MENTION_EVENT).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    harness.drain().await;
+
+    assert!(
+        harness.coordinator.submitted_scopes().is_empty(),
+        "an unpaired sender must not execute a run"
+    );
+    let messages = harness.slack_ephemeral_messages();
+    assert_eq!(
+        messages.len(),
+        1,
+        "exactly one connect notice: {messages:?}"
+    );
+    let text = messages[0]["text"]
+        .as_str()
+        .expect("the ephemeral nudge carries text");
+    assert_eq!(
+        text,
+        format!(
+            "{} Or connect directly: https://app.example.com/chat?connect=slack",
+            slack_manifest_connect_required_notice()
+        ),
+        "the nudge is the manifest copy plus the one-click connect link"
+    );
+    assert!(
+        text.ends_with("/chat?connect=slack"),
+        "the link must resolve against the configured origin exactly once: {text}"
+    );
+}
+
 /// Ephemeral-per-ping: two users mentioning the bot inside the SAME vendor
 /// thread T are each served in their OWN pinger-owned ephemeral thread
 /// (distinct canonical threads, each run acting as its own invoker); every
@@ -2647,8 +2708,8 @@ async fn slack_in_thread_mentions_each_run_in_their_own_thread_replying_in_the_v
 }
 
 /// Ephemeral-per-ping: pairing mid-thread. Unpaired carol is nudged in place
-/// inside A's ACTIVE thread (threaded connect notice, no run); carol pairs
-/// through the harness pairing seam; her next in-thread message is then served
+/// while A's thread is ACTIVE (channel-level ephemeral connect notice, no run);
+/// carol pairs through the harness pairing seam; her next message is then served
 /// in her OWN pinger-owned ephemeral thread (distinct from A's), acting as
 /// carol — the vendor thread's context is supplied by hydration, not a shared
 /// transcript.
@@ -2666,8 +2727,8 @@ async fn slack_pairing_mid_thread_runs_in_carols_own_thread() {
     assert_eq!(harness.coordinator.submitted_scopes().len(), 1);
 
     // Unpaired carol mentions inside A's active thread: NO run, one connect
-    // nudge threaded at the same T — visible only to carol (#7681), so A's
-    // room-visible reply is unaffected.
+    // nudge posted at CHANNEL level and visible only to carol (#7681) — never
+    // threaded, so A's room-visible reply is unaffected.
     let response = harness.post_event(MIDTHREAD_UNPAIRED_MENTION_CAROL).await;
     assert_eq!(response.status(), StatusCode::OK);
     harness.drain().await;
@@ -4168,7 +4229,7 @@ fn slack_response_for_approved(
         let channel = body["channel"].as_str().unwrap_or("DTEST");
         let ts_seed = stable_slack_test_ts(&approved.body);
         // `chat.postEphemeral` returns `message_ts`, not `ts` — see
-        // `SlackChatPostMessageResponse`'s `#[serde(alias = "message_ts")]`.
+        // `SlackChatPostResponse`'s `#[serde(alias = "message_ts")]`.
         let payload = if path == "/api/chat.postEphemeral" {
             serde_json::json!({ "ok": true, "channel": channel, "message_ts": ts_seed })
         } else {
@@ -4677,7 +4738,7 @@ const TOP_LEVEL_MENTION_EVENT: &str = r#"{
 }"#;
 
 /// U999 has no identity binding anywhere in the harness; used by
-/// `slack_unpaired_mention_gets_a_threaded_pairing_notice`.
+/// `slack_unpaired_mention_gets_an_ephemeral_pairing_notice`.
 const UNPAIRED_MENTION_EVENT: &str = r#"{
   "type":"event_callback",
   "team_id":"T-A",

--- a/crates/extensions/packages/slack/src/channel.rs
+++ b/crates/extensions/packages/slack/src/channel.rs
@@ -361,8 +361,12 @@ struct SlackOpenedConversation {
     id: String,
 }
 
+/// The shared `ok`/`error`/`ts` envelope every Slack write call in this module
+/// answers with — `chat.postMessage`, `chat.postEphemeral`, `chat.delete`, and
+/// `reactions.add` — hence the un-suffixed name. The `message_ts` alias below
+/// exists only for `chat.postEphemeral`.
 #[derive(Debug, Deserialize)]
-struct SlackChatPostMessageResponse {
+struct SlackChatPostResponse {
     ok: bool,
     error: Option<String>,
     // `chat.postEphemeral` answers with `message_ts` where `chat.postMessage`
@@ -431,7 +435,7 @@ async fn post_slack_chunk(
             format!("slack web api returned status {}", response.status),
         );
     }
-    let parsed: SlackChatPostMessageResponse = match serde_json::from_slice(&response.body) {
+    let parsed: SlackChatPostResponse = match serde_json::from_slice(&response.body) {
         Ok(parsed) => parsed,
         // Slack may have accepted the message even when an intermediary
         // truncated the response. Retrying would risk a duplicate.
@@ -498,7 +502,7 @@ async fn delete_slack_message(
             format!("slack web api returned status {}", response.status),
         );
     }
-    let parsed: SlackChatPostMessageResponse = match serde_json::from_slice(&response.body) {
+    let parsed: SlackChatPostResponse = match serde_json::from_slice(&response.body) {
         Ok(parsed) => parsed,
         Err(error) => {
             return PartDeliveryOutcome::Ambiguous {
@@ -576,7 +580,7 @@ async fn react_slack_message(
             format!("slack web api returned status {}", response.status),
         );
     }
-    let parsed: SlackChatPostMessageResponse = match serde_json::from_slice(&response.body) {
+    let parsed: SlackChatPostResponse = match serde_json::from_slice(&response.body) {
         Ok(parsed) => parsed,
         Err(error) => {
             return PartDeliveryOutcome::Ambiguous {

--- a/crates/product/ironclaw_assistant/src/run_delivery.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery.rs
@@ -417,8 +417,7 @@ impl RunDeliveryServices {
     }
 
     /// [`Self::post_notice`] with an explicit visibility request.
-    // arch-exempt: too_many_args, needs a notice-request bundle, which would
-    // duplicate NoticeDeliveryRequest one layer up, issue #7681
+    // arch-exempt: too_many_args, needs a notice-request bundle, which would duplicate NoticeDeliveryRequest one layer up, plan #7681
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn post_notice_with_visibility(
         &self,

--- a/crates/product/ironclaw_webui/frontend/src/lib/product-auth-oauth-events.ts
+++ b/crates/product/ironclaw_webui/frontend/src/lib/product-auth-oauth-events.ts
@@ -12,6 +12,18 @@
 //
 // Mirrors the style of `lib/channel-connection-events.ts`.
 
+// Watcher bounds, shared by every product-auth OAuth watcher (Extensions page,
+// in-chat onboarding, connect-link landing) so an abandoned popup cannot leave
+// any of them polling the server forever — and so the three cannot drift.
+export const OAUTH_FLOW_TIMEOUT_MS = 10 * 60 * 1000;
+export const OAUTH_FLOW_POLL_MS = 2000;
+// Terminal flow statuses, mapped to the i18n key each watcher shows.
+export const OAUTH_FLOW_STATUS_ERROR_KEYS = Object.freeze({
+  failed: "extensions.oauthFailed",
+  canceled: "extensions.oauthCanceled",
+  expired: "extensions.oauthExpired",
+});
+
 export const OAUTH_CALLBACK_CHANNEL = "ironclaw-product-auth";
 export const OAUTH_CALLBACK_STORAGE_KEY = "ironclaw:product-auth:oauth-complete";
 export const OAUTH_CALLBACK_MESSAGE_TYPE = "ironclaw:product-auth:oauth-complete";

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useChannelOnboarding.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useChannelOnboarding.ts
@@ -10,6 +10,9 @@ import {
   subscribeChannelConnected,
 } from "../../../lib/channel-connection-events";
 import {
+  OAUTH_FLOW_POLL_MS,
+  OAUTH_FLOW_STATUS_ERROR_KEYS,
+  OAUTH_FLOW_TIMEOUT_MS,
   completionMatchesFlow,
   failureMatchesFlow,
   openAuthPopup,
@@ -28,17 +31,6 @@ import {
 const DISMISSED_ONBOARDING_STORAGE_PREFIX =
   "ironclaw.chat.dismissedOnboarding.v1:";
 const DISMISSED_ONBOARDING_STORAGE_LIMIT = 100;
-
-// In-chat OAuth watcher bounds. Mirror the Extensions page watcher
-// (`OAUTH_SETUP_TIMEOUT_MS` / `OAUTH_SETUP_REFRESH_MS` in useExtensions.ts) so
-// an abandoned popup cannot leave the card polling the server forever.
-const CHAT_OAUTH_TIMEOUT_MS = 10 * 60 * 1000;
-const CHAT_OAUTH_POLL_MS = 2000;
-const CHAT_OAUTH_STATUS_ERROR_KEYS = Object.freeze({
-  failed: "extensions.oauthFailed",
-  canceled: "extensions.oauthCanceled",
-  expired: "extensions.oauthExpired",
-});
 
 function authPopupFailureMessage(reason, t) {
   return reason === "popup_blocked"
@@ -435,7 +427,7 @@ export function useChannelOnboarding(
         .then((result) => {
           if (!flowSnapshotIsCurrent(pending)) return null;
           if (result?.status === "completed") return finishCompletion(pending);
-          const statusErrorKey = CHAT_OAUTH_STATUS_ERROR_KEYS[result?.status];
+          const statusErrorKey = OAUTH_FLOW_STATUS_ERROR_KEYS[result?.status];
           if (statusErrorKey) {
             failOauthFlow(pending, t(statusErrorKey));
             return null;
@@ -467,14 +459,14 @@ export function useChannelOnboarding(
       if (
         !pending.completing &&
         pending.startedAt &&
-        Date.now() - pending.startedAt > CHAT_OAUTH_TIMEOUT_MS
+        Date.now() - pending.startedAt > OAUTH_FLOW_TIMEOUT_MS
       ) {
         failOauthFlow(pending, t("extensions.oauthTimedOut"));
         return;
       }
       handleCompletion(readLatestProductAuthOAuthCompletion(browserWindow));
       pollServerState();
-    }, CHAT_OAUTH_POLL_MS);
+    }, OAUTH_FLOW_POLL_MS);
     return () => {
       browserWindow.clearInterval(timer);
       unsubscribe();

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useConnectLinkLanding.test.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useConnectLinkLanding.test.tsx
@@ -17,10 +17,23 @@ import { I18nProvider } from "../../../lib/i18n";
 
 const api = vi.hoisted(() => ({
   fetchExtensionSetup: vi.fn(),
+  fetchExtensionRegistry: vi.fn(),
+  fetchExtensions: vi.fn(),
   fetchOauthFlowStatus: vi.fn(),
   installExtension: vi.fn(),
   startExtensionOauth: vi.fn(),
 }));
+
+// The server-published inventory the `connect` param is resolved against: only
+// an extension the server lists with an OAuth channel connection may be
+// installed and connected from a link.
+function oauthChannelEntry(id, displayName) {
+  return {
+    package_ref: { kind: "extension", id },
+    display_name: displayName,
+    surfaces: [{ kind: "channel", connection: { channel: id, strategy: "oauth" } }],
+  };
+}
 
 vi.mock("../../extensions/lib/extensions-api", () => api);
 
@@ -32,8 +45,7 @@ function fakePopup() {
 
 async function flush() {
   await act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let i = 0; i < 6; i += 1) await Promise.resolve();
   });
 }
 
@@ -49,6 +61,10 @@ beforeEach(() => {
   root = createRoot(container);
   latest = null;
   originalOpen = window.open;
+  api.fetchExtensions.mockResolvedValue({ extensions: [] });
+  api.fetchExtensionRegistry.mockResolvedValue({
+    entries: [oauthChannelEntry("slack", "Slack")],
+  });
 });
 
 afterEach(() => {
@@ -211,4 +227,139 @@ test("dismissing clears the landing state", async () => {
   await flush();
 
   assert.equal(latest.connectLanding, null);
+});
+
+// The `connect` param arrives on a link anyone can craft, so it must not be
+// able to install an attacker-chosen extension and start its OAuth flow. Only
+// an extension the server itself lists with an OAuth channel connection is
+// accepted; everything else is ignored silently.
+test("an unknown connect param renders no card and installs nothing", async () => {
+  renderAt("/chat?connect=google-drive");
+  await flush();
+
+  assert.equal(latest.connectLanding, null);
+  assert.equal(api.installExtension.mock.calls.length, 0);
+});
+
+test("a non-OAuth channel connect param renders no card and installs nothing", async () => {
+  api.fetchExtensionRegistry.mockResolvedValue({
+    entries: [
+      {
+        package_ref: { kind: "extension", id: "telegram" },
+        display_name: "Telegram",
+        surfaces: [
+          { kind: "channel", connection: { channel: "telegram", strategy: "inbound_proof_code" } },
+        ],
+      },
+    ],
+  });
+
+  renderAt("/chat?connect=telegram");
+  await flush();
+
+  assert.equal(latest.connectLanding, null);
+  assert.equal(api.installExtension.mock.calls.length, 0);
+});
+
+test("the button label comes from the server display name, not the raw param", async () => {
+  api.fetchExtensionRegistry.mockResolvedValue({
+    entries: [oauthChannelEntry("slack", "Slack Workspace")],
+  });
+
+  renderAt("/chat?connect=slack");
+  await flush();
+
+  assert.equal(latest.connectLanding?.submitLabel, "Continue to connect Slack Workspace");
+});
+
+// Retrying after a failure must produce a visible prop change even when the
+// second failure is identical: the card only leaves its spinner when the
+// `oauthError` VALUE changes.
+test("two consecutive identical failures both surface the error state", async () => {
+  vi.useFakeTimers();
+  try {
+    await startFlow();
+    api.fetchOauthFlowStatus.mockResolvedValue({ status: "failed" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2100);
+    });
+    const firstError = latest.connectLanding?.oauthError;
+    assert.ok(firstError, "the first failure surfaces an error");
+
+    await act(async () => {
+      await latest.startConnectLinkOAuth();
+    });
+    assert.equal(
+      latest.connectLanding?.oauthError,
+      null,
+      "the retry clears the stale error so an identical second failure is a real change",
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2100);
+    });
+    assert.equal(latest.connectLanding?.oauthError, firstError, "the second failure re-surfaces");
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("an abandoned flow times out and stops polling", async () => {
+  vi.useFakeTimers();
+  try {
+    await startFlow();
+    api.fetchOauthFlowStatus.mockResolvedValue({ status: "pending" });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 5000);
+    });
+
+    assert.equal(
+      latest.connectLanding?.oauthError,
+      "Authorization timed out. Try connecting again.",
+    );
+    const callsAtTimeout = api.fetchOauthFlowStatus.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+    assert.equal(
+      api.fetchOauthFlowStatus.mock.calls.length,
+      callsAtTimeout,
+      "the watcher stops polling once the flow is abandoned",
+    );
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("a blocked popup fails the connect click before any install", async () => {
+  window.open = vi.fn(() => null);
+  renderAt("/chat?connect=slack");
+  await flush();
+
+  await act(async () => {
+    await assert.rejects(
+      () => latest.startConnectLinkOAuth(),
+      /Authorization popup was blocked/,
+    );
+  });
+  assert.equal(api.installExtension.mock.calls.length, 0);
+});
+
+test("a failed install closes the placeholder popup instead of leaking it", async () => {
+  const popup = fakePopup();
+  window.open = vi.fn(() => popup);
+  popup.close = () => {
+    popup.closed = true;
+  };
+  api.installExtension.mockRejectedValue(new Error("install refused"));
+
+  renderAt("/chat?connect=slack");
+  await flush();
+
+  await act(async () => {
+    await assert.rejects(() => latest.startConnectLinkOAuth(), /install refused/);
+  });
+  assert.equal(popup.closed, true, "no about:blank window is left open");
+  assert.equal(api.startExtensionOauth.mock.calls.length, 0);
 });

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useConnectLinkLanding.test.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useConnectLinkLanding.test.tsx
@@ -37,6 +37,11 @@ function oauthChannelEntry(id, displayName) {
 
 vi.mock("../../extensions/lib/extensions-api", () => api);
 
+// The hook loads `lib/connect-link-flow` through a dynamic `import()` so the
+// machinery stays out of the eager /chat bundle. Importing it statically here
+// puts it in the module registry, so that `import()` resolves on a microtask
+// and the flush helper below stays deterministic.
+import "../lib/connect-link-flow";
 import { useConnectLinkLanding } from "./useConnectLinkLanding";
 
 function fakePopup() {

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useConnectLinkLanding.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useConnectLinkLanding.ts
@@ -8,27 +8,62 @@ import {
   notifyChannelConnected,
 } from "../../../lib/channel-connection-events";
 import {
+  OAUTH_FLOW_POLL_MS,
+  OAUTH_FLOW_STATUS_ERROR_KEYS,
+  OAUTH_FLOW_TIMEOUT_MS,
   completionMatchesFlow,
   openAuthPopup,
   subscribeProductAuthOAuthCompletion,
 } from "../../../lib/product-auth-oauth-events";
 import {
+  fetchExtensionRegistry,
   fetchExtensionSetup,
+  fetchExtensions,
   fetchOauthFlowStatus,
   installExtension,
   startExtensionOauth,
 } from "../../extensions/lib/extensions-api";
+import { channelConnection } from "../../extensions/lib/extensions-schema";
 
 const CONNECT_LINK_QUERY_PARAM = "connect";
-// Watcher bounds, mirroring the in-chat onboarding watcher so an abandoned
-// popup cannot leave the card polling forever.
-const CONNECT_OAUTH_TIMEOUT_MS = 10 * 60 * 1000;
-const CONNECT_OAUTH_POLL_MS = 2000;
-const CONNECT_OAUTH_STATUS_ERROR_KEYS = Object.freeze({
-  failed: "extensions.oauthFailed",
-  canceled: "extensions.oauthCanceled",
-  expired: "extensions.oauthExpired",
-});
+
+function normalizeExtensionId(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+// The `connect` param is attacker-controllable — it arrives on a link anyone can
+// craft — so it names nothing until the server's own extension inventory
+// confirms it. Resolve it against the installed list and the registry, and
+// accept it only as an extension whose channel surface actually connects over
+// OAuth. Anything else (unknown id, a tools-only extension, a channel that
+// pairs by proof code or device link) is ignored silently: an unsolicited
+// install + OAuth start is exactly what must not happen from a crafted link.
+async function resolveOauthConnectTarget(extensionName) {
+  const wanted = normalizeExtensionId(extensionName);
+  if (!wanted) return null;
+  const [installed, registry] = await Promise.all([
+    Promise.resolve(fetchExtensions()).catch(() => null),
+    Promise.resolve(fetchExtensionRegistry()).catch(() => null),
+  ]);
+  const entries = [
+    ...(Array.isArray(installed) ? installed : installed?.extensions || []),
+    ...(registry?.entries || []),
+  ];
+  const match = entries.find(
+    (entry) =>
+      normalizeExtensionId(entry?.package_ref?.id) === wanted &&
+      channelConnection(entry)?.strategy === "oauth",
+  );
+  if (!match) return null;
+  return {
+    // The id the server published, never the raw param text.
+    extensionName: match.package_ref.id,
+    // The server-provided display name, so the button cannot be made to read
+    // more plausibly than the target actually is.
+    displayName:
+      channelConnection(match)?.display_name || match.display_name || match.package_ref.id,
+  };
+}
 
 // #7681: an OAuth-strategy channel's "connect your account" chat notice can
 // carry a one-click link — `/chat?connect=<extension>`. `/chat` is an
@@ -51,21 +86,30 @@ export function useConnectLinkLanding() {
   // re-running on later location changes would find nothing to consume.
   React.useEffect(() => {
     const params = new URLSearchParams(location.search);
-    const extensionName = params.get(CONNECT_LINK_QUERY_PARAM);
-    if (!extensionName) return;
+    const requested = params.get(CONNECT_LINK_QUERY_PARAM);
+    if (!requested) return undefined;
     params.delete(CONNECT_LINK_QUERY_PARAM);
     const search = params.toString();
     navigate(
       { pathname: location.pathname, search: search ? `?${search}` : "" },
       { replace: true },
     );
-    setConnectLanding({
-      extensionName,
-      strategy: "oauth",
-      submitLabel: t("pairing.continueConnect", {
-        name: channelConnectionDisplayName(extensionName),
-      }),
-    });
+    let cancelled = false;
+    resolveOauthConnectTarget(requested)
+      .then((target) => {
+        if (cancelled || !target) return;
+        setConnectLanding({
+          extensionName: target.extensionName,
+          strategy: "oauth",
+          submitLabel: t("pairing.continueConnect", {
+            name: channelConnectionDisplayName(target.extensionName, target.displayName),
+          }),
+        });
+      })
+      .catch(() => null);
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Clear the card on real backend evidence, never optimistically on click.
@@ -74,10 +118,16 @@ export function useConnectLinkLanding() {
   // fast path but is same-origin only: when the OAuth callback lands on a
   // different origin than the opener (a tunnelled callback against a
   // 127.0.0.1 app, or split app/callback domains), it never arrives and the
-  // card would spin forever. Polling the durable flow status closes that gap
-  // and is also what recovers the card after a reload mid-flow.
+  // card would spin forever. Polling the durable flow status closes that gap.
+  // It does NOT survive a reload mid-flow: this state is component-local and
+  // the `connect` param is stripped on first render, so a reload drops the card
+  // and the user reconnects from Settings/Extensions instead.
   React.useEffect(() => {
     if (!pendingFlow) return undefined;
+    // One status call at a time. Without this a slow call would stack a new
+    // request every tick for the whole 10-minute window, and a late resolution
+    // could settle or fail a flow a newer tick already finished.
+    let statusCheckInFlight = false;
 
     const settle = async () => {
       if (flowIdRef.current !== pendingFlow.flowId) return;
@@ -104,19 +154,30 @@ export function useConnectLinkLanding() {
     const unsubscribe = subscribeProductAuthOAuthCompletion(window, (payload) => {
       if (completionMatchesFlow(payload, flowIdRef.current)) void settle();
     });
-    const timer = window.setInterval(async () => {
-      if (Date.now() - pendingFlow.startedAt > CONNECT_OAUTH_TIMEOUT_MS) {
+    const timer = window.setInterval(() => {
+      if (statusCheckInFlight) return;
+      if (Date.now() - pendingFlow.startedAt > OAUTH_FLOW_TIMEOUT_MS) {
         fail("extensions.oauthTimedOut");
         return;
       }
-      const result = await fetchOauthFlowStatus(pendingFlow.flowId, pendingFlow.invocationId);
-      if (result?.status === "completed") {
-        void settle();
-        return;
-      }
-      const errorKey = CONNECT_OAUTH_STATUS_ERROR_KEYS[result?.status];
-      if (errorKey) fail(errorKey);
-    }, CONNECT_OAUTH_POLL_MS);
+      statusCheckInFlight = true;
+      Promise.resolve(fetchOauthFlowStatus(pendingFlow.flowId, pendingFlow.invocationId))
+        .then((result) => {
+          if (flowIdRef.current !== pendingFlow.flowId) return;
+          if (result?.status === "completed") {
+            void settle();
+            return;
+          }
+          const errorKey = OAUTH_FLOW_STATUS_ERROR_KEYS[result?.status];
+          if (errorKey) fail(errorKey);
+        })
+        // A transient status-call failure is not a terminal flow outcome: keep
+        // polling rather than raising an unhandled rejection every tick.
+        .catch(() => null)
+        .finally(() => {
+          statusCheckInFlight = false;
+        });
+    }, OAUTH_FLOW_POLL_MS);
 
     return () => {
       window.clearInterval(timer);
@@ -126,6 +187,13 @@ export function useConnectLinkLanding() {
 
   const startConnectLinkOAuth = React.useCallback(async () => {
     if (!connectLanding) throw new Error("connection is no longer pending");
+    // A retry after a failed attempt clears the stale card error first. The card
+    // only leaves its spinner when the `oauthError` VALUE changes, so without
+    // this a second identical failure would produce no prop change and the card
+    // would spin forever.
+    setConnectLanding((current) =>
+      current?.oauthError ? { ...current, oauthError: null } : current,
+    );
     const packageRef = { kind: "extension", id: connectLanding.extensionName };
     // Open the placeholder popup BEFORE any await: a slow setup fetch would
     // otherwise burn the click's user activation and get the real popup

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useConnectLinkLanding.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useConnectLinkLanding.ts
@@ -7,62 +7,17 @@ import {
   channelConnectionDisplayName,
   notifyChannelConnected,
 } from "../../../lib/channel-connection-events";
-import {
-  OAUTH_FLOW_POLL_MS,
-  OAUTH_FLOW_STATUS_ERROR_KEYS,
-  OAUTH_FLOW_TIMEOUT_MS,
-  completionMatchesFlow,
-  openAuthPopup,
-  subscribeProductAuthOAuthCompletion,
-} from "../../../lib/product-auth-oauth-events";
-import {
-  fetchExtensionRegistry,
-  fetchExtensionSetup,
-  fetchExtensions,
-  fetchOauthFlowStatus,
-  installExtension,
-  startExtensionOauth,
-} from "../../extensions/lib/extensions-api";
-import { channelConnection } from "../../extensions/lib/extensions-schema";
 
 const CONNECT_LINK_QUERY_PARAM = "connect";
 
-function normalizeExtensionId(value) {
-  return String(value || "").trim().toLowerCase();
-}
-
-// The `connect` param is attacker-controllable — it arrives on a link anyone can
-// craft — so it names nothing until the server's own extension inventory
-// confirms it. Resolve it against the installed list and the registry, and
-// accept it only as an extension whose channel surface actually connects over
-// OAuth. Anything else (unknown id, a tools-only extension, a channel that
-// pairs by proof code or device link) is ignored silently: an unsolicited
-// install + OAuth start is exactly what must not happen from a crafted link.
-async function resolveOauthConnectTarget(extensionName) {
-  const wanted = normalizeExtensionId(extensionName);
-  if (!wanted) return null;
-  const [installed, registry] = await Promise.all([
-    Promise.resolve(fetchExtensions()).catch(() => null),
-    Promise.resolve(fetchExtensionRegistry()).catch(() => null),
-  ]);
-  const entries = [
-    ...(Array.isArray(installed) ? installed : installed?.extensions || []),
-    ...(registry?.entries || []),
-  ];
-  const match = entries.find(
-    (entry) =>
-      normalizeExtensionId(entry?.package_ref?.id) === wanted &&
-      channelConnection(entry)?.strategy === "oauth",
-  );
-  if (!match) return null;
-  return {
-    // The id the server published, never the raw param text.
-    extensionName: match.package_ref.id,
-    // The server-provided display name, so the button cannot be made to read
-    // more plausibly than the target actually is.
-    displayName:
-      channelConnection(match)?.display_name || match.display_name || match.package_ref.id,
-  };
+// The resolver, the install/oauth-start sequence, and the flow watcher all live
+// in `../lib/connect-link-flow`, loaded through this dynamic `import()` only
+// when a `connect` param is actually on the URL. Almost nobody lands on /chat
+// with one, and the eager chat chunk has a gzip budget
+// (`scripts/check-bundle-budgets.ts`), so that machinery — plus the extensions
+// API client and surface schema it pulls in — stays out of the initial route.
+function loadConnectLinkFlow() {
+  return import("../lib/connect-link-flow");
 }
 
 // #7681: an OAuth-strategy channel's "connect your account" chat notice can
@@ -71,9 +26,9 @@ async function resolveOauthConnectTarget(extensionName) {
 // round-trip (`RequireAuth` → `redirect_after` → `login_ticket`) unchanged:
 // a logged-out click lands through `/login` first, a logged-in one lands here
 // directly. This hook owns the landing half only — detect the param, strip it
-// so a reload cannot replay it, and drive the same
-// setup → oauth-start → popup sequence the Extensions page's Connect button
-// uses. No new backend route.
+// so a reload cannot replay it, resolve it against the server's own extension
+// inventory, and drive the same setup → oauth-start → popup sequence the
+// Extensions page's Connect button uses. No new backend route.
 export function useConnectLinkLanding() {
   const t = useT();
   const location = useLocation();
@@ -95,7 +50,8 @@ export function useConnectLinkLanding() {
       { replace: true },
     );
     let cancelled = false;
-    resolveOauthConnectTarget(requested)
+    loadConnectLinkFlow()
+      .then(({ resolveOauthConnectTarget }) => resolveOauthConnectTarget(requested))
       .then((target) => {
         if (cancelled || !target) return;
         setConnectLanding({
@@ -113,21 +69,8 @@ export function useConnectLinkLanding() {
   }, []);
 
   // Clear the card on real backend evidence, never optimistically on click.
-  //
-  // Two signals, because neither alone is sufficient. The broadcast is the
-  // fast path but is same-origin only: when the OAuth callback lands on a
-  // different origin than the opener (a tunnelled callback against a
-  // 127.0.0.1 app, or split app/callback domains), it never arrives and the
-  // card would spin forever. Polling the durable flow status closes that gap.
-  // It does NOT survive a reload mid-flow: this state is component-local and
-  // the `connect` param is stripped on first render, so a reload drops the card
-  // and the user reconnects from Settings/Extensions instead.
   React.useEffect(() => {
     if (!pendingFlow) return undefined;
-    // One status call at a time. Without this a slow call would stack a new
-    // request every tick for the whole 10-minute window, and a late resolution
-    // could settle or fail a flow a newer tick already finished.
-    let statusCheckInFlight = false;
 
     const settle = async () => {
       if (flowIdRef.current !== pendingFlow.flowId) return;
@@ -151,37 +94,26 @@ export function useConnectLinkLanding() {
       );
     };
 
-    const unsubscribe = subscribeProductAuthOAuthCompletion(window, (payload) => {
-      if (completionMatchesFlow(payload, flowIdRef.current)) void settle();
-    });
-    const timer = window.setInterval(() => {
-      if (statusCheckInFlight) return;
-      if (Date.now() - pendingFlow.startedAt > OAUTH_FLOW_TIMEOUT_MS) {
-        fail("extensions.oauthTimedOut");
-        return;
-      }
-      statusCheckInFlight = true;
-      Promise.resolve(fetchOauthFlowStatus(pendingFlow.flowId, pendingFlow.invocationId))
-        .then((result) => {
-          if (flowIdRef.current !== pendingFlow.flowId) return;
-          if (result?.status === "completed") {
-            void settle();
-            return;
-          }
-          const errorKey = OAUTH_FLOW_STATUS_ERROR_KEYS[result?.status];
-          if (errorKey) fail(errorKey);
-        })
-        // A transient status-call failure is not a terminal flow outcome: keep
-        // polling rather than raising an unhandled rejection every tick.
-        .catch(() => null)
-        .finally(() => {
-          statusCheckInFlight = false;
+    let stopWatching = null;
+    let cancelled = false;
+    // Already resolved by the time a flow exists — the click that started the
+    // flow loaded this module — so the watcher attaches on the next microtask.
+    loadConnectLinkFlow()
+      .then(({ watchConnectLinkFlow }) => {
+        if (cancelled) return;
+        stopWatching = watchConnectLinkFlow({
+          flow: pendingFlow,
+          browserWindow: window,
+          isCurrent: () => flowIdRef.current === pendingFlow.flowId,
+          onCompleted: () => void settle(),
+          onFailed: fail,
         });
-    }, OAUTH_FLOW_POLL_MS);
+      })
+      .catch(() => null);
 
     return () => {
-      window.clearInterval(timer);
-      unsubscribe();
+      cancelled = true;
+      stopWatching?.();
     };
   }, [pendingFlow, t]);
 
@@ -194,53 +126,22 @@ export function useConnectLinkLanding() {
     setConnectLanding((current) =>
       current?.oauthError ? { ...current, oauthError: null } : current,
     );
-    const packageRef = { kind: "extension", id: connectLanding.extensionName };
-    // Open the placeholder popup BEFORE any await: a slow setup fetch would
-    // otherwise burn the click's user activation and get the real popup
-    // blocked (same reasoning as `useChannelOnboarding.startOnboardingOAuth`).
+    // Open the placeholder popup BEFORE any await: a slow module load or setup
+    // fetch would otherwise burn the click's user activation and get the real
+    // popup blocked (same reasoning as
+    // `useChannelOnboarding.startOnboardingOAuth`).
     const popup = window.open("about:blank", "_blank", "width=600,height=600");
     if (!popup) throw new Error(t("authGate.popupBlocked"));
     popup.opener = null;
     try {
-      // Install first. Someone arriving from a channel nudge has, by
-      // definition, not connected this extension — and usually has not
-      // installed it either, which makes `setup/oauth/start` fail closed
-      // (`require_installed_extension` -> 409). Install is idempotent, so an
-      // already-installed extension costs one no-op call rather than a
-      // pre-flight inventory read.
-      await installExtension(packageRef);
-      const setup = await fetchExtensionSetup(packageRef);
-      const secret = (setup?.secrets || []).find(
-        (item) => (item?.setup?.kind || "manual_token") === "oauth",
-      );
-      if (!secret) throw new Error(t("extensions.oauthSetupFailed"));
-      const response = await startExtensionOauth(packageRef, secret);
-      if (response?.success === false) {
-        throw new Error(response.message || t("extensions.oauthSetupFailed"));
-      }
-      if (!response?.authorization_url || !response?.flow_id) {
-        throw new Error(t("extensions.oauthSetupFailed"));
-      }
-      const opened = openAuthPopup(response.authorization_url, popup);
-      if (!opened.ok) {
-        throw new Error(
-          opened.reason === "popup_blocked"
-            ? t("authGate.popupBlocked")
-            : t("extensions.oauthInvalidAuthorizationUrl"),
-        );
-      }
-      flowIdRef.current = response.flow_id;
-      setPendingFlow({
-        flowId: response.flow_id,
-        // The caller-scoped backend needs this to locate its own flow when
-        // reconciling status; absent on responses that mint no callback scope.
-        invocationId:
-          response?.callback_scope?.invocation_id ||
-          response?.callbackScope?.invocationId ||
-          null,
-        channel: connectLanding.extensionName,
-        startedAt: Date.now(),
+      const { startConnectLinkOauth } = await loadConnectLinkFlow();
+      const { response, flow } = await startConnectLinkOauth({
+        extensionName: connectLanding.extensionName,
+        popup,
+        t,
       });
+      flowIdRef.current = flow.flowId;
+      setPendingFlow(flow);
       return response;
     } catch (error) {
       if (!popup.closed) popup.close();

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/connect-link-flow.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/connect-link-flow.ts
@@ -1,0 +1,171 @@
+// @ts-nocheck
+//
+// The machinery behind the `/chat?connect=<extension>` landing card: resolving
+// the untrusted param against the server's extension inventory, driving the
+// install -> setup -> oauth-start sequence, and watching the flow to completion.
+//
+// This module is loaded through a dynamic `import()` from
+// `hooks/useConnectLinkLanding.ts`, and only when a `connect` param is actually
+// present on the URL. That keeps the extensions API client, the extensions
+// surface schema, and the OAuth watcher out of the eager /chat chunk, which is
+// budgeted (`scripts/check-bundle-budgets.ts`). The hook keeps the param
+// detection, the URL strip, and the card state — all tiny — inline.
+import {
+  OAUTH_FLOW_POLL_MS,
+  OAUTH_FLOW_STATUS_ERROR_KEYS,
+  OAUTH_FLOW_TIMEOUT_MS,
+  completionMatchesFlow,
+  openAuthPopup,
+  subscribeProductAuthOAuthCompletion,
+} from "../../../lib/product-auth-oauth-events";
+import {
+  fetchExtensionRegistry,
+  fetchExtensionSetup,
+  fetchExtensions,
+  fetchOauthFlowStatus,
+  installExtension,
+  startExtensionOauth,
+} from "../../extensions/lib/extensions-api";
+import { channelConnection } from "../../extensions/lib/extensions-schema";
+
+function normalizeExtensionId(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+// The `connect` param is attacker-controllable — it arrives on a link anyone can
+// craft — so it names nothing until the server's own extension inventory
+// confirms it. Resolve it against the installed list and the registry, and
+// accept it only as an extension whose channel surface actually connects over
+// OAuth. Anything else (unknown id, a tools-only extension, a channel that
+// pairs by proof code or device link) is ignored silently: an unsolicited
+// install + OAuth start is exactly what must not happen from a crafted link.
+export async function resolveOauthConnectTarget(extensionName) {
+  const wanted = normalizeExtensionId(extensionName);
+  if (!wanted) return null;
+  const [installed, registry] = await Promise.all([
+    Promise.resolve(fetchExtensions()).catch(() => null),
+    Promise.resolve(fetchExtensionRegistry()).catch(() => null),
+  ]);
+  const entries = [
+    ...(Array.isArray(installed) ? installed : installed?.extensions || []),
+    ...(registry?.entries || []),
+  ];
+  const match = entries.find(
+    (entry) =>
+      normalizeExtensionId(entry?.package_ref?.id) === wanted &&
+      channelConnection(entry)?.strategy === "oauth",
+  );
+  if (!match) return null;
+  return {
+    // The id the server published, never the raw param text.
+    extensionName: match.package_ref.id,
+    // The server-provided display name, so the button cannot be made to read
+    // more plausibly than the target actually is.
+    displayName:
+      channelConnection(match)?.display_name || match.display_name || match.package_ref.id,
+  };
+}
+
+// Drive the same setup -> oauth-start -> popup sequence the Extensions page's
+// Connect button uses, pointing the caller's already-open placeholder popup at
+// the authorization URL. The caller opens that popup synchronously on the click
+// so a slow fetch cannot burn the user activation.
+export async function startConnectLinkOauth({ extensionName, popup, t }) {
+  const packageRef = { kind: "extension", id: extensionName };
+  // Install first. Someone arriving from a channel nudge has, by definition,
+  // not connected this extension — and usually has not installed it either,
+  // which makes `setup/oauth/start` fail closed (`require_installed_extension`
+  // -> 409). Install is idempotent, so an already-installed extension costs one
+  // no-op call rather than a pre-flight inventory read.
+  await installExtension(packageRef);
+  const setup = await fetchExtensionSetup(packageRef);
+  const secret = (setup?.secrets || []).find(
+    (item) => (item?.setup?.kind || "manual_token") === "oauth",
+  );
+  if (!secret) throw new Error(t("extensions.oauthSetupFailed"));
+  const response = await startExtensionOauth(packageRef, secret);
+  if (response?.success === false) {
+    throw new Error(response.message || t("extensions.oauthSetupFailed"));
+  }
+  if (!response?.authorization_url || !response?.flow_id) {
+    throw new Error(t("extensions.oauthSetupFailed"));
+  }
+  const opened = openAuthPopup(response.authorization_url, popup);
+  if (!opened.ok) {
+    throw new Error(
+      opened.reason === "popup_blocked"
+        ? t("authGate.popupBlocked")
+        : t("extensions.oauthInvalidAuthorizationUrl"),
+    );
+  }
+  return {
+    response,
+    flow: {
+      flowId: response.flow_id,
+      // The caller-scoped backend needs this to locate its own flow when
+      // reconciling status; absent on responses that mint no callback scope.
+      invocationId:
+        response?.callback_scope?.invocation_id ||
+        response?.callbackScope?.invocationId ||
+        null,
+      channel: extensionName,
+      startedAt: Date.now(),
+    },
+  };
+}
+
+// Watch a started flow to a terminal outcome and return the teardown.
+//
+// Two signals, because neither alone is sufficient. The broadcast is the fast
+// path but is same-origin only: when the OAuth callback lands on a different
+// origin than the opener (a tunnelled callback against a 127.0.0.1 app, or
+// split app/callback domains), it never arrives and the card would spin
+// forever. Polling the durable flow status closes that gap. It does NOT survive
+// a reload mid-flow: the card state is component-local and the `connect` param
+// is stripped on first render, so a reload drops the card and the user
+// reconnects from Settings/Extensions instead.
+export function watchConnectLinkFlow({
+  flow,
+  browserWindow,
+  isCurrent,
+  onCompleted,
+  onFailed,
+}) {
+  // One status call at a time. Without this a slow call would stack a new
+  // request every tick for the whole 10-minute window, and a late resolution
+  // could settle or fail a flow a newer tick already finished.
+  let statusCheckInFlight = false;
+
+  const unsubscribe = subscribeProductAuthOAuthCompletion(browserWindow, (payload) => {
+    if (isCurrent() && completionMatchesFlow(payload, flow.flowId)) onCompleted();
+  });
+  const timer = browserWindow.setInterval(() => {
+    if (statusCheckInFlight) return;
+    if (Date.now() - flow.startedAt > OAUTH_FLOW_TIMEOUT_MS) {
+      onFailed("extensions.oauthTimedOut");
+      return;
+    }
+    statusCheckInFlight = true;
+    Promise.resolve(fetchOauthFlowStatus(flow.flowId, flow.invocationId))
+      .then((result) => {
+        if (!isCurrent()) return;
+        if (result?.status === "completed") {
+          onCompleted();
+          return;
+        }
+        const errorKey = OAUTH_FLOW_STATUS_ERROR_KEYS[result?.status];
+        if (errorKey) onFailed(errorKey);
+      })
+      // A transient status-call failure is not a terminal flow outcome: keep
+      // polling rather than raising an unhandled rejection every tick.
+      .catch(() => null)
+      .finally(() => {
+        statusCheckInFlight = false;
+      });
+  }, OAUTH_FLOW_POLL_MS);
+
+  return () => {
+    browserWindow.clearInterval(timer);
+    unsubscribe();
+  };
+}

--- a/crates/product/ironclaw_webui/frontend/src/pages/extensions/hooks/useExtensions.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/extensions/hooks/useExtensions.ts
@@ -3,6 +3,9 @@ import React from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { clientActionId, gatewayStatus } from "../../../lib/api";
 import {
+  OAUTH_FLOW_POLL_MS,
+  OAUTH_FLOW_STATUS_ERROR_KEYS,
+  OAUTH_FLOW_TIMEOUT_MS,
   completionMatchesFlow,
   failureMatchesFlow,
   isHttpsAuthUrl,
@@ -27,15 +30,8 @@ import {
   importExtension,
 } from "../lib/extensions-api";
 
-const OAUTH_SETUP_REFRESH_MS = 2000;
-const OAUTH_SETUP_TIMEOUT_MS = 10 * 60 * 1000;
 const HOSTED_MCP_AUTH_SELECTION_BLOCKER_REF =
   "hosted_mcp_auth_selection_required";
-const OAUTH_STATUS_ERROR_KEYS = Object.freeze({
-  failed: "extensions.oauthFailed",
-  canceled: "extensions.oauthCanceled",
-  expired: "extensions.oauthExpired",
-});
 
 // OAuth callback constants, HTTPS-auth-URL/popup helpers, and completion
 // parsing/matching are the shared product-auth OAuth event contract — see
@@ -518,7 +514,7 @@ export function useOauthSetup(packageRef, { onConfigured } = {}) {
             if (status === "completed") {
               complete();
             } else {
-              const errorKey = OAUTH_STATUS_ERROR_KEYS[status];
+              const errorKey = OAUTH_FLOW_STATUS_ERROR_KEYS[status];
               if (typeof errorKey !== "string") return;
               setAuthError(t(errorKey));
               stopWatcher();
@@ -548,7 +544,7 @@ export function useOauthSetup(packageRef, { onConfigured } = {}) {
           complete();
           return;
         }
-        const timedOut = Date.now() - startedAt > OAUTH_SETUP_TIMEOUT_MS;
+        const timedOut = Date.now() - startedAt > OAUTH_FLOW_TIMEOUT_MS;
         // Current product-auth OAuth callbacks close their popup after writing
         // durable flow status. With a flow id, popup.closed is expected and the
         // status/event backstop owns completion.
@@ -563,7 +559,7 @@ export function useOauthSetup(packageRef, { onConfigured } = {}) {
           stopWatcher();
           refreshSetupState();
         }
-      }, OAUTH_SETUP_REFRESH_MS);
+      }, OAUTH_FLOW_POLL_MS);
       watcherRef.current = cleanup;
       handleCompletion(readLatestProductAuthOAuthCompletion(browserWindow));
     },


### PR DESCRIPTION
## Summary

Addresses the multi-agent review findings on #7682 (review 4951078746). Two commits, targeting the PR branch so @sergeiest can fold them in.

**`fix(webui)` — connect-link landing hardening (7 findings):**
- The `?connect=` param is resolved against the server's installed + registry extension inventory and accepted only for an extension with an OAuth channel connection; the card label uses the server's display name. A crafted link can no longer install an arbitrary extension (security finding).
- Retry after an identical OAuth failure now clears the stale `oauthError`, so the card exits its spinner (bug finding).
- The flow-status poll gains the sibling watcher's in-flight latch, transient-error catch, and a stale-flow re-check before settle/fail (performance + local-patterns + bugs findings).
- OAuth timeout/poll constants and the terminal-status i18n map are consolidated into `lib/product-auth-oauth-events.ts`, replacing three hand-maintained copies.
- New tests: unknown/non-OAuth param ignored, identical-failure retry, timeout branch, popup-blocked, install-rejection popup cleanup (14/14 in the hook suite).
- The reload-recovery comment is corrected to state the actual limitation.

**`fix(channels)` — connect-link notice hardening (6 findings):**
- Composition normalizes `IRONCLAW_REBORN_WEBUI_BASE_URL` the same way the OAuth consumer does (trim, strip trailing slashes, blank ⇒ unset), so `IRONCLAW_REBORN_WEBUI_BASE_URL=` ships dark instead of posting a relative `/chat?connect=…` link into a customer channel. Threading the serve-side resolved value was evaluated and rejected: `start_channel_host` is only reachable deep inside the composed-runtime build, so it would need a new deployment-config field plus CLI plumbing.
- `extension_id` is percent-encoded in the connect link (`percent-encoding`, already in the dependency tree).
- `connect_required_notice` now has unit coverage for every branch (OAuth + base, trailing-slash trim, unset base, each non-OAuth strategy, encoding) plus an e2e scenario asserting the ephemeral nudge carries the link when an origin is configured.
- Stale "threaded" test name/comments from the ephemeral inversion are fixed; `SlackChatPostMessageResponse` → `SlackChatPostResponse`.
- Drive-by: the two-line `arch-exempt` annotation in `run_delivery.rs` is rejoined so `pre-commit-safety.sh` passes (it reads only the single line above the `#[allow]`).

**Not addressed (deliberate):** gating the connect link on an adapter private-delivery capability (design call for the PR author), and extracting a shared OAuth start/watcher machine across the three frontend hooks (follow-up-sized; constants consolidation + guard parity narrow the drift meanwhile).

## Validation

- `cargo fmt`; `cargo clippy -p ironclaw_composition -p ironclaw_extension_host -p ironclaw_slack_extension --all-targets --all-features -- -D warnings` exit 0
- `cargo test -p ironclaw_extension_host` / `-p ironclaw_slack_extension` — green
- `RUST_MIN_STACK=67108864 cargo test -p ironclaw_composition` — green (default-stack overflow is the pre-existing local issue documented on #7682)
- `cargo test -p ironclaw_architecture_tests` — green, including the extension-specificity gate (a new dep, `percent-encoding`, was added to `ironclaw_extension_host`; the layer suites pass)
- Frontend: `vitest` full run zero failures, `tsc --noEmit` exit 0, `lint:conventions` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
