### PR TITLE
fix(lints): Rust 1.98 clippy migration (unbreaks all-branch CI)

### DIFF
--- a/crates/app/ironclaw_architecture_tests/tests/reborn_tracing_target_syntax.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_tracing_target_syntax.rs
@@ -116,7 +116,7 @@ fn skip_trivia(source: &str, mut cursor: usize) -> usize {
         }
         let rest = &source[cursor.min(source.len())..];
         if let Some(stripped) = rest.strip_prefix("//") {
-            cursor += 2 + stripped.find('\n').map_or(stripped.len(), |end| end);
+            cursor += 2 + stripped.find('\n').unwrap_or(stripped.len());
         } else if let Some(stripped) = rest.strip_prefix("/*") {
             cursor += 2 + stripped.find("*/").map_or(stripped.len(), |end| end + 2);
         } else {

--- a/crates/domains/ironclaw_trace_commons/src/onboarding/tests.rs
+++ b/crates/domains/ironclaw_trace_commons/src/onboarding/tests.rs
@@ -217,7 +217,7 @@ async fn successful_onboard_writes_policy_and_promotes_key() {
     // Verify parsed path is /v1/trace-upload-claim and host matches invite.
     let issuer_parsed = reqwest::Url::parse(expected_issuer_url.as_str()).unwrap();
     assert_eq!(issuer_parsed.path(), "/v1/trace-upload-claim");
-    assert_eq!(issuer_parsed.host_str().unwrap(), format!("127.0.0.1"));
+    assert_eq!(issuer_parsed.host_str().unwrap(), "127.0.0.1".to_string());
     assert_eq!(
         policy.ingestion_endpoint.as_deref(),
         Some("https://ingest.example.com")

--- a/crates/extensions/ironclaw_extension_support/src/coding/text.rs
+++ b/crates/extensions/ironclaw_extension_support/src/coding/text.rs
@@ -29,8 +29,10 @@ pub(super) fn decode_text(
         FileEncoding::Utf16Le => {
             let data = bytes.get(2..).unwrap_or_default();
             let units = data
-                .chunks_exact(2)
-                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|pair| u16::from_le_bytes(*pair))
                 .collect::<Vec<_>>();
             String::from_utf16(&units).map_err(|_| operation_error())?
         }
@@ -81,8 +83,10 @@ pub(super) fn decode_text_lossy(bytes: &[u8]) -> (String, FileEncoding, LineEndi
         FileEncoding::Utf16Le => {
             let data = bytes.get(2..).unwrap_or_default();
             let units = data
-                .chunks_exact(2)
-                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|pair| u16::from_le_bytes(*pair))
                 .collect::<Vec<_>>();
             String::from_utf16_lossy(&units)
         }

--- a/crates/extensions/ironclaw_extension_support/src/gsuite/credential.rs
+++ b/crates/extensions/ironclaw_extension_support/src/gsuite/credential.rs
@@ -27,7 +27,9 @@ pub struct GoogleCredential {
 #[derive(Debug, Error)]
 pub enum GoogleCredentialError {
     #[error("Google credential recovery is required")]
-    Recovery(CredentialRecoveryProjection),
+    // Boxed: the projection is the enum's outlier (Rust 1.98
+    // `result_large_err`) and every `Result` in this module paid its size.
+    Recovery(Box<CredentialRecoveryProjection>),
     #[error("Google credential account is missing required scopes")]
     MissingScopes { missing_scopes: Vec<ProviderScope> },
     #[error("Google credential account has no access secret")]
@@ -296,7 +298,7 @@ impl GoogleCredentialResolver {
             .project_recovery(scope, requester_extension, provider)
             .await
         {
-            Ok(recovery) => GoogleCredentialError::Recovery(recovery),
+            Ok(recovery) => GoogleCredentialError::Recovery(Box::new(recovery)),
             Err(error) => error,
         }
     }
@@ -418,7 +420,7 @@ mod tests {
             Vec::new(),
         );
         assert!(matches!(
-            GoogleCredentialError::Recovery(recovery.clone()),
+            GoogleCredentialError::Recovery(Box::new(recovery.clone())),
             GoogleCredentialError::Recovery(_)
         ));
         assert!(matches!(

--- a/crates/extensions/ironclaw_extension_support/src/gsuite/handlers.rs
+++ b/crates/extensions/ironclaw_extension_support/src/gsuite/handlers.rs
@@ -1233,7 +1233,7 @@ fn map_credential_error(error: GoogleCredentialError) -> GsuiteDispatchError {
     match error {
         GoogleCredentialError::Recovery(recovery) => {
             GsuiteDispatchError::new(map_recovery_kind(&recovery))
-                .with_reason(GsuiteCredentialDispatchReason::Recovery(Box::new(recovery)))
+                .with_reason(GsuiteCredentialDispatchReason::Recovery(recovery))
         }
         GoogleCredentialError::MissingScopes { missing_scopes } => {
             GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
@@ -1571,23 +1571,23 @@ mod tests {
     #[test]
     fn map_credential_error_tests() {
         assert_eq!(
-            map_credential_error(GoogleCredentialError::Recovery(
+            map_credential_error(GoogleCredentialError::Recovery(Box::new(
                 ironclaw_auth::CredentialRecoveryProjection::setup_required(
                     ironclaw_auth::AuthProviderId::new("google").unwrap(),
                     ironclaw_auth::CredentialRecoveryReason::NoAccount,
                     Vec::new(),
                 ),
-            ))
+            )))
             .kind(),
             RuntimeDispatchErrorKind::Client
         );
         assert_eq!(
-            map_credential_error(GoogleCredentialError::Recovery(
+            map_credential_error(GoogleCredentialError::Recovery(Box::new(
                 ironclaw_auth::CredentialRecoveryProjection::account_selection_required(
                     ironclaw_auth::AuthProviderId::new("google").unwrap(),
                     Vec::new(),
                 ),
-            ))
+            )))
             .kind(),
             RuntimeDispatchErrorKind::Client
         );
@@ -1634,7 +1634,7 @@ mod tests {
             Some(&GsuiteCredentialDispatchReason::HostApi)
         );
 
-        let configured_recovery = map_credential_error(GoogleCredentialError::Recovery(
+        let configured_recovery = map_credential_error(GoogleCredentialError::Recovery(Box::new(
             ironclaw_auth::CredentialRecoveryProjection::configured(
                 ironclaw_auth::AuthProviderId::new("google").unwrap(),
                 ironclaw_auth::CredentialAccountProjection {
@@ -1649,7 +1649,7 @@ mod tests {
                     secret_handle_count: 1,
                 },
             ),
-        ));
+        )));
         assert_eq!(
             configured_recovery.kind(),
             RuntimeDispatchErrorKind::Backend

--- a/crates/loop/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -139,7 +139,9 @@ struct InvokedCapabilityBatch {
 }
 
 struct InvokedCapabilityBatchError {
-    error: ironclaw_loop_contracts::AgentLoopHostError,
+    // Boxed: `AgentLoopHostError` is ≥128 bytes (Rust 1.98 `result_large_err`)
+    // and this struct rides every batch `Result`.
+    error: Box<ironclaw_loop_contracts::AgentLoopHostError>,
     launched_count: usize,
 }
 
@@ -226,7 +228,7 @@ impl CapabilityStage {
                 .await
                 .map(InvokedCapabilityBatch::from_resolution_batch)
                 .map_err(|error| InvokedCapabilityBatchError {
-                    error,
+                    error: Box::new(error),
                     launched_count: 0,
                 });
         }
@@ -283,10 +285,10 @@ impl CapabilityStage {
                 }
                 None => {
                     return Err(InvokedCapabilityBatchError {
-                        error: ironclaw_loop_contracts::AgentLoopHostError::new(
+                        error: Box::new(ironclaw_loop_contracts::AgentLoopHostError::new(
                             ironclaw_loop_contracts::AgentLoopHostErrorKind::Internal,
                             "parallel capability invocation completed without an indexed outcome",
-                        ),
+                        )),
                         launched_count: launched,
                     });
                 }
@@ -754,7 +756,7 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                     .completed_turn(ctx, state, result_refs_start, capability_batch)
                     .await;
             }
-            Err(failure) => return Err(capability_host_error(failure.error)),
+            Err(failure) => return Err(capability_host_error(*failure.error)),
         };
 
         let InvokedCapabilityBatch {

--- a/crates/loop/ironclaw_turn_runner/src/turn_run_executor.rs
+++ b/crates/loop/ironclaw_turn_runner/src/turn_run_executor.rs
@@ -112,7 +112,10 @@ enum DriverInvocationError {
         reason: String,
     },
     HostFinalizationFailed {
-        error: AgentLoopHostError,
+        // Boxed: `AgentLoopHostError` is the enum's ≥128-byte outlier (Rust
+        // 1.98 `result_large_err`); the `DriverError` variant stays unboxed
+        // because five match sites destructure its payload by pattern.
+        error: Box<AgentLoopHostError>,
         cumulative_usage: Option<LoopModelUsage>,
     },
     DriverError {
@@ -405,7 +408,7 @@ impl RebornTurnRunExecutor {
             Ok(exit) => match host.finalize_terminal_output(&exit).await {
                 Ok(()) => Ok(exit),
                 Err(error) => Err(DriverInvocationError::HostFinalizationFailed {
-                    error,
+                    error: Box::new(error),
                     cumulative_usage: loop_exit_model_usage(&exit).or(claimed.state.model_usage),
                 }),
             },

--- a/crates/substrates/ironclaw_filesystem/src/vector.rs
+++ b/crates/substrates/ironclaw_filesystem/src/vector.rs
@@ -14,10 +14,16 @@ pub(crate) fn decode_embedding_blob(bytes: &[u8]) -> Option<Vec<f32>> {
     if bytes.is_empty() || !bytes.len().is_multiple_of(std::mem::size_of::<f32>()) {
         return None;
     }
+    // `as_chunks` over `chunks_exact` (clippy `chunks_exact_to_as_chunks`,
+    // new in Rust 1.98): the const chunk size gives `[u8; 4]` arrays directly,
+    // so the per-element indexing disappears. The remainder is empty by the
+    // multiple-of-size check above.
     Some(
         bytes
-            .chunks_exact(std::mem::size_of::<f32>())
-            .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .as_chunks::<{ std::mem::size_of::<f32>() }>()
+            .0
+            .iter()
+            .map(|chunk| f32::from_le_bytes(*chunk))
             .collect(),
     )
 }

--- a/tests/integration/support/db_write_measurement.rs
+++ b/tests/integration/support/db_write_measurement.rs
@@ -112,12 +112,12 @@ impl CanonicalDbWriteMeasurementReport {
 #[derive(Debug, thiserror::Error)]
 pub enum DbWriteMeasurementError {
     #[error("database probe begin failed: {0}")]
-    Begin(#[source] DbProbeError),
+    Begin(#[source] Box<DbProbeError>),
     #[error("database probe begin failed: {primary}; cleanup also failed: {cleanup}")]
     BeginAndCleanup {
         #[source]
-        primary: DbProbeError,
-        cleanup: DbProbeError,
+        primary: Box<DbProbeError>,
+        cleanup: Box<DbProbeError>,
     },
     #[error("measured workload failed: {0}")]
     Workload(#[source] BoxError),
@@ -125,18 +125,18 @@ pub enum DbWriteMeasurementError {
     WorkloadAndCleanup {
         #[source]
         primary: BoxError,
-        cleanup: DbProbeError,
+        cleanup: Box<DbProbeError>,
     },
     #[error("database probe capture failed: {0}")]
-    Capture(#[source] DbProbeError),
+    Capture(#[source] Box<DbProbeError>),
     #[error("database probe capture failed: {primary}; cleanup also failed: {cleanup}")]
     CaptureAndCleanup {
         #[source]
-        primary: DbProbeError,
-        cleanup: DbProbeError,
+        primary: Box<DbProbeError>,
+        cleanup: Box<DbProbeError>,
     },
     #[error("database probe cleanup failed: {0}")]
-    Cleanup(#[source] DbProbeError),
+    Cleanup(#[source] Box<DbProbeError>),
 }
 
 impl DbWriteMeasurementError {
@@ -164,8 +164,11 @@ where
         Ok(before) => before,
         Err(primary) => {
             return match finish(config).await {
-                Ok(()) => Err(DbWriteMeasurementError::Begin(primary)),
-                Err(cleanup) => Err(DbWriteMeasurementError::BeginAndCleanup { primary, cleanup }),
+                Ok(()) => Err(DbWriteMeasurementError::Begin(Box::new(primary))),
+                Err(cleanup) => Err(DbWriteMeasurementError::BeginAndCleanup {
+                    primary: Box::new(primary),
+                    cleanup: Box::new(cleanup),
+                }),
             };
         }
     };
@@ -176,9 +179,10 @@ where
         Err(primary) => {
             return match finish(config).await {
                 Ok(()) => Err(DbWriteMeasurementError::Workload(primary)),
-                Err(cleanup) => {
-                    Err(DbWriteMeasurementError::WorkloadAndCleanup { primary, cleanup })
-                }
+                Err(cleanup) => Err(DbWriteMeasurementError::WorkloadAndCleanup {
+                    primary,
+                    cleanup: Box::new(cleanup),
+                }),
             };
         }
     };
@@ -187,16 +191,17 @@ where
         Ok(after) => after,
         Err(primary) => {
             return match finish(config).await {
-                Ok(()) => Err(DbWriteMeasurementError::Capture(primary)),
-                Err(cleanup) => {
-                    Err(DbWriteMeasurementError::CaptureAndCleanup { primary, cleanup })
-                }
+                Ok(()) => Err(DbWriteMeasurementError::Capture(Box::new(primary))),
+                Err(cleanup) => Err(DbWriteMeasurementError::CaptureAndCleanup {
+                    primary: Box::new(primary),
+                    cleanup: Box::new(cleanup),
+                }),
             };
         }
     };
     finish(config)
         .await
-        .map_err(DbWriteMeasurementError::Cleanup)?;
+        .map_err(|error| DbWriteMeasurementError::Cleanup(Box::new(error)))?;
 
     let backend = match config.target() {
         DbProbeTarget::LibSql { .. } => MeasuredStorageBackend::Libsql,


### PR DESCRIPTION
Rust stable 1.98 rolled through CI today (clippy lanes float on stable) and armed four new lints that fail `-D warnings` on every branch. This PR makes the whole workspace clean under 1.98 (`cargo +1.98.0 clippy --workspace --all-features --tests -- -D warnings`: zero errors):

- **`chunks_exact_to_as_chunks`** — `decode_embedding_blob` (filesystem) and the two UTF-16 decoders (`coding/text.rs`). `as_chunks` is better code: const chunk size yields the arrays directly.
- **`result_large_err`** — `GoogleCredentialError` boxes its `Recovery` projection (one variant, nine warnings); `agent_loop`'s batch error boxes its host error; `turn_runner` boxes only `HostFinalizationFailed`'s payload (`DriverError` stays unboxed: five match sites destructure it by pattern and it is not the oversized member); `db_write_measurement` (test support) boxes its probe errors.
- **`map_or_identity`** — one site in an architecture test.
- **`useless_format`** — one trace_commons test.

All private types or contained call sites; no public API changes beyond boxed variant payloads inside their own crates. Behavior pinned by existing tests.

## Test Strategy
- Crate tier: existing unit tests pin decode/error behavior (vector: 6 passed; hooks/assistant/runner suites unaffected).
- Integration/E2E: Not applicable: lint conformance, no behavior change.

Landing this on main unbreaks every open branch's Clippy lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)