### PR TITLE
fix(extension-registry): accept the 1.2 activation_state row field so 1.3 boots after upgrade

### DIFF
--- a/crates/extensions/ironclaw_extension_registry/src/installations.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/installations.rs
@@ -1188,6 +1188,17 @@ struct V2InstallationRecord {
     schema_version: String,
     installation_id: ExtensionInstallationId,
     extension_id: ExtensionId,
+    /// Written by 1.2.x builds, which added the field under this same
+    /// `extension_state.v2` schema string. This release has no persisted
+    /// activation concept -- `ExtensionActivationState` is a compatibility
+    /// shim that always reports `Enabled` -- so the value is never read here.
+    /// It is nonetheless carried forward rather than discarded like the
+    /// diagnostic `health` field: `health` is regenerable, whereas this
+    /// records operator intent that a rollback to 1.2 would otherwise
+    /// silently reset to enabled. Absent on rows this release writes fresh,
+    /// which 1.2 reads as its own `enabled` default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    activation_state: Option<String>,
     manifest: WireManifestRecord,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     incarnation_id: Option<InstallationIncarnationId>,
@@ -2206,6 +2217,9 @@ impl ExtensionInstallationStore {
                         schema_version: EXTENSION_STATE_V2_SCHEMA.to_string(),
                         installation_id: installation.installation_id().clone(),
                         extension_id: installation.extension_id().clone(),
+                        activation_state: current
+                            .as_ref()
+                            .and_then(|record| record.activation_state.clone()),
                         manifest: wire,
                         incarnation_id: installation.incarnation_id().cloned(),
                         legacy_tenant_owner: installation.owner().is_tenant(),
@@ -3451,6 +3465,9 @@ impl ExtensionInstallationStorePort for ExtensionInstallationStore {
                         schema_version: EXTENSION_STATE_V2_SCHEMA.to_string(),
                         installation_id,
                         extension_id,
+                        activation_state: current
+                            .as_ref()
+                            .and_then(|record| record.activation_state.clone()),
                         manifest: wire,
                         incarnation_id: current
                             .as_ref()

--- a/crates/extensions/ironclaw_extension_registry/tests/installations_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/installations_contract.rs
@@ -2336,7 +2336,10 @@ async fn v2_rows_carrying_activation_state_load_and_preserve_it() {
     );
 
     // A later write must not silently drop the operator's setting.
-    reopened.upsert_installation(installed.clone()).await.unwrap();
+    reopened
+        .upsert_installation(installed.clone())
+        .await
+        .unwrap();
     let rows = filesystem
         .query(&installations, &Filter::All, Page::first(10))
         .await

--- a/crates/extensions/ironclaw_extension_registry/tests/installations_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/installations_contract.rs
@@ -2351,3 +2351,106 @@ async fn v2_rows_carrying_activation_state_load_and_preserve_it() {
         "a rewrite must carry the 1.2 activation state forward: {body}"
     );
 }
+
+/// The removal path rebuilds the installation record from scratch rather than
+/// mutating it in place, so it is the one other place a 1.2-written
+/// `activation_state` can be dropped. Removing an extension must not quietly
+/// reset the operator's setting: the tombstone is retained for reactivation,
+/// so it has to retain the field too.
+///
+/// `persist_removal_tombstone` keys the row by extension id, so this fixture
+/// installs under an installation id equal to the extension id to make the
+/// removal path land on the seeded row.
+#[tokio::test]
+async fn removal_tombstone_carries_the_1_2_activation_state_forward() {
+    let filesystem: Arc<dyn RootFilesystem> = Arc::new(InMemoryBackend::new());
+    let root =
+        VirtualPath::new("/system/extensions/.installations/activation-state-tombstone").unwrap();
+    let store = ExtensionInstallationStore::load_at(
+        Arc::clone(&filesystem),
+        root.clone(),
+        HostPortCatalog::empty(),
+        contracts(),
+    )
+    .await
+    .unwrap();
+    let installed = ExtensionInstallation::new(
+        installation_id("acme-tools"),
+        extension_id("acme-tools"),
+        ExtensionManifestRef::new(
+            extension_id("acme-tools"),
+            Some(manifest_hash("sha256:abc")),
+        ),
+        vec![],
+        Utc::now(),
+        InstallationOwner::Tenant,
+    )
+    .unwrap();
+    store
+        .upsert_manifest_and_installation(manifest("sha256:abc"), installed.clone())
+        .await
+        .unwrap();
+
+    let installations = VirtualPath::new(format!("{}/v2/installations", root.as_str())).unwrap();
+    let rows = filesystem
+        .query(&installations, &Filter::All, Page::first(10))
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    let mut body: serde_json::Value = rows[0].entry.parse_json().unwrap();
+    body.as_object_mut().unwrap().insert(
+        "activation_state".to_string(),
+        serde_json::json!("disabled"),
+    );
+    let mut entry = rows[0].entry.clone();
+    entry.body = serde_json::to_vec(&body).unwrap();
+    filesystem
+        .put(
+            &rows[0].path,
+            entry,
+            CasExpectation::Version(rows[0].version),
+        )
+        .await
+        .unwrap();
+
+    // Soft removal mutates the record in place, so it preserves the field for
+    // free; assert it anyway, because it is the state the rebuild path below
+    // reads from.
+    store
+        .delete_installation(installed.installation_id())
+        .await
+        .unwrap();
+    let rows = filesystem
+        .query(&installations, &Filter::All, Page::first(10))
+        .await
+        .unwrap();
+    let body: serde_json::Value = rows[0].entry.parse_json().unwrap();
+    assert_eq!(
+        body["activation_state"],
+        serde_json::json!("disabled"),
+        "soft removal must not reset the 1.2 setting: {body}"
+    );
+
+    // `persist_removal_tombstone` rebuilds the record from scratch -- this is
+    // the site the boot-path test cannot reach.
+    store
+        .persist_removal_tombstone(manifest("sha256:abc"))
+        .await
+        .unwrap();
+
+    let rows = filesystem
+        .query(&installations, &Filter::All, Page::first(10))
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1, "removal retains the row as a tombstone");
+    let body: serde_json::Value = rows[0].entry.parse_json().unwrap();
+    assert!(
+        body["removed_at"].is_string(),
+        "the row must actually be tombstoned, or this proves nothing: {body}"
+    );
+    assert_eq!(
+        body["activation_state"],
+        serde_json::json!("disabled"),
+        "removal must not reset a 1.2 operator setting: {body}"
+    );
+}

--- a/crates/extensions/ironclaw_extension_registry/tests/installations_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/installations_contract.rs
@@ -2261,3 +2261,90 @@ impl RootFilesystem for QueryCountingBackend {
         self.inner.reserve_sequence(path).await
     }
 }
