### PR TITLE
fix(runtime): bound provider diagnostic stack footprint

### DIFF
--- a/crates/contracts/ironclaw_extension_contracts/src/tool_adapter.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/tool_adapter.rs
@@ -77,7 +77,7 @@ pub enum ToolError {
         /// Raw provider rejection retained for the host's downstream
         /// model-diagnostic scrub/fence seam. Its `Debug` representation is
         /// redacted; never log or render it directly.
-        model_visible_cause: Option<ProviderDiagnostic>,
+        model_visible_cause: Option<Box<ProviderDiagnostic>>,
     },
     #[error("tool provider rejected invocation ({kind})")]
     Rejected {
@@ -85,7 +85,7 @@ pub enum ToolError {
         kind: DispatchFailureKind,
         /// Provider-authored metadata remains typed so its `Debug` output is
         /// redacted until the host's model-diagnostic scrub/fence seam.
-        diagnostic: Option<ProviderDiagnostic>,
+        diagnostic: Option<Box<ProviderDiagnostic>>,
         detail: Option<DispatchFailureDetail>,
     },
     #[error("tool invocation failed ({kind:?})")]
@@ -336,11 +336,11 @@ mod tests {
         let left = ToolError::AuthRequired {
             required_secrets: secrets.clone(),
             credential_requirements: Vec::new(),
-            model_visible_cause: Some(ProviderDiagnostic {
+            model_visible_cause: Some(Box::new(ProviderDiagnostic {
                 code: None,
                 message: None,
                 retry_after: None,
-            }),
+            })),
         };
         let right = ToolError::AuthRequired {
             required_secrets: secrets,
@@ -367,7 +367,10 @@ mod tests {
         assert_ne!(left, right);
     }
 
-    fn rejected(kind: DispatchFailureKind, diagnostic: Option<ProviderDiagnostic>) -> ToolError {
+    fn rejected(
+        kind: DispatchFailureKind,
+        diagnostic: Option<Box<ProviderDiagnostic>>,
+    ) -> ToolError {
         ToolError::Rejected {
             runtime: Some(RuntimeKind::FirstParty),
             kind,
@@ -394,11 +397,11 @@ mod tests {
         assert_ne!(
             rejected(
                 denied,
-                Some(ProviderDiagnostic {
+                Some(Box::new(ProviderDiagnostic {
                     code: None,
                     message: None,
                     retry_after: None,
-                })
+                }))
             ),
             rejected(denied, None),
             "differing diagnostic presence must break equality"

--- a/crates/contracts/ironclaw_extension_contracts/src/tool_adapter.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/tool_adapter.rs
@@ -19,8 +19,8 @@ use ironclaw_host_api::{
     action::NetworkMethod,
     decision::RuntimeCredentialAuthRequirement,
     dispatch::{
-        CapabilityDisplayOutputPreview, DispatchFailureDetail, DispatchFailureKind,
-        ProviderDiagnostic, RuntimeDispatchErrorKind,
+        CapabilityDisplayOutputPreview, DispatchAuthRequirement, DispatchFailureDetail,
+        DispatchFailureKind, ProviderDiagnostic, RuntimeDispatchErrorKind,
     },
     ids::{CapabilityId, SecretHandle},
     mount::MountView,
@@ -72,12 +72,7 @@ pub struct ToolResult {
 pub enum ToolError {
     #[error("tool invocation requires authorization")]
     AuthRequired {
-        required_secrets: Vec<SecretHandle>,
-        credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
-        /// Raw provider rejection retained for the host's downstream
-        /// model-diagnostic scrub/fence seam. Its `Debug` representation is
-        /// redacted; never log or render it directly.
-        model_visible_cause: Option<Box<ProviderDiagnostic>>,
+        requirement: Box<DispatchAuthRequirement>,
     },
     #[error("tool provider rejected invocation ({kind})")]
     Rejected {
@@ -106,16 +101,16 @@ impl PartialEq for ToolError {
         match (self, other) {
             (
                 Self::AuthRequired {
-                    required_secrets: left_secrets,
-                    credential_requirements: left_requirements,
-                    ..
+                    requirement: left_requirement,
                 },
                 Self::AuthRequired {
-                    required_secrets: right_secrets,
-                    credential_requirements: right_requirements,
-                    ..
+                    requirement: right_requirement,
                 },
-            ) => left_secrets == right_secrets && left_requirements == right_requirements,
+            ) => {
+                left_requirement.required_secrets == right_requirement.required_secrets
+                    && left_requirement.credential_requirements
+                        == right_requirement.credential_requirements
+            }
             (
                 Self::Failed {
                     kind: left_kind,
@@ -334,18 +329,22 @@ mod tests {
     fn auth_required_equality_ignores_model_visible_cause() {
         let secrets = vec![SecretHandle::new("notion-token").unwrap()];
         let left = ToolError::AuthRequired {
-            required_secrets: secrets.clone(),
-            credential_requirements: Vec::new(),
-            model_visible_cause: Some(Box::new(ProviderDiagnostic {
-                code: None,
-                message: None,
-                retry_after: None,
-            })),
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: secrets.clone(),
+                credential_requirements: Vec::new(),
+                model_visible_cause: Some(ProviderDiagnostic {
+                    code: None,
+                    message: None,
+                    retry_after: None,
+                }),
+            }),
         };
         let right = ToolError::AuthRequired {
-            required_secrets: secrets,
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: secrets,
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         };
 
         assert_eq!(left, right);
@@ -354,14 +353,18 @@ mod tests {
     #[test]
     fn auth_required_equality_still_compares_required_secrets() {
         let left = ToolError::AuthRequired {
-            required_secrets: vec![SecretHandle::new("notion-token").unwrap()],
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: vec![SecretHandle::new("notion-token").unwrap()],
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         };
         let right = ToolError::AuthRequired {
-            required_secrets: vec![SecretHandle::new("slack-token").unwrap()],
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: vec![SecretHandle::new("slack-token").unwrap()],
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         };
 
         assert_ne!(left, right);
@@ -411,9 +414,11 @@ mod tests {
     #[test]
     fn tool_error_of_different_variants_are_never_equal() {
         let auth_required = ToolError::AuthRequired {
-            required_secrets: Vec::new(),
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: Vec::new(),
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         };
         let failed = ToolError::Failed {
             kind: RuntimeDispatchErrorKind::Backend,
@@ -422,5 +427,11 @@ mod tests {
         };
 
         assert_ne!(auth_required, failed);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn tool_error_stays_within_stack_budget() {
+        assert!(std::mem::size_of::<ToolError>() <= 56);
     }
 }

--- a/crates/contracts/ironclaw_host_api/src/dispatch.rs
+++ b/crates/contracts/ironclaw_host_api/src/dispatch.rs
@@ -564,7 +564,7 @@ pub enum DispatchError {
     Rejected {
         runtime: Option<RuntimeKind>,
         kind: DispatchFailureKind,
-        diagnostic: Option<ProviderDiagnostic>,
+        diagnostic: Option<Box<ProviderDiagnostic>>,
         detail: Option<DispatchFailureDetail>,
     },
     /// MCP dispatch failure. `model_visible_cause` carries the raw backend cause —

--- a/crates/contracts/ironclaw_host_api/src/dispatch.rs
+++ b/crates/contracts/ironclaw_host_api/src/dispatch.rs
@@ -68,6 +68,16 @@ pub struct ProviderDiagnostic {
     pub retry_after: Option<Duration>,
 }
 
+/// Authentication requirements carried across the dispatch and capability
+/// error boundaries. The outer error variants box this aggregate so their
+/// common vector payloads do not inflate every future that returns them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchAuthRequirement {
+    pub required_secrets: Vec<SecretHandle>,
+    pub credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
+    pub model_visible_cause: Option<ProviderDiagnostic>,
+}
+
 impl fmt::Debug for ProviderDiagnostic {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("ProviderDiagnostic(<redacted>)")
@@ -548,15 +558,13 @@ pub enum DispatchError {
     MissingProcessAuthorization { capability: CapabilityId },
     /// Authentication is required to dispatch this capability.
     ///
-    /// `required_secrets` names the credentials the caller must stage.  The
-    /// field is intentionally absent from the `Debug` output to avoid leaking
-    /// secret-handle identifiers into logs.
+    /// `requirement.required_secrets` names the credentials the caller must
+    /// stage. The aggregate is intentionally redacted from `Debug` output to
+    /// avoid leaking secret-handle identifiers into logs.
     #[error("capability {capability} dispatch requires authentication")]
     AuthRequired {
         capability: CapabilityId,
-        required_secrets: Vec<SecretHandle>,
-        credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
-        model_visible_cause: Option<Box<ProviderDiagnostic>>,
+        requirement: Box<DispatchAuthRequirement>,
     },
     /// Provider/protocol rejection shared across runtime lanes. The lane is
     /// diagnostic metadata; callers branch on `kind`, not implementation.
@@ -656,21 +664,22 @@ impl fmt::Debug for DispatchError {
             // prevent leaking secret identifiers into logs and error chains.
             Self::AuthRequired {
                 capability,
-                required_secrets,
-                credential_requirements,
-                ..
+                requirement,
             } => f
                 .debug_struct("AuthRequired")
                 .field("capability", capability)
                 .field(
                     "required_secrets",
-                    &format!("[{} handle(s) redacted]", required_secrets.len()),
+                    &format!(
+                        "[{} handle(s) redacted]",
+                        requirement.required_secrets.len()
+                    ),
                 )
                 .field(
                     "credential_requirements",
                     &format!(
                         "[{} requirement(s) redacted]",
-                        credential_requirements.len()
+                        requirement.credential_requirements.len()
                     ),
                 )
                 .finish(),
@@ -829,5 +838,11 @@ mod tests {
         assert!(message.as_str().len() <= crate::result_meta::MODEL_DIAGNOSTIC_MAX_BYTES);
         assert!(message.as_str().is_char_boundary(message.as_str().len()));
         assert!(!format!("{diagnostic:?}").contains('é'));
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn dispatch_error_stays_within_stack_budget() {
+        assert!(std::mem::size_of::<DispatchError>() <= 72);
     }
 }

--- a/crates/contracts/ironclaw_host_api/src/dispatch_test_support.rs
+++ b/crates/contracts/ironclaw_host_api/src/dispatch_test_support.rs
@@ -24,7 +24,9 @@ use std::sync::{Mutex, MutexGuard};
 
 use async_trait::async_trait;
 
-use crate::dispatch::{CapabilityDispatchResult, CapabilityDispatcher, DispatchError};
+use crate::dispatch::{
+    CapabilityDispatchResult, CapabilityDispatcher, DispatchAuthRequirement, DispatchError,
+};
 use crate::{
     Timestamp,
     authorized::Authorized,
@@ -99,9 +101,11 @@ impl TestDispatcher {
         Self::responding(|request, _| {
             Err(DispatchError::AuthRequired {
                 capability: request.invocation.capability.clone(),
-                required_secrets: Vec::new(),
-                credential_requirements: Vec::new(),
-                model_visible_cause: None,
+                requirement: Box::new(DispatchAuthRequirement {
+                    required_secrets: Vec::new(),
+                    credential_requirements: Vec::new(),
+                    model_visible_cause: None,
+                }),
             })
         })
     }
@@ -225,9 +229,11 @@ mod tests {
     fn auth_required_err(cap: &str) -> DispatchError {
         DispatchError::AuthRequired {
             capability: CapabilityId::new(cap).unwrap(),
-            required_secrets: Vec::new(),
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: Vec::new(),
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         }
     }
 
@@ -295,9 +301,11 @@ mod tests {
             if idx == 0 && req.invocation.capability.as_str() == "test.first" {
                 Err(DispatchError::AuthRequired {
                     capability: req.invocation.capability.clone(),
-                    required_secrets: Vec::new(),
-                    credential_requirements: Vec::new(),
-                    model_visible_cause: None,
+                    requirement: Box::new(DispatchAuthRequirement {
+                        required_secrets: Vec::new(),
+                        credential_requirements: Vec::new(),
+                        model_visible_cause: None,
+                    }),
                 })
             } else {
                 Err(DispatchError::UnknownCapability {

--- a/crates/contracts/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/contracts/ironclaw_host_api/tests/host_api_contract.rs
@@ -15,8 +15,8 @@ use ironclaw_host_api::{
         RuntimeCredentialAuthRequirement,
     },
     dispatch::{
-        DispatchError, DispatchFailureDetail, DispatchFailureKind, DispatchInputIssue,
-        DispatchInputIssueCode, RuntimeDispatchErrorKind,
+        DispatchAuthRequirement, DispatchError, DispatchFailureDetail, DispatchFailureKind,
+        DispatchInputIssue, DispatchInputIssueCode, RuntimeDispatchErrorKind,
     },
     error::HostApiError,
     host_port::{
@@ -447,9 +447,11 @@ fn dispatch_errors_preserve_typed_failure_kind() {
     assert_eq!(
         DispatchError::AuthRequired {
             capability: CapabilityId::new("test.cap").unwrap(),
-            required_secrets: required_secrets.clone(),
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: required_secrets.clone(),
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         }
         .failure_kind(),
         DispatchFailureKind::AuthRequired
@@ -458,9 +460,11 @@ fn dispatch_errors_preserve_typed_failure_kind() {
     assert_eq!(
         DispatchError::AuthRequired {
             capability: CapabilityId::new("test.cap").unwrap(),
-            required_secrets: Vec::new(),
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: Vec::new(),
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         }
         .failure_kind(),
         DispatchFailureKind::AuthRequired
@@ -1801,9 +1805,11 @@ fn dispatch_error_event_kind_pins_auth_required_token() {
     assert_eq!(
         DispatchError::AuthRequired {
             capability: cap(),
-            required_secrets: vec![handle],
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: vec![handle],
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         }
         .event_kind(),
         "auth_required"
@@ -1812,9 +1818,11 @@ fn dispatch_error_event_kind_pins_auth_required_token() {
     assert_eq!(
         DispatchError::AuthRequired {
             capability: cap(),
-            required_secrets: Vec::new(),
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: Vec::new(),
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         }
         .event_kind(),
         "auth_required"
@@ -1852,15 +1860,17 @@ fn dispatch_error_auth_required_debug_redacts_required_secrets() {
     let handle = SecretHandle::new("google-access-token").unwrap();
     let error = DispatchError::AuthRequired {
         capability: CapabilityId::new("test.cap").unwrap(),
-        required_secrets: vec![handle],
-        credential_requirements: Vec::new(),
-        model_visible_cause: Some(Box::new(ironclaw_host_api::dispatch::ProviderDiagnostic {
-            code: None,
-            message: Some(ironclaw_host_api::dispatch::UntrustedProviderMessage::new(
-                "Bad credentials",
-            )),
-            retry_after: None,
-        })),
+        requirement: Box::new(DispatchAuthRequirement {
+            required_secrets: vec![handle],
+            credential_requirements: Vec::new(),
+            model_visible_cause: Some(ironclaw_host_api::dispatch::ProviderDiagnostic {
+                code: None,
+                message: Some(ironclaw_host_api::dispatch::UntrustedProviderMessage::new(
+                    "Bad credentials",
+                )),
+                retry_after: None,
+            }),
+        }),
     };
     let debug = format!("{error:?}");
     assert!(
@@ -1878,9 +1888,11 @@ fn dispatch_error_auth_required_debug_redacts_required_secrets() {
     // Empty list variant.
     let empty = DispatchError::AuthRequired {
         capability: CapabilityId::new("test.cap").unwrap(),
-        required_secrets: Vec::new(),
-        credential_requirements: Vec::new(),
-        model_visible_cause: None,
+        requirement: Box::new(DispatchAuthRequirement {
+            required_secrets: Vec::new(),
+            credential_requirements: Vec::new(),
+            model_visible_cause: None,
+        }),
     };
     let debug_empty = format!("{empty:?}");
     assert!(
@@ -1897,9 +1909,11 @@ fn dispatch_error_auth_required_debug_redacts_required_secrets() {
     };
     let with_requirement = DispatchError::AuthRequired {
         capability: CapabilityId::new("test.cap").unwrap(),
-        required_secrets: Vec::new(),
-        credential_requirements: vec![requirement],
-        model_visible_cause: None,
+        requirement: Box::new(DispatchAuthRequirement {
+            required_secrets: Vec::new(),
+            credential_requirements: vec![requirement],
+            model_visible_cause: None,
+        }),
     };
     let debug_with_requirement = format!("{with_requirement:?}");
     assert!(

--- a/crates/extensions/ironclaw_extension_host/src/resolver.rs
+++ b/crates/extensions/ironclaw_extension_host/src/resolver.rs
@@ -137,15 +137,9 @@ fn dispatch_error_for_tool_error(
     error: ToolError,
 ) -> DispatchError {
     match error {
-        ToolError::AuthRequired {
-            required_secrets,
-            credential_requirements,
-            model_visible_cause,
-        } => DispatchError::AuthRequired {
+        ToolError::AuthRequired { requirement } => DispatchError::AuthRequired {
             capability: capability_id.clone(),
-            required_secrets,
-            credential_requirements,
-            model_visible_cause,
+            requirement,
         },
         ToolError::Rejected {
             runtime,

--- a/crates/extensions/ironclaw_extension_host/src/resolver.rs
+++ b/crates/extensions/ironclaw_extension_host/src/resolver.rs
@@ -145,7 +145,7 @@ fn dispatch_error_for_tool_error(
             capability: capability_id.clone(),
             required_secrets,
             credential_requirements,
-            model_visible_cause: model_visible_cause.map(Box::new),
+            model_visible_cause,
         },
         ToolError::Rejected {
             runtime,

--- a/crates/extensions/ironclaw_extension_host/tests/lifecycle_contract.rs
+++ b/crates/extensions/ironclaw_extension_host/tests/lifecycle_contract.rs
@@ -587,7 +587,9 @@ async fn snapshot_resolver_maps_tool_auth_required_to_the_generic_gate() {
         ToolAdapter, ToolCall, ToolError, ToolPorts, ToolResult,
     };
     use ironclaw_host_api::{
-        dispatch::{DispatchError, ProviderDiagnostic, UntrustedProviderMessage},
+        dispatch::{
+            DispatchAuthRequirement, DispatchError, ProviderDiagnostic, UntrustedProviderMessage,
+        },
         ids::{CapabilityId, SecretHandle},
     };
 
@@ -601,15 +603,17 @@ async fn snapshot_resolver_maps_tool_auth_required_to_the_generic_gate() {
             _ports: &ToolPorts<'_>,
         ) -> Result<ToolResult, ToolError> {
             Err(ToolError::AuthRequired {
-                required_secrets: vec![SecretHandle::new("acme_token").unwrap()],
-                credential_requirements: Vec::new(),
-                model_visible_cause: Some(Box::new(ProviderDiagnostic {
-                    code: None,
-                    message: Some(UntrustedProviderMessage::new(
-                        "provider error code: github_api_error_status_401; provider message: Bad credentials",
-                    )),
-                    retry_after: None,
-                })),
+                requirement: Box::new(DispatchAuthRequirement {
+                    required_secrets: vec![SecretHandle::new("acme_token").unwrap()],
+                    credential_requirements: Vec::new(),
+                    model_visible_cause: Some(ProviderDiagnostic {
+                        code: None,
+                        message: Some(UntrustedProviderMessage::new(
+                            "provider error code: github_api_error_status_401; provider message: Bad credentials",
+                        )),
+                        retry_after: None,
+                    }),
+                }),
             })
         }
     }
@@ -655,14 +659,14 @@ async fn snapshot_resolver_maps_tool_auth_required_to_the_generic_gate() {
     match err {
         DispatchError::AuthRequired {
             capability,
-            required_secrets,
-            model_visible_cause,
+            requirement,
             ..
         } => {
             assert_eq!(capability.as_str(), "acme.ping");
-            assert_eq!(required_secrets.len(), 1);
+            assert_eq!(requirement.required_secrets.len(), 1);
             assert_eq!(
-                model_visible_cause
+                requirement
+                    .model_visible_cause
                     .as_ref()
                     .and_then(|diagnostic| diagnostic.message.as_ref())
                     .map(|message| message.as_str()),

--- a/crates/extensions/ironclaw_extension_host/tests/lifecycle_contract.rs
+++ b/crates/extensions/ironclaw_extension_host/tests/lifecycle_contract.rs
@@ -603,13 +603,13 @@ async fn snapshot_resolver_maps_tool_auth_required_to_the_generic_gate() {
             Err(ToolError::AuthRequired {
                 required_secrets: vec![SecretHandle::new("acme_token").unwrap()],
                 credential_requirements: Vec::new(),
-                model_visible_cause: Some(ProviderDiagnostic {
+                model_visible_cause: Some(Box::new(ProviderDiagnostic {
                     code: None,
                     message: Some(UntrustedProviderMessage::new(
                         "provider error code: github_api_error_status_401; provider message: Bad credentials",
                     )),
                     retry_after: None,
-                }),
+                })),
             })
         }
     }
@@ -702,11 +702,11 @@ async fn snapshot_resolver_preserves_typed_provider_rejection() {
             Err(ToolError::Rejected {
                 runtime: Some(RuntimeKind::Mcp),
                 kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Client),
-                diagnostic: Some(ProviderDiagnostic {
+                diagnostic: Some(Box::new(ProviderDiagnostic {
                     code: Some(ProviderErrorCode::new("mcp_tool_rejected")),
                     message: Some(UntrustedProviderMessage::new("Bad credentials")),
                     retry_after: None,
-                }),
+                })),
                 detail: None,
             })
         }

--- a/crates/extensions/packages/telegram/src/linked/mapping.rs
+++ b/crates/extensions/packages/telegram/src/linked/mapping.rs
@@ -31,7 +31,7 @@ use ironclaw_extension_contracts::tool_adapter::ToolError;
 use ironclaw_host_api::{
     capability::RuntimeCredentialAccountSetup,
     decision::RuntimeCredentialAuthRequirement,
-    dispatch::RuntimeDispatchErrorKind,
+    dispatch::{DispatchAuthRequirement, RuntimeDispatchErrorKind},
     ids::{ExtensionId, SecretHandle, VendorId},
     messaging::StandardMessagingErrorCode,
 };
@@ -96,25 +96,29 @@ pub(crate) fn failed_because(code: StandardMessagingErrorCode, cause: String) ->
 /// whereas a messaging code would tell the model to rephrase its arguments.
 pub(crate) fn auth_required() -> ToolError {
     ToolError::AuthRequired {
-        required_secrets: SecretHandle::new(TELEGRAM_LINKED_SESSION_HANDLE)
-            .map(|handle| vec![handle])
-            .unwrap_or_default(),
-        credential_requirements: match (
-            VendorId::new(TELEGRAM_VENDOR_ID),
-            ExtensionId::new(TELEGRAM_EXTENSION_ID),
-        ) {
-            (Ok(provider), Ok(requester_extension)) => vec![RuntimeCredentialAuthRequirement {
-                provider,
-                setup: RuntimeCredentialAccountSetup::DeviceLink,
-                requester_extension,
-                provider_scopes: Vec::new(),
-            }],
-            // Both ids are compile-time literals that satisfy their
-            // validators; an empty requirement list still parks the run on the
-            // generic re-auth gate, so this arm degrades rather than panics.
-            _ => Vec::new(),
-        },
-        model_visible_cause: None,
+        requirement: Box::new(DispatchAuthRequirement {
+            required_secrets: SecretHandle::new(TELEGRAM_LINKED_SESSION_HANDLE)
+                .map(|handle| vec![handle])
+                .unwrap_or_default(),
+            credential_requirements: match (
+                VendorId::new(TELEGRAM_VENDOR_ID),
+                ExtensionId::new(TELEGRAM_EXTENSION_ID),
+            ) {
+                (Ok(provider), Ok(requester_extension)) => {
+                    vec![RuntimeCredentialAuthRequirement {
+                        provider,
+                        setup: RuntimeCredentialAccountSetup::DeviceLink,
+                        requester_extension,
+                        provider_scopes: Vec::new(),
+                    }]
+                }
+                // Both ids are compile-time literals that satisfy their
+                // validators; an empty requirement list still parks the run on the
+                // generic re-auth gate, so this arm degrades rather than panics.
+                _ => Vec::new(),
+            },
+            model_visible_cause: None,
+        }),
     }
 }
 

--- a/crates/extensions/packages/telegram/src/linked/mapping/tests.rs
+++ b/crates/extensions/packages/telegram/src/linked/mapping/tests.rs
@@ -301,17 +301,13 @@ fn credential_failures_leave_the_messaging_vocabulary() {
         "SESSION_EXPIRED",
     ] {
         let mapped = map_vendor_error(OpFamily::Read, &rpc(name, None));
-        let ToolError::AuthRequired {
-            required_secrets,
-            credential_requirements,
-            ..
-        } = mapped
-        else {
+        let ToolError::AuthRequired { requirement, .. } = mapped else {
             panic!("{name} must park the run on the re-auth gate, not answer messaging.*");
         };
-        assert_eq!(required_secrets.len(), 1);
+        assert_eq!(requirement.required_secrets.len(), 1);
         assert_eq!(
-            credential_requirements
+            requirement
+                .credential_requirements
                 .first()
                 .map(|requirement| requirement.setup.clone()),
             Some(RuntimeCredentialAccountSetup::DeviceLink)

--- a/crates/kernel/ironclaw_capabilities/src/error.rs
+++ b/crates/kernel/ironclaw_capabilities/src/error.rs
@@ -1,12 +1,12 @@
 use ironclaw_authorization::CapabilityLeaseError;
 use ironclaw_host_api::{
-    decision::{DenyReason, Obligation, RuntimeCredentialAuthRequirement},
+    decision::{DenyReason, Obligation},
     dispatch::{
-        DispatchError, DispatchFailureDetail, DispatchFailureKind, ProviderDiagnostic,
-        provider_diagnostic_model_cause,
+        DispatchAuthRequirement, DispatchError, DispatchFailureDetail, DispatchFailureKind,
+        ProviderDiagnostic, provider_diagnostic_model_cause,
     },
     error::HostApiError,
-    ids::{CapabilityId, SecretHandle},
+    ids::CapabilityId,
 };
 use ironclaw_processes::{ProcessError, ProcessInvocationError, ProcessInvocationStatus};
 
@@ -53,9 +53,7 @@ pub enum CapabilityInvocationError {
     #[error("capability {capability} invocation requires authentication")]
     AuthorizationRequiresAuth {
         capability: CapabilityId,
-        required_secrets: Vec<SecretHandle>,
-        credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
-        model_visible_cause: Option<Box<ProviderDiagnostic>>,
+        requirement: Box<DispatchAuthRequirement>,
     },
     #[error("capability {capability} invocation fingerprint failed: {source}")]
     InvocationFingerprint {
@@ -145,14 +143,10 @@ impl From<DispatchError> for CapabilityInvocationError {
         match error {
             DispatchError::AuthRequired {
                 capability,
-                required_secrets,
-                credential_requirements,
-                model_visible_cause,
+                requirement,
             } => Self::AuthorizationRequiresAuth {
                 capability,
-                required_secrets,
-                credential_requirements,
-                model_visible_cause,
+                requirement,
             },
             DispatchError::Rejected {
                 kind,
@@ -462,20 +456,28 @@ mod tests {
                 .collect();
             let err = CapabilityInvocationError::from(DispatchError::AuthRequired {
                 capability: cap(),
-                required_secrets: secrets.clone(),
-                credential_requirements: Vec::new(),
-                model_visible_cause: None,
+                requirement: Box::new(DispatchAuthRequirement {
+                    required_secrets: secrets.clone(),
+                    credential_requirements: Vec::new(),
+                    model_visible_cause: None,
+                }),
             });
             match err {
                 CapabilityInvocationError::AuthorizationRequiresAuth {
                     capability,
-                    required_secrets,
-                    credential_requirements,
+                    requirement,
                     ..
                 } => {
                     assert_eq!(capability, cap(), "handles: {handles:?}");
-                    assert_eq!(required_secrets, secrets, "handles: {handles:?}");
-                    assert_eq!(credential_requirements, Vec::new(), "handles: {handles:?}");
+                    assert_eq!(
+                        requirement.required_secrets, secrets,
+                        "handles: {handles:?}"
+                    );
+                    assert_eq!(
+                        requirement.credential_requirements,
+                        Vec::new(),
+                        "handles: {handles:?}"
+                    );
                 }
                 other => panic!("expected AuthorizationRequiresAuth, got {other:?}"),
             }
@@ -494,35 +496,39 @@ mod tests {
         };
         let err = CapabilityInvocationError::from(DispatchError::AuthRequired {
             capability: cap(),
-            required_secrets: Vec::new(),
-            credential_requirements: vec![requirement.clone()],
-            model_visible_cause: Some(Box::new(ProviderDiagnostic {
-                code: None,
-                message: Some(ironclaw_host_api::dispatch::UntrustedProviderMessage::new(
-                    "Bad credentials",
-                )),
-                retry_after: None,
-            })),
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: Vec::new(),
+                credential_requirements: vec![requirement.clone()],
+                model_visible_cause: Some(ProviderDiagnostic {
+                    code: None,
+                    message: Some(ironclaw_host_api::dispatch::UntrustedProviderMessage::new(
+                        "Bad credentials",
+                    )),
+                    retry_after: None,
+                }),
+            }),
         });
 
         match err {
             CapabilityInvocationError::AuthorizationRequiresAuth {
                 capability,
-                required_secrets,
-                credential_requirements,
-                model_visible_cause,
+                requirement: auth_requirement,
             } => {
                 assert_eq!(capability, cap());
-                assert!(required_secrets.is_empty());
-                assert_eq!(credential_requirements, vec![requirement]);
+                assert!(auth_requirement.required_secrets.is_empty());
+                assert_eq!(auth_requirement.credential_requirements, vec![requirement]);
                 assert_eq!(
-                    model_visible_cause
+                    auth_requirement
+                        .model_visible_cause
                         .as_ref()
                         .and_then(|diagnostic| diagnostic.message.as_ref())
                         .map(|message| message.as_str()),
                     Some("Bad credentials")
                 );
-                assert!(!format!("{model_visible_cause:?}").contains("Bad credentials"));
+                assert!(
+                    !format!("{:?}", auth_requirement.model_visible_cause)
+                        .contains("Bad credentials")
+                );
             }
             other => panic!("expected AuthorizationRequiresAuth, got {other:?}"),
         }

--- a/crates/kernel/ironclaw_capabilities/src/error.rs
+++ b/crates/kernel/ironclaw_capabilities/src/error.rs
@@ -161,7 +161,7 @@ impl From<DispatchError> for CapabilityInvocationError {
                 ..
             } => Self::Dispatch {
                 kind,
-                provider_diagnostic: diagnostic.map(Box::new),
+                provider_diagnostic: diagnostic,
                 safe_summary: None,
                 detail,
             },
@@ -193,7 +193,7 @@ fn dispatch_error_kind(error: &DispatchError) -> DispatchFailureKind {
 fn dispatch_error_model_visible_cause(error: &DispatchError) -> Option<String> {
     match error {
         DispatchError::Rejected { diagnostic, .. } => diagnostic
-            .as_ref()
+            .as_deref()
             .and_then(provider_diagnostic_model_cause),
         DispatchError::Mcp {
             model_visible_cause,
@@ -323,7 +323,7 @@ mod tests {
         let error = CapabilityInvocationError::from(DispatchError::Rejected {
             runtime: Some(RuntimeKind::Mcp),
             kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Client),
-            diagnostic: Some(ProviderDiagnostic {
+            diagnostic: Some(Box::new(ProviderDiagnostic {
                 code: Some(ironclaw_host_api::dispatch::ProviderErrorCode::new(
                     "mcp_tool_rejected",
                 )),
@@ -331,7 +331,7 @@ mod tests {
                     "token lacks repo scope",
                 )),
                 retry_after: None,
-            }),
+            })),
             detail: Some(DispatchFailureDetail::Diagnostic {
                 text: detail_marker.to_string(),
             }),

--- a/crates/kernel/ironclaw_capabilities/src/helpers.rs
+++ b/crates/kernel/ironclaw_capabilities/src/helpers.rs
@@ -354,7 +354,7 @@ mod tests {
     use super::*;
     use crate::CapabilityInvocationError;
     use ironclaw_host_api::{
-        dispatch::{DispatchFailureKind, RuntimeDispatchErrorKind},
+        dispatch::{DispatchAuthRequirement, DispatchFailureKind, RuntimeDispatchErrorKind},
         ids::CapabilityId,
     };
 
@@ -420,9 +420,11 @@ mod tests {
     fn authorization_requires_auth_still_blocks_auth() {
         let error = CapabilityInvocationError::AuthorizationRequiresAuth {
             capability: capability(),
-            required_secrets: Vec::new(),
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: Vec::new(),
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         };
         let transition = error
             .invocation_state_transition()

--- a/crates/kernel/ironclaw_capabilities/src/host/authorize.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/authorize.rs
@@ -5,13 +5,12 @@
 //! the [`Authorized`] witness. Both are shared by invoke, spawn and the resume
 //! tail, so they live here rather than with any one workflow.
 
-use ironclaw_host_api::authorized::CapabilityAuthorizer;
 use ironclaw_host_api::{
     Timestamp,
-    authorized::{AuthorizeResult, Authorized},
+    authorized::{AuthorizeResult, Authorized, CapabilityAuthorizer},
     capability::{CapabilityDescriptor, PermissionMode},
     decision::{Decision, DenyReason},
-    dispatch::CapabilityDispatcher,
+    dispatch::{CapabilityDispatcher, DispatchAuthRequirement},
     ids::{ActivityId, CapabilityId, DenyRef, GateRef},
     invocation::{Actor, Invocation},
     lane::RuntimeLane,
@@ -265,9 +264,11 @@ where
             } => {
                 let error = CapabilityInvocationError::AuthorizationRequiresAuth {
                     capability: request.capability_id.clone(),
-                    required_secrets,
-                    credential_requirements: requirements,
-                    model_visible_cause: None,
+                    requirement: Box::new(DispatchAuthRequirement {
+                        required_secrets,
+                        credential_requirements: requirements,
+                        model_visible_cause: None,
+                    }),
                 };
                 apply_invocation_state_transition_if_configured(
                     self.invocation_state,

--- a/crates/kernel/ironclaw_capabilities/src/host/error_mapping.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/error_mapping.rs
@@ -8,7 +8,7 @@
 use ironclaw_authorization::CapabilityLeaseStorePort;
 use ironclaw_host_api::{
     decision::{DenyReason, Obligation},
-    dispatch::DispatchError,
+    dispatch::{DispatchAuthRequirement, DispatchError},
     ids::{CapabilityGrantId, CapabilityId, InvocationId},
     resource::ResourceScope,
 };
@@ -210,9 +210,11 @@ pub(super) fn prepare_obligation_error_to_invocation(
             credential_requirements,
         } => CapabilityInvocationError::AuthorizationRequiresAuth {
             capability: capability_id.clone(),
-            required_secrets: Vec::new(),
-            credential_requirements,
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: Vec::new(),
+                credential_requirements,
+                model_visible_cause: None,
+            }),
         },
         CapabilityObligationError::Failed { kind } => CapabilityInvocationError::ObligationFailed {
             capability: capability_id.clone(),
@@ -273,17 +275,22 @@ pub(super) fn enrich_dispatch_error_credential_requirements(
     error: DispatchError,
     obligations: &[Obligation],
 ) -> DispatchError {
-    // Matched by value in one pass: the guard borrows the two vectors, so a
+    // Matched by value in one pass: the guard borrows the requirement, so a
     // non-enriching outcome falls through to `other` with `error` un-moved.
     // Enriching rebuilds the variant from the parts it already owns, which is
     // what lets this be total — there is no "matched above" branch to assert.
     match error {
         DispatchError::AuthRequired {
             capability,
-            required_secrets,
-            credential_requirements,
-            model_visible_cause,
-        } if required_secrets.is_empty() && credential_requirements.is_empty() => {
+            requirement,
+        } if requirement.required_secrets.is_empty()
+            && requirement.credential_requirements.is_empty() =>
+        {
+            let DispatchAuthRequirement {
+                required_secrets,
+                credential_requirements,
+                model_visible_cause,
+            } = *requirement;
             let derived: Vec<_> = obligations
                 .iter()
                 .filter_map(Obligation::credential_auth_requirement)
@@ -291,9 +298,11 @@ pub(super) fn enrich_dispatch_error_credential_requirements(
             match derived.as_slice() {
                 [requirement] => DispatchError::AuthRequired {
                     capability,
-                    required_secrets,
-                    credential_requirements: vec![requirement.clone()],
-                    model_visible_cause,
+                    requirement: Box::new(DispatchAuthRequirement {
+                        required_secrets,
+                        credential_requirements: vec![requirement.clone()],
+                        model_visible_cause,
+                    }),
                 },
                 // Zero declared credential obligations: the capability makes
                 // no credential claim at all, so there is nothing to attribute
@@ -306,16 +315,18 @@ pub(super) fn enrich_dispatch_error_credential_requirements(
                 // ambiguous attribution (see the `_` arm below).
                 [] => DispatchError::AuthRequired {
                     capability,
-                    required_secrets,
-                    credential_requirements,
-                    model_visible_cause,
+                    requirement: Box::new(DispatchAuthRequirement {
+                        required_secrets,
+                        credential_requirements,
+                        model_visible_cause,
+                    }),
                 },
                 _ => DispatchError::Rejected {
                     runtime: None,
                     kind: ironclaw_host_api::dispatch::DispatchFailureKind::Runtime(
                         ironclaw_host_api::dispatch::RuntimeDispatchErrorKind::SecretDenied,
                     ),
-                    diagnostic: model_visible_cause,
+                    diagnostic: model_visible_cause.map(Box::new),
                     detail: Some(
                         ironclaw_host_api::dispatch::DispatchFailureDetail::Diagnostic {
                             text: format!(

--- a/crates/kernel/ironclaw_capabilities/src/host/error_mapping.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/error_mapping.rs
@@ -315,7 +315,7 @@ pub(super) fn enrich_dispatch_error_credential_requirements(
                     kind: ironclaw_host_api::dispatch::DispatchFailureKind::Runtime(
                         ironclaw_host_api::dispatch::RuntimeDispatchErrorKind::SecretDenied,
                     ),
-                    diagnostic: model_visible_cause.map(|diagnostic| *diagnostic),
+                    diagnostic: model_visible_cause,
                     detail: Some(
                         ironclaw_host_api::dispatch::DispatchFailureDetail::Diagnostic {
                             text: format!(

--- a/crates/kernel/ironclaw_capabilities/src/host/spawn.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/spawn.rs
@@ -8,7 +8,7 @@
 use ironclaw_host_api::{
     authorized::AuthorizeResult,
     decision::{Decision, DenyReason},
-    dispatch::CapabilityDispatcher,
+    dispatch::{CapabilityDispatcher, DispatchAuthRequirement},
     ids::{DenyRef, GateRef, ProcessId},
     resolution::{Blocked, GateWaypoint},
 };
@@ -294,9 +294,11 @@ where
             } => {
                 let error = CapabilityInvocationError::AuthorizationRequiresAuth {
                     capability: request.capability_id.clone(),
-                    required_secrets,
-                    credential_requirements: requirements,
-                    model_visible_cause: None,
+                    requirement: Box::new(DispatchAuthRequirement {
+                        required_secrets,
+                        credential_requirements: requirements,
+                        model_visible_cause: None,
+                    }),
                 };
                 apply_invocation_state_transition_if_configured(
                     self.invocation_state,

--- a/crates/kernel/ironclaw_capabilities/src/host/tests.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/tests.rs
@@ -6,7 +6,7 @@
 use ironclaw_host_api::{
     capability::RuntimeCredentialAccountSetup,
     decision::{Decision, Obligation},
-    dispatch::CapabilityDispatchResult,
+    dispatch::{CapabilityDispatchResult, DispatchAuthRequirement},
     ids::{CapabilityId, ExtensionId, SecretHandle, VendorId},
     invocation::Actor,
     lane::RuntimeLane,
@@ -22,18 +22,22 @@ use crate::ports::CredentialPresence;
 fn auth_required_empty(cap: &str) -> DispatchError {
     DispatchError::AuthRequired {
         capability: CapabilityId::new(cap).unwrap(),
-        required_secrets: Vec::new(),
-        credential_requirements: Vec::new(),
-        model_visible_cause: None,
+        requirement: Box::new(DispatchAuthRequirement {
+            required_secrets: Vec::new(),
+            credential_requirements: Vec::new(),
+            model_visible_cause: None,
+        }),
     }
 }
 
 fn auth_required_with_secrets(cap: &str) -> DispatchError {
     DispatchError::AuthRequired {
         capability: CapabilityId::new(cap).unwrap(),
-        required_secrets: vec![SecretHandle::new("raw_secret").unwrap()],
-        credential_requirements: Vec::new(),
-        model_visible_cause: None,
+        requirement: Box::new(DispatchAuthRequirement {
+            required_secrets: vec![SecretHandle::new("raw_secret").unwrap()],
+            credential_requirements: Vec::new(),
+            model_visible_cause: None,
+        }),
     }
 }
 
@@ -41,14 +45,16 @@ fn auth_required_with_provider(cap: &str, provider: &str) -> DispatchError {
     use ironclaw_host_api::decision::RuntimeCredentialAuthRequirement;
     DispatchError::AuthRequired {
         capability: CapabilityId::new(cap).unwrap(),
-        required_secrets: Vec::new(),
-        credential_requirements: vec![RuntimeCredentialAuthRequirement {
-            provider: VendorId::new(provider).unwrap(),
-            setup: RuntimeCredentialAccountSetup::ManualToken,
-            requester_extension: ExtensionId::new(provider).unwrap(),
-            provider_scopes: Vec::new(),
-        }],
-        model_visible_cause: None,
+        requirement: Box::new(DispatchAuthRequirement {
+            required_secrets: Vec::new(),
+            credential_requirements: vec![RuntimeCredentialAuthRequirement {
+                provider: VendorId::new(provider).unwrap(),
+                setup: RuntimeCredentialAccountSetup::ManualToken,
+                requester_extension: ExtensionId::new(provider).unwrap(),
+                provider_scopes: Vec::new(),
+            }],
+            model_visible_cause: None,
+        }),
     }
 }
 
@@ -70,16 +76,12 @@ fn enrich_fills_empty_from_single_credential_obligation() {
 
     let result = enrich_dispatch_error_credential_requirements(error, &obligations);
 
-    let DispatchError::AuthRequired {
-        credential_requirements,
-        ..
-    } = result
-    else {
+    let DispatchError::AuthRequired { requirement, .. } = result else {
         panic!("expected AuthRequired");
     };
-    assert_eq!(credential_requirements.len(), 1);
+    assert_eq!(requirement.credential_requirements.len(), 1);
     assert_eq!(
-        credential_requirements[0].provider,
+        requirement.credential_requirements[0].provider,
         VendorId::new("github").unwrap()
     );
 }
@@ -92,21 +94,16 @@ fn enrich_leaves_required_secrets_populated_unchanged() {
 
     let result = enrich_dispatch_error_credential_requirements(error, &obligations);
 
-    let DispatchError::AuthRequired {
-        required_secrets,
-        credential_requirements,
-        ..
-    } = result
-    else {
+    let DispatchError::AuthRequired { requirement, .. } = result else {
         panic!("expected AuthRequired");
     };
     assert_eq!(
-        required_secrets.len(),
+        requirement.required_secrets.len(),
         1,
         "required_secrets must be preserved"
     );
     assert!(
-        credential_requirements.is_empty(),
+        requirement.credential_requirements.is_empty(),
         "credential_requirements must remain empty when required_secrets are present"
     );
 }
@@ -119,16 +116,12 @@ fn enrich_leaves_non_empty_credential_requirements_unchanged() {
 
     let result = enrich_dispatch_error_credential_requirements(error, &obligations);
 
-    let DispatchError::AuthRequired {
-        credential_requirements,
-        ..
-    } = result
-    else {
+    let DispatchError::AuthRequired { requirement, .. } = result else {
         panic!("expected AuthRequired");
     };
-    assert_eq!(credential_requirements.len(), 1);
+    assert_eq!(requirement.credential_requirements.len(), 1);
     assert_eq!(
-        credential_requirements[0].provider,
+        requirement.credential_requirements[0].provider,
         VendorId::new("mcp_provider").unwrap(),
         "original mcp_provider must be retained, not replaced by github"
     );
@@ -145,15 +138,11 @@ fn enrich_leaves_unchanged_when_zero_credential_obligations() {
 
     let result = enrich_dispatch_error_credential_requirements(error, &obligations);
 
-    let DispatchError::AuthRequired {
-        credential_requirements,
-        ..
-    } = result
-    else {
+    let DispatchError::AuthRequired { requirement, .. } = result else {
         panic!("expected AuthRequired");
     };
     assert!(
-        credential_requirements.is_empty(),
+        requirement.credential_requirements.is_empty(),
         "zero obligations must leave credential_requirements empty"
     );
 }

--- a/crates/kernel/ironclaw_capabilities/src/registry.rs
+++ b/crates/kernel/ironclaw_capabilities/src/registry.rs
@@ -181,7 +181,7 @@ fn tool_error_to_dispatch_error(
             capability: capability_id.clone(),
             required_secrets,
             credential_requirements,
-            model_visible_cause: model_visible_cause.map(Box::new),
+            model_visible_cause,
         },
         ToolError::Rejected {
             runtime,
@@ -426,11 +426,11 @@ mod tests {
             Err(ToolError::Rejected {
                 runtime: Some(RuntimeKind::FirstParty),
                 kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::PolicyDenied),
-                diagnostic: Some(ProviderDiagnostic {
+                diagnostic: Some(Box::new(ProviderDiagnostic {
                     code: Some(ProviderErrorCode::new("channel_not_found")),
                     message: Some(UntrustedProviderMessage::new("no such channel")),
                     retry_after: None,
-                }),
+                })),
                 detail: None,
             })
         }

--- a/crates/kernel/ironclaw_capabilities/src/registry.rs
+++ b/crates/kernel/ironclaw_capabilities/src/registry.rs
@@ -173,15 +173,9 @@ fn tool_error_to_dispatch_error(
     error: ToolError,
 ) -> DispatchError {
     match error {
-        ToolError::AuthRequired {
-            required_secrets,
-            credential_requirements,
-            model_visible_cause,
-        } => DispatchError::AuthRequired {
+        ToolError::AuthRequired { requirement } => DispatchError::AuthRequired {
             capability: capability_id.clone(),
-            required_secrets,
-            credential_requirements,
-            model_visible_cause,
+            requirement,
         },
         ToolError::Rejected {
             runtime,

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_auth_invocation_state_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_auth_invocation_state_contract.rs
@@ -56,9 +56,11 @@ async fn capability_host_blocks_auth_when_dispatch_returns_auth_required() {
     let registry = registry_with_echo_capability();
     let dispatcher = TestDispatcher::scripted(vec![Err(DispatchError::AuthRequired {
         capability: capability_id(),
-        required_secrets: vec![SecretHandle::new("echo_token").unwrap()],
-        credential_requirements: Vec::new(),
-        model_visible_cause: None,
+        requirement: Box::new(ironclaw_host_api::dispatch::DispatchAuthRequirement {
+            required_secrets: vec![SecretHandle::new("echo_token").unwrap()],
+            credential_requirements: Vec::new(),
+            model_visible_cause: None,
+        }),
     })]);
     let run_state = ironclaw_processes::in_memory_backed_process_invocation_state_store();
     let authorizer = PlainAllowAuthorizer;

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_auth_required_enrichment_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_auth_required_enrichment_contract.rs
@@ -23,7 +23,7 @@ use ironclaw_host_api::dispatch_test_support::TestDispatcher;
 use ironclaw_host_api::{
     capability::{CapabilityDescriptor, CapabilitySet, RuntimeCredentialAccountSetup},
     decision::{Decision, Obligation, Obligations, RuntimeCredentialAuthRequirement},
-    dispatch::DispatchError,
+    dispatch::{DispatchAuthRequirement, DispatchError},
     ids::{ExtensionId, SecretHandle, VendorId},
     resource::ResourceEstimate,
     scope::ExecutionContext,
@@ -120,26 +120,21 @@ async fn invoke_json_enriches_auth_required_credential_requirements_from_obligat
         .await
         .unwrap_err();
 
-    let CapabilityInvocationError::AuthorizationRequiresAuth {
-        required_secrets,
-        credential_requirements,
-        ..
-    } = err
-    else {
+    let CapabilityInvocationError::AuthorizationRequiresAuth { requirement, .. } = err else {
         panic!("expected AuthorizationRequiresAuth, got {err:?}");
     };
-    assert!(required_secrets.is_empty());
+    assert!(requirement.required_secrets.is_empty());
     assert_eq!(
-        credential_requirements.len(),
+        requirement.credential_requirements.len(),
         1,
         "expected one credential requirement enriched from InjectCredentialAccountOnce obligation"
     );
     assert_eq!(
-        credential_requirements[0].provider, provider,
+        requirement.credential_requirements[0].provider, provider,
         "enriched requirement must carry the declared provider id"
     );
     assert_eq!(
-        credential_requirements[0].setup,
+        requirement.credential_requirements[0].setup,
         RuntimeCredentialAccountSetup::ManualToken,
     );
 }
@@ -163,14 +158,16 @@ async fn invoke_json_preserves_non_empty_credential_requirements_from_dispatcher
     let dispatcher = TestDispatcher::responding(|request, _| {
         Err(DispatchError::AuthRequired {
             capability: request.invocation.capability.clone(),
-            required_secrets: Vec::new(),
-            credential_requirements: vec![RuntimeCredentialAuthRequirement {
-                provider: VendorId::new("mcp_provider").unwrap(),
-                setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
-                requester_extension: ExtensionId::new("mcp_ext").unwrap(),
-                provider_scopes: Vec::new(),
-            }],
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: Vec::new(),
+                credential_requirements: vec![RuntimeCredentialAuthRequirement {
+                    provider: VendorId::new("mcp_provider").unwrap(),
+                    setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
+                    requester_extension: ExtensionId::new("mcp_ext").unwrap(),
+                    provider_scopes: Vec::new(),
+                }],
+                model_visible_cause: None,
+            }),
         })
     });
     let handler = PassthroughObligationHandler;
@@ -190,22 +187,18 @@ async fn invoke_json_preserves_non_empty_credential_requirements_from_dispatcher
         .await
         .unwrap_err();
 
-    let CapabilityInvocationError::AuthorizationRequiresAuth {
-        credential_requirements,
-        ..
-    } = err
-    else {
+    let CapabilityInvocationError::AuthorizationRequiresAuth { requirement, .. } = err else {
         panic!("expected AuthorizationRequiresAuth, got {err:?}");
     };
     assert_eq!(
-        credential_requirements.len(),
+        requirement.credential_requirements.len(),
         1,
         "non-empty runtime requirements must not be replaced by obligation enrichment"
     );
     // The retained requirement must be the one from the dispatcher (mcp_provider),
     // not the one from the obligation (github).
     assert_eq!(
-        credential_requirements[0].provider,
+        requirement.credential_requirements[0].provider,
         VendorId::new("mcp_provider").unwrap(),
     );
 }
@@ -285,21 +278,18 @@ async fn auth_resume_json_enriches_auth_required_credential_requirements_from_ob
         .await
         .unwrap_err();
 
-    let CapabilityInvocationError::AuthorizationRequiresAuth {
-        credential_requirements,
-        ..
-    } = resume_err
+    let CapabilityInvocationError::AuthorizationRequiresAuth { requirement, .. } = resume_err
     else {
         panic!("expected AuthorizationRequiresAuth from auth_resume_json, got {resume_err:?}");
     };
 
     assert_eq!(
-        credential_requirements.len(),
+        requirement.credential_requirements.len(),
         1,
         "resume path must enrich empty credential_requirements from InjectCredentialAccountOnce obligation"
     );
     assert_eq!(
-        credential_requirements[0].provider, provider,
+        requirement.credential_requirements[0].provider, provider,
         "enriched requirement on resume path must carry the declared provider id"
     );
 }
@@ -413,9 +403,11 @@ async fn invoke_json_preserves_required_secrets_from_dispatcher() {
     let dispatcher = TestDispatcher::responding(|request, _| {
         Err(DispatchError::AuthRequired {
             capability: request.invocation.capability.clone(),
-            required_secrets: vec![SecretHandle::new("raw_secret_handle").unwrap()],
-            credential_requirements: Vec::new(),
-            model_visible_cause: None,
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: vec![SecretHandle::new("raw_secret_handle").unwrap()],
+                credential_requirements: Vec::new(),
+                model_visible_cause: None,
+            }),
         })
     });
     let handler = PassthroughObligationHandler;
@@ -435,21 +427,16 @@ async fn invoke_json_preserves_required_secrets_from_dispatcher() {
         .await
         .unwrap_err();
 
-    let CapabilityInvocationError::AuthorizationRequiresAuth {
-        required_secrets,
-        credential_requirements,
-        ..
-    } = err
-    else {
+    let CapabilityInvocationError::AuthorizationRequiresAuth { requirement, .. } = err else {
         panic!("expected AuthorizationRequiresAuth, got {err:?}");
     };
     assert_eq!(
-        required_secrets.len(),
+        requirement.required_secrets.len(),
         1,
         "required_secrets from dispatcher must be preserved when non-empty"
     );
     assert!(
-        credential_requirements.is_empty(),
+        requirement.credential_requirements.is_empty(),
         "credential_requirements must remain empty when required_secrets are present \
          — enrichment from obligations must be suppressed"
     );

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_auth_resume_contract.rs
@@ -17,7 +17,9 @@ use ironclaw_host_api::{
         CapabilityDescriptor, CapabilityGrant, CapabilitySet, EffectKind, GrantConstraints,
     },
     decision::{Decision, DenyReason},
-    dispatch::{CapabilityDispatchResult, CapabilityDispatcher, DispatchError},
+    dispatch::{
+        CapabilityDispatchResult, CapabilityDispatcher, DispatchAuthRequirement, DispatchError,
+    },
     ids::{
         ApprovalRequestId, CapabilityGrantId, CapabilityId, CorrelationId, ExtensionId,
         SecretHandle, UserId,
@@ -35,9 +37,11 @@ use support::*;
 fn dispatch_auth_required(capability: CapabilityId) -> DispatchError {
     DispatchError::AuthRequired {
         capability,
-        required_secrets: vec![SecretHandle::new("echo_token").unwrap()],
-        credential_requirements: Vec::new(),
-        model_visible_cause: None,
+        requirement: Box::new(DispatchAuthRequirement {
+            required_secrets: vec![SecretHandle::new("echo_token").unwrap()],
+            credential_requirements: Vec::new(),
+            model_visible_cause: None,
+        }),
     }
 }
 

--- a/crates/kernel/ironclaw_host_runtime/src/capability_response_processor.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/capability_response_processor.rs
@@ -51,15 +51,20 @@ pub(super) async fn process_capability_response(
         )),
         Err(CapabilityInvocationError::AuthorizationRequiresAuth {
             capability,
-            required_secrets,
-            credential_requirements,
-            model_visible_cause,
-        }) => Ok(auth_required_outcome(
-            capability,
-            required_secrets,
-            credential_requirements,
-            model_visible_cause,
-        )),
+            requirement,
+        }) => {
+            let ironclaw_host_api::dispatch::DispatchAuthRequirement {
+                required_secrets,
+                credential_requirements,
+                model_visible_cause,
+            } = *requirement;
+            Ok(auth_required_outcome(
+                capability,
+                required_secrets,
+                credential_requirements,
+                model_visible_cause.map(Box::new),
+            ))
+        }
         Err(CapabilityInvocationError::AuthorizationRequiresApproval { capability }) => {
             match context.mode {
                 InlineInvocationMode::Fresh => match runtime

--- a/crates/kernel/ironclaw_host_runtime/src/lib.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/lib.rs
@@ -418,7 +418,7 @@ pub struct RuntimeAuthGate {
     pub reason: RuntimeBlockedReason,
     pub required_secrets: Vec<SecretHandle>,
     pub credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
-    provider_diagnostic: Option<ProviderDiagnostic>,
+    provider_diagnostic: Option<Box<ProviderDiagnostic>>,
 }
 
 impl RuntimeAuthGate {
@@ -439,13 +439,13 @@ impl RuntimeAuthGate {
         }
     }
 
-    pub fn with_provider_diagnostic(mut self, diagnostic: Option<ProviderDiagnostic>) -> Self {
+    pub fn with_provider_diagnostic(mut self, diagnostic: Option<Box<ProviderDiagnostic>>) -> Self {
         self.provider_diagnostic = diagnostic;
         self
     }
 
     pub fn provider_diagnostic(&self) -> Option<&ProviderDiagnostic> {
-        self.provider_diagnostic.as_ref()
+        self.provider_diagnostic.as_deref()
     }
 }
 

--- a/crates/kernel/ironclaw_host_runtime/src/production.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/production.rs
@@ -1382,7 +1382,7 @@ pub(super) fn auth_required_outcome(
             required_secrets,
             credential_requirements,
         )
-        .with_provider_diagnostic(model_visible_cause.map(|diagnostic| *diagnostic)),
+        .with_provider_diagnostic(model_visible_cause),
     )
 }
 

--- a/crates/kernel/ironclaw_host_runtime/src/production.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/production.rs
@@ -740,15 +740,20 @@ impl HostRuntime for DefaultHostRuntime {
                 match error {
                     CapabilityInvocationError::AuthorizationRequiresAuth {
                         capability,
-                        required_secrets,
-                        credential_requirements,
-                        model_visible_cause,
-                    } => Ok(auth_required_outcome(
-                        capability,
-                        required_secrets,
-                        credential_requirements,
-                        model_visible_cause,
-                    )),
+                        requirement,
+                    } => {
+                        let ironclaw_host_api::dispatch::DispatchAuthRequirement {
+                            required_secrets,
+                            credential_requirements,
+                            model_visible_cause,
+                        } = *requirement;
+                        Ok(auth_required_outcome(
+                            capability,
+                            required_secrets,
+                            credential_requirements,
+                            model_visible_cause.map(Box::new),
+                        ))
+                    }
                     other => {
                         let is_standard_write =
                             capability_is_standard_write(&registry, &capability_id);

--- a/crates/kernel/ironclaw_host_runtime/src/services/extension_tool_binder.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/extension_tool_binder.rs
@@ -197,7 +197,7 @@ pub(super) fn tool_error_from_dispatch(error: DispatchError) -> ToolError {
         } => ToolError::AuthRequired {
             required_secrets,
             credential_requirements,
-            model_visible_cause: model_visible_cause.map(|diagnostic| *diagnostic),
+            model_visible_cause,
         },
         DispatchError::Wasm {
             kind,

--- a/crates/kernel/ironclaw_host_runtime/src/services/extension_tool_binder.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/extension_tool_binder.rs
@@ -189,16 +189,7 @@ where
 /// flow is preserved end to end.
 pub(super) fn tool_error_from_dispatch(error: DispatchError) -> ToolError {
     match error {
-        DispatchError::AuthRequired {
-            required_secrets,
-            credential_requirements,
-            model_visible_cause,
-            ..
-        } => ToolError::AuthRequired {
-            required_secrets,
-            credential_requirements,
-            model_visible_cause,
-        },
+        DispatchError::AuthRequired { requirement, .. } => ToolError::AuthRequired { requirement },
         DispatchError::Wasm {
             kind,
             model_visible_cause,

--- a/crates/kernel/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -11,6 +11,7 @@ use futures_util::FutureExt;
 use ironclaw_extension_registry::ExtensionPackage;
 use ironclaw_host_api::{
     capability::CapabilityDescriptor,
+    dispatch::DispatchAuthRequirement,
     ids::UserId,
     invocation::InvocationOrigin,
     mount::MountView,
@@ -465,9 +466,11 @@ where
                     credential_requirements,
                 } => DispatchError::AuthRequired {
                     capability: request.capability_id.clone(),
-                    required_secrets,
-                    credential_requirements,
-                    model_visible_cause: None,
+                    requirement: Box::new(DispatchAuthRequirement {
+                        required_secrets,
+                        credential_requirements,
+                        model_visible_cause: None,
+                    }),
                 },
                 McpError::ProviderRejected(rejection) => DispatchError::Rejected {
                     runtime: Some(RuntimeKind::Mcp),
@@ -858,9 +861,11 @@ where
                         ..
                     } => Err(DispatchError::AuthRequired {
                         capability: request.capability_id.clone(),
-                        required_secrets,
-                        credential_requirements,
-                        model_visible_cause: None,
+                        requirement: Box::new(DispatchAuthRequirement {
+                            required_secrets,
+                            credential_requirements,
+                            model_visible_cause: None,
+                        }),
                     }),
                     FirstPartyCapabilityError::Dispatch {
                         kind,

--- a/crates/kernel/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -474,7 +474,7 @@ where
                     kind: ironclaw_host_api::dispatch::DispatchFailureKind::Runtime(
                         RuntimeDispatchErrorKind::Client,
                     ),
-                    diagnostic: Some(rejection.diagnostic),
+                    diagnostic: Some(Box::new(rejection.diagnostic)),
                     detail: None,
                 },
                 error => DispatchError::Mcp {

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/extension_tool_binder.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/extension_tool_binder.rs
@@ -9,8 +9,8 @@ use ironclaw_extension_contracts::tool_adapter::{
     ToolCall, ToolCallResources, ToolError, ToolPorts,
 };
 use ironclaw_host_api::{
-    path::VirtualPath, resource::RuntimeResourceBudget, runtime::TrustClass,
-    trust::RequestedTrustClass,
+    dispatch::DispatchAuthRequirement, path::VirtualPath, resource::RuntimeResourceBudget,
+    runtime::TrustClass, trust::RequestedTrustClass,
 };
 
 use super::super::ExtensionToolBindError;
@@ -172,10 +172,8 @@ async fn binder_preserves_the_auth_gate_payload_across_the_tool_abi() {
         .unwrap_err();
 
     match err {
-        ToolError::AuthRequired {
-            required_secrets, ..
-        } => assert_eq!(
-            required_secrets,
+        ToolError::AuthRequired { requirement } => assert_eq!(
+            requirement.required_secrets,
             vec![SecretHandle::new("fixture_token").unwrap()]
         ),
         other => panic!("expected AuthRequired, got {other:?}"),
@@ -189,25 +187,26 @@ fn binder_preserves_the_raw_auth_diagnostic_across_the_tool_abi() {
     let error = crate::services::extension_tool_binder::tool_error_from_dispatch(
         DispatchError::AuthRequired {
             capability: CapabilityId::new("github.list_issues").unwrap(),
-            required_secrets: Vec::new(),
-            credential_requirements: Vec::new(),
-            model_visible_cause: Some(Box::new(ironclaw_host_api::dispatch::ProviderDiagnostic {
-                code: None,
-                message: Some(ironclaw_host_api::dispatch::UntrustedProviderMessage::new(
-                    diagnostic,
-                )),
-                retry_after: None,
-            })),
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: Vec::new(),
+                credential_requirements: Vec::new(),
+                model_visible_cause: Some(ironclaw_host_api::dispatch::ProviderDiagnostic {
+                    code: None,
+                    message: Some(ironclaw_host_api::dispatch::UntrustedProviderMessage::new(
+                        diagnostic,
+                    )),
+                    retry_after: None,
+                }),
+            }),
         },
     );
 
-    let ToolError::AuthRequired {
-        model_visible_cause: Some(cause),
-        ..
-    } = error
-    else {
+    let ToolError::AuthRequired { requirement } = error else {
         panic!("binder must preserve the auth diagnostic");
     };
+    let cause = requirement
+        .model_visible_cause
+        .expect("binder must preserve the auth diagnostic");
     assert_eq!(
         cause.message.as_ref().map(|message| message.as_str()),
         Some(diagnostic)

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/extension_tool_binder.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/extension_tool_binder.rs
@@ -225,13 +225,13 @@ fn binder_preserves_provider_rejection_across_the_tool_abi() {
         crate::services::extension_tool_binder::tool_error_from_dispatch(DispatchError::Rejected {
             runtime: Some(ironclaw_host_api::runtime::RuntimeKind::Mcp),
             kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Client),
-            diagnostic: Some(ironclaw_host_api::dispatch::ProviderDiagnostic {
+            diagnostic: Some(Box::new(ironclaw_host_api::dispatch::ProviderDiagnostic {
                 code: Some(ProviderErrorCode::new("mcp_tool_rejected")),
                 message: Some(ironclaw_host_api::dispatch::UntrustedProviderMessage::new(
                     "Bad credentials",
                 )),
                 retry_after: None,
-            }),
+            })),
             detail: None,
         });
 

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
@@ -294,16 +294,15 @@ async fn first_party_adapter_maps_handler_auth_required_to_dispatch_auth_require
     match result {
         Err(DispatchError::AuthRequired {
             capability,
-            required_secrets,
-            credential_requirements,
-            ..
+            requirement,
         }) => {
             assert_eq!(capability, descriptor.id);
             assert!(
-                required_secrets.is_empty(),
-                "auth_required() handler yields no required handles; got {required_secrets:?}"
+                requirement.required_secrets.is_empty(),
+                "auth_required() handler yields no required handles; got {:?}",
+                requirement.required_secrets
             );
-            assert!(credential_requirements.is_empty());
+            assert!(requirement.credential_requirements.is_empty());
         }
         other => panic!("expected AuthRequired, got {other:?}"),
     }
@@ -414,10 +413,8 @@ async fn first_party_adapter_forwards_required_secrets_from_auth_required_handle
         .await;
 
     match result {
-        Err(DispatchError::AuthRequired {
-            required_secrets, ..
-        }) => {
-            assert_eq!(required_secrets, vec![handle]);
+        Err(DispatchError::AuthRequired { requirement, .. }) => {
+            assert_eq!(requirement.required_secrets, vec![handle]);
         }
         other => panic!("expected AuthRequired, got {other:?}"),
     }
@@ -481,10 +478,10 @@ async fn first_party_adapter_forwards_credential_requirements_from_auth_required
 
     match result {
         Err(DispatchError::AuthRequired {
-            credential_requirements,
+            requirement: auth_requirement,
             ..
         }) => {
-            assert_eq!(credential_requirements, vec![requirement]);
+            assert_eq!(auth_requirement.credential_requirements, vec![requirement]);
         }
         other => panic!("expected AuthRequired, got {other:?}"),
     }

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
@@ -59,13 +59,11 @@ async fn mcp_adapter_maps_executor_auth_required_to_dispatch_auth_required() {
     match result {
         Err(DispatchError::AuthRequired {
             capability,
-            required_secrets,
-            credential_requirements,
-            ..
+            requirement: auth_requirement,
         }) => {
             assert_eq!(capability, descriptor.id);
-            assert!(required_secrets.is_empty());
-            assert_eq!(credential_requirements, vec![requirement]);
+            assert!(auth_requirement.required_secrets.is_empty());
+            assert_eq!(auth_requirement.credential_requirements, vec![requirement]);
         }
         other => panic!("expected AuthRequired, got {other:?}"),
     }

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
@@ -72,6 +72,82 @@ async fn mcp_adapter_maps_executor_auth_required_to_dispatch_auth_required() {
 }
 
 #[tokio::test]
+async fn mcp_adapter_maps_provider_rejection_to_typed_dispatch_rejection() {
+    let adapter = McpRuntimeAdapter::from_executor(Arc::new(ProviderRejectedMcpExecutor {
+        rejection: ironclaw_mcp::McpProviderRejection {
+            diagnostic: ironclaw_host_api::dispatch::ProviderDiagnostic {
+                code: Some(ironclaw_host_api::dispatch::ProviderErrorCode::new(
+                    "mcp_tool_rejected",
+                )),
+                message: Some(ironclaw_host_api::dispatch::UntrustedProviderMessage::new(
+                    "provider says no",
+                )),
+                retry_after: None,
+            },
+            receipt: ResourceReceipt {
+                id: ResourceReservationId::new(),
+                scope: sample_scope(),
+                status: ReservationStatus::Released,
+                estimate: ResourceEstimate::default(),
+                actual: None,
+            },
+            usage: ResourceUsage::default(),
+        },
+    }));
+    let descriptor = test_descriptor(RuntimeKind::Mcp, Vec::new());
+    let filesystem = DiskFilesystem::new();
+    let governor = InMemoryResourceGovernor::new();
+    let package = test_package(MCP_MANIFEST, "test");
+    let policy = policy_with(
+        FilesystemBackendKind::HostWorkspace,
+        ProcessBackendKind::LocalHost,
+        NetworkMode::DirectLogged,
+        SecretMode::ScrubbedEnv,
+    );
+
+    let result = adapter
+        .dispatch_json(RuntimeLaneRequest {
+            run_id: None,
+            origin: None,
+            package: &package,
+            descriptor: &descriptor,
+            filesystem: &filesystem,
+            governor: &governor,
+            runtime_policy: &policy,
+            capability_id: &descriptor.id,
+            scope: sample_scope(),
+            authenticated_actor_user_id: None,
+            estimate: ResourceEstimate::default(),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"query": "provider rejection through adapter"}),
+        })
+        .await;
+
+    match result {
+        Err(DispatchError::Rejected {
+            runtime: Some(RuntimeKind::Mcp),
+            kind:
+                ironclaw_host_api::dispatch::DispatchFailureKind::Runtime(
+                    ironclaw_host_api::dispatch::RuntimeDispatchErrorKind::Client,
+                ),
+            diagnostic: Some(diagnostic),
+            ..
+        }) => {
+            assert_eq!(
+                diagnostic.code.as_ref().map(|code| code.as_str()),
+                Some("mcp_tool_rejected")
+            );
+            assert_eq!(
+                diagnostic.message.as_ref().map(|message| message.as_str()),
+                Some("provider says no")
+            );
+        }
+        other => panic!("expected typed MCP rejection, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn mcp_adapter_preserves_executor_failure_cause() {
     // Regression (Phase 1): an MCP dispatch failure's raw cause — including
     // path/JSON delimiters — must ride the model-visible-cause channel so the
@@ -155,6 +231,10 @@ struct AuthRequiredMcpExecutor {
     requirement: RuntimeCredentialAuthRequirement,
 }
 
+struct ProviderRejectedMcpExecutor {
+    rejection: ironclaw_mcp::McpProviderRejection,
+}
+
 struct FailingMcpExecutor {
     reason: String,
 }
@@ -169,6 +249,17 @@ impl McpExecutor for FailingMcpExecutor {
         Err(McpError::Client {
             reason: self.reason.clone(),
         })
+    }
+}
+
+#[async_trait]
+impl McpExecutor for ProviderRejectedMcpExecutor {
+    async fn execute_extension_json(
+        &self,
+        _budget: &dyn RuntimeResourceBudget,
+        _request: McpExecutionRequest<'_>,
+    ) -> Result<McpExecutionResult, McpError> {
+        Err(McpError::ProviderRejected(Box::new(self.rejection.clone())))
     }
 }
 

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/wasm_execution_fault_profiles.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/wasm_execution_fault_profiles.rs
@@ -272,14 +272,11 @@ fn a_401_parks_for_reauth_and_is_never_reported_as_a_tool_failure() {
     // capability and credential requirements carried through, which only
     // `DispatchError::AuthRequired` does.
     let dispatch = wasm_guest_dispatch_error(&payload, &capability);
-    let DispatchError::AuthRequired {
-        model_visible_cause,
-        ..
-    } = &dispatch
-    else {
+    let DispatchError::AuthRequired { requirement, .. } = &dispatch else {
         panic!("an expired credential must produce an auth gate, got {dispatch:?}");
     };
-    let cause = model_visible_cause
+    let cause = requirement
+        .model_visible_cause
         .as_ref()
         .expect("auth rejection retains its raw model diagnostic");
     assert_eq!(
@@ -298,13 +295,12 @@ fn a_401_parks_for_reauth_and_is_never_reported_as_a_tool_failure() {
     })
     .to_string();
     let code_only_dispatch = wasm_guest_dispatch_error(&code_only_payload, &capability);
-    let DispatchError::AuthRequired {
-        model_visible_cause: Some(code_only_cause),
-        ..
-    } = code_only_dispatch
-    else {
+    let DispatchError::AuthRequired { requirement, .. } = code_only_dispatch else {
         panic!("a code-only auth rejection must retain its diagnostic");
     };
+    let code_only_cause = requirement
+        .model_visible_cause
+        .expect("a code-only auth rejection must retain its diagnostic");
     assert_eq!(
         code_only_cause.code.as_ref().map(|code| code.as_str()),
         Some("github_api_error_status_401")

--- a/crates/kernel/ironclaw_host_runtime/src/services/wasm_execution.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/wasm_execution.rs
@@ -17,7 +17,7 @@ use super::{
     RuntimeLaneRequest, WasmError, WitToolHost, WitToolRuntime,
 };
 use ironclaw_host_api::dispatch::{
-    ProviderDiagnostic, ProviderErrorCode, UntrustedProviderMessage,
+    DispatchAuthRequirement, ProviderDiagnostic, ProviderErrorCode, UntrustedProviderMessage,
 };
 use ironclaw_host_api::resource::ResourceReceipt;
 
@@ -296,9 +296,11 @@ fn wasm_guest_dispatch_error(error: &str, capability: &CapabilityId) -> Dispatch
     match wasm_guest_error_kind(error) {
         WasmGuestErrorKind::AuthRequired => DispatchError::AuthRequired {
             capability: capability.clone(),
-            required_secrets: Vec::new(),
-            credential_requirements: Vec::new(),
-            model_visible_cause: wasm_guest_provider_diagnostic(error).map(Box::new),
+            requirement: Box::new(DispatchAuthRequirement {
+                required_secrets: Vec::new(),
+                credential_requirements: Vec::new(),
+                model_visible_cause: wasm_guest_provider_diagnostic(error),
+            }),
         },
         WasmGuestErrorKind::Runtime(kind) => DispatchError::Wasm {
             kind,

--- a/tests/integration/model_recovery.rs
+++ b/tests/integration/model_recovery.rs
@@ -493,6 +493,13 @@ async fn output_truncation_recovers_without_shrinking_input_context() {
 
 #[tokio::test]
 async fn transcript_write_failure_stops_without_another_model_or_tool_side_effect() {
+    // This debug integration future exceeds libtest's default 2 MiB thread
+    // stack; box it on the heap. CI sets no `RUST_MIN_STACK`, and assertions
+    // remain unchanged in the helper below.
+    Box::pin(transcript_write_failure_stops_without_another_model_or_tool_side_effect_body()).await;
+}
+
+async fn transcript_write_failure_stops_without_another_model_or_tool_side_effect_body() {
     let harness = RebornIntegrationHarness::test_default()
         .with_keyed_http_responses([ScriptedHttpResponse::for_url(
             TRANSCRIPT_FAILURE_TOOL_URL,

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -656,7 +656,10 @@ async fn invalid_json_is_recoverable() {
 /// Bounded collection operations work for both scoped files and inline rows.
 #[tokio::test]
 async fn json_runs_bounded_collection_operations() {
-    let h = run_json_collection_analysis().await;
+    // This debug workflow future exceeds libtest's default 2 MiB thread stack;
+    // box it before awaiting. CI sets no `RUST_MIN_STACK`, and assertions remain
+    // unchanged.
+    let h = Box::pin(run_json_collection_analysis()).await;
     h.assert_tool_result_contains("value-15")
         .await
         .expect("last selects the final item from the scoped JSON array");


### PR DESCRIPTION
## Summary

- Bound the provider-auth error footprint with one shared `DispatchAuthRequirement`, boxed at the three real error boundaries: `DispatchError`, `ToolError`, and `CapabilityInvocationError`.
- Preserve required secrets, credential requirements, model-visible diagnostics, redaction, equality, and all existing auth/rejection semantics.
- Heap-pin the two oversized debug integration futures on libtest's default 2 MiB worker stack, following the existing `lease_wedge.rs` test pattern; workflow logic and assertions are unchanged.
- Add x86_64 size-budget guards for `DispatchError` (<= 72 B) and `ToolError` (<= 56 B).

The regression appeared in both the [merge-group run](https://github.com/nearai/ironclaw/actions/runs/32331942516) and the subsequent [main run](https://github.com/nearai/ironclaw/actions/runs/32332759674). Both exact failures reproduce on the original PR head under Cargo's standard `[unoptimized + debuginfo]` profile with `RUST_MIN_STACK` and `CARGO_PROFILE_TEST_DEBUG` unset. The earlier apparent green reproduction used `CARGO_PROFILE_TEST_DEBUG=0` and was not representative.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. Fixes the default-stack regression introduced by #7692.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] Affected-crate all-target clippy with `-D warnings`
- [x] Exact default-stack regression tests
- [x] Affected crate suites
- [x] `cargo test -p ironclaw_architecture_tests --jobs 2`
- [ ] Manual testing: not applicable; this is an internal Rust representation and test-harness fix

Exact reproductions passed on the final head with both stack/profile overrides unset:

```text
env -u RUST_MIN_STACK -u CARGO_PROFILE_TEST_DEBUG cargo test -p ironclaw_integration_tests --test reborn_integration_model_recovery transcript_write_failure_stops_without_another_model_or_tool_side_effect -- --exact --nocapture
env -u RUST_MIN_STACK -u CARGO_PROFILE_TEST_DEBUG cargo test -p ironclaw_integration_tests --test reborn_integration_tool_call json_runs_bounded_collection_operations -- --exact --nocapture
```

Additional commands passed:

```text
cargo test -p ironclaw_host_api -p ironclaw_extension_contracts -p ironclaw_capabilities -p ironclaw_host_runtime -p ironclaw_extension_host --jobs 2
cargo test -p ironclaw_architecture_tests --jobs 2
cargo clippy -p ironclaw_host_api -p ironclaw_extension_contracts -p ironclaw_capabilities -p ironclaw_host_runtime -p ironclaw_extension_host --all-targets -- -D warnings
cargo fmt --all -- --check
git diff --check
```

## Test Strategy

User behavior: capability failures continue to surface the same typed provider diagnostics. The two deep integration workflows now complete on libtest's default stack without a repository-wide stack-size override.

Risk areas:

- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Coverage by tier:

- Unit/contract: auth-requirement propagation, diagnostic preservation/redaction, equality, and error stack budgets.
- Reborn integration: the two existing production-wired workflows that reproduced the overflow.
- Recorded fixture: not applicable; no provider transcript behavior changed.
- Browser E2E: not applicable; no browser or wire behavior changed.
- Backend/runtime: affected host-runtime and extension-host contract suites pass.
- Live canary: not applicable; no deployment or credential is required to prove a Rust stack-layout regression.

What the tests prove: the exact merge-queue failures no longer overflow under the standard debug profile, auth requirements and typed diagnostics survive all mappings, error carriers remain within their stack budgets, and architecture/dependency boundaries remain intact.

## Security Impact

None. Authorization, diagnostic redaction, credential handling, network access, and runtime policy are unchanged.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: existing runtime adapters remain the constructors; only in-process auth-error storage changes.
- [x] Untrusted prompt content: unchanged; provider diagnostics retain the existing scrub/fence path.
- [x] Hash purpose/authenticity: not applicable; no hashes changed.
- [x] Changed errors/statuses: all producers, consumers, adapters, and test doubles were audited; no semantic variant was added or removed.
- [x] Durable serde defaults: not applicable; no serialized or durable field changed.
- [x] Queue/map/buffer bounds: not applicable; none changed.
- [x] Stable operator-visible error classes: existing classifications are preserved.
- [x] Trust-boundary naming: not applicable; no boundary names changed.

## Database Impact

None. No schema, query, persistence, or migration changed.

## Compatibility and Blast Radius

There is no wire or persistence compatibility change. This does change public Rust variant construction for internal workspace consumers: callers migrate the three auth fields to `requirement: Box<DispatchAuthRequirement>`. All in-repo producers, consumers, adapters, decorators, and test doubles were updated and tested.

The test-only heap placement changes neither production execution nor assertions. The production allocation occurs only on auth-required error paths.

## Rollback Plan

Revert `d30df4c66`. No data migration or external rollback is required; reverting also restores the reproducible default-stack overflow.

## Review Follow-Through

Multi-agent correctness and strict maintainability reviews found no remaining blocker. The reviewer concern was verified as valid and fixed rather than dismissed.

---

**Review track**: C (runtime regression)
