### PR TITLE
fix(webui): make expandable sidebar sections collapsible

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/components/sidebar-nav.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/components/sidebar-nav.test.ts
@@ -1,7 +1,86 @@
+// @vitest-environment happy-dom
+
 import assert from "node:assert/strict";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { MemoryRouter, useLocation, useNavigate } from "react-router";
 import { test } from "vitest";
+import "../i18n/en";
+import { I18nProvider } from "../lib/i18n";
 
 import { visibleSidebarSubRoutes } from "./sidebar-nav";
+import { SidebarNav } from "./sidebar-nav";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const expandableRoutes = [
+  { id: "extensions", firstTab: "registry", isAdmin: false },
+  { id: "settings", firstTab: "inference", isAdmin: false },
+  { id: "admin", firstTab: "users", isAdmin: true },
+];
+
+function CurrentPath({ navigateBackPath }) {
+  const navigate = useNavigate();
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(
+      "span",
+      { "data-testid": "current-path" },
+      useLocation().pathname,
+    ),
+    React.createElement(
+      "button",
+      {
+        "data-testid": "navigate-away",
+        onClick: () => navigate("/chat"),
+      },
+      "navigate away",
+    ),
+    React.createElement(
+      "button",
+      {
+        "data-testid": "navigate-back",
+        onClick: () => navigate(navigateBackPath),
+      },
+      "navigate back",
+    ),
+  );
+}
+
+function renderSidebar({ initialPath, isAdmin = false, onNavigate = () => {} }) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      React.createElement(
+        MemoryRouter,
+        { initialEntries: [initialPath] },
+        React.createElement(
+          I18nProvider,
+          null,
+          React.createElement(
+            React.Fragment,
+            null,
+            React.createElement(SidebarNav, {
+              isAdmin,
+              isCreating: false,
+              onNavigate,
+              onNewChat: () => {},
+            }),
+            React.createElement(CurrentPath, {
+              navigateBackPath: initialPath,
+            }),
+          ),
+        ),
+      ),
+    );
+  });
+
+  return { container, root };
+}
 
 test("member sidebar exposes inference but keeps users admin-only", () => {
   const routes = visibleSidebarSubRoutes("settings", false);
@@ -9,4 +88,152 @@ test("member sidebar exposes inference but keeps users admin-only", () => {
 
   assert.ok(ids.includes("inference"));
   assert.ok(!ids.includes("users"));
+});
+
+test.each(expandableRoutes)(
+  "$id sidebar section can be collapsed and expanded without navigating away",
+  ({ id, firstTab, isAdmin }) => {
+    const path = `/${id}/${firstTab}`;
+    let navigations = 0;
+    const { container, root } = renderSidebar({
+      initialPath: path,
+      isAdmin,
+      onNavigate: () => {
+        navigations += 1;
+      },
+    });
+
+    try {
+      const parent = container.querySelector<HTMLAnchorElement>(
+        `a[href="${path}"]`,
+      );
+      assert.ok(parent, `${id} parent link should render`);
+      const childPanel = () => {
+        const controlsId = parent.getAttribute("aria-controls");
+        return controlsId ? container.querySelector(`#${controlsId}`) : null;
+      };
+      const childLinks = () => {
+        return childPanel()?.querySelectorAll("a").length ?? 0;
+      };
+
+      assert.equal(childLinks(), visibleSidebarSubRoutes(id, isAdmin).length);
+      assert.equal(parent.getAttribute("aria-expanded"), "true");
+      assert.ok(parent.getAttribute("aria-controls"));
+      assert.ok(childPanel());
+      assert.equal(container.querySelector("[data-testid=current-path]")?.textContent, path);
+
+      act(() => parent.click());
+      assert.equal(childLinks(), 0, `${id} children should collapse`);
+      assert.equal(parent.getAttribute("aria-expanded"), "false");
+      assert.equal(parent.getAttribute("aria-controls"), null);
+      assert.equal(childPanel(), null);
+      assert.equal(container.querySelector("[data-testid=current-path]")?.textContent, path);
+      assert.equal(navigations, 0);
+
+      act(() => parent.click());
+      assert.equal(
+        childLinks(),
+        visibleSidebarSubRoutes(id, isAdmin).length,
+        `${id} children should expand again`,
+      );
+      assert.equal(parent.getAttribute("aria-expanded"), "true");
+      assert.equal(
+        parent.getAttribute("aria-controls"),
+        `sidebar-${id}-subroutes`,
+      );
+      assert.equal(navigations, 0);
+
+      const navigateAway = container.querySelector<HTMLButtonElement>(
+        '[data-testid="navigate-away"]',
+      );
+      const navigateBack = container.querySelector<HTMLButtonElement>(
+        '[data-testid="navigate-back"]',
+      );
+      assert.ok(navigateAway);
+      assert.ok(navigateBack);
+      act(() => navigateAway.click());
+      assert.equal(childLinks(), 0);
+      assert.equal(parent.getAttribute("aria-expanded"), "false");
+      assert.equal(
+        container.querySelector("[data-testid=current-path]")?.textContent,
+        "/chat",
+      );
+      act(() => navigateBack.click());
+      assert.equal(childLinks(), visibleSidebarSubRoutes(id, isAdmin).length);
+      assert.equal(parent.getAttribute("aria-expanded"), "true");
+      assert.equal(
+        container.querySelector("[data-testid=current-path]")?.textContent,
+        path,
+      );
+
+      assert.equal(navigations, 0);
+
+      act(() => parent.click());
+      assert.equal(parent.getAttribute("aria-expanded"), "false");
+      assert.equal(childLinks(), 0);
+
+      const metaClick = new MouseEvent("click", {
+        bubbles: true,
+        metaKey: true,
+      });
+      act(() => parent.dispatchEvent(metaClick));
+      assert.equal(metaClick.defaultPrevented, false);
+      assert.equal(parent.getAttribute("aria-expanded"), "false");
+      assert.equal(childLinks(), 0);
+
+      const ctrlClick = new MouseEvent("click", {
+        bubbles: true,
+        ctrlKey: true,
+      });
+      act(() => parent.dispatchEvent(ctrlClick));
+      assert.equal(ctrlClick.defaultPrevented, false);
+      assert.equal(parent.getAttribute("aria-expanded"), "false");
+      assert.equal(childLinks(), 0);
+
+      act(() => parent.click());
+      assert.equal(childLinks(), visibleSidebarSubRoutes(id, isAdmin).length);
+      assert.equal(
+        container.querySelector("[data-testid=current-path]")?.textContent,
+        path,
+      );
+      assert.equal(navigations, 2);
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
+  },
+);
+
+test.each([
+  { initialPath: "/chat", description: "inactive" },
+  { initialPath: "/extensions", description: "exact parent route" },
+  { initialPath: "/extensions/", description: "trailing-slash parent route" },
+])("$description expandable parent still navigates to its first child", ({
+  initialPath,
+}) => {
+  let navigations = 0;
+  const { container, root } = renderSidebar({
+    initialPath,
+    onNavigate: () => {
+      navigations += 1;
+    },
+  });
+
+  try {
+    const parent = container.querySelector<HTMLAnchorElement>(
+      'nav > div > a[href="/extensions/registry"]',
+    );
+    assert.ok(parent);
+    act(() => parent.click());
+
+    assert.equal(navigations, 1);
+    assert.equal(
+      container.querySelector("[data-testid=current-path]")?.textContent,
+      "/extensions/registry",
+    );
+    assert.equal(parent.getAttribute("aria-expanded"), "true");
+  } finally {
+    act(() => root.unmount());
+    container.remove();
+  }
 });

--- a/crates/product/ironclaw_webui/frontend/src/components/sidebar-nav.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/components/sidebar-nav.tsx
@@ -49,20 +49,51 @@ function NavItem({ route, label, onNavigate }) {
 function ExpandableNavItem({ route, label, subRoutes, onNavigate }) {
   const t = useT();
   const location = useLocation();
-  const isExpanded =
-    location.pathname === route.path ||
-    location.pathname.startsWith(route.path + "/");
+  const isExactRoute =
+    location.pathname === route.path || location.pathname === route.path + "/";
+  const isSubRouteActive =
+    !isExactRoute && location.pathname.startsWith(route.path + "/");
+  const isActive = isExactRoute || isSubRouteActive;
+  const [collapsedLocationKey, setCollapsedLocationKey] = React.useState<
+    string | null
+  >(null);
   const defaultPath = `${route.path}/${subRoutes[0].id}`;
+
+  const handleParentClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    const isModifiedClick =
+      event.button !== 0 ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey;
+
+    if (isSubRouteActive && !isModifiedClick) {
+      event.preventDefault();
+      setCollapsedLocationKey((collapsedKey) =>
+        collapsedKey === location.key ? null : location.key
+      );
+      return;
+    }
+    onNavigate?.(event);
+  };
+
+  const sectionIsExpanded =
+    isActive && collapsedLocationKey !== location.key;
 
   return (
     <div className="flex flex-col">
       <NavLink
         to={defaultPath}
-        onClick={onNavigate}
+        data-testid={`nav-${route.id}`}
+        onClick={handleParentClick}
+        aria-expanded={sectionIsExpanded ? "true" : "false"}
+        aria-controls={
+          sectionIsExpanded ? `sidebar-${route.id}-subroutes` : undefined
+        }
         className={() =>
           cn(
             "flex items-center gap-3 rounded-[10px] px-3 py-2 text-[13px] font-medium",
-            isExpanded
+            isActive
               ? "bg-[var(--v2-accent-soft)] text-[var(--v2-accent-text)]"
               : "text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]"
           )}
@@ -76,14 +107,16 @@ function ExpandableNavItem({ route, label, subRoutes, onNavigate }) {
           name="chevron"
           className={cn(
             "h-3.5 w-3.5 shrink-0 transition-transform duration-150",
-            isExpanded && "rotate-180"
+            sectionIsExpanded && "rotate-180"
           )}
         />
       </NavLink>
 
-      {isExpanded &&
-      (
-        <div className="mt-0.5 flex flex-col gap-0.5 pl-3">
+      {sectionIsExpanded && (
+        <div
+          id={`sidebar-${route.id}-subroutes`}
+          className="mt-0.5 flex flex-col gap-0.5 pl-3"
+        >
           {subRoutes.map(
             (sub) => (
               <NavLink

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -64,7 +64,7 @@ Tier-selection rule: `.claude/rules/testing.md`.
 
 Totals: **59** group scenarios · **60** flat integration bins (53 in
 `tests/integration/`, 7 in `tests/integration/auth/`) · **39** top-level Rust bins ·
-**102** Python scenario files (**869** test functions) registered in the active
+**102** Python scenario files (**870** test functions) registered in the active
 Reborn coverage map below. Section 6 separately inventories retained and legacy
 Python scenarios, so its exhaustive totals are intentionally broader.
 
@@ -351,7 +351,7 @@ enums), `trace_format.rs`, `trace_llm_tests.rs`,
 
 ---
 
-## 6. Python E2E scenarios — `tests/e2e/scenarios/` (103 files, 1,143 tests)
+## 6. Python E2E scenarios — `tests/e2e/scenarios/` (103 files, 1,144 tests)
 
 This is an exhaustive inventory, not a claim that every retained scenario is
 currently executable. Current Reborn coverage starts `ironclaw serve` through the
@@ -376,7 +376,7 @@ entries.
 | Keep DOM bounded on huge histories, without SSE timer leaks | `test_reborn_webui_v2_legacy_dom_resource_limits.py` (4) |
 | Copy a message, use the command palette | `test_reborn_webui_v2_legacy_chat_actions.py` (3) |
 | Delete a thread behind a shared confirmation dialog | `test_reborn_webui_v2_smoke.py::test_reborn_v2_thread_delete_uses_shared_confirmation_dialog` |
-| Collapse the sidebar, pick a theme, pick a language — and have it persist | `test_reborn_webui_v2_smoke.py` |
+| Collapse the sidebar, collapse and reopen each expandable navigation section, and pick a theme that persists | `test_reborn_webui_v2_smoke.py::test_reborn_v2_desktop_sidebar_can_collapse_and_persist`, `test_reborn_webui_v2_smoke.py::test_reborn_v2_expandable_sidebar_sections_can_collapse`, `test_reborn_webui_v2_smoke.py::test_reborn_v2_appearance_theme_selection_persists` |
 | Opt into the inspector for the browser session, toggle it from the header icon, preserve its selected tab while closing, resizing, reloading, and reconnecting after visibility changes, explicitly disable it, and leave the ordinary chat shell unchanged when debug mode is off | `test_reborn_webui_v2_smoke.py::test_inspector_debug_activation_and_responsive_shell` |
 | Inspect the bounded host-resolved prompt, ordered activity timeline, turn navigation, and model-call statistics for completed runs, including continued diagnostic observation while the panel is closed | `test_reborn_webui_v2_smoke.py::test_inspector_prompt_and_stats_render_host_diagnostics` |
 | Reconnect SSE without gaps or duplicates; multiple tabs both get the reply; excess connections are rate-limited | `test_reborn_webui_v2_legacy_sse_history.py`, `test_reborn_webui_v2_streaming_run_control_api.py` (10) |

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -289,6 +289,7 @@ SEL_V2 = {
     "admin_secret_delete_dialog": "[data-testid='admin-secret-delete-dialog']",
     "admin_secret_delete_confirm": "[data-testid='admin-secret-delete-confirm']",
     "sidebar":        "#gateway-sidebar",  # app navigation sidebar
+    "sidebar_nav_for": "nav-{id}",
     "sidebar_button": "#gateway-sidebar button",
     "nav_workspace": "[data-testid='nav-workspace']",
     "workspace_heading": "[data-testid='workspace-heading']",

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -2998,6 +2998,39 @@ async def test_reborn_v2_desktop_sidebar_can_collapse_and_persist(reborn_v2_page
     )
 
 
+async def test_reborn_v2_expandable_sidebar_sections_can_collapse(reborn_v2_page):
+    """Active expandable navigation sections can be closed and reopened."""
+    origin = await reborn_v2_page.evaluate("location.origin")
+    sidebar = reborn_v2_page.locator(SEL_V2["sidebar"])
+
+    for section_id, path in (
+        ("extensions", "/extensions/registry"),
+        ("settings", "/settings/inference"),
+        ("admin", "/admin/users"),
+    ):
+        await reborn_v2_page.goto(f"{origin}{path}?token={REBORN_V2_AUTH_TOKEN}")
+        parent = sidebar.get_by_test_id(
+            SEL_V2["sidebar_nav_for"].format(id=section_id)
+        )
+        panel_id = await parent.get_attribute("aria-controls")
+        assert panel_id is not None
+        children = sidebar.locator(f"#{panel_id}").get_by_role("link")
+
+        await expect(parent).to_be_visible(timeout=15000)
+        await expect(parent).to_have_attribute("aria-expanded", "true")
+        await expect(children.first).to_be_visible()
+
+        before_collapse_url = reborn_v2_page.url
+        await parent.click()
+        assert reborn_v2_page.url == before_collapse_url
+        await expect(parent).to_have_attribute("aria-expanded", "false")
+        await expect(children).to_have_count(0)
+
+        await parent.click()
+        await expect(parent).to_have_attribute("aria-expanded", "true")
+        await expect(children.first).to_be_visible()
+
+
 async def test_reborn_v2_messages_omit_identity_labels(reborn_v2_page):
     """User and assistant messages render content without persistent identity labels."""
     composer = reborn_v2_page.locator(SEL_V2["chat_composer"])


### PR DESCRIPTION
## Summary

- Make active Extensions, Settings, and Admin sidebar sections collapsible without navigating away.
- Preserve normal navigation for inactive/parent routes and modified clicks.
- Add component and Reborn browser regression coverage, with centralized sidebar selectors.

## Verified bug

On base `d1284ce67`, the regression test applied without the production fix failed 6 of 7 cases: active expandable sections had no independent collapsed state, and clicking a parent navigated to its first child instead of toggling the visible subroutes.

## Root cause

`ExpandableNavItem` conflated route activity with expansion state. The parent link always navigated to the first subroute, so an active section could not be collapsed in place.

## Tests

- `./node_modules/.bin/vitest run` — 158 files, 1,340 tests passed.
- `./node_modules/.bin/vitest run src/components/sidebar-nav.test.ts` — 7 tests passed.
- `./node_modules/.bin/tsc --noEmit` — passed.
- Source-convention check — passed via the equivalent TypeScript-compiled runner because this Node build cannot execute `--experimental-strip-types`.
- `python3 -m py_compile tests/e2e/helpers.py tests/e2e/scenarios/test_reborn_webui_v2_smoke.py` — passed.
- `git diff --check` — passed.

The Playwright E2E scenario was not executed locally because this environment has no `pip`/`venv`/`pytest` or Playwright installation; CI should run it.

No issue number was supplied, so this PR intentionally has no `Closes #...` reference.
