### PR TITLE
refactor(turns,subagent): collapse the two duplicated turn/subagent vocabulary types

### DIFF
--- a/crates/kernel/ironclaw_turns/src/lib.rs
+++ b/crates/kernel/ironclaw_turns/src/lib.rs
@@ -80,10 +80,10 @@ pub use loop_exit::{
     LoopExitValidationDecision, LoopExitViolation, LoopExitViolationKind,
 };
 pub use process_projection::{
-    AGENT_TURN_PROCESS_KIND, AgentTurnProcessCommitObserver, AgentTurnProcessMetadata,
-    AgentTurnProcessRuntime, AgentTurnProcessStateMetadata, ProcessJournalStoreTurnAdapter,
-    ProcessLoopCheckpointStore, TurnEventProjectionFromProcessJournal,
-    claimed_turn_run_from_process_claim, turn_run_state_from_process_snapshot,
+    AGENT_TURN_PROCESS_KIND, AgentTurnProcessCommitObserver, AgentTurnProcessRuntime,
+    AgentTurnProcessStateMetadata, ProcessJournalStoreTurnAdapter, ProcessLoopCheckpointStore,
+    TurnEventProjectionFromProcessJournal, claimed_turn_run_from_process_claim,
+    turn_run_state_from_process_snapshot,
 };
 pub use request::{
     ActivateThreadRequest, CancelRunRequest, GetRunStateRequest, ResumeTurnPrecondition,

--- a/crates/kernel/ironclaw_turns/src/process_projection/metadata.rs
+++ b/crates/kernel/ironclaw_turns/src/process_projection/metadata.rs
@@ -6,71 +6,10 @@ use serde_json::{Value, json};
 
 use crate::{
     AcceptedMessageRef, ActivationProvenance, GateResumeDisposition, ProductTurnContext,
-    RunProfileId, RunProfileVersion, TurnActor, TurnRunRecord, TurnRunState,
-    runner::ClaimedTurnRun,
+    RunProfileId, RunProfileVersion, TurnActor, TurnRunState, runner::ClaimedTurnRun,
 };
 use ironclaw_host_api::turn::TurnExecutionOutcome;
 use ironclaw_loop_contracts::{LoopModelRouteSnapshot, LoopModelUsage, ResolvedRunProfile};
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AgentTurnProcessMetadata {
-    pub turn_id: crate::TurnId,
-    pub accepted_message_ref: AcceptedMessageRef,
-    pub resolved_run_profile_id: RunProfileId,
-    pub resolved_run_profile_version: RunProfileVersion,
-    /// Immutable terminal output contract. Omitted legacy metadata defaults
-    /// to an ordinary assistant message.
-    #[serde(default, skip_serializing_if = "OutputContract::is_assistant_message")]
-    pub output_contract: OutputContract,
-    /// Snapshot of the resolved profile's `SteeringPolicy::allow_steering`,
-    /// persisted so busy-submit admission can consult it without re-resolving
-    /// the profile. Legacy rows predate the field and default to allowed.
-    #[serde(default = "steering_allowed_metadata_default")]
-    pub allow_steering: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub resolved_model_route: Option<LoopModelRouteSnapshot>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_usage: Option<LoopModelUsage>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub execution_outcome: Option<TurnExecutionOutcome>,
-    #[serde(default)]
-    pub subagent_depth: u32,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub product_context: Option<ProductTurnContext>,
-    #[serde(
-        rename = "auth_resume_disposition",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub resume_disposition: Option<GateResumeDisposition>,
-    /// True when the run's thread owner is `Ownerless` (unbound runs). The
-    /// `__system__` owner slot alone cannot distinguish ownerless runs from
-    /// actor-fallback runs without an explicit owner, so the disposition is
-    /// journaled; absent (legacy rows) means actor-fallback.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub ownerless_thread: bool,
-}
-
-impl AgentTurnProcessMetadata {
-    pub(super) fn from_record(record: &TurnRunRecord) -> Self {
-        Self {
-            turn_id: record.turn_id,
-            accepted_message_ref: record.accepted_message_ref.clone(),
-            resolved_run_profile_id: record.profile.id.clone(),
-            resolved_run_profile_version: record.profile.version,
-            output_contract: record.output_contract.clone(),
-            allow_steering: record.profile.allow_steering,
-            resolved_model_route: record.resolved_model_route.clone(),
-            model_usage: record.model_usage,
-            execution_outcome: record.execution_outcome,
-            subagent_depth: record.subagent_depth,
-            product_context: record.product_context.clone(),
-            resume_disposition: record.resume_disposition.clone(),
-            ownerless_thread: record.scope.thread_owner
-                == ironclaw_host_api::turn::TurnThreadOwner::Ownerless,
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentTurnProcessStateMetadata {

--- a/crates/kernel/ironclaw_turns/src/process_projection/mod.rs
+++ b/crates/kernel/ironclaw_turns/src/process_projection/mod.rs
@@ -15,9 +15,7 @@ pub use event_projection::{
     turn_lifecycle_event_from_process_journal_entry, turn_status_from_process_status,
 };
 pub use loop_checkpoint::ProcessLoopCheckpointStore;
-pub use metadata::{
-    AgentTurnProcessMetadata, AgentTurnProcessStateMetadata, agent_turn_metadata_from_claimed,
-};
+pub use metadata::{AgentTurnProcessStateMetadata, agent_turn_metadata_from_claimed};
 pub use runtime::*;
 pub use store_adapter::{
     ProcessJournalStoreTurnAdapter, turn_error_from_process_journal_store_error,

--- a/crates/kernel/ironclaw_turns/src/process_projection/runtime.rs
+++ b/crates/kernel/ironclaw_turns/src/process_projection/runtime.rs
@@ -16,10 +16,10 @@ use ironclaw_processes::{
     JournaledProcessSnapshot, ProcessCheckpointId, ProcessCheckpointPort, ProcessCheckpointRef,
     ProcessConcurrencyClass, ProcessControlPort, ProcessJournalCommit,
     ProcessJournalCommitObserver, ProcessJournalCursor, ProcessJournalEntry, ProcessJournalKind,
-    ProcessJournalSource, ProcessKind, ProcessLeaseSnapshot, ProcessLeaseToken,
-    ProcessLifecycleStatus, ProcessOperationId, ProcessOutcome, ProcessRuntimePort,
-    ProcessSnapshotSource, ProcessSubmissionPort, ProcessSuspension, ProcessSuspensionKind,
-    ProcessTreePort, ProcessWorkerId, PruneReleasedProcessRequest, RecordProcessCheckpointRequest,
+    ProcessJournalSource, ProcessKind, ProcessLeaseToken, ProcessLifecycleStatus,
+    ProcessOperationId, ProcessOutcome, ProcessRuntimePort, ProcessSnapshotSource,
+    ProcessSubmissionPort, ProcessSuspension, ProcessSuspensionKind, ProcessTreePort,
+    ProcessWorkerId, PruneReleasedProcessRequest, RecordProcessCheckpointRequest,
     ReleaseProcessTreeRequest, ReserveProcessTreeRequest, ResumeProcessRequest,
     SubmitProcessRequest, SubmitProcessWithCheckpointRequest,
 };
@@ -29,7 +29,7 @@ use super::{
         turn_lifecycle_event_from_process_journal_entry, turn_scope_from_process_scope,
         turn_status_from_process_status,
     },
-    metadata::{AgentTurnProcessMetadata, AgentTurnProcessStateMetadata},
+    metadata::AgentTurnProcessStateMetadata,
     store_adapter::ProcessJournalStoreTurnAdapter,
 };
 use crate::{
@@ -819,40 +819,6 @@ fn resumed_agent_turn_metadata(
     Ok(json!({ "agent_turn": metadata }))
 }
 
-pub trait TurnRunProcessExt {
-    fn to_process_snapshot(&self) -> JournaledProcessSnapshot;
-}
-
-impl TurnRunProcessExt for TurnRunRecord {
-    fn to_process_snapshot(&self) -> JournaledProcessSnapshot {
-        JournaledProcessSnapshot {
-            process_id: process_id_from_turn_run_id(self.run_id),
-            process_kind: ProcessKind::AgentTurn,
-            scope: self.scope.to_resource_scope(),
-            status: process_status_from_turn_status(self.status),
-            suspension: process_suspension_from_record(self),
-            checkpoint_ref: self.checkpoint_id.map(process_checkpoint_ref),
-            // Legacy turn-record projection: the record carries only the
-            // checkpoint id, so the kind reads as unknown.
-            checkpoint_kind: None,
-            input_ref: None,
-            failure: self.failure.clone(),
-            journal_cursor: ProcessJournalCursor(self.event_cursor.0),
-            lease: process_lease_from_record(self),
-            crash_reclaim_count: 0,
-            created_at: self.received_at,
-            owner_user_id: self.scope.explicit_owner_user_id().cloned(),
-            concurrency_class: process_concurrency_class(
-                self.product_context.as_ref(),
-                &self.profile.id,
-            ),
-            parent_process_id: self.parent_run_id.map(process_id_from_turn_run_id),
-            root_process_id: self.spawn_tree_root_run_id.map(process_id_from_turn_run_id),
-            metadata: json!({ "agent_turn": AgentTurnProcessMetadata::from_record(self) }),
-        }
-    }
-}
-
 pub trait TurnRunStateProcessExt {
     fn to_process_state_snapshot(&self) -> JournaledProcessSnapshot;
 }
@@ -998,17 +964,6 @@ pub fn process_journal_kind_from_turn_event_kind(kind: TurnEventKind) -> Process
     }
 }
 
-pub(crate) fn process_suspension_from_record(record: &TurnRunRecord) -> Option<ProcessSuspension> {
-    let kind = GateKind::from_status(record.status).map(process_suspension_kind_from_gate_kind)?;
-    Some(ProcessSuspension {
-        kind,
-        gate_ref: record.gate_ref.clone(),
-        activity_id: record.blocked_activity_id,
-        credential_requirements: record.credential_requirements.clone(),
-        detail: None,
-    })
-}
-
 fn process_suspension_from_state(state: &TurnRunState) -> Option<ProcessSuspension> {
     let kind = GateKind::from_status(state.status).map(process_suspension_kind_from_gate_kind)?;
     Some(ProcessSuspension {
@@ -1028,16 +983,6 @@ fn process_suspension_from_event(event: &TurnLifecycleEvent) -> Option<ProcessSu
         activity_id: gate.activity_id,
         credential_requirements: gate.credential_requirements.clone(),
         detail: None,
-    })
-}
-
-fn process_lease_from_record(record: &TurnRunRecord) -> Option<ProcessLeaseSnapshot> {
-    Some(ProcessLeaseSnapshot {
-        worker_id: ProcessWorkerId::from_trusted(record.runner_id?.to_wire_string()),
-        lease_token: ProcessLeaseToken::from_trusted(record.lease_token?.to_wire_string()),
-        lease_expires_at: record.lease_expires_at,
-        last_heartbeat_at: record.last_heartbeat_at,
-        claim_count: record.claim_count,
     })
 }
 

--- a/crates/kernel/ironclaw_turns/src/process_projection/tests.rs
+++ b/crates/kernel/ironclaw_turns/src/process_projection/tests.rs
@@ -35,20 +35,23 @@ fn profile() -> TurnRunProfile {
     .expect("profile")
 }
 
-fn record_with_status(status: TurnStatus) -> TurnRunRecord {
-    TurnRunRecord {
-        subagent_activation_provenance: None,
-        run_id: TurnRunId::new(),
-        turn_id: TurnId::new(),
+fn state_with_status(status: TurnStatus) -> crate::TurnRunState {
+    crate::TurnRunState {
         scope: scope(),
+        actor: None,
+        turn_id: TurnId::new(),
+        run_id: TurnRunId::new(),
+        status,
         accepted_message_ref: AcceptedMessageRef::new("accepted-process-journal")
             .expect("accepted"),
-        status,
-        profile: profile(),
+        resolved_run_profile_id: profile().id.clone(),
+        resolved_run_profile_version: profile().version,
         output_contract: Default::default(),
+        allow_steering: profile().allow_steering,
         resolved_model_route: None,
         model_usage: None,
         execution_outcome: None,
+        received_at: Utc::now(),
         checkpoint_id: None,
         gate_ref: GateKind::from_status(status)
             .map(|_| TurnGateRef::new("gate:process-journal").expect("gate")),
@@ -56,15 +59,6 @@ fn record_with_status(status: TurnStatus) -> TurnRunRecord {
         credential_requirements: Vec::new(),
         failure: None,
         event_cursor: EventCursor(7),
-        runner_id: None,
-        lease_token: None,
-        lease_expires_at: None,
-        last_heartbeat_at: None,
-        claim_count: 0,
-        received_at: Utc::now(),
-        parent_run_id: None,
-        subagent_depth: 0,
-        spawn_tree_root_run_id: None,
         product_context: None,
         resume_disposition: None,
     }
@@ -219,9 +213,10 @@ fn legacy_agent_turn_metadata_without_activation_provenance_defaults_to_none() {
 }
 
 #[test]
-fn legacy_agent_turn_process_metadata_without_output_contract_defaults_to_assistant_message() {
-    let metadata = AgentTurnProcessMetadata {
+fn legacy_agent_turn_metadata_without_output_contract_defaults_to_assistant_message() {
+    let metadata = AgentTurnProcessStateMetadata {
         turn_id: TurnId::new(),
+        actor: None,
         accepted_message_ref: AcceptedMessageRef::new("accepted-metadata-output-contract")
             .expect("accepted message"),
         resolved_run_profile_id: RunProfileId::default_profile(),
@@ -233,10 +228,13 @@ fn legacy_agent_turn_process_metadata_without_output_contract_defaults_to_assist
             schema: serde_json::json!({"type": "object"}),
         },
         allow_steering: false,
+        resolved_run_profile: None,
         resolved_model_route: None,
         model_usage: None,
         execution_outcome: None,
         subagent_depth: 0,
+        subagent_activation_provenance: None,
+        spawn_tree_descendant_cap: None,
         product_context: None,
         resume_disposition: None,
         ownerless_thread: false,
@@ -249,7 +247,7 @@ fn legacy_agent_turn_process_metadata_without_output_contract_defaults_to_assist
             .is_some(),
         "current wire shape must serialize a non-default output contract"
     );
-    let restored: AgentTurnProcessMetadata =
+    let restored: AgentTurnProcessStateMetadata =
         serde_json::from_value(wire).expect("restore legacy metadata");
     assert_eq!(
         restored.output_contract,
@@ -1205,7 +1203,7 @@ fn blocked_turn_statuses_map_to_process_suspension_kinds() {
     ];
 
     for (turn_status, suspension_kind) in cases {
-        let snapshot = record_with_status(turn_status).to_process_snapshot();
+        let snapshot = state_with_status(turn_status).to_process_state_snapshot();
         assert_eq!(snapshot.status, ProcessLifecycleStatus::Suspended);
         assert_eq!(
             snapshot.suspension.expect("suspension").kind,

--- a/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/resolver.rs
+++ b/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/resolver.rs
@@ -33,8 +33,7 @@ use ironclaw_turns::{
 
 use super::{AwaitEdge, AwaitEdgeState, EdgeTerminalKind, store::AwaitEdgeStore};
 use crate::subagent::spawn_result::{
-    SpawnedChildRunPayload, SubagentSpawnMode as PayloadSpawnMode,
-    SubagentSpawnStatus as PayloadSpawnStatus, SubagentTerminalEventKind,
+    SpawnedChildRunPayload, SubagentSpawnStatus as PayloadSpawnStatus, SubagentTerminalEventKind,
     SubagentTerminalEventPayload,
 };
 use crate::subagent::untrusted_text::{
@@ -1931,7 +1930,7 @@ fn background_completion_payload(
         child_run_id: event.run_id,
         child_thread_id: edge.child_thread_id.clone(),
         subagent_kind: edge.subagent_kind.clone(),
-        mode: payload_spawn_mode(edge.mode),
+        mode: edge.mode,
         status: payload_spawn_status(event.status)?,
         output_available: event.status == TurnStatus::Completed,
         final_text,
@@ -2092,13 +2091,6 @@ fn thread_scope_from_turn_scope(
         owner_user_id: event.owner_user_id.clone(),
         mission_id: None,
     })
-}
-
-fn payload_spawn_mode(mode: ironclaw_loop_host::SpawnSubagentMode) -> PayloadSpawnMode {
-    match mode {
-        ironclaw_loop_host::SpawnSubagentMode::Blocking => PayloadSpawnMode::Blocking,
-        ironclaw_loop_host::SpawnSubagentMode::Background => PayloadSpawnMode::Background,
-    }
 }
 
 fn payload_spawn_status(status: TurnStatus) -> Result<PayloadSpawnStatus, TurnError> {

--- a/crates/loop/ironclaw_turn_runner/src/subagent/spawn_result.rs
+++ b/crates/loop/ironclaw_turn_runner/src/subagent/spawn_result.rs
@@ -1,7 +1,7 @@
 //! Wire-stable subagent result and tombstone payloads.
 
 use ironclaw_host_api::ids::ThreadId;
-use ironclaw_loop_host::SubagentKindId;
+use ironclaw_loop_host::{SpawnSubagentMode, SubagentKindId};
 use ironclaw_turns::{EventCursor, TurnRunId, TurnStatus};
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +12,7 @@ pub struct SpawnedChildRunPayload {
     pub child_thread_id: ThreadId,
     #[serde(rename = "flavor")]
     pub subagent_kind: SubagentKindId,
-    pub mode: SubagentSpawnMode,
+    pub mode: SpawnSubagentMode,
     pub status: SubagentSpawnStatus,
     pub output_available: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -21,13 +21,6 @@ pub struct SpawnedChildRunPayload {
     pub failure_summary: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub terminal_event: Option<SubagentTerminalEventPayload>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SubagentSpawnMode {
-    Blocking,
-    Background,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -88,7 +81,7 @@ mod tests {
             child_run_id: TurnRunId::new(),
             child_thread_id: ThreadId::new("child-thread-1").unwrap(),
             subagent_kind: SubagentKindId::new("planner").unwrap(),
-            mode: SubagentSpawnMode::Background,
+            mode: SpawnSubagentMode::Background,
             status: SubagentSpawnStatus::Spawned,
             output_available: false,
             final_text: None,
@@ -105,6 +98,25 @@ mod tests {
             serde_json::from_value::<SpawnedChildRunPayload>(value).unwrap(),
             payload
         );
+    }
+
+    /// Both spawn-mode wire strings are model-visible in the spawn-result
+    /// payload. Pinned as an explicit round-trip so a change of the mode type
+    /// cannot silently alter or drop either emitted string.
+    #[test]
+    fn spawn_mode_wire_strings_round_trip_for_every_variant() {
+        for (mode, expected) in [
+            (SpawnSubagentMode::Blocking, "blocking"),
+            (SpawnSubagentMode::Background, "background"),
+        ] {
+            let encoded = serde_json::to_value(mode).unwrap();
+            assert_eq!(encoded, expected, "emitted wire string for {mode:?}");
+            assert_eq!(
+                serde_json::from_value::<SpawnSubagentMode>(encoded).unwrap(),
+                mode,
+                "round-trip for {mode:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/loop/ironclaw_turn_runner/src/turn_scheduler.rs
+++ b/crates/loop/ironclaw_turn_runner/src/turn_scheduler.rs
@@ -545,7 +545,7 @@ mod tests {
             .execute_claimed_process(ClaimedProcess::from(&claimed))
             .await
             .expect_err("executor must surface structured finalization failure");
-        let metadata: ironclaw_turns::process_projection::AgentTurnProcessMetadata =
+        let metadata: ironclaw_turns::process_projection::AgentTurnProcessStateMetadata =
             serde_json::from_value(
                 error
                     .metadata()

--- a/docs/internal/reborn/subagent-spawn/pr2-pr6-shape.md
+++ b/docs/internal/reborn/subagent-spawn/pr2-pr6-shape.md
@@ -76,7 +76,7 @@ each.
   (`:62`, enum `["blocking","background"]`, default blocking); thread
   `args.mode` through `finish_spawn` instead of the hard-coded `Blocking`
   (`:908`); background spawns return an immediate spawn-result payload
-  (`spawn_result.rs` `SubagentSpawnMode::Background`) instead of
+  (`ironclaw_loop_host::SpawnSubagentMode::Background`) instead of
   `await_dependent_run`.
 - Update `prompts/spawn_subagent_description.md` (currently blocking-only
   wording).

--- a/docs/internal/reborn/subagent-spawn/thread-harness-design.md
+++ b/docs/internal/reborn/subagent-spawn/thread-harness-design.md
@@ -272,7 +272,7 @@ One struct, one file per parent↔child, fields previously scattered across §2/
 AwaitEdge {
   child_scope: TurnScope,                          // §1
   child_thread_id: ThreadId,
-  mode: SubagentSpawnMode,                         // Blocking | Background
+  mode: SpawnSubagentMode,                         // Blocking | Background
   state: AwaitEdgeState,                           // Open | Settled | Drained | Abandoned (§2)
   terminal_kind: Option<EdgeTerminalKind>,         // set in the settle CAS
   terminal_byte_len: Option<u64>,                  // §5.4 — same settle CAS, observability only

--- a/tests/integration/changed-coverage-exemptions.toml
+++ b/tests/integration/changed-coverage-exemptions.toml
@@ -382,7 +382,7 @@ review_after = "2026-10-31"
 
 [[exemption]]
 path = "crates/loop/ironclaw_turn_runner/src/subagent/await_edge/resolver.rs"
-lines = [2033]
+lines = [2032]
 owner = "@nearai/reborn"
 reason = "Background subagent spawn-mode arm; base lcov shows 0 hits at the same statement (67088a426 line 2024). Only GateRef::new -> TurnGateRef::new changed."
 issue = "https://github.com/nearai/ironclaw/issues/6963"
@@ -1002,7 +1002,7 @@ review_after = "2026-11-01"
 
 [[exemption]]
 path = "crates/kernel/ironclaw_turns/src/process_projection/metadata.rs"
-lines = [130, 131, 132]
+lines = [123, 124, 125]
 owner = "@nearai/reborn"
 reason = "serde default fn for legacy persisted rows missing steering_allowed; integration always writes the field. Crate-tier legacy-row deserialization test covers it."
 issue = "https://github.com/nearai/ironclaw/issues/7006"


### PR DESCRIPTION
## Summary

- Collapses the two duplicated turn/subagent vocabulary types named in #7755. Both slices are **strictly structural — behavior unchanged**.
- **F2** (`a59122b60`) deletes `AgentTurnProcessMetadata`, a 13-field strict subset of `AgentTurnProcessStateMetadata` that serialized under the *same* durable `"agent_turn"` key. Two Rust types writing one key is the structural cause of the bug class fixed in #7752: a row written by the subset type deserializes into the superset with serde defaults for the missing fields, which is exactly how `subagent_activation_provenance` was silently read back as `None` and left the autonomous-wake cap unable to fire. #7752 fixed the instance; this removes the second writer so the class cannot recur through this path.
- **F1** (`6a10c067b`) collapses `SubagentSpawnMode` into `SpawnSubagentMode` — identical variant sets, identical derives, identical `#[serde(rename_all = "snake_case")]`, transposed names, joined by a field-for-field identity converter. `type-placement.md` names that exact shape a violation.
- Dead code dies in the slice that orphans it: F2 also removes `TurnRunProcessExt` (the deleted struct's only entry point) plus `process_suspension_from_record` and `process_lease_from_record`; F1 removes `payload_spawn_mode` and its aliased import.
- Net −108 lines across 8 code files, plus a 2-line docs follow-up. Every touched source file shrank except the one carrying a new wire pin.
- A local multi-agent review (5 lanes) ran against this branch. Correctness, Security, and Performance returned zero findings. Design and Coverage independently flagged the same real gap — `SubagentSpawnMode` left dangling in design docs — fixed in `6cf956091`.

## Change Type

- [x] Refactor

## Linked Issue

Closes #7755

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — **not run: clippy is unavailable in this environment's toolchain.** CI is the first gate for it.
- [x] `cargo build` (via test compilation)
- [x] Relevant tests pass: see Commands run
- [ ] `cargo test -p <crate> --features integration` — `Not applicable: no database-backed or runtime-integration behavior changed.`
- [x] Manual testing: mutation-verified the re-pointed tests (below)

## Test Strategy

User behavior: None. Both slices are behavior-preserving deletions of duplicate types; no user-visible surface changes.

Risk areas:
- [x] Persistence — the deleted F2 struct and the F1 enum both ride durable records.
- [x] Cross-component behavior — F1 moves a type across a crate boundary.

Tests added or updated:
- Unit or contract: **1 added** — `spawn_mode_wire_strings_round_trip_for_every_variant` pins both emitted wire strings and their round-trip. **3 re-pointed** (not deleted) from the removed F2 type onto the survivor: the `output_contract` serde-default pin, the five blocked-status -> suspension-kind mappings, and the turn_runner typed failure-metadata read-back.
- Reborn integration: `Not applicable: no production-wired behavior changes; both slices are type-identity collapses proven by equivalence.`
- Recorded fixture: `Not applicable: no model or tool-choice behavior changed.`
- Browser E2E: `Not applicable: no user-visible surface changed.`
- Backend or runtime: `Not applicable: no backend or lane behavior changed.`
- Live canary: `Not applicable.`

What the tests prove:

1. **No wire drift (F1).** The mode is model-visible in `SpawnedChildRunPayload` and rides `AwaitedChildSetRecord.mode` / `SubagentThreadMetadata.mode`. The new round-trip pin was proven green **before** the collapse and re-run unchanged **after** it — that ordering is the equivalence proof. The pre-existing payload test only ever asserted `"background"` and never round-tripped, so this closes a real gap rather than restating coverage.
2. **No lost coverage (F2).** Three tests pinned behavior *only* reachable through the deleted type. Deleting them would have been a silent coverage regression dressed as cleanup, so they were re-pointed at the survivor. Safe because `process_suspension_from_state` is field-identical to the deleted twin and shares both underlying mapping fns.
3. **The re-pointed tests are still load-bearing.** Mutation-verified: removing the survivor's serde `default` fails the first; flipping one `GateKind` -> `ProcessSuspensionKind` mapping fails the second. Both pass again on restore.
4. **No remaining second writer.** `AgentTurnProcessMetadata`, `TurnRunProcessExt`, `process_suspension_from_record`, `process_lease_from_record`, `SubagentSpawnMode`, and `payload_spawn_mode` are all at **0 references** tree-wide.

Non-consumers confirmed for the F2 key (each reads the payload another way, so none is affected): the journal-store migration builds a raw map, the rolling-compat contract uses its own frozen shape, and the suggestions observer reads untyped JSON.

Commands run:

```
cargo test -p ironclaw_turns --no-fail-fast            234 passed, 0 failed
cargo test -p ironclaw_turn_runner --no-fail-fast      321 passed, 0 failed
cargo test -p ironclaw_loop_host --no-fail-fast        980 passed, 0 failed
cargo test -p ironclaw_processes --no-fail-fast        125 passed, 0 failed
cargo test -p ironclaw_architecture_tests --no-fail-fast   42 suites, exit 0, 0 failed
cargo fmt -p ironclaw_turns -p ironclaw_turn_runner
```

All runs were full and unfiltered (`--no-fail-fast`, output not piped through `head`/`tail`), per `.claude/rules/review-discipline.md`.

## Review

A local 5-lane review (correctness, security, performance/concurrency, design/maintainability, coverage/verification) ran against this branch, plus a deterministic mechanical pre-pass.

- Correctness / Security / Performance: **0 findings.**
- Design + Coverage: both independently flagged that F1 left `SubagentSpawnMode` dangling in internal design docs — a real miss against AGENTS.md's "after moves/renames, search docs and guidance for old paths". Fixed in `6cf956091`.
- The two lanes disagreed on scope: Coverage wanted all three docs updated, Design argued `phase-2-mechanisms.md` is exempt. Design was right — that file carries an explicit "Code citations are point-in-time (2026-05) and have drifted" banner, making it a frozen historical record. It is deliberately left unchanged.
- Mechanical pre-pass clean: no production `.unwrap()`/`.expect()` (both hits are inside `#[cfg(test)]`), no byte-index slicing, no feature-gate changes, no lockfile or generated-file churn.

## Compatibility, rollback, follow-up

- **Compatibility:** no durable format change. F2's deleted fields are a strict subset of the survivor's, all serde-defaulted, under the same key — existing rows written by either type still rehydrate. F1's wire strings are unchanged and pinned.
- **Rollback:** safe to revert either commit independently; they touch disjoint crates.
- **Follow-up:** none required. `TurnOwner` vs `TurnThreadOwner` look collapsible and deliberately are **not** — product ownership *shape* vs thread-owner *resolution disposition*, per #7755's "Not in scope".

Metric: Rust writers of the durable `"agent_turn"` key **2 -> 1**; duplicate spawn-mode enums **2 -> 1**.