### PR TITLE
test: exercise /benchmark on qa-automation-preview

### DIFF
--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -10,6 +10,12 @@
 # Setup / usage docs:
 # https://github.com/nearai/benchmarks/blob/main/docs/ci/README.md
 #
+# The suite name is validated against `suites/*.toml` on nearai/benchmarks main, so a new
+# suite is dispatchable as soon as it lands there — no allowlist to update here. Two worth
+# knowing about for reborn's integration/automation behaviour:
+#   /benchmark qa-automation-preview   10 routine tasks; the axis that separates harnesses
+#   /benchmark qa-preview              the full 38-task QA corpus
+#
 # nearai/benchmarks is a PRIVATE repo (since 2026-07-22, PR #291). A
 # cross-repo reusable-workflow `uses:` call (the previous approach here) is
 # structurally incapable of working for a public caller -> private callee:


### PR DESCRIPTION
**Test PR — not intended for merge unless the doc note is judged useful.**

Purpose: exercise the `/benchmark` path end to end on `qa-automation-preview`, the new 10-task routine/automation suite on nearai/benchmarks main. This is the first run of an `enterprise`-type suite through `/benchmark`, which until nearai/benchmarks#373 could not work at all — that workflow provisioned neither the emulate fork nor the private world seed, so every task would have failed in `setup_task` and reported as a capability collapse.

Diff is a comment-only note in the dispatcher header naming the two QA preview suites. The suite argument is validated dynamically against `suites/*.toml` on benchmarks main, so nothing here gates a new suite.

What the run should demonstrate:

- the suite name resolves (dynamic validation, not an allowlist)
- `emulate` builds and the meridian world seed is fetched (nearai/benchmarks#373)
- the run stays at `--parallelism 1` even though `bench-daily` passes `parallelism: 6` by default — the enterprise adapter declares `requires_serial_execution`, and running it concurrently grades tasks against other tasks' assertions
- the published trajectories carry the verifier detail: per-predicate L1 sub-points, L2 with the fire-window outcome, recovered tool inputs, and the standing context the harness published outside the user turn