### PR TITLE
feat(slack): per-field help text on the Slack deployment configuration card

### DIFF
--- a/crates/extensions/packages/slack/manifest.toml
+++ b/crates/extensions/packages/slack/manifest.toml
@@ -12,16 +12,16 @@ module = "wasm/slack_user_tool.wasm"
 [admin_configuration]
 group_id = "extension.slack"
 display_name = "Slack deployment configuration"
-description = "Deployment credentials and routing configuration for the Slack channel."
+description = "Deployment credentials for the Slack workspace bot, from your app at api.slack.com/apps. Slack delivers events by webhook, so the instance must be reachable over public HTTPS — a local installation needs a tunnel (such as ngrok or Cloudflare Tunnel) in front of it. Each person connects their own Slack account separately, from the Extensions page."
 fields = [
-  { handle = "slack_bot_token", label = "Bot token", secret = true, required = true },
-  { handle = "slack_signing_secret", label = "Signing secret", secret = true, required = true },
-  { handle = "slack_team_id", label = "Workspace (team) ID", secret = false, required = true },
-  { handle = "slack_api_app_id", label = "App ID", secret = false, required = true },
-  { handle = "slack_installation_id", label = "Installation ID", secret = false, required = true },
-  { handle = "slack_bot_user_id", label = "Bot user ID", secret = false, required = true },
-  { handle = "slack_oauth_client_id", label = "OAuth client ID", secret = false, required = true },
-  { handle = "slack_oauth_client_secret", label = "OAuth client secret", secret = true, required = true },
+  { handle = "slack_bot_token", label = "Bot token", secret = true, required = true, description = "The Bot User OAuth Token (xoxb-…) under OAuth & Permissions, available once the app is installed to your workspace." },
+  { handle = "slack_signing_secret", label = "Signing secret", secret = true, required = true, description = "From Basic Information → App Credentials. Used to verify that incoming requests really came from Slack." },
+  { handle = "slack_team_id", label = "Workspace (team) ID", secret = false, required = true, description = "Your workspace id (T…) — also the team_id in every Events API payload." },
+  { handle = "slack_api_app_id", label = "App ID", secret = false, required = true, description = "From Basic Information → App ID (A…) — also the api_app_id in Events API payloads." },
+  { handle = "slack_installation_id", label = "Installation ID", secret = false, required = true, description = "A stable label you choose for this app/workspace installation, e.g. slack-acme." },
+  { handle = "slack_bot_user_id", label = "Bot user ID", secret = false, required = true, description = "The bot's member id (U…), shown under App Home or returned by auth.test with the bot token." },
+  { handle = "slack_oauth_client_id", label = "OAuth client ID", secret = false, required = true, description = "From Basic Information → App Credentials. Used for personal (per-user) Slack authorization." },
+  { handle = "slack_oauth_client_secret", label = "OAuth client secret", secret = true, required = true, description = "From Basic Information → App Credentials, next to the client ID." },
 ]
 # Retired handles (run-acts-as-invoker): `slack_shared_subject_user_id`,
 # `slack_subject_routes`, and the interim `slack_allowed_channels` allowlist

--- a/tests/integration/webui_v2_product_api.rs
+++ b/tests/integration/webui_v2_product_api.rs
@@ -1213,6 +1213,38 @@ async fn operator_lists_uninstalled_manifest_admin_configuration_with_secrets_re
         expected_fragments.len(),
         "every telegram field is covered by a help-text expectation"
     );
