### PR TITLE
fix(llm): preserve OpenAI-compatible reasoning-only responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7803,9 +7803,9 @@ dependencies = [
 
 [[package]]
 name = "rig-core"
-version = "0.33.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a529b9b72f51a46a9ea87c9ba8031e36593de7a89461983f01d8c24462f9eb06"
+checksum = "9ac7d75266ac1f79b1faeff611c85cb40be00a0a983db10036591424f0433dc1"
 dependencies = [
  "as-any",
  "async-stream",

--- a/crates/domains/ironclaw_llm/CONTRACT.md
+++ b/crates/domains/ironclaw_llm/CONTRACT.md
@@ -371,11 +371,12 @@ capture-server tests in both files.
 - **System messages** are extracted into the rig-core `preamble` field (concatenated with newlines if multiple).
 - **Tool call IDs** are generated (`generated_tool_call_{seed}`) if the provider returns empty/whitespace IDs.
 - **Tool name normalization**: strips `proxy_` prefix if it matches a known tool (handles some proxy implementations).
+- **OpenAI-compatible reasoning-only responses**: rig-core 0.36 `reasoning_content` is preserved separately from assistant text by both plain and tool-capable non-streaming completions.
 - **OpenAI uses Chat Completions API** (`completions_api()`), not the newer Responses API — the Responses API path panics when tool results are sent back (rig-core doesn't thread `call_id` through `ToolCall`).
 
 ## Streaming Support
 
-`LlmProvider` exposes `complete_streaming()` and `complete_with_tools_streaming()` for provider text deltas. Native streaming is enabled only where IronClaw can observe an authoritative terminal event: NEAR AI, Anthropic OAuth, and Codex Responses. Rig-backed OpenAI Chat Completions and Anthropic API-key providers retain the buffered trait fallback because rig-core 0.33 synthesizes its final response after EOF, so IronClaw cannot distinguish completion from truncation. Other unvalidated providers also remain buffered, including custom OpenAI-compatible endpoints, Gemini OAuth, GitHub Copilot, Bedrock, and Rig-backed Ollama, DeepSeek, OpenRouter, and native Gemini.
+`LlmProvider` exposes `complete_streaming()` and `complete_with_tools_streaming()` for provider text deltas. Native streaming is enabled only where IronClaw can observe an authoritative terminal event: NEAR AI, Anthropic OAuth, and Codex Responses. Rig-backed OpenAI Chat Completions and Anthropic API-key providers retain the buffered trait fallback because rig-core 0.36 synthesizes its final response after EOF, so IronClaw cannot distinguish completion from truncation. Other unvalidated providers also remain buffered, including custom OpenAI-compatible endpoints, Gemini OAuth, GitHub Copilot, Bedrock, and Rig-backed Ollama, DeepSeek, OpenRouter, and native Gemini.
 
 Text deltas are advisory UI progress; the returned response remains authoritative for text, tool calls, finish reason, reasoning artifacts, and usage. Provider decorators must forward both streaming methods. Retry or failover must not append a replacement after visible partial text unless the sink advertises atomic text-replacement support. The response cache bypasses lookup for streaming calls because a stored response cannot reproduce provider deltas honestly.
 

--- a/crates/domains/ironclaw_llm/Cargo.toml
+++ b/crates/domains/ironclaw_llm/Cargo.toml
@@ -45,7 +45,9 @@ rand = "0.10"
 urlencoding = "2"
 regex = "1"
 reqwest = { version = "0.13", default-features = false, features = ["form", "json", "multipart", "rustls", "stream", "system-proxy"] }
-rig-core = { version = "0.33", default-features = false, features = ["reqwest-rustls"] }
+# Rig 0.36 preserves non-streaming OpenAI-compatible `reasoning_content`.
+# Older releases classify valid reasoning-only Qwen responses as empty.
+rig-core = { version = "0.36", default-features = false, features = ["reqwest", "rustls"] }
 rust_decimal = { version = "1", features = ["serde", "serde-with-str", "maths"] }
 rust_decimal_macros = "1"
 secrecy = { version = "0.10", features = ["serde"] }

--- a/crates/domains/ironclaw_llm/src/lib.rs
+++ b/crates/domains/ironclaw_llm/src/lib.rs
@@ -1987,6 +1987,95 @@ mod tests {
         }
     }
 
+    /// Regression for Qwen 3.8 responses whose final non-streaming message
+    /// contains provider reasoning but neither plain text nor a tool call.
+    ///
+    /// SGLang correctly returns that reasoning in the OpenAI-compatible
+    /// `reasoning_content` field. The registry provider must preserve it
+    /// instead of failing the whole call as an empty response.
+    #[tokio::test]
+    async fn openai_compatible_nonstreaming_preserves_reasoning_only_response() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback listener");
+        let address = listener.local_addr().expect("loopback address");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 4096];
+            loop {
+                let read = socket.read(&mut buffer).await.expect("read request");
+                assert!(read > 0, "connection closed before request arrived");
+                request.extend_from_slice(&buffer[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let response_body = serde_json::json!({
+                "id": "chatcmpl-qwen-reasoning-only",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "Qwen/Qwen3.8-27B",
+                "system_fingerprint": null,
+                "choices": [{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "reasoning_content": "I should inspect the available tools first.",
+                        "tool_calls": []
+                    },
+                    "logprobs": null,
+                    "finish_reason": "stop"
+                }],
+                "usage": {
+                    "prompt_tokens": 12,
+                    "completion_tokens": 9,
+                    "total_tokens": 21
+                }
+            })
+            .to_string();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+
+        let config = RegistryProviderConfig::generic(
+            ProviderProtocol::OpenAiCompletions,
+            "openai-compatible",
+            Some(secrecy::SecretString::from("test-key".to_string())),
+            format!("http://{address}"),
+            "Qwen/Qwen3.8-27B",
+        );
+        let provider = create_registry_provider_inner(&config, 5)
+            .expect("registry provider construction succeeds");
+
+        let response = provider
+            .complete_with_tools(ToolCompletionRequest::new(
+                vec![ChatMessage::user("Inspect the tools")],
+                Vec::new(),
+            ))
+            .await
+            .expect("reasoning-only response must not be classified as empty");
+        server.await.expect("loopback server task");
+
+        assert_eq!(
+            response.reasoning.as_deref(),
+            Some("I should inspect the available tools first.")
+        );
+        assert!(response.content.is_none());
+        assert!(response.tool_calls.is_empty());
+    }
+
     #[test]
     fn test_normalize_openai_base_url_leaves_v1_alone() {
         assert_eq!(

--- a/crates/domains/ironclaw_llm/src/lib.rs
+++ b/crates/domains/ironclaw_llm/src/lib.rs
@@ -683,7 +683,7 @@ fn create_deepseek_from_registry(
     Ok(Arc::new(
         RigAdapter::new(model, &config.model)
             .with_provider_id(config.provider_id.clone())
-            // rig-core 0.33's DeepSeek request serializer silently omits
+            // rig-core 0.36's DeepSeek request serializer silently omits
             // `output_schema`; reject structured-output requests at the
             // provider boundary instead of claiming the contract was sent.
             .with_structured_output_support(false)
@@ -779,7 +779,7 @@ fn create_openrouter_from_registry(
     Ok(Arc::new(
         RigAdapter::new(model, &config.model)
             .with_provider_id(config.provider_id.clone())
-            // rig-core 0.33's OpenRouter request serializer silently omits
+            // rig-core 0.36's OpenRouter request serializer silently omits
             // `output_schema`; reject structured-output requests at the
             // provider boundary instead of claiming the contract was sent.
             .with_structured_output_support(false)
@@ -2060,10 +2060,9 @@ mod tests {
             .expect("registry provider construction succeeds");
 
         let response = provider
-            .complete_with_tools(ToolCompletionRequest::new(
-                vec![ChatMessage::user("Inspect the tools")],
-                Vec::new(),
-            ))
+            .complete(CompletionRequest::new(vec![ChatMessage::user(
+                "Inspect the tools",
+            )]))
             .await
             .expect("reasoning-only response must not be classified as empty");
         server.await.expect("loopback server task");
@@ -2072,8 +2071,7 @@ mod tests {
             response.reasoning.as_deref(),
             Some("I should inspect the available tools first.")
         );
-        assert!(response.content.is_none());
-        assert!(response.tool_calls.is_empty());
+        assert!(response.content.is_empty());
     }
 
     #[test]

--- a/crates/domains/ironclaw_llm/src/rig_adapter.rs
+++ b/crates/domains/ironclaw_llm/src/rig_adapter.rs
@@ -2006,6 +2006,7 @@ mod tests {
                     output_tokens: 1,
                     total_tokens: 2,
                     cached_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
                 },
                 raw_response: serde_json::json!({}),
                 message_id: None,
@@ -2517,6 +2518,7 @@ mod tests {
                 output_tokens: self.output_tokens,
                 total_tokens: self.input_tokens + self.output_tokens,
                 cached_input_tokens: 0,
+                cache_creation_input_tokens: 0,
             })
         }
     }

--- a/crates/domains/ironclaw_llm/src/rig_adapter.rs
+++ b/crates/domains/ironclaw_llm/src/rig_adapter.rs
@@ -70,7 +70,7 @@ pub struct RigAdapter<M: CompletionModel> {
     native_streaming: bool,
     /// Whether this rig-core provider serializes `CompletionRequest::output_schema`.
     ///
-    /// rig-core 0.33's dedicated DeepSeek and OpenRouter request paths accept
+    /// rig-core 0.36's dedicated DeepSeek and OpenRouter request paths accept
     /// the field in the shared request type but omit it from their wire
     /// payloads. Keep that limitation explicit at the adapter boundary rather
     /// than silently dispatching a request whose structured-output contract is
@@ -432,21 +432,16 @@ impl<M: CompletionModel> RigAdapter<M> {
         // completed call. Raising it here, before a response object exists,
         // is what lets retry and failover see a failure instead of a success.
         //
-        // What this actually detects, in rig-core 0.33: **Ollama only**. Its
-        // stream yields `FinalResponse` solely inside `if response.done`
-        // (`providers/ollama.rs:706`), so a stream that stops early genuinely
-        // leaves `stream.response` unset. OpenAI
-        // (`providers/openai/completion/streaming.rs:330`), Anthropic
-        // (`providers/anthropic/streaming.rs:333`), Gemini
-        // (`providers/gemini/streaming.rs:233`), OpenRouter
-        // (`providers/openrouter/streaming.rs:323`) and DeepSeek
-        // (`providers/deepseek.rs:862`) all yield a usage-only `FinalResponse`
-        // unconditionally after the SSE loop — including after the plain
-        // `Err(StreamEnded) => break` arm — so on those five a server that
-        // closes mid-answer still sets `stream.response` and this check does
-        // not fire. Catching that needs a terminal-observed signal rig-core
-        // does not carry; it is a known limitation of this adapter, not a
-        // claim it makes.
+        // What this actually detects, in rig-core 0.36: **Ollama only**. Its
+        // stream yields `FinalResponse` solely inside `if response.done`, so a
+        // stream that stops early genuinely leaves `stream.response` unset.
+        // Anthropic and Gemini, plus the shared OpenAI-compatible stream driver
+        // used by OpenAI, OpenRouter, and DeepSeek, all yield a usage-only
+        // `FinalResponse` after the SSE loop — including after the plain
+        // `Err(StreamEnded) => break` arm. On those five a server that closes
+        // mid-answer still sets `stream.response` and this check does not fire.
+        // Catching that needs a terminal-observed signal rig-core does not
+        // carry; it is a known limitation of this adapter, not a claim it makes.
         let Some(terminal_frame) = stream.response.as_ref() else {
             return Err(LlmError::StreamInterrupted {
                 provider: self.model_name.clone(),
@@ -457,7 +452,7 @@ impl<M: CompletionModel> RigAdapter<M> {
         let raw_terminal_frame = serialize_raw_response(terminal_frame);
         let cache_creation_input_tokens = extract_cache_creation(raw_terminal_frame.as_ref());
         let provider_finish = extract_finish_reason(raw_terminal_frame.as_ref());
-        // Note: in rig-core 0.33 only Ollama's terminal frame still carries a
+        // Note: in rig-core 0.36 only Ollama's terminal frame still carries a
         // finish reason (`done_reason`). The other five define
         // `StreamingResponse` as usage-only, so their per-chunk
         // `finish_reason`/`stop_reason` is dropped before it reaches this
@@ -1066,7 +1061,7 @@ fn extract_finish_reason(raw: Option<&serde_json::Value>) -> Option<FinishReason
 
 /// Locate the provider's finish-reason field across the response shapes rig fronts.
 ///
-/// Paths verified against rig-core 0.33:
+/// Paths verified against rig-core 0.36:
 /// - OpenAI-shaped (`openai`, `openai_compatible`, `tinfoil`, `azure`,
 ///   `deepseek`, `openrouter`): `choices[0].finish_reason`
 /// - Anthropic-by-key: `stop_reason`
@@ -1376,7 +1371,7 @@ where
 
         let raw_response = serialize_raw_response(&response.raw_response);
         let provider_finish = extract_finish_reason(raw_response.as_ref());
-        let (text, _tool_calls, finish, _reasoning, _reasoning_details) =
+        let (text, _tool_calls, finish, reasoning, _reasoning_details) =
             extract_response(&response.choice, &response.usage, provider_finish);
 
         let resp = CompletionResponse {
@@ -1384,7 +1379,7 @@ where
             input_tokens: saturate_u32(response.usage.input_tokens),
             output_tokens: saturate_u32(response.usage.output_tokens),
             finish_reason: finish,
-            reasoning: None,
+            reasoning,
             cache_read_input_tokens: saturate_u32(response.usage.cached_input_tokens),
             cache_creation_input_tokens: extract_cache_creation(raw_response.as_ref()),
         };

--- a/crates/domains/ironclaw_llm/src/rig_adapter/tests/finish_reason_tests.rs
+++ b/crates/domains/ironclaw_llm/src/rig_adapter/tests/finish_reason_tests.rs
@@ -96,7 +96,7 @@ fn discarding_sink() -> Arc<dyn CompletionStreamSink> {
 /// raised *before* a response object is constructed, so retry and failover
 /// see a failure rather than a completed call.
 ///
-/// **Scope, honestly:** in rig-core 0.33 only Ollama can reach this. Its
+/// **Scope, honestly:** in rig-core 0.36 only Ollama can reach this. Its
 /// stream yields `FinalResponse` solely inside `if response.done`. OpenAI,
 /// Anthropic, Gemini, OpenRouter and DeepSeek yield their usage-only
 /// `FinalResponse` unconditionally after the SSE loop — including after a
@@ -155,7 +155,7 @@ async fn streaming_tool_call_without_terminal_frame_is_a_retryable_incomplete_st
 }
 
 /// When the provider *does* carry a finish reason on its terminal frame
-/// (rig-core 0.33: Ollama only), the adapter reports it — including over
+/// (rig-core 0.36: Ollama only), the adapter reports it — including over
 /// the tool-call shape.
 #[tokio::test]
 async fn streaming_reads_the_terminal_frames_finish_reason() {
@@ -178,7 +178,7 @@ async fn streaming_reads_the_terminal_frames_finish_reason() {
 }
 
 /// A terminal frame that carries no finish reason at all is the common
-/// case: rig-core 0.33 drops it for OpenAI, Anthropic, Gemini, OpenRouter
+/// case: rig-core 0.36 drops it for OpenAI, Anthropic, Gemini, OpenRouter
 /// and DeepSeek, whose `StreamingResponse` types hold usage only. Those
 /// five also yield that frame unconditionally, so its presence proves
 /// nothing about whether the server actually finished — shape inference

--- a/crates/loop/ironclaw_loop_host/src/model_gateway.rs
+++ b/crates/loop/ironclaw_loop_host/src/model_gateway.rs
@@ -1938,7 +1938,8 @@ async fn tool_response_to_host(
     match response.finish_reason {
         FinishReason::Stop => {
             let content = clean_response(&response.content.unwrap_or_default());
-            if content.trim().is_empty() {
+            let reasoning = response.reasoning.filter(|value| !value.trim().is_empty());
+            if content.trim().is_empty() && reasoning.is_none() {
                 return Err(HostManagedModelError::safe(
                     HostManagedModelErrorKind::InvalidOutput,
                     InvalidOutputReason::EmptyAssistantResponse.safe_summary(),
@@ -1948,16 +1949,15 @@ async fn tool_response_to_host(
                 content_bytes = content.len(),
                 "reborn model gateway classified tool-capable provider response as assistant reply"
             );
-            Ok(HostManagedModelResponse::assistant_reply_with_reasoning(
-                content,
-                response.reasoning,
+            Ok(
+                HostManagedModelResponse::assistant_reply_with_reasoning(content, reasoning)
+                    .with_usage(LoopModelUsage {
+                        input_tokens: response.input_tokens,
+                        output_tokens: response.output_tokens,
+                        cache_read_input_tokens: response.cache_read_input_tokens,
+                        cache_creation_input_tokens: response.cache_creation_input_tokens,
+                    }),
             )
-            .with_usage(LoopModelUsage {
-                input_tokens: response.input_tokens,
-                output_tokens: response.output_tokens,
-                cache_read_input_tokens: response.cache_read_input_tokens,
-                cache_creation_input_tokens: response.cache_creation_input_tokens,
-            }))
         }
         FinishReason::Length => Err(HostManagedModelError::safe(
             HostManagedModelErrorKind::OutputTruncated,

--- a/crates/loop/ironclaw_loop_host/tests/llm_gateway.rs
+++ b/crates/loop/ironclaw_loop_host/tests/llm_gateway.rs
@@ -626,9 +626,9 @@ async fn gateway_coalesces_late_system_messages_before_provider_call() {
 }
 
 #[tokio::test]
-async fn gateway_preserves_text_only_provider_reasoning() {
+async fn gateway_preserves_reasoning_only_plain_response() {
     let provider = Arc::new(RecordingLlmProvider::reply_with_reasoning(
-        "assistant response",
+        "",
         "text-only reasoning",
     ));
     let gateway = LlmProviderModelGateway::with_provider_identity(
@@ -647,6 +647,11 @@ async fn gateway_preserves_text_only_provider_reasoning() {
         response.safe_reasoning_deltas,
         vec!["text-only reasoning".to_string()]
     );
+    assert_eq!(response.safe_text_deltas, vec![String::new()]);
+    let ParentLoopOutput::AssistantReply(reply) = response.output else {
+        panic!("expected assistant reply");
+    };
+    assert!(reply.content.is_empty());
 }
 
 #[tokio::test]
@@ -750,6 +755,43 @@ async fn gateway_cleans_legacy_tool_marker_from_tool_capable_stop_reply() {
         panic!("expected assistant reply");
     };
     assert_eq!(reply.content, "Finished.");
+}
+
+#[tokio::test]
+async fn gateway_preserves_reasoning_only_tool_capable_stop_response() {
+    let provider = Arc::new(ToolAwareProvider::tool_response(ToolCompletionResponse {
+        content: None,
+        tool_calls: Vec::new(),
+        input_tokens: 1,
+        output_tokens: 1,
+        finish_reason: FinishReason::Stop,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning: Some("tool-capable reasoning".to_string()),
+        reasoning_details: None,
+    }));
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider,
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
+
+    let response = gateway
+        .stream_model_with_capabilities(model_request(interactive_model()), capabilities)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.safe_reasoning_deltas,
+        vec!["tool-capable reasoning".to_string()]
+    );
+    assert_eq!(response.safe_text_deltas, vec![String::new()]);
+    let ParentLoopOutput::AssistantReply(reply) = response.output else {
+        panic!("expected assistant reply");
+    };
+    assert!(reply.content.is_empty());
 }
 
 #[tokio::test]

--- a/tools/ironclaw_stress/Cargo.toml
+++ b/tools/ironclaw_stress/Cargo.toml
@@ -41,7 +41,7 @@ tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
-rig = { package = "rig-core", version = "0.33" }
+rig = { package = "rig-core", version = "0.36" }
 ironclaw_auth = { path = "../../crates/domains/ironclaw_auth" }
 ironclaw_composition = { path = "../../crates/app/ironclaw_composition", features = ["test-support"] }
 ironclaw_libsql_runtime = { path = "../../crates/substrates/ironclaw_libsql_runtime" }


### PR DESCRIPTION
## Summary

- Upgrade `rig-core` from 0.33 to 0.36 so non-streaming OpenAI-compatible responses retain `reasoning_content`.
- Accept valid reasoning-only responses with `content: null` instead of returning an empty-response error.
- Add a caller-level loopback regression through the registry provider and update Rig usage fixtures.

Related benchmark fixes: nearai/benchmarks#316 (timeout propagation) and nearai/benchmarks#417 (empty-timeout error).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [x] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo +1.96.0 test -p ironclaw_llm` (977 unit tests and 2 module-charter tests)
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (not applicable: no database/runtime integration change)
- [x] Manual testing: `cargo +1.96.0 test -p ironclaw_stress --no-run`
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior:

OpenAI-compatible models can return reasoning without visible assistant text or a tool call. The response now succeeds and preserves the reasoning separately instead of surfacing an empty-response error.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: caller-level loopback test exercises the registry provider with a synthetic `content: null` plus `reasoning_content` response.
- Reborn integration: Not applicable: this is provider response parsing, covered through the owning crate's public caller path.
- Recorded fixture: Not applicable: the exact wire response is embedded in the deterministic loopback test.
- Browser E2E: Not applicable: no browser behavior.
- Backend or runtime: the full `ironclaw_llm` suite passes, and `ironclaw_stress` compiles against Rig 0.36.
- Live canary: Not applicable: no deployment change in this PR.

What the tests prove:

A valid reasoning-only response is accepted, the reasoning is preserved in `response.reasoning`, visible content remains absent, and no tool call is invented.

Commands run:

- `cargo +1.96.0 test -p ironclaw_llm`
- `cargo +1.96.0 test -p ironclaw_stress --no-run`
- `cargo +1.96.0 fmt --all -- --check`
- `git diff --check`

## Security Impact

None. This changes provider response parsing through a dependency upgrade; it does not change credentials, permissions, egress policy, file access, tool execution, or sandbox behavior.

## Reborn Trust-Boundary Checklist

N/A: no Reborn, security, runtime, database, status, or policy contract changes.

## Database Impact

None.

## Blast Radius

The Rig-backed OpenAI, OpenAI-compatible, Anthropic, Ollama, and Tinfoil adapters pick up Rig 0.36. The behavioral fix is specific to non-streaming OpenAI-compatible reasoning fields; the owning crate's full provider test suite covers the shared adapter surface.

## Rollback Plan

Revert this PR and restore `rig-core` 0.33 plus its previous feature flags. That restores the prior behavior, including the reasoning-only empty-response failure.

## Review Follow-Through

No known follow-up. The main review point is the shared Rig dependency upgrade and its adapter compatibility.

---

**Review track**: B