### PR TITLE
fix(ci): clear the clippy 1.98 lint cascade blocking the merge queue

### DIFF
--- a/crates/app/ironclaw_architecture_tests/tests/reborn_tracing_target_syntax.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_tracing_target_syntax.rs
@@ -116,7 +116,7 @@ fn skip_trivia(source: &str, mut cursor: usize) -> usize {
         }
         let rest = &source[cursor.min(source.len())..];
         if let Some(stripped) = rest.strip_prefix("//") {
-            cursor += 2 + stripped.find('\n').map_or(stripped.len(), |end| end);
+            cursor += 2 + stripped.find('\n').unwrap_or(stripped.len());
         } else if let Some(stripped) = rest.strip_prefix("/*") {
             cursor += 2 + stripped.find("*/").map_or(stripped.len(), |end| end + 2);
         } else {

--- a/crates/domains/ironclaw_trace_commons/src/onboarding/tests.rs
+++ b/crates/domains/ironclaw_trace_commons/src/onboarding/tests.rs
@@ -217,7 +217,7 @@ async fn successful_onboard_writes_policy_and_promotes_key() {
     // Verify parsed path is /v1/trace-upload-claim and host matches invite.
     let issuer_parsed = reqwest::Url::parse(expected_issuer_url.as_str()).unwrap();
     assert_eq!(issuer_parsed.path(), "/v1/trace-upload-claim");
-    assert_eq!(issuer_parsed.host_str().unwrap(), format!("127.0.0.1"));
+    assert_eq!(issuer_parsed.host_str().unwrap(), "127.0.0.1");
     assert_eq!(
         policy.ingestion_endpoint.as_deref(),
         Some("https://ingest.example.com")

--- a/crates/extensions/ironclaw_extension_support/src/coding/text.rs
+++ b/crates/extensions/ironclaw_extension_support/src/coding/text.rs
@@ -29,8 +29,10 @@ pub(super) fn decode_text(
         FileEncoding::Utf16Le => {
             let data = bytes.get(2..).unwrap_or_default();
             let units = data
-                .chunks_exact(2)
-                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|pair| u16::from_le_bytes(*pair))
                 .collect::<Vec<_>>();
             String::from_utf16(&units).map_err(|_| operation_error())?
         }
@@ -81,8 +83,10 @@ pub(super) fn decode_text_lossy(bytes: &[u8]) -> (String, FileEncoding, LineEndi
         FileEncoding::Utf16Le => {
             let data = bytes.get(2..).unwrap_or_default();
             let units = data
-                .chunks_exact(2)
-                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|pair| u16::from_le_bytes(*pair))
                 .collect::<Vec<_>>();
             String::from_utf16_lossy(&units)
         }

--- a/crates/extensions/ironclaw_extension_support/src/gsuite/credential.rs
+++ b/crates/extensions/ironclaw_extension_support/src/gsuite/credential.rs
@@ -27,7 +27,7 @@ pub struct GoogleCredential {
 #[derive(Debug, Error)]
 pub enum GoogleCredentialError {
     #[error("Google credential recovery is required")]
-    Recovery(CredentialRecoveryProjection),
+    Recovery(Box<CredentialRecoveryProjection>),
     #[error("Google credential account is missing required scopes")]
     MissingScopes { missing_scopes: Vec<ProviderScope> },
     #[error("Google credential account has no access secret")]
@@ -296,7 +296,7 @@ impl GoogleCredentialResolver {
             .project_recovery(scope, requester_extension, provider)
             .await
         {
-            Ok(recovery) => GoogleCredentialError::Recovery(recovery),
+            Ok(recovery) => GoogleCredentialError::Recovery(Box::new(recovery)),
             Err(error) => error,
         }
     }
@@ -418,7 +418,7 @@ mod tests {
             Vec::new(),
         );
         assert!(matches!(
-            GoogleCredentialError::Recovery(recovery.clone()),
+            GoogleCredentialError::Recovery(Box::new(recovery.clone())),
             GoogleCredentialError::Recovery(_)
         ));
         assert!(matches!(

--- a/crates/extensions/ironclaw_extension_support/src/gsuite/handlers.rs
+++ b/crates/extensions/ironclaw_extension_support/src/gsuite/handlers.rs
@@ -1233,7 +1233,7 @@ fn map_credential_error(error: GoogleCredentialError) -> GsuiteDispatchError {
     match error {
         GoogleCredentialError::Recovery(recovery) => {
             GsuiteDispatchError::new(map_recovery_kind(&recovery))
-                .with_reason(GsuiteCredentialDispatchReason::Recovery(Box::new(recovery)))
+                .with_reason(GsuiteCredentialDispatchReason::Recovery(recovery))
         }
         GoogleCredentialError::MissingScopes { missing_scopes } => {
             GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
@@ -1571,23 +1571,23 @@ mod tests {
     #[test]
     fn map_credential_error_tests() {
         assert_eq!(
-            map_credential_error(GoogleCredentialError::Recovery(
+            map_credential_error(GoogleCredentialError::Recovery(Box::new(
                 ironclaw_auth::CredentialRecoveryProjection::setup_required(
                     ironclaw_auth::AuthProviderId::new("google").unwrap(),
                     ironclaw_auth::CredentialRecoveryReason::NoAccount,
                     Vec::new(),
                 ),
-            ))
+            )))
             .kind(),
             RuntimeDispatchErrorKind::Client
         );
         assert_eq!(
-            map_credential_error(GoogleCredentialError::Recovery(
+            map_credential_error(GoogleCredentialError::Recovery(Box::new(
                 ironclaw_auth::CredentialRecoveryProjection::account_selection_required(
                     ironclaw_auth::AuthProviderId::new("google").unwrap(),
                     Vec::new(),
                 ),
-            ))
+            )))
             .kind(),
             RuntimeDispatchErrorKind::Client
         );
@@ -1634,7 +1634,7 @@ mod tests {
             Some(&GsuiteCredentialDispatchReason::HostApi)
         );
 
-        let configured_recovery = map_credential_error(GoogleCredentialError::Recovery(
+        let configured_recovery = map_credential_error(GoogleCredentialError::Recovery(Box::new(
             ironclaw_auth::CredentialRecoveryProjection::configured(
                 ironclaw_auth::AuthProviderId::new("google").unwrap(),
                 ironclaw_auth::CredentialAccountProjection {
@@ -1649,7 +1649,7 @@ mod tests {
                     secret_handle_count: 1,
                 },
             ),
-        ));
+        )));
         assert_eq!(
             configured_recovery.kind(),
             RuntimeDispatchErrorKind::Backend

--- a/crates/loop/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -139,7 +139,7 @@ struct InvokedCapabilityBatch {
 }
 
 struct InvokedCapabilityBatchError {
-    error: ironclaw_loop_contracts::AgentLoopHostError,
+    error: Box<ironclaw_loop_contracts::AgentLoopHostError>,
     launched_count: usize,
 }
 
@@ -226,7 +226,7 @@ impl CapabilityStage {
                 .await
                 .map(InvokedCapabilityBatch::from_resolution_batch)
                 .map_err(|error| InvokedCapabilityBatchError {
-                    error,
+                    error: Box::new(error),
                     launched_count: 0,
                 });
         }
@@ -283,10 +283,10 @@ impl CapabilityStage {
                 }
                 None => {
                     return Err(InvokedCapabilityBatchError {
-                        error: ironclaw_loop_contracts::AgentLoopHostError::new(
+                        error: Box::new(ironclaw_loop_contracts::AgentLoopHostError::new(
                             ironclaw_loop_contracts::AgentLoopHostErrorKind::Internal,
                             "parallel capability invocation completed without an indexed outcome",
-                        ),
+                        )),
                         launched_count: launched,
                     });
                 }
@@ -754,7 +754,7 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                     .completed_turn(ctx, state, result_refs_start, capability_batch)
                     .await;
             }
-            Err(failure) => return Err(capability_host_error(failure.error)),
+            Err(failure) => return Err(capability_host_error(*failure.error)),
         };
 
         let InvokedCapabilityBatch {

--- a/crates/loop/ironclaw_turn_runner/src/turn_run_executor.rs
+++ b/crates/loop/ironclaw_turn_runner/src/turn_run_executor.rs
@@ -112,7 +112,7 @@ enum DriverInvocationError {
         reason: String,
     },
     HostFinalizationFailed {
-        error: AgentLoopHostError,
+        error: Box<AgentLoopHostError>,
         cumulative_usage: Option<LoopModelUsage>,
     },
     DriverError {
@@ -405,7 +405,7 @@ impl RebornTurnRunExecutor {
             Ok(exit) => match host.finalize_terminal_output(&exit).await {
                 Ok(()) => Ok(exit),
                 Err(error) => Err(DriverInvocationError::HostFinalizationFailed {
-                    error,
+                    error: Box::new(error),
                     cumulative_usage: loop_exit_model_usage(&exit).or(claimed.state.model_usage),
                 }),
             },

--- a/crates/substrates/ironclaw_filesystem/src/vector.rs
+++ b/crates/substrates/ironclaw_filesystem/src/vector.rs
@@ -16,8 +16,10 @@ pub(crate) fn decode_embedding_blob(bytes: &[u8]) -> Option<Vec<f32>> {
     }
     Some(
         bytes
-            .chunks_exact(std::mem::size_of::<f32>())
-            .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .as_chunks::<{ std::mem::size_of::<f32>() }>()
+            .0
+            .iter()
+            .map(|chunk| f32::from_le_bytes(*chunk))
             .collect(),
     )
 }

--- a/tests/integration/support/db_write_measurement.rs
+++ b/tests/integration/support/db_write_measurement.rs
@@ -117,7 +117,7 @@ pub enum DbWriteMeasurementError {
     BeginAndCleanup {
         #[source]
         primary: DbProbeError,
-        cleanup: DbProbeError,
+        cleanup: Box<DbProbeError>,
     },
     #[error("measured workload failed: {0}")]
     Workload(#[source] BoxError),
@@ -125,7 +125,7 @@ pub enum DbWriteMeasurementError {
     WorkloadAndCleanup {
         #[source]
         primary: BoxError,
-        cleanup: DbProbeError,
+        cleanup: Box<DbProbeError>,
     },
     #[error("database probe capture failed: {0}")]
     Capture(#[source] DbProbeError),
@@ -133,7 +133,7 @@ pub enum DbWriteMeasurementError {
     CaptureAndCleanup {
         #[source]
         primary: DbProbeError,
-        cleanup: DbProbeError,
+        cleanup: Box<DbProbeError>,
     },
     #[error("database probe cleanup failed: {0}")]
     Cleanup(#[source] DbProbeError),
@@ -144,7 +144,7 @@ impl DbWriteMeasurementError {
         match self {
             Self::BeginAndCleanup { cleanup, .. }
             | Self::WorkloadAndCleanup { cleanup, .. }
-            | Self::CaptureAndCleanup { cleanup, .. } => Some(cleanup),
+            | Self::CaptureAndCleanup { cleanup, .. } => Some(cleanup.as_ref()),
             Self::Cleanup(error) => Some(error),
             Self::Begin(_) | Self::Workload(_) | Self::Capture(_) => None,
         }
@@ -165,7 +165,10 @@ where
         Err(primary) => {
             return match finish(config).await {
                 Ok(()) => Err(DbWriteMeasurementError::Begin(primary)),
-                Err(cleanup) => Err(DbWriteMeasurementError::BeginAndCleanup { primary, cleanup }),
+                Err(cleanup) => Err(DbWriteMeasurementError::BeginAndCleanup {
+                    primary,
+                    cleanup: Box::new(cleanup),
+                }),
             };
         }
     };
@@ -176,9 +179,10 @@ where
         Err(primary) => {
             return match finish(config).await {
                 Ok(()) => Err(DbWriteMeasurementError::Workload(primary)),
-                Err(cleanup) => {
-                    Err(DbWriteMeasurementError::WorkloadAndCleanup { primary, cleanup })
-                }
+                Err(cleanup) => Err(DbWriteMeasurementError::WorkloadAndCleanup {
+                    primary,
+                    cleanup: Box::new(cleanup),
+                }),
             };
         }
     };
@@ -188,9 +192,10 @@ where
         Err(primary) => {
             return match finish(config).await {
                 Ok(()) => Err(DbWriteMeasurementError::Capture(primary)),
-                Err(cleanup) => {
-                    Err(DbWriteMeasurementError::CaptureAndCleanup { primary, cleanup })
-                }
+                Err(cleanup) => Err(DbWriteMeasurementError::CaptureAndCleanup {
+                    primary,
+                    cleanup: Box::new(cleanup),
+                }),
             };
         }
     };


### PR DESCRIPTION
## Summary

CI resolves its toolchain as floating `stable` (`dtolnay/rust-toolchain@29eef33 # stable`), and a new clippy promoted several lints at once. `main` is currently **red** on the `Check all-target lints` step ([run 32397319267](https://github.com/nearai/ironclaw/actions/runs/32397319267)). This PR clears the whole resulting cascade.

**Why this PR grew.** The full-workspace lint never runs on a PR — `code_style.yml:421` gates it on `github.event_name != 'pull_request'`, so the PR lane lints only the *changed* packages. This PR was green as a PR and failed the instant the merge queue ran the full lane, which is what ejected it ([run 32402014261](https://github.com/nearai/ironclaw/actions/runs/32402014261)). And because `-D warnings` stops a crate from compiling, each failure hid the next behind it: fixing `ironclaw_filesystem` is what let clippy reach the crates below it.

Walking the cascade to its end, with the lint's own suggestion at each step and no behavior change:

| Crate / area | Lint | Fix |
|---|---|---|
| `ironclaw_filesystem` | `chunks_exact_to_as_chunks` | `as_chunks::<{size_of::<f32>()}>()`; `from_le_bytes(*chunk)` replaces the manual 4-index copy |
| `ironclaw_extension_support` | `chunks_exact_to_as_chunks` ×2 | `as_chunks::<2>()` in the two UTF-16LE decoders |
| `ironclaw_extension_support` | `result_large_err` ×9 | Boxed the 184-byte `GoogleCredentialError::Recovery` payload; this also drops a now-double `Box::new` in `handlers.rs` |
| `ironclaw_agent_loop` | `result_large_err` | Boxed the host error inside `InvokedCapabilityBatchError` |
| `ironclaw_turn_runner` | `result_large_err` | Boxed the host error inside `DriverInvocationError::HostFinalizationFailed` |
| `ironclaw_architecture_tests` | `map_or_identity` | `map_or(x, \|e\| e)` → `unwrap_or(x)` |
| `ironclaw_trace_commons` | `useless_format` | `format!("127.0.0.1")` → plain `&str` comparison |
| `tests/integration/support` | `result_large_err` | Boxed the secondary `cleanup` cause in the three paired `DbWriteMeasurementError` variants |

Boxing matches the existing `GsuiteCredentialDispatchReason::Recovery(Box<..>)` sitting next door in `handlers.rs`. Every remaining `Recovery(..)` site is a match pattern, where the binding derefs transparently.

## Change Type

- [x] Refactor
- [x] CI / build

## Linked Issue

None (CI unblock; first surfaced on the docs-only #7763, then ejected #7777 from the merge queue).

## Validation

Run locally on clippy 1.98.0 / rustc 1.98.0 — the same floating `stable` CI resolves — across **all three merge-queue lanes, workspace-wide**:

- [x] `cargo clippy --all --tests --examples --all-features -- -D warnings` — exit 0
- [x] `cargo clippy --all --tests --examples -- -D warnings` — exit 0
- [x] `cargo clippy --all --lib --bins -- -D warnings` — exit 0
- [x] `cargo fmt --all --check` — exit 0
- [x] `cargo test -p ironclaw_extension_support -p ironclaw_agent_loop -p ironclaw_turn_runner -p ironclaw_trace_commons` — 1367 passed, 0 failed
- [x] `cargo test -p ironclaw_architecture_tests` — 312 passed, 0 failed

The local `ironclaw_webui` build script needs `SKIP_FRONTEND_BUILD=1` on this box (broken corepack/node, unrelated to the change); CI builds the frontend for real. The Rust crate still lints either way — `SKIP_FRONTEND_BUILD` only empties the embedded `ASSETS` slice.

## Test Strategy

**User behavior:** None. Every hunk is an equivalent-code rewrite.

**Risk areas:** The boxed error variants change struct layout but not values, matching, `Display`, or `#[source]` chains. `cleanup_error()` keeps returning `Option<&DbProbeError>` via `as_ref()`.

**Tests added or updated:** None. `Not applicable: lint-driven equivalent rewrites; the existing suites for each touched crate pin the behavior.`

**What the tests prove:** UTF-16LE decode and blob decode are byte-identical; credential recovery still routes to the same dispatch kinds and reasons (`map_credential_error_tests`); capability-batch and turn-finalization error paths still carry the same host error to the same terminal handling.

**Commands run:** see Validation.

## Follow-up risk

The floating `stable` toolchain means the next clippy release can red `main` again with no repo change, and the PR lane structurally cannot catch it — it only ever lints changed packages. Pinning the toolchain (a `rust-toolchain.toml`, or a version on the action) would turn that into a deliberate, reviewable bump. Worth filing separately; deliberately not done here to keep this PR to the unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