+
+/// A 1.2.x build persists an `activation_state` field into the
+/// `extension_state.v2` installation row without bumping the schema string, so
+/// the row still declares `extension_state.v2` and is routed to the current
+/// typed reader. `V2InstallationRecord` denies unknown fields, so a release
+/// that does not model the field aborts composition with `extension
+/// installation state could not be loaded` and the process crash-loops with
+/// every installed extension unreachable.
+///
+/// The field is accepted, and — unlike the diagnostic `health` field, which is
+/// regenerable and therefore discarded — it is preserved verbatim across
+/// writes, because it records operator intent that a rollback to 1.2 would
+/// otherwise silently reset to enabled.
+#[tokio::test]
+async fn v2_rows_carrying_activation_state_load_and_preserve_it() {
+    let filesystem: Arc<dyn RootFilesystem> = Arc::new(InMemoryBackend::new());
+    let root =
+        VirtualPath::new("/system/extensions/.installations/activation-state-compat").unwrap();
+    let store = ExtensionInstallationStore::load_at(
+        Arc::clone(&filesystem),
+        root.clone(),
+        HostPortCatalog::empty(),
+        contracts(),
+    )
+    .await
+    .unwrap();
+    let installed = normalized_installation("sha256:abc");
+    store
+        .upsert_manifest_and_installation(manifest("sha256:abc"), installed.clone())
+        .await
+        .unwrap();
+
+    // Rewrite the persisted row into the shape a 1.2.x build leaves behind.
+    // Mutating the stored entry in place keeps its real `kind` and `indexed`
+    // map, neither of which is constructible from this crate.
+    let installations = VirtualPath::new(format!("{}/v2/installations", root.as_str())).unwrap();
+    let rows = filesystem
+        .query(&installations, &Filter::All, Page::first(10))
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    let mut body: serde_json::Value = rows[0].entry.parse_json().unwrap();
+    body.as_object_mut()
+        .unwrap()
+        .insert("activation_state".to_string(), serde_json::json!("enabled"));
+    let mut entry = rows[0].entry.clone();
+    entry.body = serde_json::to_vec(&body).unwrap();
+    filesystem
+        .put(
+            &rows[0].path,
+            entry,
+            CasExpectation::Version(rows[0].version),
+        )
+        .await
+        .unwrap();
+
+    // Reopening the root is what `serve` does on every boot.
+    let reopened = ExtensionInstallationStore::load_at(
+        Arc::clone(&filesystem),
+        root.clone(),
+        HostPortCatalog::empty(),
+        contracts(),
+    )
+    .await
+    .expect("a 1.2-written installation row must not fail composition");
+    assert_eq!(
+        reopened
+            .get_installation(installed.installation_id())
+            .await
+            .unwrap(),
+        Some(installed.clone()),
+        "the installation must survive the upgrade, not just the boot"
+    );
+
+    // A later write must not silently drop the operator's setting.
+    reopened.upsert_installation(installed.clone()).await.unwrap();
+    let rows = filesystem
+        .query(&installations, &Filter::All, Page::first(10))
+        .await
+        .unwrap();
+    let body: serde_json::Value = rows[0].entry.parse_json().unwrap();
+    assert_eq!(
+        body["activation_state"],
+        serde_json::json!("enabled"),
+        "a rewrite must carry the 1.2 activation state forward: {body}"
+    );
+}


