### PR TITLE
fix(ci): forward-port the clippy 1.98 lint fixes to 1.3

### DIFF
--- a/crates/app/ironclaw_architecture_tests/tests/reborn_tracing_target_syntax.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_tracing_target_syntax.rs
@@ -116,7 +116,7 @@ fn skip_trivia(source: &str, mut cursor: usize) -> usize {
         }
         let rest = &source[cursor.min(source.len())..];
         if let Some(stripped) = rest.strip_prefix("//") {
-            cursor += 2 + stripped.find('\n').map_or(stripped.len(), |end| end);
+            cursor += 2 + stripped.find('\n').unwrap_or(stripped.len());
         } else if let Some(stripped) = rest.strip_prefix("/*") {
             cursor += 2 + stripped.find("*/").map_or(stripped.len(), |end| end + 2);
         } else {

--- a/crates/domains/ironclaw_trace_commons/src/onboarding/tests.rs
+++ b/crates/domains/ironclaw_trace_commons/src/onboarding/tests.rs
@@ -217,7 +217,7 @@ async fn successful_onboard_writes_policy_and_promotes_key() {
     // Verify parsed path is /v1/trace-upload-claim and host matches invite.
     let issuer_parsed = reqwest::Url::parse(expected_issuer_url.as_str()).unwrap();
     assert_eq!(issuer_parsed.path(), "/v1/trace-upload-claim");
-    assert_eq!(issuer_parsed.host_str().unwrap(), format!("127.0.0.1"));
+    assert_eq!(issuer_parsed.host_str().unwrap(), "127.0.0.1");
     assert_eq!(
         policy.ingestion_endpoint.as_deref(),
         Some("https://ingest.example.com")

--- a/crates/extensions/ironclaw_extension_support/src/coding/text.rs
+++ b/crates/extensions/ironclaw_extension_support/src/coding/text.rs
@@ -29,8 +29,10 @@ pub(super) fn decode_text(
         FileEncoding::Utf16Le => {
             let data = bytes.get(2..).unwrap_or_default();
             let units = data
-                .chunks_exact(2)
-                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|pair| u16::from_le_bytes(*pair))
                 .collect::<Vec<_>>();
             String::from_utf16(&units).map_err(|_| operation_error())?
         }
@@ -81,8 +83,10 @@ pub(super) fn decode_text_lossy(bytes: &[u8]) -> (String, FileEncoding, LineEndi
         FileEncoding::Utf16Le => {
             let data = bytes.get(2..).unwrap_or_default();
             let units = data
-                .chunks_exact(2)
-                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|pair| u16::from_le_bytes(*pair))
                 .collect::<Vec<_>>();
             String::from_utf16_lossy(&units)
         }

--- a/crates/extensions/ironclaw_extension_support/src/gsuite/credential.rs
+++ b/crates/extensions/ironclaw_extension_support/src/gsuite/credential.rs
@@ -27,7 +27,7 @@ pub struct GoogleCredential {
 #[derive(Debug, Error)]
 pub enum GoogleCredentialError {
     #[error("Google credential recovery is required")]
-    Recovery(CredentialRecoveryProjection),
+    Recovery(Box<CredentialRecoveryProjection>),
     #[error("Google credential account is missing required scopes")]
     MissingScopes { missing_scopes: Vec<ProviderScope> },
     #[error("Google credential account has no access secret")]
@@ -296,7 +296,7 @@ impl GoogleCredentialResolver {
             .project_recovery(scope, requester_extension, provider)
             .await
         {
-            Ok(recovery) => GoogleCredentialError::Recovery(recovery),
+            Ok(recovery) => GoogleCredentialError::Recovery(Box::new(recovery)),
             Err(error) => error,
         }
     }
@@ -418,7 +418,7 @@ mod tests {
             Vec::new(),
         );
         assert!(matches!(
-            GoogleCredentialError::Recovery(recovery.clone()),
+            GoogleCredentialError::Recovery(Box::new(recovery.clone())),
             GoogleCredentialError::Recovery(_)
         ));
         assert!(matches!(

--- a/crates/extensions/ironclaw_extension_support/src/gsuite/handlers.rs
+++ b/crates/extensions/ironclaw_extension_support/src/gsuite/handlers.rs
@@ -1233,7 +1233,7 @@ fn map_credential_error(error: GoogleCredentialError) -> GsuiteDispatchError {
     match error {
         GoogleCredentialError::Recovery(recovery) => {
             GsuiteDispatchError::new(map_recovery_kind(&recovery))
-                .with_reason(GsuiteCredentialDispatchReason::Recovery(Box::new(recovery)))
+                .with_reason(GsuiteCredentialDispatchReason::Recovery(recovery))
         }
         GoogleCredentialError::MissingScopes { missing_scopes } => {
             GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
@@ -1571,23 +1571,23 @@ mod tests {
     #[test]
     fn map_credential_error_tests() {
         assert_eq!(
-            map_credential_error(GoogleCredentialError::Recovery(
+            map_credential_error(GoogleCredentialError::Recovery(Box::new(
                 ironclaw_auth::CredentialRecoveryProjection::setup_required(
                     ironclaw_auth::AuthProviderId::new("google").unwrap(),
                     ironclaw_auth::CredentialRecoveryReason::NoAccount,
                     Vec::new(),
                 ),
-            ))
+            )))
             .kind(),
             RuntimeDispatchErrorKind::Client
         );
         assert_eq!(
-            map_credential_error(GoogleCredentialError::Recovery(
+            map_credential_error(GoogleCredentialError::Recovery(Box::new(
                 ironclaw_auth::CredentialRecoveryProjection::account_selection_required(
                     ironclaw_auth::AuthProviderId::new("google").unwrap(),
                     Vec::new(),
                 ),
-            ))
+            )))
             .kind(),
             RuntimeDispatchErrorKind::Client
         );
@@ -1634,7 +1634,7 @@ mod tests {
             Some(&GsuiteCredentialDispatchReason::HostApi)
         );
 
-        let configured_recovery = map_credential_error(GoogleCredentialError::Recovery(
+        let configured_recovery = map_credential_error(GoogleCredentialError::Recovery(Box::new(
             ironclaw_auth::CredentialRecoveryProjection::configured(
                 ironclaw_auth::AuthProviderId::new("google").unwrap(),
                 ironclaw_auth::CredentialAccountProjection {
@@ -1649,7 +1649,7 @@ mod tests {
                     secret_handle_count: 1,
                 },
             ),
-        ));
+        )));
         assert_eq!(
             configured_recovery.kind(),
             RuntimeDispatchErrorKind::Backend

--- a/crates/loop/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/loop/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -139,7 +139,7 @@ struct InvokedCapabilityBatch {
 }
 
 struct InvokedCapabilityBatchError {
-    error: ironclaw_loop_contracts::AgentLoopHostError,
+    error: Box<ironclaw_loop_contracts::AgentLoopHostError>,
     launched_count: usize,
 }
 
@@ -226,7 +226,7 @@ impl CapabilityStage {
                 .await
                 .map(InvokedCapabilityBatch::from_resolution_batch)
                 .map_err(|error| InvokedCapabilityBatchError {
-                    error,
+                    error: Box::new(error),
                     launched_count: 0,
                 });
         }
@@ -283,10 +283,10 @@ impl CapabilityStage {
                 }
                 None => {
                     return Err(InvokedCapabilityBatchError {
-                        error: ironclaw_loop_contracts::AgentLoopHostError::new(
+                        error: Box::new(ironclaw_loop_contracts::AgentLoopHostError::new(
                             ironclaw_loop_contracts::AgentLoopHostErrorKind::Internal,
                             "parallel capability invocation completed without an indexed outcome",
-                        ),
+                        )),
                         launched_count: launched,
                     });
                 }
@@ -754,7 +754,7 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                     .completed_turn(ctx, state, result_refs_start, capability_batch)
                     .await;
             }
-            Err(failure) => return Err(capability_host_error(failure.error)),
+            Err(failure) => return Err(capability_host_error(*failure.error)),
         };
 
         let InvokedCapabilityBatch {

--- a/crates/substrates/ironclaw_filesystem/src/vector.rs
+++ b/crates/substrates/ironclaw_filesystem/src/vector.rs
@@ -16,8 +16,10 @@ pub(crate) fn decode_embedding_blob(bytes: &[u8]) -> Option<Vec<f32>> {
     }
     Some(
         bytes
-            .chunks_exact(std::mem::size_of::<f32>())
-            .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .as_chunks::<{ std::mem::size_of::<f32>() }>()
+            .0
+            .iter()
+            .map(|chunk| f32::from_le_bytes(*chunk))
             .collect(),
     )
 }

--- a/tests/integration/support/db_write_measurement.rs
+++ b/tests/integration/support/db_write_measurement.rs
@@ -117,7 +117,7 @@ pub enum DbWriteMeasurementError {
     BeginAndCleanup {
         #[source]
         primary: DbProbeError,
-        cleanup: DbProbeError,
+        cleanup: Box<DbProbeError>,
     },
     #[error("measured workload failed: {0}")]
     Workload(#[source] BoxError),
@@ -125,7 +125,7 @@ pub enum DbWriteMeasurementError {
     WorkloadAndCleanup {
         #[source]
         primary: BoxError,
-        cleanup: DbProbeError,
+        cleanup: Box<DbProbeError>,
     },
     #[error("database probe capture failed: {0}")]
     Capture(#[source] DbProbeError),
@@ -133,7 +133,7 @@ pub enum DbWriteMeasurementError {
     CaptureAndCleanup {
         #[source]
         primary: DbProbeError,
-        cleanup: DbProbeError,
+        cleanup: Box<DbProbeError>,
     },
     #[error("database probe cleanup failed: {0}")]
     Cleanup(#[source] DbProbeError),
@@ -144,7 +144,7 @@ impl DbWriteMeasurementError {
         match self {
             Self::BeginAndCleanup { cleanup, .. }
             | Self::WorkloadAndCleanup { cleanup, .. }
-            | Self::CaptureAndCleanup { cleanup, .. } => Some(cleanup),
+            | Self::CaptureAndCleanup { cleanup, .. } => Some(cleanup.as_ref()),
             Self::Cleanup(error) => Some(error),
             Self::Begin(_) | Self::Workload(_) | Self::Capture(_) => None,
         }
@@ -165,7 +165,10 @@ where
         Err(primary) => {
             return match finish(config).await {
                 Ok(()) => Err(DbWriteMeasurementError::Begin(primary)),
-                Err(cleanup) => Err(DbWriteMeasurementError::BeginAndCleanup { primary, cleanup }),
+                Err(cleanup) => Err(DbWriteMeasurementError::BeginAndCleanup {
+                    primary,
+                    cleanup: Box::new(cleanup),
+                }),
             };
         }
     };
@@ -176,9 +179,10 @@ where
         Err(primary) => {
             return match finish(config).await {
                 Ok(()) => Err(DbWriteMeasurementError::Workload(primary)),
-                Err(cleanup) => {
-                    Err(DbWriteMeasurementError::WorkloadAndCleanup { primary, cleanup })
-                }
+                Err(cleanup) => Err(DbWriteMeasurementError::WorkloadAndCleanup {
+                    primary,
+                    cleanup: Box::new(cleanup),
+                }),
             };
         }
     };
@@ -188,9 +192,10 @@ where
         Err(primary) => {
             return match finish(config).await {
                 Ok(()) => Err(DbWriteMeasurementError::Capture(primary)),
-                Err(cleanup) => {
-                    Err(DbWriteMeasurementError::CaptureAndCleanup { primary, cleanup })
-                }
+                Err(cleanup) => Err(DbWriteMeasurementError::CaptureAndCleanup {
+                    primary,
+                    cleanup: Box::new(cleanup),
+                }),
             };
         }
     };


### PR DESCRIPTION
## Problem

`Clippy (all-features)` fails on **every** PR into `release/2026-08-17`, regardless of what the PR touches:

```
error: using `chunks_exact` with a constant chunk size
  --> crates/substrates/ironclaw_filesystem/src/vector.rs:19:14
error: could not compile `ironclaw_filesystem` (lib) due to 1 previous error
```

The repo pins no toolchain (`rust-toolchain.toml` does not exist), so CI clippy tracks latest stable. Clippy 1.98 promoted `chunks_exact_to_as_chunks` and several other lints.

That was already fixed on `main` in **3a7417dc95 (#7777)** — "clear the clippy 1.98 lint cascade blocking the merge queue" — and never forward-ported. So `main` is green while this release branch is red for everyone. Confirmed live on #7804 and #7790, neither of which touches any of these files.

## Change

Cherry-pick of `3a7417dc95`, **minus one inapplicable hunk**. That commit also boxes the `HostFinalizationFailed` payload in `turn_run_executor.rs::DriverInvocationError`; this branch's enum has no such variant (the release-branch code diverged), so the hunk is dropped rather than force-fitted. The other eight files apply unchanged.

## Verification

Verified against **Rust 1.96** — the version the release image pins (`Dockerfile: rust:1.96-bookworm`). This was the risk worth checking, since the fix targets a 1.98 lint: if `as_chunks::<{ size_of::<f32>() }>()` were not stable in 1.96, this would fix CI and break the shipped image build. It compiles.

```
$ cargo check -p ironclaw_filesystem -p ironclaw_extension_support \
    -p ironclaw_agent_loop -p ironclaw_trace_commons
exit 0 — 0 errors, 0 warnings

$ cargo clippy (same crates) --all-targets --all-features -- -D warnings
exit 0

$ cargo fmt --check
exit 0
```

The 1.98 lint itself cannot be reproduced locally (local toolchain is 1.96.0); CI's clippy lane is the authority on that half, and it is the check this PR exists to turn green.

## Test Strategy

- **Integration / Crate:** Not applicable — equivalent-code lint migration, no behavior change.
- **Regression test:** `Regression-test exemption: this is an equivalent-code lint migration with no behavior change, pinned by the existing decode/cosine/nearest suites in ironclaw_filesystem; a new test could not distinguish the two spellings.`

## Rollback / follow-up

Straight revert; no behavior, schema, or persisted-state change.

Follow-up worth considering: pinning the toolchain via `rust-toolchain.toml` would turn a silent stable-clippy bump into a deliberate, reviewable change instead of a branch-wide outage — this is the second time the cascade has had to be cleared by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)