+    let slack_fields = groups
+        .iter()
+        .find(|group| group["group_id"] == "extension.slack")
+        .and_then(|group| group["fields"].as_array())
+        .expect("slack group lists fields");
+    let expected_slack_fragments = [
+        ("slack_bot_token", "xoxb-"),
+        ("slack_signing_secret", "really came from Slack"),
+        ("slack_team_id", "team_id"),
+        ("slack_api_app_id", "api_app_id"),
+        ("slack_installation_id", "label you choose"),
+        ("slack_bot_user_id", "auth.test"),
+        ("slack_oauth_client_id", "personal"),
+        ("slack_oauth_client_secret", "next to the client ID"),
+    ];
+    for (handle, fragment) in expected_slack_fragments {
+        let description = slack_fields
+            .iter()
+            .find(|field| field["handle"] == handle)
+            .and_then(|field| field["description"].as_str())
+            .unwrap_or_else(|| panic!("field {handle} carries help text on the wire"));
+        assert!(
+            description.contains(fragment),
+            "field {handle} must carry its own manifest help text \
+             (expected fragment {fragment:?}): {description}"
+        );
+    }
+    assert_eq!(
+        slack_fields.len(),
+        expected_slack_fragments.len(),
+        "every slack field is covered by a help-text expectation"
+    );
 
     drop(webui);
     runtime.shutdown().await.expect("runtime shuts down");


### PR DESCRIPTION
## Summary

- Every `[admin_configuration]` field in `crates/extensions/packages/slack/manifest.toml` now carries a `description`, rendered as the hint under each input on **Admin → Configuration** (the seam #7550 added; Telegram was the first consumer). Operators filling the Slack card see where each value comes from — `xoxb-` token under OAuth & Permissions, signing secret / client id / client secret under Basic Information → App Credentials, `T…`/`A…`/`U…` ids, and that Installation ID is a label they choose.
- The group description drops the retired "and routing configuration" wording (routes/allowlists are gone since run-acts-as-invoker) and gains the same public-HTTPS / tunnel note Telegram's card shows, plus a pointer that personal accounts connect from the Extensions page.
- No code changes: the registry, host, assistant wire DTO, and frontend already thread `description` (#7550). Manifest data + one integration assertion.

## Change Type

- [x] New feature

## Linked Issue

Related #7550 (help-text seam), companion to #7737 (Slack docs drift).

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] clippy — Not run: no Rust production code changed (manifest TOML + one test)
- [x] Relevant tests pass: `cargo test -p ironclaw_integration_tests --test reborn_integration_webui_v2_product_api operator_lists_uninstalled_manifest_admin_configuration_with_secrets_redacted`, `cargo test -p ironclaw_composition --test first_party_manifest_v3_parity`, `cargo test -p ironclaw_slack_extension`
- [ ] Manual testing: not done — frontend rendering of `field.description` / `group.description` is already covered by `configuration-tab.test.ts` from #7550

## Test Strategy

User behavior: An operator opening Admin → Configuration → Slack deployment configuration sees a hint under each of the eight inputs explaining what to enter and where to find it in the Slack app.

Risk areas:
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Not applicable: no new code path; manifest v3 contract already proves declared descriptions survive resolution
- Reborn integration: `webui_v2_product_api.rs::operator_lists_uninstalled_manifest_admin_configuration_with_secrets_redacted` — pins each Slack handle to a distinctive fragment of its own help text on the wire, plus a field-count guard (same shape as the Telegram assertions)
- Recorded fixture: Not applicable
- Browser E2E: Not applicable: rendering covered by existing vitest from #7550
- Backend or runtime: Not applicable
- Live canary: Not applicable

What the tests prove: The production stack (composition → product surface → operator router) serves every Slack field with its own manifest help text; the assertion was observed red without the manifest change (`field slack_bot_token carries help text on the wire`) and green with it.

Commands run: listed under Validation.

## Security Impact

None — descriptions are non-secret static strings; secret redaction is unchanged and still asserted in the same test.

## Reborn Trust-Boundary Checklist

N/A — manifest metadata only.

## Database Impact

None.

## Blast Radius

Slack manifest `[admin_configuration]` block; the Admin → Configuration Slack card in the WebUI.

## Rollback Plan

Revert the commit; `description` is `serde(default)` so either direction parses.

## Review Follow-Through

Wording of the hints is the reviewable part — happy to tighten. Docs PR #7737 carries the matching field table.

---

**Review track**: B

🤖 Generated with [Claude Code](https://claude.com/claude-code)