### PR DESCRIPTION
## Summary

- `1.3.0-rc.1` crash-loops at boot on every deployment upgraded from `1.2.x`. Composition aborts with `extension installation state could not be loaded: ... unknown field 'activation_state'`, so the worker's HTTP and SSH ports go dead and all installed extensions become unreachable.
- Root cause is a forward-port gap, not a bad row. Commit `bdf8aef02` added `activation_state` to `V2InstallationRecord` **without bumping** `EXTENSION_STATE_V2_SCHEMA`, so 1.2-written rows still declare `extension_state.v2` and are routed to the current typed reader. `bdf8aef02` lives only on `origin/release/2026-08-11` — it is not an ancestor of `ironclaw-v1.3.0-rc.1` and is not on `main`. The reader is `#[serde(deny_unknown_fields)]`, which turns the extra key into a fail-closed startup error.
- Accept the field and carry it forward across writes. This release has no persisted activation concept, so the value is never read; it is preserved so a rollback to 1.2 keeps the operator's setting.
- Regression test drives the real boot path (`ExtensionInstallationStore::load_at` over a root holding a 1.2-shaped row), red at the base commit with the exact production error.

## Change Type

- [x] Bug fix

## Linked Issue

Closes #7720

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_extension_registry --all-targets --all-features -- -D warnings` — clean. Full-workspace clippy not run: the change is one private field plus two carry-forward expressions inside a single crate, with no cross-crate surface.
- [x] `cargo build` — via `cargo test -p ironclaw_extension_registry` (exit 0)
- [x] Relevant tests pass: `cargo test -p ironclaw_extension_registry --test installations_contract` → **33 passed, 0 failed**, including both new tests and the existing `normalized_v2_contract_runs_on_libsql`
- [x] Manual testing: diagnosed against the live failure on `staging-01` (`eager-lion-dulap-worker`, `Exited (1)`, `RestartCount 5`) and the on-disk row in its state volume
- [ ] `--features integration`: not applicable, this crate has no integration feature and the behavior is serde-shape, not backend-specific

## Test Strategy

**User behavior:** an operator upgrades a deployment from `1.2.x` to `1.3.x` and the agent comes back up with its installed extensions intact, instead of crash-looping.

Risk areas:
- [x] Persistence
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `v2_rows_carrying_activation_state_load_and_preserve_it` and `removal_tombstone_carries_the_1_2_activation_state_forward`, both in `crates/extensions/ironclaw_extension_registry/tests/installations_contract.rs`
- Reborn integration: Not applicable: the failure is inside `ExtensionInstallationStore::load_at`, which the contract tier drives directly over a real filesystem backend; the integration tier would add process startup without reaching a seam the contract tier misses
- Recorded fixture: Not applicable: no LLM interaction
- Browser E2E: Not applicable: no UI surface
- Backend or runtime: covered by the existing `normalized_v2_contract_runs_on_libsql` / `..._on_postgres_when_configured` legs in the same file, which exercise the same store against real backends
- Live canary: Not applicable: fix is pre-boot

**What the tests prove:** the test installs through the store, rewrites the persisted row **in place** into the shape a 1.2.x build leaves behind (mutating the stored entry preserves its real `kind` and `indexed` map, neither of which is constructible from the test crate), then reopens the root with `load_at` — exactly what `serve` does on every boot. It asserts the store loads, that the installation itself survives the upgrade rather than merely the boot succeeding, and that a later `upsert_installation` still carries `activation_state` in the raw stored JSON.

There are two write sites that rebuild the record from scratch, and they need separate coverage. The boot-path test reaches `put_v2_installation_core`; `persist_removal_tombstone` is reachable only through the removal path, and a review of this diff correctly flagged it as uncovered. The second test closes that — a soft removal followed by a tombstone persist, asserting the value survives both. It was proven red by neutralizing that one carry-forward to `None`: it fails while the boot-path test still passes, confirming it covers a site the other cannot reach.

Red at the base commit `5d71d1c25` with the exact production error, down to the column:

```
unknown field `activation_state`, expected one of `schema_version`, `installation_id`,
`extension_id`, `manifest`, `incarnation_id`, `legacy_tenant_owner`, `updated_at`,
`removed_at`, `lease`, `removal_cleanup_pending` at line 1 column 19
```

**Commands run:**

```
cargo test -p ironclaw_extension_registry --test installations_contract   # 33 passed
cargo test -p ironclaw_extension_registry                                 # exit 0
cargo clippy -p ironclaw_extension_registry --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
```

## Why preserve rather than discard

This repo already has the accept-an-unmodelled-field idiom: the manual `Deserialize for ExtensionInstallation` accepts a released `health` object as `serde::de::IgnoredAny` and drops it. This change deliberately deviates — `health` is regenerable diagnostics, whereas `activation_state` records operator intent, and dropping it would let a rollback to 1.2 silently reset a disabled extension to enabled. The field's doc comment states the difference so the divergence is explicit.

The value is `Option<String>` rather than a typed enum on purpose: nothing in this release reads it, and a typed enum would re-break on any future variant 1.2 adds — reproducing the exact failure being fixed here.

## Compatibility and rollback

- Forward (`1.2.x` → `1.3.x`): fixed. No migration, no schema bump, no data rewrite.
- Backward (`1.3.x` → `1.2.x`): already worked and still works. The field is optional in both directions; rows this release writes fresh omit it, and 1.2 reads absence as its own `enabled` default (verified against the `ironclaw-v1.2.0` tag, where the field is `#[serde(default = "default_enabled_activation_state")]`). 1.2 serializes the enum as a snake_case string, so `Option<String>` round-trips it losslessly.

