### PR TITLE
test: trigger PR for /benchmark qa-automation-preview (close after run)

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -82,3 +82,5 @@ reconnect your providers and channels.
 [Full release notes](https://github.com/nearai/ironclaw/releases/tag/ironclaw-v1.0.0)
 
 </Update>
+
+<!-- Benchmark trigger PR: no product change. Close after the run. -->


### PR DESCRIPTION
**Not a product change** — a comment-only line, so that a PR exists to comment `/benchmark` on. Close once the run finishes.

Purpose: re-measure `qa-automation-preview` against ironclaw main now that the harness wiring fixes are on benchmarks main (nearai/benchmarks#391). The previous published automation runs were measuring our plumbing as much as the agent:

- **telegram is no longer activated as a first-party integration.** Its tools were reachable but its auth needs an api_id/api_hash plus a phone login with an SMS code, so every dispatch went `provider=telegram auth_error=CredentialMissing` → `dispatch_failure_kind=AuthRequired` → `status=BlockedAuth`. That parks the turn waiting for a human rather than failing one call, so the whole run died and the harness waited out its 15-minute timeout. It fired 10/22/17 times across seven published runs.
- **reborn's storage-layer failures are now attributed.** 535 of 13,577 recorded capability calls (3.9%, and up to 39% within a single run) fail inside reborn's own local-dev stores; they now surface as a `reborn-storage` degraded capability instead of silently failing tool calls that scored against the agent.
- **failed capability calls carry reborn's own reason**, read back from its database, instead of arriving as `success: false` with no explanation.

Expectation: L2/automation moves up, and any remaining shortfall is attributable rather than mysterious — most likely `builtin.trigger_create`, which rejected 114 of 189 recorded calls with an error that names no field (missing `name`/`schedule`), so a model cannot self-correct.