### PR TITLE
fix(sandbox): preserve failed Railway audit appends

### DIFF
--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway.rs
@@ -117,7 +117,7 @@ drain_proxy_audit() {
     rm -f "$audit_append" "$audit_capture"
     return 1
   fi
-  cat "$audit_append" >> "$audit_log"
+  cat "$audit_append" >> "$audit_log" || return 1
   chmod 600 "$audit_log"
   rm -f "$audit_append" "$audit_capture"
   if [ -n "$last_record" ]; then

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway/tests.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway/tests.rs
@@ -694,7 +694,9 @@ async fn ephemeral_worker_uses_managed_proxy_and_hardened_private_network() {
             && RAILWAY_MANAGED_EGRESS_WRAPPER
                 .contains("for audit_file in \"$material\"/audit/proxy.log*; do")
             && RAILWAY_MANAGED_EGRESS_WRAPPER
-                .contains("if [ \"$audit_total\" -gt 268435456 ]; then"),
+                .contains("if [ \"$audit_total\" -gt 268435456 ]; then")
+            && RAILWAY_MANAGED_EGRESS_WRAPPER
+                .contains("cat \"$audit_append\" >> \"$audit_log\" || return 1"),
         "Railway audit append must fail closed before aggregate retained evidence exceeds 256 MiB"
     );
     assert!(


### PR DESCRIPTION
## Summary
- fail closed when appending staged Railway proxy audit records fails
- preserve the staged capture and proxy for retry
- pin the failure propagation in the Railway wrapper regression

## Test Strategy
- `cargo test -p ironclaw_sandbox --lib sandbox_process::railway::tests::ephemeral_worker_uses_managed_proxy_and_hardened_private_network -- --exact`
- `cargo clippy -p ironclaw_sandbox --all-targets --all-features -- -D warnings`

## Compatibility and rollback
No wire or configuration change. Rollback is the single commit, but would restore possible audit loss on append failure.