### PR TITLE
fix(docker): restore Reborn in-worker SSH

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -82,7 +82,7 @@ jobs:
             echo "has_clippy=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(crates/|tests/|migrations/|Cargo\.toml$|Cargo\.lock$|Dockerfile|\.gitignore$|scripts/ci/|\.githooks/|docker/reborn/entrypoint\.sh$|scripts/reborn_webui_v2_live_qa/|scripts/live-canary/|\.github/workflows/(live-canary|reborn-e2e)\.yml$|scripts/check_no_panics\.py$|scripts/no_panics_reborn_baseline\.txt$|\.github/scripts/(pr-labeler|test-pr-labeler)\.sh$|\.github/workflows/(code_style|main-ci-slack-alerts)\.yml$|\.github/workflows/ironclaw-release\.yml$)'; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(crates/|tests/|migrations/|Cargo\.toml$|Cargo\.lock$|Dockerfile|\.gitignore$|scripts/ci/|\.githooks/|docker/reborn/(entrypoint|start-sshd)\.sh$|scripts/reborn_webui_v2_live_qa/|scripts/live-canary/|\.github/workflows/(live-canary|reborn-e2e)\.yml$|scripts/check_no_panics\.py$|scripts/no_panics_reborn_baseline\.txt$|\.github/scripts/(pr-labeler|test-pr-labeler)\.sh$|\.github/workflows/(code_style|main-ci-slack-alerts)\.yml$|\.github/workflows/ironclaw-release\.yml$)'; then
             echo "has_code=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_code=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -133,7 +133,7 @@ jobs:
             echo "has_wasm_abi_risk=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if has_match '^(Dockerfile|\.dockerignore$|\.github/workflows/platform-and-compat\.yml$)'; then
+          if has_match '^(Dockerfile|\.dockerignore$|docker/reborn/(entrypoint|start-sshd)\.sh$|\.github/workflows/platform-and-compat\.yml$)'; then
             echo "has_docker_risk=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_docker_risk=false" >> "$GITHUB_OUTPUT"
@@ -343,9 +343,9 @@ jobs:
     # Dockerfile changes must not be a main-only failure: the merge queue
     # builds the image when the merge group actually touches Docker inputs.
     # The merge_group arm deliberately does not require has_legacy_tests —
-    # the scope classifier matches the literal `Dockerfile`, so a
-    # .dockerignore-only merge group reports has_legacy_tests=false while
-    # has_docker_risk=true.
+    # the scope classifier matches Docker inputs directly, so a merge group
+    # changing only .dockerignore or a Reborn startup script reports
+    # has_legacy_tests=false while has_docker_risk=true.
     if: >
       needs.changes.outputs.docs_only != 'true' &&
       ((needs.changes.outputs.has_legacy_tests == 'true' &&
@@ -361,6 +361,59 @@ jobs:
           persist-credentials: false
       - name: Build Docker image
         run: docker build --target runtime -t ironclaw-reborn-test:ci .
+      - name: Verify in-worker SSH
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          test "$(docker image inspect --format '{{.Config.User}}' ironclaw-reborn-test:ci)" = "root"
+          docker image inspect --format '{{json .Config.ExposedPorts}}' ironclaw-reborn-test:ci \
+            | grep -q '"2222/tcp"'
+
+          ssh_work="$(mktemp -d)"
+          container_name="ironclaw-reborn-ssh-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() {
+            docker rm --force "$container_name" >/dev/null 2>&1 || true
+            rm -rf "$ssh_work"
+          }
+          trap cleanup EXIT
+
+          ssh-keygen -q -t ed25519 -N '' -f "$ssh_work/id_ed25519"
+          docker run --detach \
+            --name "$container_name" \
+            --publish 127.0.0.1::2222 \
+            --env IRONCLAW_REBORN_WEBUI_TOKEN=ssh-ci-webui-token-0123456789abcdef0123456789abcdef \
+            --env "IRONCLAW_REBORN_SSH_PUBLIC_KEY=$(cat "$ssh_work/id_ed25519.pub")" \
+            ironclaw-reborn-test:ci
+
+          ssh_port="$(docker port "$container_name" 2222/tcp | awk -F: 'NR == 1 { print $NF }')"
+          ssh_ready=false
+          for _ in $(seq 1 30); do
+            if ssh \
+              -i "$ssh_work/id_ed25519" \
+              -p "$ssh_port" \
+              -o BatchMode=yes \
+              -o ConnectTimeout=1 \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              agent@127.0.0.1 \
+              'test "$USER" = agent && test "$HOME" = /workspace && test "$PWD" = /workspace'
+            then
+              ssh_ready=true
+              break
+            fi
+            if [ "$(docker inspect --format '{{.State.Running}}' "$container_name")" != "true" ]; then
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "$ssh_ready" != "true" ]; then
+            docker logs "$container_name"
+            echo "Reborn runtime did not accept an SSH session as agent" >&2
+            exit 1
+          fi
 
   version-check:
     name: Version Bump Check

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,8 @@ RUN apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         ca-certificates \
         curl \