## Known limit, stated plainly

A `"disabled"` row cannot be *honored* by this release — there is no disable mechanism here; `ExtensionActivationState` is a compat shim whose getter hardcodes `Enabled` and whose setter is a no-op. Such a row loads and its value is preserved on disk, but the extension runs as enabled until a rollback to 1.2. Across the 13 affected staging boxes all 14 rows are `"enabled"`, so no live deployment is in that state today.

## Blast radius this fixes

Scanned all 41 `*_state` volumes on `staging-01`: 13 hold v2 installation rows and **14 of 14 carry `activation_state`, zero mixed**. The remaining 28 have no v2 installation rows and upgrade cleanly. In other words, before this fix no worker with an installed extension could take `1.3.0-rc.1`.

## Follow-ups, deliberately not in this PR

1. **The forward-port gap itself.** 14 commits on `origin/release/2026-08-11` are absent from both `1.3` and `main`. Most consequentially `59eae2574 ci(release): gate 1.2 on stateful upgrades`, which adds `scripts/ci/release-upgrade-canary.py` and exists **only** on the 1.2 line — that gate is designed to catch exactly this failure, and its absence is why the break shipped. `c163f4d33` (thread-index listability, #7470) is also missing from `1.3` and `main`.
2. **`parse_v2_entry` ordering.** It deserializes into the typed struct before checking `schema_version`, while its sibling helper ~30 lines above checks first. Proven *non-causal* here — 1.2 kept the same schema string, so check-first would have deserialized the row anyway — and therefore excluded from a release-branch hotfix.