+        gosu \
+        openssh-server \
         postgresql-client \
         sqlite3 \
     && rm -rf /var/lib/apt/lists/*
@@ -128,20 +130,23 @@ COPY docker/reborn/config.hosted-single-tenant.toml /opt/ironclaw/reborn/config.
 COPY docker/reborn/config.hosted-single-tenant-volume.toml /opt/ironclaw/reborn/config.hosted-single-tenant-volume.toml
 COPY docker/reborn/config.production.toml /opt/ironclaw/reborn/config.production.toml
 COPY docker/reborn/entrypoint.sh /usr/local/bin/ironclaw-reborn-entrypoint
+COPY docker/reborn/start-sshd.sh /usr/local/bin/ironclaw-reborn-start-sshd
 
 ENV HOME=/home/ironclaw \
     IRONCLAW_REBORN_LOG=info \
     IRONCLAW_REBORN_SERVE_HOST=127.0.0.1
 
 RUN useradd -m -d /home/ironclaw -u 1000 ironclaw \
+    && useradd --non-unique --uid 1000 --gid ironclaw --home-dir /workspace --shell /bin/bash agent \
+    && passwd -d agent \
     && mkdir -p /data/ironclaw-reborn /workspace \
     && chown -R ironclaw:ironclaw /home/ironclaw /data/ironclaw-reborn /workspace \
-    && chmod +x /usr/local/bin/ironclaw-reborn-entrypoint
+    && chmod +x /usr/local/bin/ironclaw-reborn-entrypoint /usr/local/bin/ironclaw-reborn-start-sshd
 
 WORKDIR /workspace
 
-EXPOSE 3000
+EXPOSE 3000 2222
 
-USER ironclaw
+USER root
 
 ENTRYPOINT ["ironclaw-reborn-entrypoint"]

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -33,6 +33,22 @@ else
   IRONCLAW_REBORN_HOME="/data/ironclaw-reborn"
 fi
 export IRONCLAW_REBORN_HOME
+
+ssh_public_key="${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}"
+if [ "$(id -u)" = "0" ]; then
+  mkdir -p "$IRONCLAW_REBORN_HOME" /workspace
+  chown ironclaw:ironclaw "$IRONCLAW_REBORN_HOME" /workspace
+  if [ -n "$ssh_public_key" ]; then
+    ironclaw-reborn-start-sshd
+  fi
+  unset IRONCLAW_REBORN_SSH_PUBLIC_KEY
+  exec gosu ironclaw "$0" "$@"
+fi
+if [ -n "$ssh_public_key" ]; then
+  echo "direct SSH requires the container entrypoint to start as root" >&2
+  exit 1
+fi
+
 if [ -n "${IRONCLAW_REBORN_DEFAULT_CONFIG:-}" ]; then
   default_config="$IRONCLAW_REBORN_DEFAULT_CONFIG"
 else

--- a/docker/reborn/start-sshd.sh
+++ b/docker/reborn/start-sshd.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+set -eu
+
+public_key="${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}"
+if [ -z "$public_key" ]; then
+  exit 0
+fi
+
+ssh_dir="$IRONCLAW_REBORN_HOME/ssh"
+host_key="$ssh_dir/ssh_host_ed25519_key"
+authorized_keys="$ssh_dir/authorized_keys"
+config="$ssh_dir/sshd_config"
+
+if [ ! -d "$IRONCLAW_REBORN_HOME" ]; then
+  echo "IRONCLAW_REBORN_HOME must exist before SSH starts: $IRONCLAW_REBORN_HOME" >&2
+  exit 1
+fi
+
+if [ -e "$ssh_dir" ] || [ -L "$ssh_dir" ]; then
+  if [ ! -d "$ssh_dir" ] || [ -L "$ssh_dir" ]; then
+    echo "refusing unsafe SSH state path: $ssh_dir" >&2
+    exit 1
+  fi
+  ssh_dir_owner="$(stat -c '%u' "$ssh_dir")"
+  ssh_dir_mode="$(stat -c '%a' "$ssh_dir")"
+  if [ "$ssh_dir_owner" != "0" ]; then
+    echo "refusing SSH state directory not owned by root: $ssh_dir" >&2
+    exit 1
+  fi
+  case "$ssh_dir_mode" in
+    *[2367][0-7]|*[0-7][2367])
+      echo "refusing group/world-writable SSH state directory: $ssh_dir" >&2
+      exit 1
+      ;;
+  esac
+else
+  mkdir -m 755 "$ssh_dir"
+fi
+chmod 755 "$ssh_dir"
+mkdir -p /run/sshd
+chmod 755 /run/sshd
+
+host_key_tmp="$ssh_dir/ssh_host_ed25519_key.tmp.$$"
+authorized_keys_tmp="$ssh_dir/authorized_keys.tmp.$$"
+config_tmp="$ssh_dir/sshd_config.tmp.$$"
+trap 'rm -f "$host_key_tmp" "$host_key_tmp.pub" "$authorized_keys_tmp" "$config_tmp"' EXIT HUP INT TERM
+
+if [ -e "$host_key" ] || [ -L "$host_key" ]; then
+  if [ ! -f "$host_key" ] || [ -L "$host_key" ]; then
+    echo "refusing unsafe SSH host key path: $host_key" >&2
+    exit 1
+  fi
+  if ! ssh-keygen -l -f "$host_key" >/dev/null 2>&1; then
+    echo "persisted SSH host key is invalid: $host_key" >&2
+    exit 1
+  fi
+else
+  ssh-keygen -q -t ed25519 -N '' -f "$host_key_tmp"
+  chmod 600 "$host_key_tmp"
+  mv "$host_key_tmp" "$host_key"
+  rm -f "$host_key_tmp.pub"
+fi
+chmod 600 "$host_key"
+
+printf '%s\n' "$public_key" > "$authorized_keys_tmp"
+if ! ssh-keygen -l -f "$authorized_keys_tmp" >/dev/null 2>&1; then
+  echo "IRONCLAW_REBORN_SSH_PUBLIC_KEY is not a valid OpenSSH public key" >&2
+  exit 1
+fi
+chmod 644 "$authorized_keys_tmp"
+mv "$authorized_keys_tmp" "$authorized_keys"
+
+{
+  printf '%s\n' \
+    'Port 2222' \
+    'ListenAddress 0.0.0.0' \
+    "HostKey \"$host_key\"" \
+    "PidFile \"$ssh_dir/sshd.pid\"" \
+    "AuthorizedKeysFile \"$authorized_keys\"" \
+    'AllowUsers agent' \
+    'AuthenticationMethods publickey' \
+    'PubkeyAuthentication yes' \
+    'PasswordAuthentication no' \
+    'KbdInteractiveAuthentication no' \
+    'PermitEmptyPasswords no' \
+    'PermitRootLogin no' \
+    'StrictModes yes' \
+    'UsePAM no' \
+    'X11Forwarding no' \
+    'PrintMotd no' \
+    "SetEnv IRONCLAW_REBORN_HOME=$IRONCLAW_REBORN_HOME CARGO_HOME=/usr/local/cargo RUSTUP_HOME=/usr/local/rustup" \
+    'Subsystem sftp internal-sftp'
+} > "$config_tmp"
+chmod 600 "$config_tmp"
+mv "$config_tmp" "$config"
+
+/usr/sbin/sshd -t -f "$config"
+/usr/sbin/sshd -f "$config"
+
+trap - EXIT HUP INT TERM

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -503,18 +503,16 @@ PR_STATIC_CONTROL_PATHS = {
     "ironclaw.png",
     "LICENSE-APACHE",
     "LICENSE-MIT",
-    # The Reborn container entrypoint is shell, not Rust: no Reborn test lane
-    # executes it. Code Style owns it end to end — `code_style.yml`'s `has_code`
-    # filter names `docker/reborn/entrypoint.sh` and its "Self-test CI scripts"
-    # step runs `scripts/ci/test-reborn-docker-entrypoint.sh`, which drives the
-    # real script. (`platform-and-compat.yml`'s `has_docker_risk` deliberately
-    # does not cover it — that filter is keyed to `Dockerfile`/`.dockerignore`
-    # and owns the image build, not the entrypoint's behaviour. `docker/` stays
-    # per-file, never a prefix: it mixes classes, and the shipped runtime
+    # The Reborn container startup scripts are shell, not Rust: no Reborn test
+    # lane executes them. Code Style owns their fast self-tests, while
+    # `platform-and-compat.yml` classifies both as Docker risk and exercises
+    # them through the built runtime image. `docker/` stays per-file, never a
+    # prefix: it mixes classes, and the shipped runtime
     # configs beside this script belong to a Rust lane instead — see
     # `DOCKER_RUNTIME_CONFIG_OWNERS` below. `docker/process-sandbox-entrypoint.sh`
     # has no owning lane and must keep refusing.)
     "docker/reborn/entrypoint.sh",
+    "docker/reborn/start-sshd.sh",
 }
 # Shipped container configs a Reborn Rust test parses and asserts on, mapped to
 # the test source that owns them. They are NOT static control: the membership

--- a/scripts/ci/test-reborn-docker-entrypoint.sh
+++ b/scripts/ci/test-reborn-docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Self-test for docker/reborn/entrypoint.sh's legacy-Slack field migration.
+# Self-test for docker/reborn/entrypoint.sh's startup contracts.
 #
 # #7115: the migration was gated on `IRONCLAW_REBORN_SLACK_ENABLED` not being
 # truthy. That variable lost its last Rust reader in #6116, while the operator
@@ -34,6 +34,56 @@ exit 0
 STUB
 chmod +x "${WORK}/bin/ironclaw"
 
+# Root startup is exercised without requiring the test process itself to run as
+# root. The entrypoint resolves these commands through PATH, so the stubs model
+# the one root pass followed by gosu's non-root re-exec while recording ordering
+# and environment consumption.
+mkdir -p "${WORK}/root-bin"
+cat > "${WORK}/root-bin/id" <<'STUB'
+#!/bin/sh
+test "${1:-}" = "-u"
+printf '%s\n' "${IRONCLAW_STUB_UID:-1000}"
+STUB
+cat > "${WORK}/root-bin/ironclaw-reborn-start-sshd" <<'STUB'
+#!/bin/sh
+test -d "${IRONCLAW_REBORN_HOME}"
+printf '%s\n' "${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}" > "${IRONCLAW_STUB_SSH_PATH}"
+STUB
+cat > "${WORK}/root-bin/chown" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$*" > "${IRONCLAW_STUB_CHOWN_PATH}"
+STUB
+cat > "${WORK}/root-bin/mkdir" <<'STUB'
+#!/bin/sh
+for path in "$@"; do
+  case "$path" in
+    -*) ;;
+    /workspace) ;;
+    *) /bin/mkdir -p "$path" ;;
+  esac
+done
+STUB
+cat > "${WORK}/root-bin/gosu" <<'STUB'
+#!/bin/sh
+if [ "${1:-}" != "ironclaw" ]; then
+  echo "unexpected gosu user: ${1:-}" >&2
+  exit 1
+fi
+if [ -n "${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}" ]; then
+  echo "SSH public key survived the privilege drop" >&2
+  exit 1
+fi
+printf '%s\n' "$*" > "${IRONCLAW_STUB_GOSU_PATH}"
+shift
+export IRONCLAW_STUB_UID=1000
+exec "$@"
+STUB
+chmod +x "${WORK}/root-bin/id" \
+  "${WORK}/root-bin/ironclaw-reborn-start-sshd" \
+  "${WORK}/root-bin/chown" \
+  "${WORK}/root-bin/mkdir" \
+  "${WORK}/root-bin/gosu"
+
 failures=0
 
 # Runs the entrypoint over a seeded config and echoes the resulting file.
@@ -59,11 +109,12 @@ run_entrypoint() {
     for assignment in "$@"; do
       export "${assignment?}"
     done
-    sh "$ENTRYPOINT" >/dev/null 2>&1
+    sh "$ENTRYPOINT" >/dev/null 2>"${home}/entrypoint.err"
   )
 
   if [ ! -f "${home}/argv" ]; then
     echo "FAIL[${name}]: entrypoint never reached the ironclaw exec" >&2
+    cat "${home}/entrypoint.err" >&2
     # Every caller invokes this function inside a command substitution, so the
     # body runs in a subshell and a `failures=$((failures + 1))` here would
     # mutate a copy the parent never sees (the run stayed green with this
@@ -129,7 +180,55 @@ out="$(run_entrypoint enabled_true "$LEGACY_ENABLED")"
 expect_present enabled_true 'signing_secret_env' "$out"
 expect_present enabled_true 'bot_token_env' "$out"
 
-# 4. The dead variable has no reader left anywhere in the tree.
+# 4. Keyed SSH starts during the root pass, consumes the public key, then
+#    re-executes the same entrypoint as the unprivileged application user.
+ssh_key='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestOnlyKey entrypoint-test'
+ssh_record="${WORK}/ssh-started"
+gosu_record="${WORK}/gosu-argv"
+chown_record="${WORK}/chown-argv"
+out="$(run_entrypoint ssh_root "$LEGACY_DISABLED" \
+  "PATH=${WORK}/root-bin:${WORK}/bin:${PATH}" \
+  "IRONCLAW_STUB_UID=0" \
+  "IRONCLAW_STUB_SSH_PATH=${ssh_record}" \
+  "IRONCLAW_STUB_GOSU_PATH=${gosu_record}" \
+  "IRONCLAW_STUB_CHOWN_PATH=${chown_record}" \
+  "IRONCLAW_REBORN_SSH_PUBLIC_KEY=${ssh_key}")"
+expect_absent ssh_root 'signing_secret_env' "$out"
+if [ "$(cat "$ssh_record")" != "$ssh_key" ]; then
+  echo "FAIL[ssh_root]: SSH did not start with the configured public key" >&2
+  failures=$((failures + 1))
+fi
+if ! grep -q '^ironclaw .*docker/reborn/entrypoint.sh' "$gosu_record"; then
+  echo "FAIL[ssh_root]: entrypoint did not re-exec through gosu: $(cat "$gosu_record")" >&2
+  failures=$((failures + 1))
+fi
+if [ "$(cat "$chown_record")" != "ironclaw:ironclaw ${WORK}/ssh_root /workspace" ]; then
+  echo "FAIL[ssh_root]: root pass did not hand runtime paths to ironclaw: $(cat "$chown_record")" >&2
+  failures=$((failures + 1))
+fi
+
+# 5. A keyed non-root launch cannot silently advertise SSH without starting
+#    the daemon. This is also the guard for an operator overriding USER.
+nonroot_home="${WORK}/ssh-nonroot"
+mkdir -p "$nonroot_home"
+if (
+  export PATH="${WORK}/root-bin:${WORK}/bin:${PATH}"
+  export IRONCLAW_STUB_UID=1000
+  export IRONCLAW_REBORN_HOME="$nonroot_home"
+  export IRONCLAW_REBORN_SSH_PUBLIC_KEY="$ssh_key"
+  sh "$ENTRYPOINT" >"${WORK}/ssh-nonroot.out" 2>"${WORK}/ssh-nonroot.err"
+); then
+  echo "FAIL[ssh_nonroot]: keyed SSH launch unexpectedly succeeded without root" >&2
+  failures=$((failures + 1))
+elif ! grep -q 'direct SSH requires the container entrypoint to start as root' \
+  "${WORK}/ssh-nonroot.err"
+then
+  echo "FAIL[ssh_nonroot]: expected fail-closed diagnostic" >&2
+  cat "${WORK}/ssh-nonroot.err" >&2
+  failures=$((failures + 1))
+fi
+
+# 6. The dead variable has no reader left anywhere in the tree.
 if grep -rn 'IRONCLAW_REBORN_SLACK_ENABLED' \
   --include='*.rs' --include='*.sh' --include='*.toml' \
   "${ROOT}/crates" "${ROOT}/docker" "${ROOT}/scripts" 2>/dev/null \

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -1516,8 +1516,8 @@ class RebornPrTestPlanTests(unittest.TestCase):
     # covered by `test_repo_root_example_env_is_classified_and_selects_no_rust_lane`
     # above — main classified it independently via `IGNORED_ROOT_FILES` while
     # this branch was in flight, same fix by the same route.
-    def test_reborn_container_entrypoint_is_owned_by_code_style(self) -> None:
-        """`docker/reborn/entrypoint.sh` is shell that Code Style self-tests.
+    def test_reborn_container_startup_scripts_are_owned_by_static_gates(self) -> None:
+        """The Reborn startup scripts are shell with explicit static owners.
 
         Second half of the same rejection. It is deliberately *not* an ignore:
         the plan names an owner, because one exists —
@@ -1526,13 +1526,18 @@ class RebornPrTestPlanTests(unittest.TestCase):
         filter lights that lane for this exact path. No Reborn Rust lane
         executes it, so it selects nothing here.
         """
-        plan = self.plan("pull_request", ["docker/reborn/entrypoint.sh"])
-        self.assertEqual(plan["mode"], "none")
-        self.assertEqual(plan["crate_buckets"], [])
-        self.assertIn(
-            "static CI or workspace-policy checks own: docker/reborn/entrypoint.sh",
-            plan["reasons"],
-        )
+        for path in (
+            "docker/reborn/entrypoint.sh",
+            "docker/reborn/start-sshd.sh",
+        ):
+            with self.subTest(path=path):
+                plan = self.plan("pull_request", [path])
+                self.assertEqual(plan["mode"], "none")
+                self.assertEqual(plan["crate_buckets"], [])
+                self.assertIn(
+                    f"static CI or workspace-policy checks own: {path}",
+                    plan["reasons"],
+                )
 
     def test_classified_operator_paths_do_not_mask_a_real_lane(self) -> None:
         """Neither classification may swallow its neighbours.
@@ -1547,6 +1552,7 @@ class RebornPrTestPlanTests(unittest.TestCase):
             [
                 ".env.example",
                 "docker/reborn/entrypoint.sh",
+                "docker/reborn/start-sshd.sh",
                 "crates/alpha/src/lib.rs",
             ],
         )

--- a/scripts/ci/ws12_workflow_contracts.py
+++ b/scripts/ci/ws12_workflow_contracts.py
@@ -79,6 +79,13 @@ REQUIRED_MARKERS: dict[str, tuple[str, ...]] = {
         "python3 scripts/ci/test_docs_publication_boundary.py",
         "python3 scripts/ci/docs_publication_boundary.py",
         '"${{ needs.docs-publication-boundary.result }}" != "success"',
+        "docker/reborn/(entrypoint|start-sshd)",
+    ),
+    ".github/workflows/platform-and-compat.yml": (
+        "docker/reborn/(entrypoint|start-sshd)",
+        "Verify in-worker SSH",
+        "IRONCLAW_REBORN_WEBUI_TOKEN=ssh-ci-webui-token-",
+        "agent@127.0.0.1",
     ),
     ".github/workflows/reborn-playwright.yml": (
         "python3 scripts/ci/ws12_suite_shards.py --github-output",

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -310,7 +310,7 @@ channel-delivery journeys (two-lane model):
 |---|---|
 | A provider failure yields a sanitized, *retryable* failure and the user can retry and resume | `reborn_failure_retry_resume_e2e.rs` (6) |
 | Sub-agents spawn end-to-end | `reborn_subagent_spawn_e2e.rs` (5) |
-| The shipped Docker image has a usable runtime home | `dockerfile_runtime_home.rs` (19) |
+| The shipped Docker image has a usable runtime home and an in-worker public-key SSH shell | `dockerfile_runtime_home.rs` (21) |
 | Live GitHub API contracts still hold (ignored canary, needs a real PAT) | `reborn_live_github_pat_contract.rs` |
 
 **Scope isolation parity** — one bin per boundary; each proves data from one scope is

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -204,6 +204,91 @@ fn reborn_runtime_image_includes_sql_debug_clients() {
 }
 
 #[test]
+fn reborn_runtime_image_provides_in_worker_ssh_contract() {
+    let dockerfile = read_repo_file("Dockerfile");
+    let runtime_stage = dockerfile
+        .rsplit_once(" AS runtime\n")
+        .map(|(_, stage)| stage)
+        .expect("Dockerfile must define a final runtime stage");
+    let runtime_packages = runtime_stage
+        .split_once("install -y --no-install-recommends \\\n")
+        .and_then(|(_, packages)| packages.split_once("    && rm -rf /var/lib/apt/lists/*"))
+        .map(|(packages, _)| packages)
+        .expect("runtime stage must install its package list before apt cleanup");
+
+    for package in ["gosu", "openssh-server"] {
+        assert!(
+            runtime_packages
+                .lines()
+                .any(|line| line.trim().trim_end_matches('\\').trim() == package),
+            "runtime image must install {package} for in-worker SSH"
+        );
+    }
+    assert!(
+        runtime_stage
+            .contains("COPY docker/reborn/start-sshd.sh /usr/local/bin/ironclaw-reborn-start-sshd"),
+        "runtime image must install the SSH startup script"
+    );
+    assert!(
+        runtime_stage.contains(
+            "chmod +x /usr/local/bin/ironclaw-reborn-entrypoint /usr/local/bin/ironclaw-reborn-start-sshd"
+        ),
+        "runtime image must make the SSH startup script executable"
+    );
+    assert!(
+        runtime_stage.contains(
+            "useradd --non-unique --uid 1000 --gid ironclaw --home-dir /workspace --shell /bin/bash agent"
+        ),
+        "runtime image must create the advertised agent login"
+    );
+    assert!(
+        runtime_stage.contains("passwd -d agent"),
+        "runtime image must unlock the agent account for public-key authentication"
+    );
+    assert!(
+        runtime_stage.contains("EXPOSE 3000 2222"),
+        "runtime image must publish the SSH container port"
+    );
+    assert!(
+        runtime_stage.contains("USER root"),
+        "runtime entrypoint must start as root so it can launch sshd before dropping privileges"
+    );
+
+    let entrypoint = read_repo_file("docker/reborn/entrypoint.sh");
+    assert!(
+        entrypoint.contains("ironclaw-reborn-start-sshd")
+            && entrypoint.contains("exec gosu ironclaw \"$0\" \"$@\""),
+        "entrypoint must launch SSH before re-executing as ironclaw"
+    );
+
+    let ssh_startup = read_repo_file("docker/reborn/start-sshd.sh");
+    for directive in [
+        "Port 2222",
+        "ListenAddress 0.0.0.0",
+        "AllowUsers agent",
+        "AuthenticationMethods publickey",
+        "PasswordAuthentication no",
+        "PermitRootLogin no",
+    ] {
+        assert!(
+            ssh_startup.contains(directive),
+            "SSH startup must preserve the security directive: {directive}"
+        );
+    }
+    assert!(
+        ssh_startup.contains("chmod 755 \"$ssh_dir\"")
+            && ssh_startup.contains("chmod 644 \"$authorized_keys_tmp\""),
+        "the root-owned SSH state must remain readable by the unprivileged agent key check"
+    );
+
+    let docker_workflow = read_repo_file(".github/workflows/platform-and-compat.yml");
+    assert!(
+        docker_workflow.contains("--env IRONCLAW_REBORN_WEBUI_TOKEN=ssh-ci-webui-token-"),
+        "live SSH verification must keep the application alive with a test-only WebUI token"
+    );
+}
+
+#[test]
 fn reborn_runtime_image_can_run_the_orchestrator_healthcheck() {
     // Earlier build stages install curl for downloads, so inspect only the
     // shipped runtime stage used by container healthchecks.


### PR DESCRIPTION
## Summary

- Restore public-key SSH as `agent` on port 2222 in the canonical Reborn runtime image.
- Start `sshd` during the root entrypoint pass, then drop the application process to the existing `ironclaw` user.
- Add static and built-image CI coverage so future image rebuilds cannot silently remove the SSH contract.
- Preserve hardened authentication and persisted host-key handling while supporting fresh mounted runtime homes.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [x] Security
- [x] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `dockerfile_runtime_home`, Reborn entrypoint self-tests, PR test-plan tests, WS12 workflow tests, architecture tests
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (not applicable: no database-backed behavior changed)
- [x] Manual testing: built the runtime image and completed a real Ed25519 SSH session as `agent`; verified `HOME` and `PWD` are `/workspace`, PID 1 runs as UID 1000, and `sshd` remains active
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: Reborn users can again connect to the advertised worker SSH port with their configured public key and receive an in-worker shell as `agent`.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: extended `dockerfile_runtime_home.rs`, entrypoint shell self-tests, CI workflow marker tests, and PR lane classification tests.
- Reborn integration: the canonical runtime image contract test covers packages, users, ports, startup wiring, and authentication directives.
- Recorded fixture: Not applicable: no recorded external interaction.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: Docker CI builds the real runtime image and performs an Ed25519 SSH login as `agent`.
- Live canary: Not applicable: verification uses the production-shaped local image without contacting a deployed environment.

What the tests prove:
- The image contains `gosu` and `openssh-server`, exposes 2222, and creates the advertised `agent` login.
- Root startup initializes mounted state, starts SSH only when a key is configured, consumes the key before privilege drop, and fails closed when keyed SSH is requested from a non-root entrypoint.
- SSH accepts the configured public key, rejects password/root authentication by configuration, and opens in `/workspace`.
- Docker/startup-script changes select both the fast static gates and the built-image Docker lane.

Commands run:
- `cargo fmt --check`
- `bash -n docker/reborn/entrypoint.sh docker/reborn/start-sshd.sh scripts/ci/test-reborn-docker-entrypoint.sh`
- `bash scripts/ci/test-reborn-docker-entrypoint.sh`
- `python3 scripts/ci/test_reborn_pr_test_plan.py`
- `python3 scripts/ci/test_ws12_workflow_contracts.py`
- `python3 scripts/ci/ws12_workflow_contracts.py`
- `SKIP_FRONTEND_BUILD=1 cargo test -p ironclaw_integration_tests --test dockerfile_runtime_home`
- `cargo test -p ironclaw_architecture_tests`
- `docker build --target runtime -t ironclaw-reborn-test:ssh .`
- Live SSH connection and privilege-drop probe against `ironclaw-reborn-test:ssh`
- `git diff --check`

## Security Impact

The container now starts as root long enough to initialize the runtime home and launch `sshd`, then re-execs IronClaw as UID 1000 via `gosu`. SSH is opt-in through `IRONCLAW_REBORN_SSH_PUBLIC_KEY`, restricted to `agent`, public-key-only, and configured with password, keyboard-interactive, empty-password, and root login disabled. Host keys persist under the runtime home. The public key is removed from the application environment before privilege drop.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: N/A; no Rust trust-bearing types changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: N/A; no prompt path changed.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check: N/A; no application hash contract changed.
- [x] New/changed status, exit, policy, runtime, or error variants: N/A; no typed variants changed.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: N/A; no serde fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: N/A; none added.
- [x] Driver/operator-visible errors have stable class semantics: N/A; shell startup diagnostics only.
- [x] Sandbox/native/host names accurately describe trust boundary: the SSH daemon is explicitly host-managed in the native runtime image and the application remains unprivileged.

## Database Impact

None.

## Blast Radius

Touches the canonical Reborn Docker runtime, its root-to-unprivileged startup sequence, Docker-risk CI classification, and container contract tests. Compatibility is preserved for launches without an SSH key; they still run IronClaw as UID 1000 after a brief root bootstrap. The main operational risks are SSH startup failure from invalid key/state and fresh-volume ownership, both covered by fail-closed checks and regression tests.

## Rollback Plan

Revert this commit and republish the prior runtime image. That removes the SSH packages, `agent` login, port exposure, and root bootstrap, returning to the previous app-only container behavior. Persisted `ssh/` state can remain unused on existing volumes and does not affect the application.

## Review Follow-Through

Review should focus on the root bootstrap boundary, persisted SSH-state permissions, duplicate-UID `agent` login, and whether the release workflow should add a published-artifact smoke test in a follow-up.

---

**Review track**: C (security/runtime/CI)
