### PR TITLE
feat(sandbox): mediate GitHub CLI credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5086,6 +5086,7 @@ dependencies = [
  "libc",
  "rcgen",
  "rust_decimal_macros",
+ "secrecy",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Dockerfile.sandbox-worker
+++ b/Dockerfile.sandbox-worker
@@ -7,6 +7,7 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
+        gh \
         jq \
         nodejs \
         npm \
@@ -20,8 +21,8 @@ RUN groupadd --gid 1000 sandbox \
 COPY --chmod=0755 docker/sandbox/ironclaw-exec \
     docker/sandbox/ironclaw-sandbox-idle \
     /usr/local/bin/
-
-ENV HOME=/home/sandbox
+ENV HOME=/home/sandbox \
+    GH_CONFIG_DIR=/workspace/.config/gh
 WORKDIR /workspace
 USER 1000:1000
 

--- a/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
@@ -894,7 +894,12 @@ fn reborn_contracts_crates_carry_a_checked_size_ceiling() {
         // unit variants and a serde derive, no behavior. The 35-line delta is
         // from the merged `turn.rs`; the resulting ceiling is re-captured from
         // this test's own report, never counted by eye.
-        ("ironclaw_host_api", 20_516),
+        // 20_516 -> 20_784 (2026-08-21, #7732 sandbox job execution): typed
+        // direct-argument sandbox command, credential-binding, and resource
+        // limit DTOs shared by the process manager, host runtime, and sandbox
+        // transport. Validation and execution remain in `ironclaw_sandbox`;
+        // this crate only owns the provider-neutral authority vocabulary.
+        ("ironclaw_host_api", 20_784),
         // 14_479 -> 13_949 (2026-08-07, #7157): downward re-capture after the
         // delivery-heuristic vocabulary (stored trigger delivery targets and
         // their run-profile plumbing) left this crate with the two-lane

--- a/crates/app/ironclaw_architecture_tests/tests/reborn_struct_test_support_ratchet.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_struct_test_support_ratchet.rs
@@ -72,7 +72,7 @@ struct FrozenPathCount {
 /// test-support-only, then #7171 did the same for the skill mount view once
 /// `skill_mounts_for` began deriving it per gate.
 const WS0_PRODUCTION_STRUCT_DEBT_PATH_BASELINE: usize = 79;
-const WS0_PRODUCTION_STRUCT_DEBT_MEMBER_BASELINE: usize = 270;
+const WS0_PRODUCTION_STRUCT_DEBT_MEMBER_BASELINE: usize = 269;
 
 const FROZEN_PATH_COUNTS: &[FrozenPathCount] = &[
     FrozenPathCount {
@@ -112,7 +112,7 @@ const FROZEN_PATH_COUNTS: &[FrozenPathCount] = &[
         count: 1,
     },
     // Unwired sandbox credential-firewall primitives (W5/W8). Retire these
-    // four entries when the egress proxy consumer (W6) lands on main and the
+    // three entries when their remaining consumers land and the
     // `#[allow(dead_code)]` attributes come off — the `removed` assertion
     // below only shrinks this baseline if the attributes are actually
     // deleted, not merely left in place.
@@ -120,7 +120,7 @@ const FROZEN_PATH_COUNTS: &[FrozenPathCount] = &[
         category: "dead-code",
         item_kind: "method",
         path: "crates/ironclaw_sandbox/src/sandbox_process/ca.rs",
-        count: 4,
+        count: 3,
     },
     // Same W6 retirement trigger as the `ca.rs` entry above.
     FrozenPathCount {

--- a/crates/app/ironclaw_cli/src/first_party/gsuite.rs
+++ b/crates/app/ironclaw_cli/src/first_party/gsuite.rs
@@ -315,7 +315,10 @@ mod tests {
         assert_eq!(credential_requirements.len(), 1);
         let requirement = &credential_requirements[0];
         assert_eq!(requirement.provider.as_str(), GOOGLE_PROVIDER_ID);
-        assert_eq!(requirement.requester_extension.as_str(), "gmail");
+        assert_eq!(
+            requirement.consumer.extension_id().map(ExtensionId::as_str),
+            Some("gmail")
+        );
     }
 
     #[test]

--- a/crates/app/ironclaw_composition/src/factory.rs
+++ b/crates/app/ironclaw_composition/src/factory.rs
@@ -161,7 +161,7 @@ use ironclaw_host_runtime::{
 };
 use ironclaw_host_runtime::{
     builtin_first_party_handlers_with_trigger_services_for_process_backend,
-    builtin_first_party_package_for_process_backend,
+    builtin_first_party_package_for_process_backend, user_sandbox_process_package,
 };
 use ironclaw_identity::projects::ProjectRepository;
 use ironclaw_identity::projects::RebornProjectService;
@@ -1212,6 +1212,17 @@ fn production_builtin_extension_registry(
         .map_err(|error| RebornBuildError::InvalidConfig {
             reason: format!("built-in first-party registry is invalid: {error}"),
         })?;
+    if process_backend == ProcessBackendKind::UserSandbox {
+        registry
+            .insert(user_sandbox_process_package().map_err(|error| {
+                RebornBuildError::InvalidConfig {
+                    reason: format!("user sandbox process package is invalid: {error}"),
+                }
+            })?)
+            .map_err(|error| RebornBuildError::InvalidConfig {
+                reason: format!("user sandbox process registry is invalid: {error}"),
+            })?;
+    }
     insert_bound_memory_package(&mut registry, memory_package)?;
     Ok(registry)
 }
@@ -1259,7 +1270,9 @@ fn manifest_channel_account_setup_descriptors(
                 auth_requirement: ironclaw_host_api::decision::RuntimeCredentialAuthRequirement {
                     provider: connection.provider.clone(),
                     setup: account_setup,
-                    requester_extension: manifest.id.clone(),
+                    consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                        extension_id: manifest.id.clone(),
+                    },
                     provider_scopes: Vec::new(),
                 },
                 connection_requirement: ChannelConnectionRequirement {

--- a/crates/app/ironclaw_composition/src/factory/auth_engine_assembly.rs
+++ b/crates/app/ironclaw_composition/src/factory/auth_engine_assembly.rs
@@ -557,7 +557,7 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
             request.provider,
             request.setup.clone(),
             request.provider_scopes,
-            request.requester_extension,
+            request.consumer.extension_id(),
         )?;
         let account = self
             .accounts
@@ -566,7 +566,7 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
             .map_err(|error| {
                 tracing::debug!(
                     provider = %request.provider,
-                    requester_extension = %request.requester_extension,
+                    requester_extension = ?request.consumer.extension_id(),
                     auth_error = ?error,
                     "runtime product-auth account selection failed"
                 );
@@ -574,7 +574,7 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
             })?;
         tracing::debug!(
             provider = %request.provider,
-            requester_extension = %request.requester_extension,
+            consumer = ?request.consumer,
             has_access_secret = account.access_secret.is_some(),
             has_refresh_secret = account.refresh_secret.is_some(),
             status = ?account.status,
@@ -587,7 +587,7 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
             .map_err(|error| {
                 tracing::debug!(
                     provider = %request.provider,
-                    requester_extension = %request.requester_extension,
+                    consumer = ?request.consumer,
                     auth_error = ?error,
                     "runtime product-auth account refresh failed"
                 );
@@ -595,7 +595,7 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
             })?;
         tracing::debug!(
             provider = %request.provider,
-            requester_extension = %request.requester_extension,
+            consumer = ?request.consumer,
             has_access_secret = account.access_secret.is_some(),
             has_refresh_secret = account.refresh_secret.is_some(),
             status = ?account.status,

--- a/crates/app/ironclaw_composition/src/factory/auth_tests.rs
+++ b/crates/app/ironclaw_composition/src/factory/auth_tests.rs
@@ -855,8 +855,10 @@ async fn submit_and_block_provider_auth_run(
                 setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth {
                     scopes: Vec::new(),
                 },
-                requester_extension: ironclaw_host_api::ids::ExtensionId::new(requester_extension)
-                    .unwrap(),
+                consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                    extension_id: ironclaw_host_api::ids::ExtensionId::new(requester_extension)
+                        .unwrap(),
+                },
                 provider_scopes: Vec::new(),
             },
         ],

--- a/crates/app/ironclaw_composition/src/factory/production_backend_assembly.rs
+++ b/crates/app/ironclaw_composition/src/factory/production_backend_assembly.rs
@@ -712,7 +712,9 @@ pub(super) async fn build_backend_production(
     };
     let user_sandbox_process_port = match &production_wiring.runtime_process_binding {
         RebornRuntimeProcessBinding::None => None,
-        RebornRuntimeProcessBinding::UserSandbox { process_port } => Some(Arc::clone(process_port)),
+        RebornRuntimeProcessBinding::UserSandbox { process_port, .. } => {
+            Some(Arc::clone(process_port))
+        }
     };
     let services = apply_production_runtime_process_binding(
         services,

--- a/crates/app/ironclaw_composition/src/factory/runtime_lane_assembly.rs
+++ b/crates/app/ironclaw_composition/src/factory/runtime_lane_assembly.rs
@@ -123,8 +123,11 @@ where
 {
     match binding {
         RebornRuntimeProcessBinding::None => services,
-        RebornRuntimeProcessBinding::UserSandbox { process_port } => {
-            services.with_production_user_sandbox_process_port(process_port)
-        }
+        RebornRuntimeProcessBinding::UserSandbox {
+            process_port,
+            process_executor,
+        } => services
+            .with_production_user_sandbox_process_port(process_port)
+            .with_process_sandbox_executor_dyn(process_executor),
     }
 }

--- a/crates/app/ironclaw_composition/src/factory/tests.rs
+++ b/crates/app/ironclaw_composition/src/factory/tests.rs
@@ -2375,13 +2375,16 @@ async fn standalone_nearai_mcp_auto_bootstraps_from_injected_config() {
         thread_id: None,
         invocation_id: InvocationId::new(),
     };
+    let nearai_consumer = ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+        extension_id: ExtensionId::new("nearai").unwrap(),
+    };
     let resolved = resolver
         .resolve_access_secret(RuntimeCredentialAccountRequest {
             scope: &sso_scope,
             provider: &VendorId::new("nearai").unwrap(),
             setup: &RuntimeCredentialAccountSetup::ManualToken,
             provider_scopes: &[],
-            requester_extension: &ExtensionId::new("nearai").unwrap(),
+            consumer: &nearai_consumer,
         })
         .await
         .expect("SSO user should resolve host-managed NEAR AI credential");
@@ -3696,7 +3699,9 @@ fn pairing_account_setup_descriptor(extension_id: &str) -> ExtensionAccountSetup
         auth_requirement: ironclaw_host_api::decision::RuntimeCredentialAuthRequirement {
             provider: VendorId::new(extension_id).expect("provider id"),
             setup: RuntimeCredentialAccountSetup::Pairing,
-            requester_extension: ExtensionId::new(extension_id).expect("requester extension id"),
+            consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new(extension_id).expect("requester extension id"),
+            },
             provider_scopes: Vec::new(),
         },
         connection_requirement: ironclaw_assistant::ChannelConnectionRequirement {

--- a/crates/app/ironclaw_composition/src/input.rs
+++ b/crates/app/ironclaw_composition/src/input.rs
@@ -16,6 +16,7 @@ use ironclaw_host_runtime::memory_binding::MemoryBindingPolicy;
 #[cfg(any(test, feature = "test-support"))]
 use ironclaw_network::NetworkHttpEgress;
 use ironclaw_processes::ProcessConcurrencyLimits;
+use ironclaw_processes::ProcessExecutor;
 use ironclaw_trust::HostTrustPolicy;
 use ironclaw_turns::TurnRunWakeNotifier;
 use secrecy::SecretString;
@@ -105,13 +106,25 @@ pub(crate) struct OAuthDcrCallbackConfig {
     pub(crate) callback_origin: String,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
 pub enum RebornRuntimeProcessBinding {
     #[default]
     None,
     UserSandbox {
         process_port: Arc<UserSandboxProcessPort>,
+        process_executor: Arc<dyn ProcessExecutor>,
     },
+}
+
+impl std::fmt::Debug for RebornRuntimeProcessBinding {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => formatter.write_str("RebornRuntimeProcessBinding::None"),
+            Self::UserSandbox { .. } => formatter
+                .debug_struct("RebornRuntimeProcessBinding::UserSandbox")
+                .finish_non_exhaustive(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -140,7 +153,11 @@ impl RebornRuntimeProcessBinding {
     }
 
     pub fn user_sandbox(process_port: Arc<UserSandboxProcessPort>) -> Self {
-        Self::UserSandbox { process_port }
+        let process_executor: Arc<dyn ProcessExecutor> = process_port.clone();
+        Self::UserSandbox {
+            process_port,
+            process_executor,
+        }
     }
 
     pub(crate) fn validate_for_production_policy(

--- a/crates/app/ironclaw_composition/src/runtime/tests/core.rs
+++ b/crates/app/ironclaw_composition/src/runtime/tests/core.rs
@@ -8230,8 +8230,17 @@ async fn thread_one_authors_a_scripted_skill_and_thread_two_executes_it() {
 /// mocked model reads the advertised workdir and runs the command through the real `builtin.shell`.
 /// Closes the half the sibling fixture cannot see: the path the model is TOLD. When that string was
 /// wrong, every command failed with `Failed to spawn command` and nothing noticed.
-#[tokio::test]
-async fn the_model_runs_a_skills_script_from_the_workdir_the_body_advertises() {
+#[test]
+fn the_model_runs_a_skills_script_from_the_workdir_the_body_advertises() {
+    std::thread::Builder::new()
+        .name("skills-script-e2e".to_string())
+        .stack_size(4 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime builds")
+                .block_on(async {
     let root = tempfile::tempdir().expect("tempdir");
     let storage_root = root.path().join("standalone");
 
@@ -8300,6 +8309,11 @@ async fn the_model_runs_a_skills_script_from_the_workdir_the_body_advertises() {
     );
 
     runtime.shutdown().await.expect("thread two shutdown");
+                });
+        })
+        .expect("test thread spawns")
+        .join()
+        .expect("test thread completes");
 }
 
 /// A manifest with no `description:` must not become an invisible skill.

--- a/crates/app/ironclaw_composition/tests/gsuite.rs
+++ b/crates/app/ironclaw_composition/tests/gsuite.rs
@@ -835,7 +835,10 @@ async fn bundled_gsuite_handler_projects_stage_auth_required_to_first_party_auth
         requirement.provider.as_str(),
         ironclaw_auth::GOOGLE_PROVIDER_ID
     );
-    assert_eq!(requirement.requester_extension.as_str(), "gmail");
+    assert_eq!(
+        requirement.consumer.extension_id().map(|id| id.as_str()),
+        Some("gmail")
+    );
     assert_eq!(
         requirement.provider_scopes,
         vec![GOOGLE_GMAIL_SEND_SCOPE.to_string()]

--- a/crates/app/ironclaw_composition/tests/service_factory.rs
+++ b/crates/app/ironclaw_composition/tests/service_factory.rs
@@ -520,7 +520,7 @@ async fn assert_production_services_ready_with_first_party_runtime(services: &Re
         .expect("production host runtime health should resolve");
     assert!(
         health.ready,
-        "production host runtime should report first-party backend ready"
+        "production host runtime should report first-party backend ready: {health:?}"
     );
     assert!(health.missing_runtime_backends.is_empty());
 }

--- a/crates/contracts/ironclaw_host_api/Cargo.toml
+++ b/crates/contracts/ironclaw_host_api/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = "1"
 sha2 = "0.11"
 thiserror = "2"
 tracing = "0.1"
+tokio = { version = "1", features = ["sync"] }
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 zeroize = "1"
 
@@ -53,4 +54,4 @@ rust_decimal_macros = "1"
 static_assertions = "1"
 toml = "1.1"
 # `#[tokio::test]` for the async `dispatch_test_support::TestDispatcher` tests.
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt", "time"] }

--- a/crates/contracts/ironclaw_host_api/src/capability.rs
+++ b/crates/contracts/ironclaw_host_api/src/capability.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     Timestamp,
     action::{NetworkPolicy, NetworkTargetPattern},
-    decision::RuntimeCredentialAuthRequirement,
+    decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     http::RuntimeCredentialTarget,
     ids::{CapabilityGrantId, CapabilityId, ExtensionId, SecretHandle, VendorId},
     invocation::InvocationOrigin,
@@ -298,6 +298,15 @@ impl RuntimeCredentialRequirement {
         &self,
         requester_extension: ExtensionId,
     ) -> Option<RuntimeCredentialAuthRequirement> {
+        self.product_auth_requirement_for_consumer(RuntimeCredentialConsumer::Extension {
+            extension_id: requester_extension,
+        })
+    }
+
+    pub fn product_auth_requirement_for_consumer(
+        &self,
+        consumer: RuntimeCredentialConsumer,
+    ) -> Option<RuntimeCredentialAuthRequirement> {
         let RuntimeCredentialRequirementSource::ProductAuthAccount { provider, setup } =
             &self.source
         else {
@@ -306,7 +315,7 @@ impl RuntimeCredentialRequirement {
         Some(RuntimeCredentialAuthRequirement {
             provider: provider.clone(),
             setup: setup.clone(),
-            requester_extension,
+            consumer,
             provider_scopes: self.provider_scopes.clone(),
         })
     }

--- a/crates/contracts/ironclaw_host_api/src/decision.rs
+++ b/crates/contracts/ironclaw_host_api/src/decision.rs
@@ -66,7 +66,23 @@ pub enum Obligation {
         setup: RuntimeCredentialAccountSetup,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         provider_scopes: Vec<String>,
-        requester_extension: ExtensionId,
+        #[serde(
+            alias = "requester_extension",
+            deserialize_with = "deserialize_credential_consumer"
+        )]
+        consumer: RuntimeCredentialConsumer,
+    },
+    InjectSandboxCredentialAccountOnce {
+        handle: SecretHandle,
+        provider: VendorId,
+        #[serde(default)]
+        setup: RuntimeCredentialAccountSetup,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        provider_scopes: Vec<String>,
+        #[serde(default)]
+        required: bool,
+        audience: crate::action::NetworkTargetPattern,
+        target: crate::http::RuntimeCredentialTarget,
     },
     FirstPartyCredentialStagedViaHostPort {
         capability_id: CapabilityId,
@@ -92,12 +108,24 @@ impl Obligation {
                 provider,
                 setup,
                 provider_scopes,
-                requester_extension,
+                consumer,
                 ..
             } => Some(RuntimeCredentialAuthRequirement {
                 provider: provider.clone(),
                 setup: setup.clone(),
-                requester_extension: requester_extension.clone(),
+                consumer: consumer.clone(),
+                provider_scopes: provider_scopes.clone(),
+            }),
+            Obligation::InjectSandboxCredentialAccountOnce {
+                provider,
+                setup,
+                provider_scopes,
+                required: true,
+                ..
+            } => Some(RuntimeCredentialAuthRequirement {
+                provider: provider.clone(),
+                setup: setup.clone(),
+                consumer: RuntimeCredentialConsumer::SandboxProcess,
                 provider_scopes: provider_scopes.clone(),
             }),
             _ => None,
@@ -110,9 +138,44 @@ pub struct RuntimeCredentialAuthRequirement {
     pub provider: VendorId,
     #[serde(default)]
     pub setup: RuntimeCredentialAccountSetup,
-    pub requester_extension: ExtensionId,
+    #[serde(
+        alias = "requester_extension",
+        deserialize_with = "deserialize_credential_consumer"
+    )]
+    pub consumer: RuntimeCredentialConsumer,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub provider_scopes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RuntimeCredentialConsumer {
+    Extension { extension_id: ExtensionId },
+    SandboxProcess,
+}
+
+impl RuntimeCredentialConsumer {
+    pub fn extension_id(&self) -> Option<&ExtensionId> {
+        match self {
+            Self::Extension { extension_id } => Some(extension_id),
+            Self::SandboxProcess => None,
+        }
+    }
+}
+
+fn deserialize_credential_consumer<'de, D>(
+    deserializer: D,
+) -> Result<RuntimeCredentialConsumer, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if let Some(extension_id) = value.as_str() {
+        return ExtensionId::new(extension_id)
+            .map(|extension_id| RuntimeCredentialConsumer::Extension { extension_id })
+            .map_err(serde::de::Error::custom);
+    }
+    serde_json::from_value(value).map_err(serde::de::Error::custom)
 }
 
 /// Canonical obligation evaluation classes.
@@ -240,8 +303,9 @@ fn normalize_multi_inject<'a>(
 
 fn extract_inject_handle(obligation: &Obligation, kind: &ObligationKind) -> SecretHandle {
     match obligation {
-        Obligation::InjectSecretOnce { handle } => handle.clone(),
-        Obligation::InjectCredentialAccountOnce { handle, .. } => handle.clone(),
+        Obligation::InjectSecretOnce { handle }
+        | Obligation::InjectCredentialAccountOnce { handle, .. }
+        | Obligation::InjectSandboxCredentialAccountOnce { handle, .. } => handle.clone(),
         _ => unreachable!("extract_inject_handle called for {kind:?}"),
     }
 }
@@ -265,7 +329,10 @@ impl Obligation {
             Self::ReserveResources { .. } => ObligationKind::ReserveResources,
             Self::UseScopedMounts { .. } => ObligationKind::UseScopedMounts,
             Self::InjectSecretOnce { .. } => ObligationKind::InjectSecretOnce,
-            Self::InjectCredentialAccountOnce { .. } => ObligationKind::InjectCredentialAccountOnce,
+            Self::InjectCredentialAccountOnce { .. }
+            | Self::InjectSandboxCredentialAccountOnce { .. } => {
+                ObligationKind::InjectCredentialAccountOnce
+            }
             Self::FirstPartyCredentialStagedViaHostPort { .. } => {
                 ObligationKind::FirstPartyCredentialStagedViaHostPort
             }
@@ -286,7 +353,9 @@ mod tests {
             provider: VendorId::new("github").unwrap(),
             setup: RuntimeCredentialAccountSetup::ManualToken,
             provider_scopes: vec!["repo".to_string()],
-            requester_extension: ExtensionId::new("github").unwrap(),
+            consumer: RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("github").unwrap(),
+            },
         }
     }
 
@@ -299,8 +368,50 @@ mod tests {
 
         assert_eq!(req.provider, VendorId::new("github").unwrap());
         assert_eq!(req.setup, RuntimeCredentialAccountSetup::ManualToken);
-        assert_eq!(req.requester_extension, ExtensionId::new("github").unwrap());
+        assert_eq!(
+            req.consumer,
+            RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("github").unwrap(),
+            }
+        );
         assert_eq!(req.provider_scopes, vec!["repo".to_string()]);
+    }
+
+    #[test]
+    fn sandbox_process_is_a_first_class_credential_consumer() {
+        let requirement = RuntimeCredentialAuthRequirement {
+            provider: VendorId::new("github").unwrap(),
+            setup: RuntimeCredentialAccountSetup::ManualToken,
+            consumer: RuntimeCredentialConsumer::SandboxProcess,
+            provider_scopes: vec!["repo".to_string()],
+        };
+
+        assert_eq!(
+            serde_json::to_value(requirement).unwrap(),
+            serde_json::json!({
+                "provider": "github",
+                "setup": {"kind": "manual_token"},
+                "consumer": {"kind": "sandbox_process"},
+                "provider_scopes": ["repo"],
+            })
+        );
+    }
+
+    #[test]
+    fn legacy_requester_extension_decodes_as_extension_consumer() {
+        let requirement: RuntimeCredentialAuthRequirement =
+            serde_json::from_value(serde_json::json!({
+                "provider": "github",
+                "requester_extension": "github",
+            }))
+            .unwrap();
+
+        assert_eq!(
+            requirement.consumer,
+            RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("github").unwrap(),
+            }
+        );
     }
 
     #[test]

--- a/crates/contracts/ironclaw_host_api/src/gate_record.rs
+++ b/crates/contracts/ironclaw_host_api/src/gate_record.rs
@@ -136,6 +136,7 @@ mod tests {
     use super::*;
     use crate::{
         capability::RuntimeCredentialAccountSetup,
+        decision::RuntimeCredentialConsumer,
         ids::{ExtensionId, VendorId},
     };
 
@@ -147,7 +148,9 @@ mod tests {
         RuntimeCredentialAuthRequirement {
             provider: VendorId::new("github").unwrap(),
             setup: RuntimeCredentialAccountSetup::ManualToken,
-            requester_extension: ExtensionId::new("github").unwrap(),
+            consumer: RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("github").unwrap(),
+            },
             provider_scopes: vec!["repo".to_string()],
         }
     }

--- a/crates/contracts/ironclaw_host_api/src/process.rs
+++ b/crates/contracts/ironclaw_host_api/src/process.rs
@@ -13,12 +13,91 @@
 //! capture, alias rewriting, and the local-host port. Only the shapes that
 //! cross the kernel↔lane seam live here.
 
-use std::{collections::HashMap, path::PathBuf, time::Duration};
+use std::{
+    collections::HashMap,
+    fmt,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use thiserror::Error;
 
 use crate::{mount::MountView, resource::ResourceScope};
+/// Cooperative cancellation shared across the kernel-to-sandbox transport seam.
+#[derive(Clone)]
+pub struct CommandCancellationToken {
+    inner: Arc<CommandCancellationState>,
+}
+
+struct CommandCancellationState {
+    cancelled: AtomicBool,
+    notify: tokio::sync::Notify,
+}
+
+impl Default for CommandCancellationToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandCancellationToken {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(CommandCancellationState {
+                cancelled: AtomicBool::new(false),
+                notify: tokio::sync::Notify::new(),
+            }),
+        }
+    }
+
+    pub fn cancel(&self) {
+        if !self.inner.cancelled.swap(true, Ordering::SeqCst) {
+            self.inner.notify.notify_waiters();
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::SeqCst)
+    }
+
+    pub async fn cancelled(&self) {
+        if self.is_cancelled() {
+            return;
+        }
+        loop {
+            let notified = self.inner.notify.notified();
+            if self.is_cancelled() {
+                return;
+            }
+            notified.await;
+            if self.is_cancelled() {
+                return;
+            }
+        }
+    }
+}
+
+impl fmt::Debug for CommandCancellationToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommandCancellationToken")
+            .field("cancelled", &self.is_cancelled())
+            .finish()
+    }
+}
+
+impl PartialEq for CommandCancellationToken {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl Eq for CommandCancellationToken {}
 
 /// Metadata for command output persisted behind a saved-output reference.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,9 +123,20 @@ pub struct CommandExecutionRequest {
     pub scope: ResourceScope,
     pub mounts: Option<MountView>,
     pub command: String,
+    /// Arguments passed directly to `command`. No shell parsing is permitted.
+    pub args: Vec<String>,
     pub workdir: Option<String>,
     pub timeout_secs: Option<u64>,
     pub extra_env: HashMap<String, String>,
+    pub cancellation: CommandCancellationToken,
+}
+
+impl CommandExecutionRequest {
+    pub fn argv(&self) -> Vec<&str> {
+        std::iter::once(self.command.as_str())
+            .chain(self.args.iter().map(String::as_str))
+            .collect()
+    }
 }
 
 /// Process-port command result normalized for capability handlers.
@@ -59,11 +149,62 @@ pub struct CommandExecutionOutput {
     pub duration: Duration,
 }
 
+/// One invocation-scoped credential binding handed only to the sandbox
+/// transport. The command receives `placeholder`; only the proxy-side
+/// transport may expose `secret`.
+#[derive(Clone)]
+pub struct SandboxCommandCredential {
+    pub placeholder_env: String,
+    pub placeholder: String,
+    pub approved_host: String,
+    pub header_name: String,
+    pub header_prefix: Option<String>,
+    secret: zeroize::Zeroizing<String>,
+}
+
+impl SandboxCommandCredential {
+    pub fn new(
+        placeholder_env: String,
+        placeholder: String,
+        approved_host: String,
+        header_name: String,
+        header_prefix: Option<String>,
+        secret: String,
+    ) -> Self {
+        Self {
+            placeholder_env,
+            placeholder,
+            approved_host,
+            header_name,
+            header_prefix,
+            secret: zeroize::Zeroizing::new(secret),
+        }
+    }
+
+    pub fn expose_secret(&self) -> &str {
+        self.secret.as_str()
+    }
+}
+
+impl std::fmt::Debug for SandboxCommandCredential {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SandboxCommandCredential")
+            .field("placeholder_env", &self.placeholder_env)
+            .field("approved_host", &self.approved_host)
+            .field("header_name", &self.header_name)
+            .field("header_prefix", &self.header_prefix)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Stable redacted process-port failure.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum RuntimeProcessError {
     #[error("command timed out after {0:?}")]
     Timeout(Duration),
+    #[error("process execution cancelled")]
+    Cancelled,
     #[error("process execution failed: {0}")]
     ExecutionFailed(String),
 }
@@ -84,10 +225,73 @@ pub trait SandboxCommandTransport: Send + Sync {
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError>;
 
+    async fn run_credentialed_command(
+        &self,
+        request: CommandExecutionRequest,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        if !credentials.is_empty() {
+            return Err(RuntimeProcessError::ExecutionFailed(
+                "sandbox transport does not support credential bindings".to_string(),
+            ));
+        }
+        self.run_command(request).await
+    }
+
     /// Release remote resources owned by this transport after command
     /// producers have stopped. Local transports may keep the default no-op;
     /// remote transports override this with idempotent provider cleanup.
     async fn shutdown(&self) -> Result<(), RuntimeProcessError> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_request_preserves_argument_boundaries() {
+        let request = CommandExecutionRequest {
+            scope: ResourceScope::system(),
+            mounts: None,
+            command: "printf".to_string(),
+            args: vec!["%s".to_string(), "one; echo injected".to_string()],
+            workdir: None,
+            timeout_secs: None,
+            extra_env: HashMap::new(),
+            cancellation: CommandCancellationToken::new(),
+        };
+
+        assert_eq!(
+            request.argv(),
+            ["printf", "%s", "one; echo injected"],
+            "the process boundary must never reinterpret arguments as shell syntax"
+        );
+    }
+    #[tokio::test]
+    async fn command_cancellation_wakes_in_flight_waiter() {
+        let token = CommandCancellationToken::new();
+        let waiter = token.clone();
+        let waiting = tokio::spawn(async move {
+            waiter.cancelled().await;
+        });
+
+        token.cancel();
+        tokio::time::timeout(Duration::from_secs(1), waiting)
+            .await
+            .expect("cancellation waiter must wake")
+            .expect("cancellation waiter must not panic");
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn command_cancellation_before_wait_returns_immediately() {
+        let token = CommandCancellationToken::new();
+        token.cancel();
+
+        tokio::time::timeout(Duration::from_secs(1), token.cancelled())
+            .await
+            .expect("pre-cancelled token must not block");
     }
 }

--- a/crates/contracts/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/contracts/ironclaw_host_api/tests/host_api_contract.rs
@@ -12,7 +12,7 @@ use ironclaw_host_api::{
     capability_profile::CapabilityProfileSchemaRef,
     decision::{
         Decision, DenyReason, Obligation, ObligationKind, Obligations,
-        RuntimeCredentialAuthRequirement,
+        RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer,
     },
     dispatch::{
         DispatchAuthRequirement, DispatchError, DispatchFailureKind, DispatchInputIssueCode,
@@ -1847,7 +1847,9 @@ fn runtime_credential_auth_requirement_defaults_setup_and_round_trips_oauth() {
         setup: RuntimeCredentialAccountSetup::OAuth {
             scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
         },
-        requester_extension: ExtensionId::new("gmail").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("gmail").unwrap(),
+        },
         provider_scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
     };
     let round_trip: RuntimeCredentialAuthRequirement =
@@ -1906,7 +1908,9 @@ fn dispatch_error_auth_required_debug_redacts_required_secrets() {
         setup: RuntimeCredentialAccountSetup::OAuth {
             scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
         },
-        requester_extension: ExtensionId::new("gmail").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("gmail").unwrap(),
+        },
         provider_scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
     };
     let with_requirement = DispatchError::AuthRequired {

--- a/crates/contracts/ironclaw_loop_contracts/src/resolution.rs
+++ b/crates/contracts/ironclaw_loop_contracts/src/resolution.rs
@@ -914,6 +914,7 @@ mod tests {
     use super::*;
     use ironclaw_host_api::{
         capability::RuntimeCredentialAccountSetup,
+        decision::RuntimeCredentialConsumer,
         dispatch::DispatchInputIssueCode,
         gate_record::GateRecord,
         ids::{ApprovalRequestId, CorrelationId, ExtensionId, VendorId},
@@ -935,7 +936,9 @@ mod tests {
         RuntimeCredentialAuthRequirement {
             provider: VendorId::new("github").unwrap(),
             setup: RuntimeCredentialAccountSetup::ManualToken,
-            requester_extension: ExtensionId::new("github").unwrap(),
+            consumer: RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("github").unwrap(),
+            },
             provider_scopes: vec!["repo".to_string()],
         }
     }

--- a/crates/domains/ironclaw_auth/src/product_auth/credentials/runtime_credentials.rs
+++ b/crates/domains/ironclaw_auth/src/product_auth/credentials/runtime_credentials.rs
@@ -153,7 +153,7 @@ async fn configured_runtime_credential_account(
         &requirement.provider,
         requirement.setup.clone(),
         &requirement.provider_scopes,
-        &requirement.requester_extension,
+        requirement.consumer.extension_id(),
     )?;
     match accounts
         .select_unique_configured_runtime_account(request)
@@ -497,7 +497,7 @@ pub fn runtime_credential_account_selection_request(
     provider: &VendorId,
     setup: RuntimeCredentialAccountSetup,
     provider_scopes: &[String],
-    requester_extension: &ExtensionId,
+    requester_extension: Option<&ExtensionId>,
 ) -> Result<RuntimeCredentialAccountSelectionRequest, CredentialStageError> {
     let owner_scope = AuthProductScope::credential_owner(scope, AuthSurface::Api);
     let provider = AuthProviderId::new(provider.as_str()).map_err(|e| {
@@ -521,9 +521,12 @@ pub fn runtime_credential_account_selection_request(
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
+    let mut selection = CredentialAccountSelectionRequest::new(owner_scope, provider);
+    if let Some(requester_extension) = requester_extension {
+        selection = selection.for_extension(requester_extension.clone());
+    }
     Ok(RuntimeCredentialAccountSelectionRequest::new(
-        CredentialAccountSelectionRequest::new(owner_scope, provider)
-            .for_extension(requester_extension.clone()),
+        selection,
         AuthProductScope::new(scope.clone(), AuthSurface::Api),
         setup,
         provider_scopes,

--- a/crates/domains/ironclaw_auth/src/product_auth/credentials/runtime_credentials/tests.rs
+++ b/crates/domains/ironclaw_auth/src/product_auth/credentials/runtime_credentials/tests.rs
@@ -125,7 +125,7 @@ impl ProductAuthRuntimeCredentialResolver {
             request.provider,
             request.setup.clone(),
             request.provider_scopes,
-            request.requester_extension,
+            Some(request.requester_extension),
         )?;
         let account = self
             .accounts
@@ -1749,7 +1749,9 @@ async fn activation_preflight_maps_configured_account_without_access_secret_to_b
         vec![RuntimeCredentialAuthRequirement {
             provider: VendorId::new("github").unwrap(),
             setup: Default::default(),
-            requester_extension: ExtensionId::new("github").unwrap(),
+            consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("github").unwrap(),
+            },
             provider_scopes: Vec::new(),
         }],
     )

--- a/crates/domains/ironclaw_auth/src/product_auth/durable/tests.rs
+++ b/crates/domains/ironclaw_auth/src/product_auth/durable/tests.rs
@@ -270,7 +270,7 @@ async fn filesystem_runtime_account_selection_matches_new_thread_reusable_accoun
         &VendorId::new("google").unwrap(),
         ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
         &[],
-        &ExtensionId::new("google-calendar").unwrap(),
+        Some(&ExtensionId::new("google-calendar").unwrap()),
     )
     .unwrap();
     let resolved = selector

--- a/crates/domains/ironclaw_auth/src/product_auth/oauth/oauth_gate.rs
+++ b/crates/domains/ironclaw_auth/src/product_auth/oauth/oauth_gate.rs
@@ -11,7 +11,7 @@ use chrono::{Duration as ChronoDuration, Utc};
 use ironclaw_host_api::turn::{TurnRunId, TurnScope};
 use ironclaw_host_api::{
     decision::RuntimeCredentialAuthRequirement,
-    ids::{InvocationId, SecretHandle},
+    ids::{ExtensionId, InvocationId, SecretHandle},
     resource::ResourceScope,
 };
 use ironclaw_secrets::{SecretMaterial, SecretStorePort};
@@ -60,11 +60,14 @@ impl OAuthGateFlowDriver {
     ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
         for requirement in request.requirements {
             let vendor = requirement.provider.as_str();
+            let Some(requester_extension) = requirement.consumer.extension_id() else {
+                continue;
+            };
             if self
                 .engine
                 .recipes()
                 .resolve(
-                    Some(&requirement.requester_extension),
+                    Some(requester_extension),
                     Some(request.owner_user_id),
                     vendor,
                 )
@@ -73,7 +76,10 @@ impl OAuthGateFlowDriver {
             {
                 continue;
             }
-            match self.challenge_for_requirement(request, requirement).await {
+            match self
+                .challenge_for_requirement(request, requirement, requester_extension)
+                .await
+            {
                 Ok(challenge) => return Ok(Some(challenge)),
                 // A resolvable-but-unconfigured vendor (e.g. missing operator
                 // client credentials) must not swallow the whole gate: fall
@@ -107,6 +113,7 @@ impl OAuthGateFlowDriver {
         &self,
         request: OAuthGateChallengeRequest<'_>,
         requirement: &RuntimeCredentialAuthRequirement,
+        requester_extension: &ExtensionId,
     ) -> Result<AuthFlowRecord, AuthProductError> {
         let auth_scope = auth_scope_for_blocked_turn(request.scope, request.owner_user_id);
         let turn_run_ref = TurnRunRef::new(request.run_id.to_string())?;
@@ -120,7 +127,7 @@ impl OAuthGateFlowDriver {
                 request.flow_source,
                 query.clone(),
                 &provider,
-                &requirement.requester_extension,
+                requester_extension,
             )
             .await?
         {
@@ -134,7 +141,7 @@ impl OAuthGateFlowDriver {
             .engine
             .prepare_oauth_flow(PrepareOAuthFlowRequest {
                 vendor: vendor.to_string(),
-                requester_extension: Some(requirement.requester_extension.clone()),
+                requester_extension: Some(requester_extension.clone()),
                 scope: auth_scope.clone(),
                 flow_id,
                 account_label: CredentialAccountLabel::new(vendor)?,
@@ -181,7 +188,7 @@ impl OAuthGateFlowDriver {
                     request.flow_source,
                     query,
                     &provider,
-                    &requirement.requester_extension,
+                    requester_extension,
                 )
                 .await?
                 .ok_or(AuthProductError::BackendConflict)?
@@ -544,7 +551,9 @@ mod tests {
                     setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth {
                         scopes: vec!["msg:read".to_string()],
                     },
-                    requester_extension: ExtensionId::new("acme-messenger-fixture").unwrap(),
+                    consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                        extension_id: ExtensionId::new("acme-messenger-fixture").unwrap(),
+                    },
                     provider_scopes: vec!["msg:read".to_string()],
                 },
             }
@@ -597,7 +606,7 @@ mod tests {
         assert_eq!(flow.provider.as_str(), "acmevendor");
         assert_eq!(
             flow.requester_extension.as_ref(),
-            Some(&fixture.requirement.requester_extension),
+            fixture.requirement.consumer.extension_id(),
             "the gate flow durably retains the extension whose recipe was resolved"
         );
         let AuthChallenge::OAuthUrl {
@@ -898,7 +907,9 @@ mod tests {
         let unknown_requirement = RuntimeCredentialAuthRequirement {
             provider: VendorId::new("unknownvendor").unwrap(),
             setup: Default::default(),
-            requester_extension: ExtensionId::new("acme-messenger-fixture").unwrap(),
+            consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("acme-messenger-fixture").unwrap(),
+            },
             provider_scopes: Vec::new(),
         };
         let serviceable = fixture.requirement.clone();

--- a/crates/domains/ironclaw_auth/src/product_prompt.rs
+++ b/crates/domains/ironclaw_auth/src/product_prompt.rs
@@ -643,8 +643,10 @@ mod tests {
         RuntimeCredentialAuthRequirement {
             provider: VendorId::new("acme").expect("vendor"),
             setup,
-            requester_extension: ironclaw_host_api::ids::ExtensionId::new("acme")
-                .expect("extension id"),
+            consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                extension_id: ironclaw_host_api::ids::ExtensionId::new("acme")
+                    .expect("extension id"),
+            },
             provider_scopes: Vec::new(),
         }
     }

--- a/crates/extensions/ironclaw_extension_host/src/activation_transaction.rs
+++ b/crates/extensions/ironclaw_extension_host/src/activation_transaction.rs
@@ -467,7 +467,9 @@ mod tests {
         let requirement = RuntimeCredentialAuthRequirement {
             provider: VendorId::new("hosted-provider").expect("vendor id"),
             setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
-            requester_extension: fixture_extension_id(),
+            consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                extension_id: fixture_extension_id(),
+            },
             provider_scopes: Vec::new(),
         };
         let operations =

--- a/crates/extensions/ironclaw_extension_host/src/channel_pairing/tests.rs
+++ b/crates/extensions/ironclaw_extension_host/src/channel_pairing/tests.rs
@@ -576,7 +576,9 @@ async fn recipe_auth_prompt_reuses_the_live_pairing_code_and_connection_recipe()
         ironclaw_host_api::decision::RuntimeCredentialAuthRequirement {
             provider: ironclaw_host_api::ids::VendorId::new(EXT).expect("provider"),
             setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::Pairing,
-            requester_extension: ExtensionId::new(EXT).expect("extension"),
+            consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new(EXT).expect("extension"),
+            },
             provider_scopes: Vec::new(),
         },
     ];

--- a/crates/extensions/ironclaw_extension_host/src/extension_credential_requirements.rs
+++ b/crates/extensions/ironclaw_extension_host/src/extension_credential_requirements.rs
@@ -115,7 +115,7 @@ fn can_merge_runtime_credential_auth_requirement(
     candidate: &RuntimeCredentialAuthRequirement,
 ) -> bool {
     existing.provider == candidate.provider
-        && existing.requester_extension == candidate.requester_extension
+        && existing.consumer == candidate.consumer
         && can_merge_runtime_credential_setup(&existing.setup, &candidate.setup)
 }
 

--- a/crates/extensions/ironclaw_extension_host/src/linked_account_resolution.rs
+++ b/crates/extensions/ironclaw_extension_host/src/linked_account_resolution.rs
@@ -117,7 +117,7 @@ impl LinkedAccountResolver for CredentialLinkedAccountResolver {
             &self.vendor,
             RuntimeCredentialAccountSetup::DeviceLink,
             &[],
-            &self.extension_id,
+            Some(&self.extension_id),
         )
         .map_err(|error| {
             debug!(error = ?error, "linked-account selection request could not be built");

--- a/crates/extensions/ironclaw_extension_host/src/product_lifecycle.rs
+++ b/crates/extensions/ironclaw_extension_host/src/product_lifecycle.rs
@@ -2886,7 +2886,7 @@ fn is_device_link_channel_requirement(
         && setup.auth_requirement.setup == RuntimeCredentialAccountSetup::DeviceLink
         && requirement.setup == RuntimeCredentialAccountSetup::DeviceLink
         && requirement.provider == setup.auth_requirement.provider
-        && requirement.requester_extension == setup.auth_requirement.requester_extension
+        && requirement.consumer == setup.auth_requirement.consumer
 }
 
 fn activation_success_message(
@@ -3391,7 +3391,9 @@ mod tests {
             auth_requirement: RuntimeCredentialAuthRequirement {
                 provider: VendorId::new(provider).expect("provider id"),
                 setup: RuntimeCredentialAccountSetup::DeviceLink,
-                requester_extension: extension_id.clone(),
+                consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                    extension_id: extension_id.clone(),
+                },
                 provider_scopes: Vec::new(),
             },
             connection_requirement:
@@ -3433,7 +3435,9 @@ mod tests {
         ));
 
         let unrelated_requester = RuntimeCredentialAuthRequirement {
-            requester_extension: ExtensionId::new("other-extension").expect("extension id"),
+            consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("other-extension").expect("extension id"),
+            },
             ..channel_requirement.clone()
         };
         assert!(!is_device_link_channel_requirement(

--- a/crates/extensions/ironclaw_extension_host/src/run_delivery_ports.rs
+++ b/crates/extensions/ironclaw_extension_host/src/run_delivery_ports.rs
@@ -63,10 +63,13 @@ impl AuthChallengeProvider for RecipeAuthChallengeProvider {
         if let [requirement] = credential_requirements
             && requirement.setup == RuntimeCredentialAccountSetup::Pairing
         {
+            let Some(requester_extension) = requirement.consumer.extension_id() else {
+                return Ok(None);
+            };
             let Some(service) = self
                 .pairing
                 .as_ref()
-                .and_then(|registry| registry.get(requirement.requester_extension.as_str()))
+                .and_then(|registry| registry.get(requester_extension.as_str()))
             else {
                 return Ok(None);
             };

--- a/crates/extensions/ironclaw_extension_manager/src/extension_lifecycle_capabilities.rs
+++ b/crates/extensions/ironclaw_extension_manager/src/extension_lifecycle_capabilities.rs
@@ -1859,7 +1859,10 @@ mod tests {
         assert_eq!(gate.credential_requirements.len(), 1);
         let requirement = &gate.credential_requirements[0];
         assert_eq!(requirement.provider.as_str(), "github");
-        assert_eq!(requirement.requester_extension.as_str(), "github");
+        assert_eq!(
+            requirement.consumer.extension_id().map(ExtensionId::as_str),
+            Some("github")
+        );
 
         let active = active_extension_capability_ids(&extension_management).await;
         assert!(!active.iter().any(|id| id == "github.search_issues"));
@@ -2051,7 +2054,10 @@ mod tests {
         assert_eq!(gate.credential_requirements.len(), 1);
         let requirement = &gate.credential_requirements[0];
         assert_eq!(requirement.provider.as_str(), "google");
-        assert_eq!(requirement.requester_extension.as_str(), "google-calendar");
+        assert_eq!(
+            requirement.consumer.extension_id().map(ExtensionId::as_str),
+            Some("google-calendar")
+        );
         assert_eq!(
             requirement
                 .provider_scopes
@@ -2095,7 +2101,10 @@ mod tests {
         );
         let requirement = &gate.credential_requirements[0];
         assert_eq!(requirement.provider.as_str(), "google");
-        assert_eq!(requirement.requester_extension.as_str(), "gmail");
+        assert_eq!(
+            requirement.consumer.extension_id().map(ExtensionId::as_str),
+            Some("gmail")
+        );
         assert_eq!(
             requirement
                 .provider_scopes

--- a/crates/extensions/ironclaw_extension_manager/src/test_support/lifecycle.rs
+++ b/crates/extensions/ironclaw_extension_manager/src/test_support/lifecycle.rs
@@ -20,7 +20,7 @@ use ironclaw_filesystem::{
 use ironclaw_host_api::{
     action::Action,
     capability::CapabilityDescriptor,
-    decision::{Decision, Obligation, Obligations},
+    decision::{Decision, Obligation, Obligations, RuntimeCredentialConsumer},
     dispatch::CredentialStageError,
     ids::{CapabilityId, VendorId},
     mount::{MountGrant, MountPermissions, MountView},
@@ -592,7 +592,7 @@ impl RuntimeCredentialAccountResolver for TestProductAuthRuntimeCredentialResolv
             request.provider,
             request.setup.clone(),
             request.provider_scopes,
-            request.requester_extension,
+            request.consumer.extension_id(),
         )?;
         let account = self
             .accounts
@@ -722,7 +722,9 @@ impl ironclaw_authorization::TrustAwareCapabilityDispatchAuthorizer
                     provider: provider.clone(),
                     setup: setup.clone(),
                     provider_scopes: credential.provider_scopes.clone(),
-                    requester_extension: descriptor.provider.clone(),
+                    consumer: RuntimeCredentialConsumer::Extension {
+                        extension_id: descriptor.provider.clone(),
+                    },
                 }),
             }
         }

--- a/crates/extensions/packages/telegram/src/linked/mapping.rs
+++ b/crates/extensions/packages/telegram/src/linked/mapping.rs
@@ -30,7 +30,7 @@ use grammers_client::{
 use ironclaw_extension_contracts::tool_adapter::ToolError;
 use ironclaw_host_api::{
     capability::RuntimeCredentialAccountSetup,
-    decision::RuntimeCredentialAuthRequirement,
+    decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     dispatch::{
         DispatchAuthRequirement, ProviderDiagnostic, ProviderErrorCode, RuntimeDispatchErrorKind,
         UntrustedProviderMessage,
@@ -132,7 +132,9 @@ pub(crate) fn auth_required() -> ToolError {
             credential_requirements: vec![RuntimeCredentialAuthRequirement {
                 provider,
                 setup: RuntimeCredentialAccountSetup::DeviceLink,
-                requester_extension,
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: requester_extension,
+                },
                 provider_scopes: Vec::new(),
             }],
             model_visible_cause: None,

--- a/crates/kernel/ironclaw_approvals/tests/gate_record_store_contract.rs
+++ b/crates/kernel/ironclaw_approvals/tests/gate_record_store_contract.rs
@@ -15,7 +15,7 @@ use ironclaw_approvals::*;
 use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
     capability::RuntimeCredentialAccountSetup,
-    decision::RuntimeCredentialAuthRequirement,
+    decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     gate_record::GateRecord,
     ids::{ExtensionId, GateRef, InvocationId, ProjectId, ResultRef, TenantId, UserId, VendorId},
     mount::{MountGrant, MountPermissions, MountView},
@@ -234,7 +234,9 @@ fn credential_requirement() -> RuntimeCredentialAuthRequirement {
     RuntimeCredentialAuthRequirement {
         provider: VendorId::new("github").unwrap(),
         setup: RuntimeCredentialAccountSetup::ManualToken,
-        requester_extension: ExtensionId::new("github").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("github").unwrap(),
+        },
         provider_scopes: vec!["repo".to_string()],
     }
 }

--- a/crates/kernel/ironclaw_authorization/src/lib.rs
+++ b/crates/kernel/ironclaw_authorization/src/lib.rs
@@ -30,7 +30,7 @@ use ironclaw_host_api::{
     capability::{
         CapabilityDescriptor, CapabilityGrant, EffectKind, RuntimeCredentialRequirementSource,
     },
-    decision::{Decision, DenyReason, Obligation, Obligations},
+    decision::{Decision, DenyReason, Obligation, Obligations, RuntimeCredentialConsumer},
     error::HostApiError,
     ids::{AgentId, CapabilityGrantId, MissionId, ProjectId, TenantId, ThreadId, UserId},
     path::ScopedPath,
@@ -1097,16 +1097,27 @@ fn obligations_for_grant(
                     }
                 }
                 RuntimeCredentialRequirementSource::ProductAuthAccount { provider, setup } => {
-                    // Mirror SecretHandle: only mandate the obligation when the credential is
-                    // required. An optional product-auth credential is skipped rather than
-                    // injected so that a missing account does not hard-fail dispatch.
-                    if credential.required {
+                    if descriptor.id.as_str()
+                        == ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID
+                    {
+                        obligations.push(Obligation::InjectSandboxCredentialAccountOnce {
+                            handle: credential.handle.clone(),
+                            provider: provider.clone(),
+                            setup: setup.clone(),
+                            provider_scopes: credential.provider_scopes.clone(),
+                            required: credential.required,
+                            audience: credential.audience.clone(),
+                            target: credential.target.clone(),
+                        });
+                    } else if credential.required {
                         obligations.push(Obligation::InjectCredentialAccountOnce {
                             handle: credential.handle.clone(),
                             provider: provider.clone(),
                             setup: setup.clone(),
                             provider_scopes: credential.provider_scopes.clone(),
-                            requester_extension: descriptor.provider.clone(),
+                            consumer: RuntimeCredentialConsumer::Extension {
+                                extension_id: descriptor.provider.clone(),
+                            },
                         });
                     }
                 }

--- a/crates/kernel/ironclaw_authorization/tests/runtime_credentials_contract.rs
+++ b/crates/kernel/ironclaw_authorization/tests/runtime_credentials_contract.rs
@@ -6,7 +6,7 @@ use ironclaw_host_api::{
         PermissionMode, RuntimeCredentialAccountSetup, RuntimeCredentialRequirement,
         RuntimeCredentialRequirementSource,
     },
-    decision::{Decision, DenyReason, Obligation},
+    decision::{Decision, DenyReason, Obligation, RuntimeCredentialConsumer},
     http::RuntimeCredentialTarget,
     ids::{
         CapabilityGrantId, CapabilityId, CorrelationId, ExtensionId, InvocationId, ProjectId,
@@ -230,7 +230,9 @@ async fn capability_access_resolves_product_auth_account_runtime_credentials() {
             provider: VendorId::new("github").unwrap(),
             setup: Default::default(),
             provider_scopes: vec!["repo".to_string()],
-            requester_extension: ExtensionId::new("echo").unwrap(),
+            consumer: RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("echo").unwrap(),
+            },
         }]
     );
 }
@@ -279,8 +281,78 @@ async fn capability_access_preserves_oauth_product_auth_account_setup() {
             provider: VendorId::new("github").unwrap(),
             setup: oauth_setup,
             provider_scopes: vec!["repo".to_string()],
-            requester_extension: ExtensionId::new("echo").unwrap(),
+            consumer: RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("echo").unwrap(),
+            },
         }]
+    );
+}
+
+#[tokio::test]
+async fn process_sandbox_product_auth_credential_uses_sandbox_consumer() {
+    let slot = SecretHandle::new("github_runtime_token").unwrap();
+    let descriptor = CapabilityDescriptor {
+        id: CapabilityId::new(ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID)
+            .unwrap(),
+        provider: ExtensionId::new("system.process_sandbox").unwrap(),
+        runtime: RuntimeKind::System,
+        effects: vec![
+            EffectKind::ExecuteCode,
+            EffectKind::SpawnProcess,
+            EffectKind::UseSecret,
+        ],
+        runtime_credentials: vec![RuntimeCredentialRequirement {
+            source: RuntimeCredentialRequirementSource::ProductAuthAccount {
+                provider: VendorId::new("github").unwrap(),
+                setup: Default::default(),
+            },
+            provider_scopes: vec!["repo".to_string()],
+            ..runtime_credential(slot.clone(), github_audience(), true)
+        }],
+        ..wasm_descriptor()
+    };
+    let grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        descriptor.effects.clone(),
+    );
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &execution_context(CapabilitySet {
+                grants: vec![grant],
+            }),
+            &descriptor,
+            &ResourceEstimate::default(),
+        )
+        .await;
+
+    let Decision::Allow { obligations } = decision else {
+        panic!("expected allow decision, got {decision:?}");
+    };
+    assert_eq!(
+        obligations.as_slice(),
+        &[
+            Obligation::UseScopedMounts {
+                mounts: MountView::default(),
+            },
+            Obligation::InjectSandboxCredentialAccountOnce {
+                handle: slot,
+                provider: VendorId::new("github").unwrap(),
+                setup: Default::default(),
+                provider_scopes: vec!["repo".to_string()],
+                required: true,
+                audience: NetworkTargetPattern {
+                    scheme: Some(NetworkScheme::Https),
+                    host_pattern: "api.github.com".to_string(),
+                    port: None,
+                },
+                target: RuntimeCredentialTarget::Header {
+                    name: "authorization".to_string(),
+                    prefix: Some("Bearer ".to_string()),
+                },
+            },
+        ],
     );
 }
 

--- a/crates/kernel/ironclaw_capabilities/src/error.rs
+++ b/crates/kernel/ironclaw_capabilities/src/error.rs
@@ -400,7 +400,7 @@ fn dispatch_error_model_visible_cause(error: &DispatchError) -> Option<String> {
 mod tests {
     use super::*;
     use ironclaw_host_api::{
-        decision::RuntimeCredentialAuthRequirement,
+        decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
         dispatch::{
             DispatchAuthRequirement, DispatchFailureDetail, DispatchInputIssue,
             DispatchInputIssueCode, RuntimeDispatchErrorKind,
@@ -820,7 +820,9 @@ mod tests {
             setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth {
                 scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
             },
-            requester_extension: ExtensionId::new("gmail").unwrap(),
+            consumer: RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("gmail").unwrap(),
+            },
             provider_scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
         };
         let err = CapabilityInvocationError::from(DispatchError::AuthRequired {

--- a/crates/kernel/ironclaw_capabilities/src/host/approval_resume.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/approval_resume.rs
@@ -185,7 +185,7 @@ where
             });
         }
 
-        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+        let Some(base_descriptor) = self.registry.get_capability(&request.capability_id) else {
             fail_invocation_if_configured(
                 Some(invocation_state),
                 &scope,
@@ -196,6 +196,22 @@ where
             return Err(CapabilityInvocationError::UnknownCapability {
                 capability: request.capability_id,
             });
+        };
+        let descriptor = match self
+            .enrich_invocation_descriptor(base_descriptor, &request.capability_id, &request.input)
+            .await
+        {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                fail_invocation_if_configured(
+                    Some(invocation_state),
+                    &scope,
+                    invocation_id,
+                    "AuthorizationDenied",
+                )
+                .await;
+                return Err(error);
+            }
         };
 
         let Some(lease) = matching_approval_lease(
@@ -237,7 +253,7 @@ where
             estimate: request.estimate,
             input: request.input,
             authorized_context,
-            descriptor,
+            descriptor: &descriptor,
             lease_state: ResumedLeaseState::PendingClaim(PendingClaimAfterAuth {
                 leases: capability_leases,
                 grant_id,

--- a/crates/kernel/ironclaw_capabilities/src/host/auth_resume.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/auth_resume.rs
@@ -125,7 +125,7 @@ where
         // touching the lease at all — preventing a one-shot lease from being
         // permanently stranded in `Claimed`/`Dispatching` when the capability
         // was unregistered between the original invocation and this resume.
-        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+        let Some(base_descriptor) = self.registry.get_capability(&request.capability_id) else {
             fail_invocation_if_configured(
                 Some(invocation_state),
                 &scope,
@@ -136,6 +136,22 @@ where
             return Err(CapabilityInvocationError::UnknownCapability {
                 capability: request.capability_id,
             });
+        };
+        let descriptor = match self
+            .enrich_invocation_descriptor(base_descriptor, &request.capability_id, &request.input)
+            .await
+        {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                fail_invocation_if_configured(
+                    Some(invocation_state),
+                    &scope,
+                    invocation_id,
+                    "AuthorizationDenied",
+                )
+                .await;
+                return Err(error);
+            }
         };
 
         // When the invocation previously passed an approval gate, validate and
@@ -378,7 +394,7 @@ where
             estimate: request.estimate,
             input: request.input,
             authorized_context,
-            descriptor,
+            descriptor: &descriptor,
             lease_state: match approval_lease_to_consume {
                 Some((leases, lease)) => ResumedLeaseState::AlreadyClaimed(leases, Box::new(lease)),
                 None => ResumedLeaseState::NoPriorLease,

--- a/crates/kernel/ironclaw_capabilities/src/host/authorize.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/authorize.rs
@@ -67,6 +67,27 @@ where
             )),
         }
     }
+    pub(super) async fn enrich_invocation_descriptor(
+        &self,
+        descriptor: &CapabilityDescriptor,
+        capability_id: &CapabilityId,
+        input: &serde_json::Value,
+    ) -> Result<CapabilityDescriptor, CapabilityInvocationError> {
+        let mut descriptor = descriptor.clone();
+        let invocation_credentials = self
+            .policy_facts
+            .invocation_runtime_credentials(capability_id, input)
+            .await
+            .map_err(|detail| CapabilityInvocationError::AuthorizationDenied {
+                capability: capability_id.clone(),
+                reason: DenyReason::PolicyDenied,
+                detail: Some(detail),
+            })?;
+        descriptor
+            .runtime_credentials
+            .extend(invocation_credentials);
+        Ok(descriptor)
+    }
 
     /// Persistent-approval fold (§5.2.7/§5.3.2): a prior scoped approval may
     /// already authorize this invocation. Relocated from host_runtime's former
@@ -194,12 +215,15 @@ where
         // fingerprint above nor `invocation_state.start` below needs the descriptor, so
         // hoisting this lookup is safe; everything from `start` onward keeps its
         // original order (the credential pre-flight still runs after `start`).
-        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+        let Some(base_descriptor) = self.registry.get_capability(&request.capability_id) else {
             debug!("capability invocation failed before authorization: unknown capability");
             return Err(CapabilityInvocationError::UnknownCapability {
                 capability: request.capability_id.clone(),
             });
         };
+        let descriptor = self
+            .enrich_invocation_descriptor(base_descriptor, &request.capability_id, &request.input)
+            .await?;
 
         if let Some(invocation_state) = self.invocation_state {
             invocation_state
@@ -233,7 +257,7 @@ where
                 return Err(error);
             }
         };
-        if let Err(error) = self.enforce_runtime_policy(descriptor) {
+        if let Err(error) = self.enforce_runtime_policy(&descriptor) {
             apply_invocation_state_transition_if_configured(
                 self.invocation_state,
                 &scope,
@@ -287,7 +311,7 @@ where
         let frozen_deadline = self
             .apply_persistent_approval(
                 &mut authorize_context,
-                descriptor,
+                &descriptor,
                 &request.capability_id,
                 &request.estimate,
                 &trust_decision,
@@ -299,7 +323,7 @@ where
             .authorizer
             .authorize_dispatch_with_trust(
                 &authorize_context,
-                descriptor,
+                &descriptor,
                 &request.estimate,
                 &trust_decision,
             )
@@ -347,7 +371,7 @@ where
                     &request.capability_id,
                     &request.estimate,
                     &request.input,
-                    descriptor,
+                    &descriptor,
                     &obligation_outcome,
                     frozen_deadline,
                 );

--- a/crates/kernel/ironclaw_capabilities/src/host/spawn.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/spawn.rs
@@ -233,11 +233,14 @@ where
         // Resolve the descriptor BEFORE starting a invocation record (see `authorize`):
         // an unknown capability short-circuits without creating a invocation record, so
         // no `fail_invocation_if_configured` is needed here.
-        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+        let Some(base_descriptor) = self.registry.get_capability(&request.capability_id) else {
             return Err(CapabilityInvocationError::UnknownCapability {
                 capability: request.capability_id.clone(),
             });
         };
+        let descriptor = self
+            .enrich_invocation_descriptor(base_descriptor, &request.capability_id, &request.input)
+            .await?;
 
         if let Some(invocation_state) = self.invocation_state {
             invocation_state
@@ -268,7 +271,7 @@ where
                 return Err(error);
             }
         };
-        if let Err(error) = self.enforce_runtime_policy(descriptor) {
+        if let Err(error) = self.enforce_runtime_policy(&descriptor) {
             apply_invocation_state_transition_if_configured(
                 self.invocation_state,
                 &scope,
@@ -317,7 +320,7 @@ where
         let frozen_deadline = self
             .apply_persistent_approval(
                 &mut authorize_context,
-                descriptor,
+                &descriptor,
                 &request.capability_id,
                 &request.estimate,
                 &trust_decision,
@@ -329,7 +332,7 @@ where
             .authorizer
             .authorize_spawn_with_trust(
                 &authorize_context,
-                descriptor,
+                &descriptor,
                 &request.estimate,
                 &trust_decision,
             )
@@ -366,7 +369,7 @@ where
                     &request.capability_id,
                     &request.estimate,
                     &request.input,
-                    descriptor,
+                    &descriptor,
                     &obligation_outcome,
                     frozen_deadline,
                 );

--- a/crates/kernel/ironclaw_capabilities/src/host/spawn_resume.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/spawn_resume.rs
@@ -190,7 +190,7 @@ where
             });
         }
 
-        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+        let Some(base_descriptor) = self.registry.get_capability(&request.capability_id) else {
             fail_invocation_if_configured(
                 Some(invocation_state),
                 &scope,
@@ -201,6 +201,22 @@ where
             return Err(CapabilityInvocationError::UnknownCapability {
                 capability: request.capability_id,
             });
+        };
+        let descriptor = match self
+            .enrich_invocation_descriptor(base_descriptor, &request.capability_id, &request.input)
+            .await
+        {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                fail_invocation_if_configured(
+                    Some(invocation_state),
+                    &scope,
+                    invocation_id,
+                    "AuthorizationDenied",
+                )
+                .await;
+                return Err(error);
+            }
         };
 
         let Some(lease) = matching_approval_lease(
@@ -247,7 +263,7 @@ where
             .authorizer
             .authorize_spawn_with_trust(
                 &authorized_context,
-                descriptor,
+                &descriptor,
                 &request.estimate,
                 &trust_decision,
             )
@@ -360,7 +376,7 @@ where
             &request.capability_id,
             &request.estimate,
             &request.input,
-            descriptor,
+            &descriptor,
             &obligation_outcome,
             claimed_lease.grant.constraints.expires_at,
         );

--- a/crates/kernel/ironclaw_capabilities/src/host/tests.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/tests.rs
@@ -5,7 +5,7 @@
 
 use ironclaw_host_api::{
     capability::RuntimeCredentialAccountSetup,
-    decision::{Decision, Obligation},
+    decision::{Decision, Obligation, RuntimeCredentialConsumer},
     dispatch::{CapabilityDispatchResult, DispatchAuthRequirement},
     ids::{CapabilityId, ExtensionId, SecretHandle, VendorId},
     invocation::Actor,
@@ -50,7 +50,9 @@ fn auth_required_with_provider(cap: &str, provider: &str) -> DispatchError {
             credential_requirements: vec![RuntimeCredentialAuthRequirement {
                 provider: VendorId::new(provider).unwrap(),
                 setup: RuntimeCredentialAccountSetup::ManualToken,
-                requester_extension: ExtensionId::new(provider).unwrap(),
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new(provider).unwrap(),
+                },
                 provider_scopes: Vec::new(),
             }],
             model_visible_cause: None,
@@ -64,7 +66,9 @@ fn inject_credential_obligation(provider: &str) -> Obligation {
         provider: VendorId::new(provider).unwrap(),
         setup: RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: Vec::new(),
-        requester_extension: ExtensionId::new(provider).unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new(provider).unwrap(),
+        },
     }
 }
 
@@ -211,6 +215,37 @@ struct SatisfiedPolicyFacts;
 
 #[async_trait::async_trait]
 impl HostPolicyFacts for SatisfiedPolicyFacts {
+    async fn credential_presence(
+        &self,
+        _capability_id: &CapabilityId,
+        _scope: &ResourceScope,
+    ) -> CredentialPresence {
+        CredentialPresence::Satisfied
+    }
+
+    async fn persistent_grants(
+        &self,
+        _capability_id: &CapabilityId,
+        _context: &ExecutionContext,
+        _action: crate::ports::PolicyAction,
+    ) -> Vec<ironclaw_host_api::capability::CapabilityGrant> {
+        Vec::new()
+    }
+}
+struct InvocationCredentialPolicyFacts {
+    requirement: ironclaw_host_api::capability::RuntimeCredentialRequirement,
+}
+
+#[async_trait::async_trait]
+impl HostPolicyFacts for InvocationCredentialPolicyFacts {
+    async fn invocation_runtime_credentials(
+        &self,
+        _capability_id: &CapabilityId,
+        _input: &serde_json::Value,
+    ) -> Result<Vec<ironclaw_host_api::capability::RuntimeCredentialRequirement>, String> {
+        Ok(vec![self.requirement.clone()])
+    }
+
     async fn credential_presence(
         &self,
         _capability_id: &CapabilityId,
@@ -477,6 +512,74 @@ async fn authorize_allow_path_seals_authorized_with_lane_and_invocation() {
     // No frozen fact → the bounded default TTL from authorize-time.
     assert!(authorized.deadline() >= before + WITNESS_DEFAULT_TTL);
     assert!(authorized.deadline() <= after + WITNESS_DEFAULT_TTL);
+}
+#[tokio::test]
+async fn invocation_credentials_enrich_only_the_authorized_descriptor_snapshot() {
+    use ironclaw_host_api::{
+        action::{NetworkScheme, NetworkTargetPattern},
+        capability::{RuntimeCredentialRequirement, RuntimeCredentialRequirementSource},
+        http::RuntimeCredentialTarget,
+    };
+
+    let registry = echo_registry();
+    let dispatcher =
+        ironclaw_host_api::dispatch_test_support::TestDispatcher::responding(|req, _| {
+            Err(DispatchError::UnknownCapability {
+                capability: req.invocation.capability.clone(),
+            })
+        });
+    let authorizer = AllowAuthorizer;
+    let trust_policy = StaticTrustPolicy;
+    let runtime_policy = permissive_runtime_policy();
+    let policy_facts = InvocationCredentialPolicyFacts {
+        requirement: RuntimeCredentialRequirement {
+            handle: SecretHandle::new("fixture_runtime_token").unwrap(),
+            source: RuntimeCredentialRequirementSource::ProductAuthAccount {
+                provider: VendorId::new("fixture-vendor").unwrap(),
+                setup: RuntimeCredentialAccountSetup::ManualToken,
+            },
+            provider_scopes: Vec::new(),
+            audience: NetworkTargetPattern {
+                scheme: Some(NetworkScheme::Https),
+                host_pattern: "api.example.com".to_string(),
+                port: None,
+            },
+            target: RuntimeCredentialTarget::Header {
+                name: "Authorization".to_string(),
+                prefix: Some("token ".to_string()),
+            },
+            required: true,
+        },
+    };
+    let host = CapabilityHost::new(
+        &registry,
+        &dispatcher,
+        &authorizer,
+        &trust_policy,
+        &runtime_policy,
+        &policy_facts,
+    );
+    let capability_id = CapabilityId::new("echo.say").unwrap();
+    let base = registry.get_capability(&capability_id).unwrap();
+
+    let enriched = host
+        .enrich_invocation_descriptor(base, &capability_id, &serde_json::json!({"message": "hi"}))
+        .await
+        .unwrap();
+
+    assert_eq!(enriched.runtime_credentials.len(), 1);
+    assert_eq!(
+        enriched.runtime_credentials[0].handle.as_str(),
+        "fixture_runtime_token"
+    );
+    assert!(
+        registry
+            .get_capability(&capability_id)
+            .unwrap()
+            .runtime_credentials
+            .is_empty(),
+        "per-invocation authority must not mutate the shared registry descriptor"
+    );
 }
 
 // When a persistent grant carrying an `expires_at` is adopted in the fold, the

--- a/crates/kernel/ironclaw_capabilities/src/ports.rs
+++ b/crates/kernel/ironclaw_capabilities/src/ports.rs
@@ -25,12 +25,13 @@
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    capability::CapabilityGrant,
+    capability::{CapabilityGrant, RuntimeCredentialRequirement},
     decision::RuntimeCredentialAuthRequirement,
     ids::{CapabilityId, SecretHandle},
     resource::ResourceScope,
     scope::ExecutionContext,
 };
+use serde_json::Value;
 
 /// Presence of a capability's required credentials, read from the host secret
 /// store. A *fact*, not a decision.
@@ -68,7 +69,19 @@ pub enum PolicyAction {
 /// Host-mediated policy facts consumed by `authorize()`. **Facts only** — this
 /// port never decides; the kernel maps each fact into the sealed verdict.
 #[async_trait]
+
 pub trait HostPolicyFacts: Send + Sync {
+    /// Resolve invocation-selected credential requirements from host-owned
+    /// declarations. The returned facts are folded into a per-invocation
+    /// descriptor before policy runs; callers cannot declare credential
+    /// authority through model input alone.
+    async fn invocation_runtime_credentials(
+        &self,
+        _capability_id: &CapabilityId,
+        _input: &Value,
+    ) -> Result<Vec<RuntimeCredentialRequirement>, String> {
+        Ok(Vec::new())
+    }
     /// Whether the capability's required credentials are present for `scope`.
     ///
     /// Presence only — the pre-flight exists solely to order the auth gate ahead

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_auth_required_enrichment_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_auth_required_enrichment_contract.rs
@@ -22,7 +22,10 @@ use ironclaw_capabilities::*;
 use ironclaw_host_api::dispatch_test_support::TestDispatcher;
 use ironclaw_host_api::{
     capability::{CapabilityDescriptor, CapabilitySet, RuntimeCredentialAccountSetup},
-    decision::{Decision, Obligation, Obligations, RuntimeCredentialAuthRequirement},
+    decision::{
+        Decision, Obligation, Obligations, RuntimeCredentialAuthRequirement,
+        RuntimeCredentialConsumer,
+    },
     dispatch::{DispatchAuthRequirement, DispatchError},
     ids::{ExtensionId, SecretHandle, VendorId},
     resource::ResourceEstimate,
@@ -60,7 +63,9 @@ impl TrustAwareCapabilityDispatchAuthorizer for CredentialObligationAuthorizer {
                 provider: self.provider.clone(),
                 setup: self.setup.clone(),
                 provider_scopes: Vec::new(),
-                requester_extension: self.requester_extension.clone(),
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: self.requester_extension.clone(),
+                },
             }])
             .unwrap(),
         }
@@ -163,7 +168,9 @@ async fn invoke_json_preserves_non_empty_credential_requirements_from_dispatcher
                 credential_requirements: vec![RuntimeCredentialAuthRequirement {
                     provider: VendorId::new("mcp_provider").unwrap(),
                     setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
-                    requester_extension: ExtensionId::new("mcp_ext").unwrap(),
+                    consumer: RuntimeCredentialConsumer::Extension {
+                        extension_id: ExtensionId::new("mcp_ext").unwrap(),
+                    },
                     provider_scopes: Vec::new(),
                 }],
                 model_visible_cause: None,
@@ -325,14 +332,18 @@ async fn invoke_json_fails_without_auth_gate_when_credential_attribution_is_ambi
                         provider: VendorId::new("github").unwrap(),
                         setup: RuntimeCredentialAccountSetup::ManualToken,
                         provider_scopes: Vec::new(),
-                        requester_extension: ExtensionId::new("github").unwrap(),
+                        consumer: RuntimeCredentialConsumer::Extension {
+                            extension_id: ExtensionId::new("github").unwrap(),
+                        },
                     },
                     Obligation::InjectCredentialAccountOnce {
                         handle: SecretHandle::new("gitlab_pat").unwrap(),
                         provider: VendorId::new("gitlab").unwrap(),
                         setup: RuntimeCredentialAccountSetup::ManualToken,
                         provider_scopes: Vec::new(),
-                        requester_extension: ExtensionId::new("gitlab").unwrap(),
+                        consumer: RuntimeCredentialConsumer::Extension {
+                            extension_id: ExtensionId::new("gitlab").unwrap(),
+                        },
                     },
                 ])
                 .unwrap(),

--- a/crates/kernel/ironclaw_capabilities/tests/support/mod.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/support/mod.rs
@@ -25,7 +25,10 @@ use ironclaw_host_api::{
         CapabilityDescriptor, CapabilityGrant, CapabilitySet, EffectKind, GrantConstraints,
         RuntimeCredentialAccountSetup,
     },
-    decision::{Decision, Obligation, Obligations, RuntimeCredentialAuthRequirement},
+    decision::{
+        Decision, Obligation, Obligations, RuntimeCredentialAuthRequirement,
+        RuntimeCredentialConsumer,
+    },
     dispatch::{CapabilityDispatchResult, CapabilityDispatcher, DispatchError},
     host_port::HostPortCatalog,
     ids::{
@@ -123,7 +126,9 @@ impl HostPolicyFacts for MissingCredentialPolicyFacts {
             requirements: vec![RuntimeCredentialAuthRequirement {
                 provider: VendorId::new("test_provider").unwrap(),
                 setup: RuntimeCredentialAccountSetup::ManualToken,
-                requester_extension: ExtensionId::new("caller").unwrap(),
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new("caller").unwrap(),
+                },
                 provider_scopes: Vec::new(),
             }],
         }

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -35,7 +35,10 @@ use ironclaw_extension_support::coding::{
     CodingCapabilityError, CodingCapabilityKind, CodingCapabilityRequest, CodingCapabilityState,
 };
 use ironclaw_host_api::{
-    capability::{EffectKind, OriginGateMatrix, OriginGatePolicy, PermissionMode},
+    capability::{
+        EffectKind, OriginGateMatrix, OriginGatePolicy, PROCESS_SANDBOX_CAPABILITY_ID,
+        PermissionMode,
+    },
     capability_profile::CapabilityProfileSchemaRef,
     dispatch::RuntimeDispatchErrorKind,
     error::HostApiError,
@@ -276,6 +279,44 @@ pub fn builtin_first_party_package_for_process_backend(
     let mut package = builtin_first_party_package()?;
     restrict_package_for_process_backend(&mut package, process_backend)?;
     Ok(package)
+}
+
+pub fn user_sandbox_process_package() -> Result<ExtensionPackage, ExtensionError> {
+    ExtensionPackage::from_manifest(
+        ExtensionManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION.to_string(),
+            id: ExtensionId::new("system.process_sandbox")?,
+            name: "User sandbox process".to_string(),
+            version: "0.1.0".to_string(),
+            description: "Host-mediated direct-argument user sandbox execution".to_string(),
+            source: ManifestSource::HostBundled,
+            requested_trust: RequestedTrustClass::SystemRequested,
+            descriptor_trust_default: TrustClass::Sandbox,
+            runtime: ExtensionRuntime::System {
+                service: "process_sandbox".to_string(),
+            },
+            host_apis: Vec::new(),
+            host_api_surfaces: Vec::new(),
+            capabilities: vec![user_sandbox_process_manifest()?],
+            hooks: Vec::new(),
+        },
+        VirtualPath::new("/system/extensions/system.process_sandbox")?,
+    )
+}
+
+fn user_sandbox_process_manifest() -> Result<CapabilityManifest, ExtensionError> {
+    first_party_capability_manifest(
+        PROCESS_SANDBOX_CAPABILITY_ID,
+        "Run a direct-argument process in the isolated user sandbox",
+        vec![
+            EffectKind::DispatchCapability,
+            EffectKind::SpawnProcess,
+            EffectKind::UseSecret,
+            EffectKind::ExecuteCode,
+        ],
+        PermissionMode::Ask,
+        None,
+    )
 }
 
 fn restrict_package_for_process_backend(
@@ -1020,4 +1061,27 @@ fn coding_capability_metadata(capability_id: &str) -> Option<CodingCapabilityMet
         .iter()
         .copied()
         .find(|metadata| metadata.id == capability_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_sandbox_package_exposes_isolated_process_without_generic_network_privilege() {
+        let package = user_sandbox_process_package().unwrap();
+        let descriptor = package
+            .capabilities
+            .iter()
+            .find(|descriptor| descriptor.id.as_str() == PROCESS_SANDBOX_CAPABILITY_ID)
+            .expect("user-sandbox package must expose the direct-argument process capability");
+
+        assert!(descriptor.effects.contains(&EffectKind::UseSecret));
+        assert!(!descriptor.effects.contains(&EffectKind::Network));
+        assert!(
+            descriptor.runtime_credentials.is_empty(),
+            "credential authority is resolved per invocation from extension declarations"
+        );
+        assert!(descriptor.network_targets.is_empty());
+    }
 }

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/shell.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/shell.rs
@@ -85,9 +85,11 @@ pub(super) async fn dispatch(
             scope: request.scope.clone(),
             mounts: request.mounts.clone(),
             command: parsed.command,
+            args: Vec::new(),
             workdir: parsed.workdir,
             timeout_secs: parsed.timeout_secs,
             extra_env: parsed.extra_env,
+            cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
         })
         .await
         .map_err(process_error)?;
@@ -289,6 +291,10 @@ fn process_error(error: RuntimeProcessError) -> FirstPartyCapabilityError {
         RuntimeProcessError::Timeout(duration) => (
             RuntimeDispatchErrorKind::Resource,
             format!("shell command timed out after {}s", duration.as_secs()),
+        ),
+        RuntimeProcessError::Cancelled => (
+            RuntimeDispatchErrorKind::Executor,
+            "shell execution cancelled".to_string(),
         ),
         RuntimeProcessError::ExecutionFailed(reason) => (
             RuntimeDispatchErrorKind::Executor,

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/trace_commons.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/trace_commons.rs
@@ -24,7 +24,7 @@ use ironclaw_host_api::{
         RuntimeCredentialInjection, RuntimeCredentialSource, RuntimeCredentialTarget,
         RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
     },
-    ids::{CapabilityId, SecretHandle},
+    ids::{CapabilityId, SecretHandle, TenantId, UserId},
     resource::{ResourceEstimate, ResourceProfile, ResourceScope},
     runtime::RuntimeKind,
 };
@@ -763,6 +763,21 @@ pub(crate) fn format_credits(report: &TraceCreditReport) -> Value {
 pub(super) async fn dispatch_profile_token(
     request: &FirstPartyCapabilityRequest,
 ) -> Result<Value, FirstPartyCapabilityError> {
+    dispatch_profile_token_with_enrollment(request, |tenant_id, user_id| {
+        resolve_trace_credentials(tenant_id, user_id)
+            .map(|resolution| resolution.is_some())
+            .map_err(ProfileAttributionError::PolicyRead)
+    })
+    .await
+}
+
+async fn dispatch_profile_token_with_enrollment<F>(
+    request: &FirstPartyCapabilityRequest,
+    resolve_enrollment: F,
+) -> Result<Value, FirstPartyCapabilityError>
+where
+    F: FnOnce(&TenantId, &UserId) -> Result<bool, ProfileAttributionError>,
+{
     // Consent gate: minting persists a bearer profile-management credential.
     // The runtime approval gate (PermissionMode::Ask) can be auto-approved in
     // local-yolo, so this in-turn confirmed=true check is the hard fail-closed
@@ -796,17 +811,15 @@ pub(super) async fn dispatch_profile_token(
     // guard for the confirmed+enrolled mint path. Route through the shared
     // resolver so instance-only contributors (personal policy absent, instance
     // policy enabled) pass the gate instead of being falsely rejected.
-    match resolve_trace_credentials(&request.scope.tenant_id, &request.scope.user_id) {
-        Ok(Some(_)) => {}
-        Ok(None) => {
+    match resolve_enrollment(&request.scope.tenant_id, &request.scope.user_id) {
+        Ok(true) => {}
+        Ok(false) => {
             return Ok(profile_token_error_value(
                 &ProfileAttributionError::NotEnrolled,
             ));
         }
         Err(error) => {
-            return Ok(profile_token_error_value(
-                &ProfileAttributionError::PolicyRead(error),
-            ));
+            return Ok(profile_token_error_value(&error));
         }
     }
 
@@ -969,6 +982,21 @@ fn profile_token_error_value(error: &ProfileAttributionError) -> Value {
 pub(super) async fn dispatch_profile_set(
     request: &FirstPartyCapabilityRequest,
 ) -> Result<Value, FirstPartyCapabilityError> {
+    dispatch_profile_set_with_enrollment(request, |tenant_id, user_id| {
+        resolve_trace_credentials(tenant_id, user_id)
+            .map(|resolution| resolution.is_some())
+            .map_err(ProfileAttributionError::PolicyRead)
+    })
+    .await
+}
+
+async fn dispatch_profile_set_with_enrollment<F>(
+    request: &FirstPartyCapabilityRequest,
+    resolve_enrollment: F,
+) -> Result<Value, FirstPartyCapabilityError>
+where
+    F: FnOnce(&TenantId, &UserId) -> Result<bool, ProfileAttributionError>,
+{
     let input = parse_profile_set_input(&request.input)?;
 
     // Consent gate: publishing/updating the public community profile is a
@@ -989,16 +1017,16 @@ pub(super) async fn dispatch_profile_set(
     // Route the enrollment gate through the shared resolver so instance-only
     // contributors (personal policy absent, instance policy enabled) pass
     // instead of being falsely rejected as not enrolled.
-    match resolve_trace_credentials(&request.scope.tenant_id, &request.scope.user_id) {
-        Ok(Some(_)) => {}
-        Ok(None) => {
+    match resolve_enrollment(&request.scope.tenant_id, &request.scope.user_id) {
+        Ok(true) => {}
+        Ok(false) => {
             return Ok(profile_set_error_value(
                 &CommunityProfileError::Attribution(ProfileAttributionError::NotEnrolled),
             ));
         }
         Err(error) => {
             return Ok(profile_set_error_value(
-                &CommunityProfileError::Attribution(ProfileAttributionError::PolicyRead(error)),
+                &CommunityProfileError::Attribution(error),
             ));
         }
     }
@@ -1847,7 +1875,9 @@ mod tests {
     #[tokio::test]
     async fn dispatch_profile_token_without_enrollment_returns_onboard_guidance() {
         let request = test_request(json!({ "confirmed": true }));
-        let result = dispatch_profile_token(&request).await.unwrap();
+        let result = dispatch_profile_token_with_enrollment(&request, |_, _| Ok(false))
+            .await
+            .unwrap();
         assert_eq!(result["minted"], json!(false));
         assert_eq!(result["error_code"], json!("NotEnrolled"));
         let message = result["message"].as_str().unwrap();
@@ -1864,7 +1894,9 @@ mod tests {
             "bio": "Trace Commons pilot contributor",
             "confirmed": true
         }));
-        let result = dispatch_profile_set(&request).await.unwrap();
+        let result = dispatch_profile_set_with_enrollment(&request, |_, _| Ok(false))
+            .await
+            .unwrap();
         assert_eq!(result["updated"], json!(false));
         assert_eq!(result["error_code"], json!("NotEnrolled"));
         let message = result["message"].as_str().unwrap();

--- a/crates/kernel/ironclaw_host_runtime/src/invocation_services/tests.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/invocation_services/tests.rs
@@ -160,9 +160,11 @@ async fn local_resolver_routes_post_edit_check_to_the_deployment_isolated_proces
                 scope: ResourceScope::system(),
                 mounts: None,
                 command: "cargo check".to_string(),
+                args: Vec::new(),
                 workdir: None,
                 timeout_secs: Some(30),
                 extra_env: std::collections::HashMap::new(),
+                cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
             })
             .await
             .expect("named test port runs");
@@ -267,9 +269,11 @@ async fn local_resolver_uses_configured_sandbox_process_backend() {
             scope: ResourceScope::system(),
             mounts: None,
             command: "echo hi".to_string(),
+            args: Vec::new(),
             workdir: None,
             timeout_secs: None,
             extra_env: Default::default(),
+            cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
         })
         .await
         .unwrap();

--- a/crates/kernel/ironclaw_host_runtime/src/lib.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/lib.rs
@@ -115,6 +115,7 @@ pub use first_party_tools::{
     memory_invocation_for_request, memory_tool_profiles, normalize_memory_tool_input,
     register_memory_tool_handler, register_native_memory_tools,
     register_outbound_deliver_first_party_handler, register_reply_attachment_first_party_handler,
+    user_sandbox_process_package,
 };
 #[cfg(any(test, feature = "test-support"))]
 pub use first_party_tools::{
@@ -149,7 +150,7 @@ pub use services::{
     ProductAuthCredentialStageError, ProductAuthProviderRuntimePorts,
     ProductionEventStoreWiringError, ProductionWiringComponent, ProductionWiringConfig,
     ProductionWiringIssue, ProductionWiringIssueKind, ProductionWiringReport,
-    RegisteredRuntimeHealth,
+    RegisteredRuntimeHealth, SandboxTransportProcessExecutor,
 };
 pub use surface::{VisibleCapability, VisibleCapabilityAccess};
 /// Stable, validated idempotency key supplied by upper turn/loop services.

--- a/crates/kernel/ironclaw_host_runtime/src/obligations/handler.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/obligations/handler.rs
@@ -23,9 +23,9 @@ use ironclaw_host_api::{
     action::NetworkPolicy,
     audit::{ActionResultSummary, ActionSummary, AuditEnvelope, AuditStage, DecisionSummary},
     capability::{EffectKind, RuntimeCredentialAccountSetup},
-    decision::{Obligation, RuntimeCredentialAuthRequirement},
+    decision::{Obligation, RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     dispatch::{CapabilityDispatchResult, CredentialStageError},
-    ids::{AuditEventId, CapabilityId, ExtensionId, SecretHandle, VendorId},
+    ids::{AuditEventId, CapabilityId, SecretHandle, VendorId},
     mount::MountView,
     resource::{
         ResourceCeiling, ResourceEstimate, ResourceReservation, ResourceScope, ResourceUsage,
@@ -39,7 +39,7 @@ use secrecy::ExposeSecret;
 
 use super::staged_handoffs::{
     NetworkObligationPolicyStore, RuntimeCredentialAccountRequest,
-    RuntimeCredentialAccountResolver, RuntimeSecretInjectionStore,
+    RuntimeCredentialAccountResolver, RuntimeCredentialBindingPolicy, RuntimeSecretInjectionStore,
 };
 
 /// Built-in obligation handler for the current host-runtime slice.
@@ -300,7 +300,14 @@ impl BuiltinObligationHandler {
             return Ok(());
         }
         let Some(resolver) = &self.credential_account_resolver else {
-            return Err(secret_obligation_failed());
+            return if account_obligations
+                .iter()
+                .all(|obligation| !obligation.required)
+            {
+                Ok(())
+            } else {
+                Err(secret_obligation_failed())
+            };
         };
         let Some(secret_store) = &self.secret_store else {
             return Err(secret_obligation_failed());
@@ -310,34 +317,50 @@ impl BuiltinObligationHandler {
         };
 
         for obligation in account_obligations {
-            let access_secret = resolver
+            let access_secret = match resolver
                 .resolve_access_secret(RuntimeCredentialAccountRequest {
                     scope: &request.context.resource_scope,
                     provider: obligation.provider,
                     setup: obligation.setup,
                     provider_scopes: obligation.provider_scopes,
-                    requester_extension: obligation.requester_extension,
+                    consumer: &obligation.consumer,
                 })
                 .await
-                .map_err(|error| {
-                    credential_stage_error_to_obligation_error(error, Some(&obligation))
-                })?;
+            {
+                Ok(access_secret) => access_secret,
+                Err(CredentialStageError::AuthRequired) if !obligation.required => continue,
+                Err(error) => {
+                    return Err(credential_stage_error_to_obligation_error(
+                        error,
+                        Some(&obligation),
+                    ));
+                }
+            };
             // Retrieve and stage the resolved credential under the obligation's injection handle.
             // The access_secret names the material in the secret store; obligation.handle is
             // the slot name the WASM guest expects.
-            stage_credential_material(
+            if let Err(error) = stage_credential_material(
                 secret_store.as_ref(),
                 secret_injections,
-                &access_secret.scope,
-                &request.context.resource_scope,
-                request.capability_id,
-                &access_secret.handle,
-                obligation.handle,
+                CredentialMaterialStage {
+                    source_scope: &access_secret.scope,
+                    target_scope: &request.context.resource_scope,
+                    capability_id: request.capability_id,
+                    source: &access_secret.handle,
+                    target: obligation.handle,
+                    binding: obligation.binding.clone(),
+                },
             )
             .await
-            .map_err(|error| {
-                credential_stage_error_to_obligation_error(error, Some(&obligation))
-            })?;
+            {
+                if error == CredentialStageError::AuthRequired && !obligation.required {
+                    continue;
+                }
+                return Err(credential_stage_error_to_obligation_error(
+                    error,
+                    Some(&obligation),
+                ));
+            }
         }
 
         Ok(())
@@ -718,6 +741,7 @@ fn obligation_supported(phase: CapabilityObligationPhase, obligation: &Obligatio
         | Obligation::ApplyNetworkPolicy { .. }
         | Obligation::FirstPartyCredentialStagedViaHostPort { .. }
         | Obligation::InjectCredentialAccountOnce { .. }
+        | Obligation::InjectSandboxCredentialAccountOnce { .. }
         | Obligation::InjectSecretOnce { .. }
         | Obligation::ReserveResources { .. }
         | Obligation::UseScopedMounts { .. } => true,
@@ -747,7 +771,9 @@ struct CredentialAccountInjectionObligation<'a> {
     provider: &'a VendorId,
     setup: &'a RuntimeCredentialAccountSetup,
     provider_scopes: &'a [String],
-    requester_extension: &'a ExtensionId,
+    consumer: RuntimeCredentialConsumer,
+    required: bool,
+    binding: Option<RuntimeCredentialBindingPolicy>,
 }
 
 fn credential_account_injection_obligations(
@@ -761,13 +787,35 @@ fn credential_account_injection_obligations(
                 provider,
                 setup,
                 provider_scopes,
-                requester_extension,
+                consumer,
             } => Some(CredentialAccountInjectionObligation {
                 handle,
                 provider,
                 setup,
                 provider_scopes,
-                requester_extension,
+                consumer: consumer.clone(),
+                required: true,
+                binding: None,
+            }),
+            Obligation::InjectSandboxCredentialAccountOnce {
+                handle,
+                provider,
+                setup,
+                provider_scopes,
+                required,
+                audience,
+                target,
+            } => Some(CredentialAccountInjectionObligation {
+                handle,
+                provider,
+                setup,
+                provider_scopes,
+                consumer: RuntimeCredentialConsumer::SandboxProcess,
+                required: *required,
+                binding: Some(RuntimeCredentialBindingPolicy {
+                    audience: audience.clone(),
+                    target: target.clone(),
+                }),
             }),
             _ => None,
         })
@@ -779,7 +827,8 @@ fn staged_secret_injection_handles(obligations: &[Obligation]) -> Vec<SecretHand
         .iter()
         .filter_map(|obligation| match obligation {
             Obligation::InjectSecretOnce { handle }
-            | Obligation::InjectCredentialAccountOnce { handle, .. } => Some(handle.clone()),
+            | Obligation::InjectCredentialAccountOnce { handle, .. }
+            | Obligation::InjectSandboxCredentialAccountOnce { handle, .. } => Some(handle.clone()),
             _ => None,
         })
         .collect()
@@ -802,7 +851,7 @@ fn credential_stage_error_to_obligation_error(
                     vec![RuntimeCredentialAuthRequirement {
                         provider: obligation.provider.clone(),
                         setup: obligation.setup.clone(),
-                        requester_extension: obligation.requester_extension.clone(),
+                        consumer: obligation.consumer.clone(),
                         provider_scopes: obligation.provider_scopes.to_vec(),
                     }]
                 })
@@ -812,50 +861,44 @@ fn credential_stage_error_to_obligation_error(
     }
 }
 
-/// Retrieve `source` from the secret store and stage the material under `target`
-/// in the injection store for the given capability invocation.
-///
-/// Used when the secret store key (`source`) differs from the runtime injection slot
-/// (`target`) — for example, when a product-auth account's backing secret is resolved
-/// to a concrete handle before being injected under the WASM guest's declared slot name.
-/// Lease → consume → insert the staged credential material.
-///
+struct CredentialMaterialStage<'a> {
+    source_scope: &'a ResourceScope,
+    target_scope: &'a ResourceScope,
+    capability_id: &'a CapabilityId,
+    source: &'a SecretHandle,
+    target: &'a SecretHandle,
+    binding: Option<RuntimeCredentialBindingPolicy>,
+}
+
 /// Mirrors [`crate::services::ProductAuthProviderRuntimePorts::stage_secret_once`]
-/// so the WASM `InjectCredentialAccountOnce` path and the first-party stager path
-/// (e.g. `ProductAuthRuntimeGsuiteCredentialStager`) share identical lease/consume
-/// semantics and `CredentialStageError` mapping. `SecretStoreError` variants for
-/// unknown/expired/revoked/consumed material map to
-/// [`CredentialStageError::AuthRequired`] via [`crate::services::stage_secret_error`];
-/// other failures map to [`CredentialStageError::Backend`].
+/// so account credentials use the same lease/consume semantics and error mapping.
 async fn stage_credential_material(
     secret_store: &dyn SecretStorePort,
     secret_injections: &RuntimeSecretInjectionStore,
-    source_scope: &ResourceScope,
-    target_scope: &ResourceScope,
-    capability_id: &CapabilityId,
-    source: &SecretHandle,
-    target: &SecretHandle,
+    stage: CredentialMaterialStage<'_>,
 ) -> Result<(), CredentialStageError> {
+    let CredentialMaterialStage {
+        source_scope,
+        target_scope,
+        capability_id,
+        source,
+        target,
+        binding,
+    } = stage;
     let lease = secret_store
         .lease_once(source_scope, source)
         .await
-        .map_err(|e| {
-            tracing::debug!(err = %e, "stage_credential_material: lease_once failed");
-            crate::services::stage_secret_error(e)
+        .map_err(|error| {
+            tracing::debug!(%error, "stage_credential_material: lease_once failed");
+            crate::services::stage_secret_error(error)
         })?;
     let secret = secret_store
         .consume(source_scope, lease.id)
         .await
-        .map_err(|e| {
-            tracing::debug!(err = %e, "stage_credential_material: consume failed");
-            crate::services::stage_secret_error(e)
+        .map_err(|error| {
+            tracing::debug!(%error, "stage_credential_material: consume failed");
+            crate::services::stage_secret_error(error)
         })?;
-    // A "Configured" account whose resolved material is empty cannot
-    // authenticate anything; staging it would only let the guest fail later
-    // with an opaque `operation_failed` (e.g. an ironhub tool probing
-    // `secret-exists` sees an unusable slot and reports "API key not
-    // configured" as a generic domain failure). Surface the typed re-auth
-    // signal at authorization time instead so the model can act on it.
     if secret.expose_secret().is_empty() {
         tracing::debug!(
             handle = %target.as_str(),
@@ -863,12 +906,16 @@ async fn stage_credential_material(
         );
         return Err(CredentialStageError::AuthRequired);
     }
-    secret_injections
-        .insert(target_scope, capability_id, target, secret)
-        .map_err(|e| {
-            tracing::debug!(err = %e, "stage_credential_material: insert failed");
-            CredentialStageError::Backend
-        })
+    let inserted = match binding {
+        Some(binding) => {
+            secret_injections.insert_bound(target_scope, capability_id, target, secret, binding)
+        }
+        None => secret_injections.insert(target_scope, capability_id, target, secret),
+    };
+    inserted.map_err(|error| {
+        tracing::debug!(%error, "stage_credential_material: insert failed");
+        CredentialStageError::Backend
+    })
 }
 
 fn network_policy_obligation(
@@ -1264,7 +1311,10 @@ fn obligation_label(obligation: &Obligation) -> Option<&'static str> {
         Obligation::RedactOutput => Some("redact_output"),
         Obligation::ApplyNetworkPolicy { .. } => Some("apply_network_policy"),
         Obligation::InjectSecretOnce { .. } => Some("inject_secret_once"),
-        Obligation::InjectCredentialAccountOnce { .. } => Some("inject_credential_account_once"),
+        Obligation::InjectCredentialAccountOnce { .. }
+        | Obligation::InjectSandboxCredentialAccountOnce { .. } => {
+            Some("inject_credential_account_once")
+        }
         Obligation::FirstPartyCredentialStagedViaHostPort { .. } => {
             Some("first_party_credential_staged_via_host_port")
         }

--- a/crates/kernel/ironclaw_host_runtime/src/obligations/mod.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/obligations/mod.rs
@@ -43,6 +43,8 @@ pub use staged_handoffs::{
 };
 
 pub(crate) use handler::secret_owner_scope;
+#[cfg(test)]
+pub(crate) use staged_handoffs::RuntimeCredentialBindingPolicy;
 pub(crate) use staged_handoffs::{
     NetworkObligationPolicyStore, RuntimeSecretInjectionStore, SharedSecretStore,
 };

--- a/crates/kernel/ironclaw_host_runtime/src/obligations/staged_handoffs.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/obligations/staged_handoffs.rs
@@ -18,10 +18,12 @@ use std::{
 use async_trait::async_trait;
 use ironclaw_host_api::{
     Timestamp,
-    action::NetworkPolicy,
+    action::{NetworkPolicy, NetworkTargetPattern},
     capability::RuntimeCredentialAccountSetup,
+    decision::RuntimeCredentialConsumer,
     dispatch::CredentialStageError,
-    ids::{CapabilityId, ExtensionId, SecretHandle, VendorId},
+    http::RuntimeCredentialTarget,
+    ids::{CapabilityId, SecretHandle, VendorId},
     resource::ResourceScope,
 };
 use ironclaw_secrets::{
@@ -38,7 +40,7 @@ pub struct RuntimeCredentialAccountRequest<'a> {
     pub provider: &'a VendorId,
     pub setup: &'a RuntimeCredentialAccountSetup,
     pub provider_scopes: &'a [String],
-    pub requester_extension: &'a ExtensionId,
+    pub consumer: &'a RuntimeCredentialConsumer,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,9 +81,15 @@ struct RuntimeSecretInjectionState {
     secrets: Mutex<HashMap<RuntimeSecretInjectionKey, RuntimeSecretInjectionEntry>>,
     ttl: Duration,
 }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeCredentialBindingPolicy {
+    pub audience: NetworkTargetPattern,
+    pub target: RuntimeCredentialTarget,
+}
 
 struct RuntimeSecretInjectionEntry {
     material: SecretMaterial,
+    binding: Option<RuntimeCredentialBindingPolicy>,
     expires_at: Instant,
 }
 
@@ -106,6 +114,28 @@ impl RuntimeSecretInjectionStore {
         handle: &SecretHandle,
         material: SecretMaterial,
     ) -> Result<(), RuntimeSecretInjectionStoreError> {
+        self.insert_inner(scope, capability_id, handle, material, None)
+    }
+
+    pub(crate) fn insert_bound(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+        material: SecretMaterial,
+        binding: RuntimeCredentialBindingPolicy,
+    ) -> Result<(), RuntimeSecretInjectionStoreError> {
+        self.insert_inner(scope, capability_id, handle, material, Some(binding))
+    }
+
+    fn insert_inner(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+        material: SecretMaterial,
+        binding: Option<RuntimeCredentialBindingPolicy>,
+    ) -> Result<(), RuntimeSecretInjectionStoreError> {
         let now = Instant::now();
         let expires_at = now.checked_add(self.state.ttl).unwrap_or(now);
         let mut secrets = self.lock()?;
@@ -114,6 +144,7 @@ impl RuntimeSecretInjectionStore {
             RuntimeSecretInjectionKey::new(scope, capability_id, handle),
             RuntimeSecretInjectionEntry {
                 material,
+                binding,
                 expires_at,
             },
         );
@@ -136,6 +167,26 @@ impl RuntimeSecretInjectionStore {
                 handle,
             ))
             .map(|entry| entry.material))
+    }
+    pub(crate) fn take_bound(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+    ) -> Result<
+        Option<(SecretMaterial, Option<RuntimeCredentialBindingPolicy>)>,
+        RuntimeSecretInjectionStoreError,
+    > {
+        let now = Instant::now();
+        let mut secrets = self.lock()?;
+        prune_expired_entries(&mut secrets, now);
+        Ok(secrets
+            .remove(&RuntimeSecretInjectionKey::new(
+                scope,
+                capability_id,
+                handle,
+            ))
+            .map(|entry| (entry.material, entry.binding)))
     }
 
     pub(crate) fn clone_material(

--- a/crates/kernel/ironclaw_host_runtime/src/obligations/tests.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/obligations/tests.rs
@@ -165,6 +165,105 @@ async fn builtin_obligation_handler_satisfy_release_preserves_staged_handoffs() 
     );
 }
 
+#[derive(Debug)]
+struct SandboxCredentialResolver {
+    source_scope: ResourceScope,
+    source_handle: SecretHandle,
+}
+
+#[async_trait::async_trait]
+impl RuntimeCredentialAccountResolver for SandboxCredentialResolver {
+    async fn resolve_access_secret(
+        &self,
+        request: RuntimeCredentialAccountRequest<'_>,
+    ) -> Result<RuntimeCredentialAccessSecret, ironclaw_host_api::dispatch::CredentialStageError>
+    {
+        assert_eq!(
+            request.consumer,
+            &ironclaw_host_api::decision::RuntimeCredentialConsumer::SandboxProcess
+        );
+        assert_eq!(request.provider.as_str(), "github");
+        Ok(RuntimeCredentialAccessSecret {
+            scope: self.source_scope.clone(),
+            handle: self.source_handle.clone(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn sandbox_credential_obligation_stages_bound_material_for_process_executor() {
+    let secret_store = Arc::new(SecretStore::ephemeral());
+    let secret_injections = Arc::new(RuntimeSecretInjectionStore::new());
+    let context = execution_context();
+    let capability_id =
+        CapabilityId::new(ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID).unwrap();
+    let source_handle = SecretHandle::new("github_access_token").unwrap();
+    let injection_handle = SecretHandle::new("github_runtime_token").unwrap();
+    secret_store
+        .put(
+            context.resource_scope.clone(),
+            source_handle.clone(),
+            SecretMaterial::from("github-secret"),
+            None,
+        )
+        .await
+        .unwrap();
+    let services = BuiltinObligationServices::with_handoff_stores(
+        Arc::new(InMemoryAuditSink::new()),
+        Arc::new(NetworkObligationPolicyStore::new()),
+        secret_store,
+        secret_injections.clone(),
+        Arc::new(InMemoryResourceGovernor::new()),
+    )
+    .with_credential_account_resolver(Arc::new(SandboxCredentialResolver {
+        source_scope: context.resource_scope.clone(),
+        source_handle,
+    }));
+    let audience = NetworkTargetPattern {
+        scheme: Some(NetworkScheme::Https),
+        host_pattern: "api.github.com".to_string(),
+        port: None,
+    };
+    let target = ironclaw_host_api::http::RuntimeCredentialTarget::Header {
+        name: "Authorization".to_string(),
+        prefix: Some("token ".to_string()),
+    };
+    let obligations = vec![Obligation::InjectSandboxCredentialAccountOnce {
+        handle: injection_handle.clone(),
+        provider: ironclaw_host_api::ids::VendorId::new("github").unwrap(),
+        setup: Default::default(),
+        provider_scopes: Vec::new(),
+        required: true,
+        audience: audience.clone(),
+        target: target.clone(),
+    }];
+
+    services
+        .obligation_handler()
+        .satisfy(CapabilityObligationRequest {
+            phase: CapabilityObligationPhase::Invoke,
+            context: &context,
+            capability_id: &capability_id,
+            estimate: &ResourceEstimate::default(),
+            obligations: &obligations,
+        })
+        .await
+        .unwrap();
+
+    let (material, binding) = secret_injections
+        .take_bound(&context.resource_scope, &capability_id, &injection_handle)
+        .unwrap()
+        .expect("sandbox credential must be staged");
+    assert_eq!(
+        secrecy::ExposeSecret::expose_secret(&material),
+        "github-secret"
+    );
+    assert_eq!(
+        binding,
+        Some(RuntimeCredentialBindingPolicy { audience, target })
+    );
+}
+
 // #5459 tenant-shared credential resolution: a caller's own secret wins;
 // otherwise the tenant-shared admin-managed scope; otherwise absent.
 #[tokio::test]

--- a/crates/kernel/ironclaw_host_runtime/src/post_edit_check.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/post_edit_check.rs
@@ -357,9 +357,11 @@ pub(crate) async fn run_post_edit_check(
             scope: scope.clone(),
             mounts: mounts.cloned(),
             command: config.command().to_string(),
+            args: Vec::new(),
             workdir,
             timeout_secs: Some(config.timeout().as_secs()),
             extra_env: HashMap::new(),
+            cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
         })
         .await;
     match outcome {
@@ -373,6 +375,7 @@ pub(crate) async fn run_post_edit_check(
             Some(value)
         }
         Err(RuntimeProcessError::Timeout(_)) => Some(json!({"timed_out": true})),
+        Err(RuntimeProcessError::Cancelled) => None,
         Err(RuntimeProcessError::ExecutionFailed(reason)) => {
             tracing::debug!(reason = %reason, "post-edit check could not run");
             None

--- a/crates/kernel/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/process_port.rs
@@ -6,7 +6,7 @@
 //! existing local-host behavior behind an explicit port without changing
 //! placement semantics.
 
-use std::{collections::HashMap, path::PathBuf, process::Stdio, time::Duration};
+use std::{collections::HashMap, path::PathBuf, process::Stdio, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use ironclaw_host_api::process::{
@@ -78,7 +78,7 @@ pub trait RuntimeProcessPort: Send + Sync {
 /// Tenant-isolated process port backed by a sandbox command transport.
 #[derive(Clone)]
 pub struct UserSandboxProcessPort {
-    transport: std::sync::Arc<dyn SandboxCommandTransport>,
+    transport: Arc<dyn SandboxCommandTransport>,
 }
 
 impl std::fmt::Debug for UserSandboxProcessPort {
@@ -91,8 +91,12 @@ impl std::fmt::Debug for UserSandboxProcessPort {
 }
 
 impl UserSandboxProcessPort {
-    pub fn new(transport: std::sync::Arc<dyn SandboxCommandTransport>) -> Self {
+    pub fn new(transport: Arc<dyn SandboxCommandTransport>) -> Self {
         Self { transport }
+    }
+
+    pub(crate) fn transport(&self) -> Arc<dyn SandboxCommandTransport> {
+        Arc::clone(&self.transport)
     }
 
     pub async fn shutdown(&self) -> Result<(), RuntimeProcessError> {
@@ -243,6 +247,7 @@ impl RuntimeProcessPort for HostProcessPort {
             timeout,
             &request.extra_env,
             self.env_mode,
+            &request.cancellation,
         )
         .await?;
         // The command was rewritten alias->host before execution, so any host
@@ -269,6 +274,7 @@ async fn execute_local_command(
     timeout: Duration,
     extra_env: &HashMap<String, String>,
     env_mode: HostProcessEnvMode,
+    cancellation: &ironclaw_host_api::process::CommandCancellationToken,
 ) -> Result<(CapturedCommandOutput, i32), RuntimeProcessError> {
     let mut command = if cfg!(target_os = "windows") {
         let mut c = Command::new("cmd");
@@ -310,40 +316,49 @@ async fn execute_local_command(
     let stdout_handle = child.stdout.take();
     let stderr_handle = child.stderr.take();
 
-    let result = tokio::time::timeout(timeout, async {
-        let stdout_fut = async {
-            if let Some(out) = stdout_handle {
-                read_stream_capped(scope, out).await
-            } else {
-                Ok(StreamCapture::default())
-            }
-        };
+    let result = {
+        let timed_run = tokio::time::timeout(timeout, async {
+            let stdout_fut = async {
+                if let Some(out) = stdout_handle {
+                    read_stream_capped(scope, out).await
+                } else {
+                    Ok(StreamCapture::default())
+                }
+            };
 
-        let stderr_fut = async {
-            if let Some(err) = stderr_handle {
-                read_stream_capped(scope, err).await
-            } else {
-                Ok(StreamCapture::default())
-            }
-        };
+            let stderr_fut = async {
+                if let Some(err) = stderr_handle {
+                    read_stream_capped(scope, err).await
+                } else {
+                    Ok(StreamCapture::default())
+                }
+            };
 
-        let (stdout, stderr, wait_result) = tokio::join!(stdout_fut, stderr_fut, child.wait());
-        let status = wait_result.map_err(|error| {
-            RuntimeProcessError::ExecutionFailed(format!("Command execution failed: {error}"))
-        })?;
-        Ok::<_, RuntimeProcessError>((stdout?, stderr?, status.code().unwrap_or(-1)))
-    })
-    .await;
+            let (stdout, stderr, wait_result) = tokio::join!(stdout_fut, stderr_fut, child.wait());
+            let status = wait_result.map_err(|error| {
+                RuntimeProcessError::ExecutionFailed(format!("Command execution failed: {error}"))
+            })?;
+            Ok::<_, RuntimeProcessError>((stdout?, stderr?, status.code().unwrap_or(-1)))
+        });
+        tokio::pin!(timed_run);
+        tokio::select! {
+            outcome = &mut timed_run => match outcome {
+                Ok(result) => result,
+                Err(_) => Err(RuntimeProcessError::Timeout(timeout)),
+            },
+            () = cancellation.cancelled() => Err(RuntimeProcessError::Cancelled),
+        }
+    };
 
+    if matches!(
+        &result,
+        Err(RuntimeProcessError::Timeout(_) | RuntimeProcessError::Cancelled)
+    ) {
+        terminate_child_tree(&mut child).await;
+    }
     match result {
-        Ok(Ok((stdout, stderr, code))) => {
-            Ok((capture_command_output(scope, stdout, stderr)?, code))
-        }
-        Ok(Err(e)) => Err(e),
-        Err(_) => {
-            terminate_child_tree(&mut child).await;
-            Err(RuntimeProcessError::Timeout(timeout))
-        }
+        Ok((stdout, stderr, code)) => Ok((capture_command_output(scope, stdout, stderr)?, code)),
+        Err(error) => Err(error),
     }
 }
 
@@ -444,9 +459,11 @@ mod tests {
                 scope: ResourceScope::system(),
                 mounts: None,
                 command: "echo sandbox".to_string(),
+                args: Vec::new(),
                 workdir: None,
                 timeout_secs: None,
                 extra_env: HashMap::new(),
+                cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
             })
             .await
             .unwrap();
@@ -464,9 +481,11 @@ mod tests {
             scope: ResourceScope::system(),
             mounts: None,
             command: "echo sandbox".to_string(),
+            args: Vec::new(),
             workdir: None,
             timeout_secs: None,
             extra_env: HashMap::new(),
+            cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
         })
         .await
         .unwrap();
@@ -487,9 +506,11 @@ mod tests {
                 scope: ResourceScope::system(),
                 mounts: None,
                 command: "echo sandbox".to_string(),
+                args: Vec::new(),
                 workdir: None,
                 timeout_secs: None,
                 extra_env: HashMap::new(),
+                cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
             })
             .await
             .unwrap_err();
@@ -509,9 +530,11 @@ mod tests {
                 scope: ResourceScope::system(),
                 mounts: None,
                 command: "echo sandbox".to_string(),
+                args: Vec::new(),
                 workdir: None,
                 timeout_secs: Some(1),
                 extra_env: HashMap::new(),
+                cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
             })
             .await
             .unwrap_err();
@@ -532,9 +555,11 @@ mod tests {
                 scope: ResourceScope::system(),
                 mounts: None,
                 command: "echo sandbox".to_string(),
+                args: Vec::new(),
                 workdir: None,
                 timeout_secs: None,
                 extra_env: HashMap::new(),
+                cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
             })
             .await
             .unwrap();
@@ -555,6 +580,7 @@ mod tests {
             Duration::from_secs(5),
             &HashMap::new(),
             HostProcessEnvMode::Scrubbed,
+            &ironclaw_host_api::process::CommandCancellationToken::new(),
         )
         .await
         .expect("command succeeds");
@@ -585,6 +611,7 @@ mod tests {
             Duration::from_secs(5),
             &HashMap::new(),
             HostProcessEnvMode::Scrubbed,
+            &ironclaw_host_api::process::CommandCancellationToken::new(),
         )
         .await
         .expect("command succeeds");
@@ -610,6 +637,7 @@ mod tests {
                 "inherited".to_string(),
             )]),
             HostProcessEnvMode::Inherited,
+            &ironclaw_host_api::process::CommandCancellationToken::new(),
         )
         .await
         .expect("command succeeds");
@@ -640,9 +668,11 @@ mod tests {
                 scope: ResourceScope::system(),
                 mounts: None,
                 command: "printf '%s' \"$PWD\"".to_string(),
+                args: Vec::new(),
                 workdir: Some("/workspace/qa-coding-smoke".to_string()),
                 timeout_secs: Some(5),
                 extra_env: HashMap::new(),
+                cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
             })
             .await
             .expect("command succeeds");
@@ -670,9 +700,11 @@ mod tests {
                 scope: ResourceScope::system(),
                 mounts: None,
                 command: "printf 'saved to %s\\n' /workspace/out.pdf".to_string(),
+                args: Vec::new(),
                 workdir: None,
                 timeout_secs: Some(5),
                 extra_env: HashMap::new(),
+                cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
             })
             .await
             .expect("command succeeds");
@@ -693,9 +725,11 @@ mod tests {
                 scope: ResourceScope::system(),
                 mounts: None,
                 command: "mkdir -p /workspace/qa-coding-smoke && test -d /workspace/qa-coding-smoke && printf ok".to_string(),
+                args: Vec::new(),
                 workdir: None,
                 timeout_secs: Some(5),
                 extra_env: HashMap::new(),
+                cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
             })
             .await
             .expect("command succeeds");

--- a/crates/kernel/ironclaw_host_runtime/src/production.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/production.rs
@@ -29,10 +29,13 @@ use ironclaw_capabilities::{
 };
 use ironclaw_extension_registry::{ExtensionRegistry, SharedExtensionRegistry};
 use ironclaw_filesystem::RootFilesystem;
-use ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID;
 use ironclaw_host_api::{
     approval::sha256_digest_token,
-    decision::{DenyReason, RuntimeCredentialAuthRequirement},
+    capability::{
+        PROCESS_SANDBOX_CAPABILITY_ID, RuntimeCredentialRequirement,
+        RuntimeCredentialRequirementSource,
+    },
+    decision::{DenyReason, RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     dispatch::{CapabilityDispatcher, provider_diagnostic_model_cause},
     ids::{ApprovalRequestId, CapabilityId, InvocationId, SecretHandle},
     resource::ResourceScope,
@@ -1037,6 +1040,69 @@ impl DefaultHostRuntime {
     }
 }
 
+fn resolve_invocation_runtime_credentials(
+    registry: &ExtensionRegistry,
+    capability_id: &CapabilityId,
+    input: &serde_json::Value,
+) -> Result<Vec<RuntimeCredentialRequirement>, String> {
+    if capability_id.as_str() != PROCESS_SANDBOX_CAPABILITY_ID {
+        return Ok(Vec::new());
+    }
+
+    let plan = serde_json::from_value::<SandboxProcessPlan>(input.clone())
+        .map_err(|error| format!("sandbox credential request is invalid: {error}"))?;
+    let plan = ValidatedSandboxProcessPlan::new(plan)
+        .map_err(|error| format!("sandbox credential request is invalid: {error}"))?;
+    let mut resolved = Vec::with_capacity(plan.credentials.len());
+
+    for binding in &plan.credentials {
+        let mut matched: Option<RuntimeCredentialRequirement> = None;
+        for declared in registry
+            .capabilities()
+            .flat_map(|descriptor| descriptor.runtime_credentials.iter())
+        {
+            if declared.handle != binding.handle
+                || !matches!(
+                    declared.source,
+                    RuntimeCredentialRequirementSource::ProductAuthAccount { .. }
+                )
+                || !declared
+                    .audience
+                    .host_pattern
+                    .eq_ignore_ascii_case(&binding.approved_host)
+            {
+                continue;
+            }
+
+            if let Some(existing) = &matched
+                && (existing.source != declared.source
+                    || existing.provider_scopes != declared.provider_scopes
+                    || existing.audience != declared.audience)
+            {
+                return Err(format!(
+                    "sandbox credential handle '{}' has conflicting host declarations",
+                    binding.handle
+                ));
+            }
+
+            let mut requirement = declared.clone();
+            requirement.target = binding.target.clone();
+            requirement.required = binding.required;
+            matched = Some(requirement);
+        }
+
+        let Some(requirement) = matched else {
+            return Err(format!(
+                "sandbox credential handle '{}' is not declared for host '{}'",
+                binding.handle, binding.approved_host
+            ));
+        };
+        resolved.push(requirement);
+    }
+
+    Ok(resolved)
+}
+
 /// `DefaultHostRuntime` is the sole production implementor of the kernel's
 /// [`ironclaw_capabilities::HostPolicyFacts`] port (§5.3.2/§9). It surfaces
 /// host-mediated policy *facts* — never a verdict — that the capability kernel's
@@ -1047,10 +1113,18 @@ impl DefaultHostRuntime {
 /// - [`persistent_grants`](DefaultHostRuntime::persistent_grants) surfaces the
 ///   active persistent-approval grants (via the same scope × grantee fan-out the
 ///   former `apply_persistent_approval_policy` used). The kernel's `authorize()`
-///   fold owns the re-authorize loop that reads it and adopts the first grant
-///   that flips the decision to `Allow`.
+///   fold owns the re-authorize loop that reads it, adopts the first grant that
+///   flips the decision to `Allow`.
 #[async_trait]
 impl ironclaw_capabilities::HostPolicyFacts for DefaultHostRuntime {
+    async fn invocation_runtime_credentials(
+        &self,
+        capability_id: &CapabilityId,
+        input: &serde_json::Value,
+    ) -> Result<Vec<RuntimeCredentialRequirement>, String> {
+        let registry = self.registry.snapshot();
+        resolve_invocation_runtime_credentials(&registry, capability_id, input)
+    }
     async fn credential_presence(
         &self,
         capability_id: &CapabilityId,
@@ -1404,10 +1478,16 @@ fn stable_auth_gate_id(
             // `for_auth_gate` key; the write-once store then reports
             // `GateRecordAlreadyExists` and silently keeps the stale record, so
             // the runner reloads and renders the wrong authentication flow.
+            let consumer = match &requirement.consumer {
+                RuntimeCredentialConsumer::Extension { extension_id } => {
+                    format!("extension:{}", extension_id.as_str())
+                }
+                RuntimeCredentialConsumer::SandboxProcess => "sandbox_process".to_string(),
+            };
             format!(
                 "credential={}:{}:setup={}:{}",
                 requirement.provider.as_str(),
-                requirement.requester_extension.as_str(),
+                consumer,
                 stable_setup_token(&requirement.setup),
                 canonical_scope_list(&requirement.provider_scopes),
             )
@@ -1880,7 +1960,9 @@ mod tests {
             setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth {
                 scopes: scopes.iter().map(|scope| scope.to_string()).collect(),
             },
-            requester_extension: ExtensionId::new("notion").unwrap(),
+            consumer: RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("notion").unwrap(),
+            },
             provider_scopes: scopes.iter().map(|scope| scope.to_string()).collect(),
         }
     }
@@ -1969,7 +2051,9 @@ mod tests {
         let requirement_with = |setup: Setup| RuntimeCredentialAuthRequirement {
             provider: VendorId::new("notion").unwrap(),
             setup,
-            requester_extension: ExtensionId::new("notion").unwrap(),
+            consumer: RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("notion").unwrap(),
+            },
             provider_scopes: vec!["read".to_string()],
         };
         let gate_id = |setup: Setup| {
@@ -2025,7 +2109,9 @@ mod tests {
             let requirement = RuntimeCredentialAuthRequirement {
                 provider: VendorId::new("notion").unwrap(),
                 setup: Setup::ManualToken,
-                requester_extension: ExtensionId::new("notion").unwrap(),
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new("notion").unwrap(),
+                },
                 provider_scopes: scopes,
             };
             let RuntimeCapabilityOutcome::AuthRequired(gate) =
@@ -2648,16 +2734,8 @@ mod tests {
             "NetworkDenied must not be in the quiet-retry set"
         );
     }
-    // ─── capability_credential_requirements unit tests ──────────────────────────
-    //
-    // These were previously integration tests in host_runtime_services_contract.rs
-    // that called the function via `ironclaw_host_runtime::capability_credential_requirements`.
-    // They are kept here as unit tests because the function is now `pub(crate)`,
-    // making it invisible to external test binaries. Coverage is equivalent.
 
-    fn build_descriptor_for_manifest(
-        manifest_toml: &str,
-    ) -> ironclaw_host_api::capability::CapabilityDescriptor {
+    fn build_registry_for_manifest(manifest_toml: &str) -> ExtensionRegistry {
         let manifest = ExtensionManifest::parse(
             manifest_toml,
             ManifestSource::InstalledLocal,
@@ -2665,13 +2743,22 @@ mod tests {
             &capability_provider_contracts(),
         )
         .expect("manifest must parse");
-        let cap_id = manifest.capabilities[0].id.clone();
         let root =
             VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
         let package = ExtensionPackage::from_manifest(manifest, root).expect("package must build");
         let mut registry = ExtensionRegistry::new();
         registry.insert(package).unwrap();
-        registry.get_capability(&cap_id).unwrap().clone()
+        registry
+    }
+
+    fn build_descriptor_for_manifest(
+        manifest_toml: &str,
+    ) -> ironclaw_host_api::capability::CapabilityDescriptor {
+        build_registry_for_manifest(manifest_toml)
+            .capabilities()
+            .next()
+            .expect("fixture package must declare a capability")
+            .clone()
     }
 
     /// `capability_credential_requirements` must return exactly the required
@@ -2870,6 +2957,110 @@ required = true
             !credential_requirements.is_empty(),
             "a required product_auth_account credential must still surface in credential_requirements"
         );
+    }
+    fn sandbox_credential_registry() -> ExtensionRegistry {
+        const MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "credential-fixture"
+name = "Credential Fixture"
+version = "0.1.0"
+description = "Fixture with a product-auth runtime credential"
+trust = "untrusted"
+
+[runtime]
+kind = "script"
+runner = "sandboxed_process"
+command = "echo"
+args = []
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "credential-fixture.call"
+description = "Call the fixture provider"
+effects = ["dispatch_capability", "use_secret"]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/test/input.v1.json"
+output_schema_ref = "schemas/test/output.v1.json"
+prompt_doc_ref = "prompts/test.md"
+
+[[capability_provider.tools.capabilities.runtime_credentials]]
+handle = "fixture_runtime_token"
+source = { type = "product_auth_account", provider = "fixture-vendor" }
+audience = { scheme = "https", host_pattern = "api.example.com" }
+target = { type = "header", name = "authorization", prefix = "Bearer " }
+required = true
+"#;
+        build_registry_for_manifest(MANIFEST)
+    }
+
+    fn sandbox_credential_input(host: &str) -> serde_json::Value {
+        serde_json::json!({
+            "run": {
+                "command": "provider-cli",
+                "args": [],
+                "env": {
+                    "PROVIDER_TOKEN": "icsbx_test_placeholder"
+                }
+            },
+            "network": {
+                "runtime_hosts": [host],
+                "direct_egress_lockdown": true
+            },
+            "credentials": [{
+                "handle": "fixture_runtime_token",
+                "approved_host": host,
+                "target": {
+                    "type": "header",
+                    "name": "Authorization",
+                    "prefix": "token "
+                },
+                "placeholder_env": "PROVIDER_TOKEN",
+                "placeholder_value": "icsbx_test_placeholder",
+                "required": true
+            }]
+        })
+    }
+
+    #[test]
+    fn sandbox_invocation_credentials_resolve_from_extension_authority() {
+        let requirements = resolve_invocation_runtime_credentials(
+            &sandbox_credential_registry(),
+            &CapabilityId::new(PROCESS_SANDBOX_CAPABILITY_ID).unwrap(),
+            &sandbox_credential_input("api.example.com"),
+        )
+        .expect("declared sandbox credential resolves");
+
+        assert_eq!(requirements.len(), 1);
+        assert_eq!(requirements[0].handle.as_str(), "fixture_runtime_token");
+        assert!(requirements[0].required);
+        assert!(matches!(
+            &requirements[0].source,
+            RuntimeCredentialRequirementSource::ProductAuthAccount { provider, .. }
+                if provider.as_str() == "fixture-vendor"
+        ));
+        assert!(matches!(
+            &requirements[0].target,
+            ironclaw_host_api::http::RuntimeCredentialTarget::Header { name, prefix }
+                if name == "Authorization" && prefix.as_deref() == Some("token ")
+        ));
+    }
+
+    #[test]
+    fn sandbox_invocation_credentials_reject_undeclared_host() {
+        let error = resolve_invocation_runtime_credentials(
+            &sandbox_credential_registry(),
+            &CapabilityId::new(PROCESS_SANDBOX_CAPABILITY_ID).unwrap(),
+            &sandbox_credential_input("other.example.com"),
+        )
+        .expect_err("an undeclared credential audience must fail closed");
+
+        assert!(error.contains("is not declared for host"));
     }
 
     #[test]

--- a/crates/kernel/ironclaw_host_runtime/src/services.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services.rs
@@ -7,6 +7,7 @@
 //! lifecycle, and runtime execution semantics remain in their owning crates.
 
 mod process_executor;
+pub use process_executor::SandboxTransportProcessExecutor;
 
 use std::sync::{Arc, Mutex};
 
@@ -159,7 +160,7 @@ where
     tool_call_http_egress: SharedToolCallHttpEgress,
     process_port: Arc<dyn RuntimeProcessPort>,
     managed_process_port: bool,
-    user_sandbox_process_port: Option<Arc<dyn RuntimeProcessPort>>,
+    user_sandbox_process_port: Option<Arc<UserSandboxProcessPort>>,
     wasm_credential_provider: Option<Arc<dyn WasmRuntimeCredentialProvider>>,
     runtime_health: Option<Arc<dyn RuntimeBackendHealth>>,
     runtime_policy: Option<EffectiveRuntimePolicy>,
@@ -321,13 +322,16 @@ impl ProductAuthProviderRuntimePorts {
                     .credential_account_resolver
                     .as_ref()
                     .ok_or(ProductAuthCredentialStageError::Backend)?;
+                let consumer = ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                    extension_id: requester_extension.clone(),
+                };
                 let access_secret = resolver
                     .resolve_access_secret(crate::obligations::RuntimeCredentialAccountRequest {
                         scope,
                         provider,
                         setup,
                         provider_scopes: &requirement.provider_scopes,
-                        requester_extension,
+                        consumer: &consumer,
                     })
                     .await?;
                 self.stage_material_once(
@@ -619,8 +623,9 @@ where
                 invocation_services_resolver.with_audit_sink(Arc::clone(audit_sink));
         }
         if let Some(process_port) = &self.user_sandbox_process_port {
-            invocation_services_resolver = invocation_services_resolver
-                .with_user_sandbox_process_port(Arc::clone(process_port));
+            let process_port: Arc<dyn RuntimeProcessPort> = process_port.clone();
+            invocation_services_resolver =
+                invocation_services_resolver.with_user_sandbox_process_port(process_port);
         }
         if let Some(post_edit_check) = &self.post_edit_check {
             invocation_services_resolver =
@@ -717,13 +722,16 @@ where
         }
         let dispatcher: Arc<dyn CapabilityDispatcher> = Arc::new(self.runtime_dispatcher());
         let process_runtime = self.process_services.process_runtime();
-        let process_executor = Arc::new(HostProcessExecutor::new(
-            Arc::new(RuntimeDispatchProcessExecutor::new(
-                Arc::clone(&dispatcher),
-                ironclaw_capabilities::process_authorization_remint_port(process_runtime),
-            )),
-            self.process_sandbox_executor.clone(),
-        ));
+        let process_executor = Arc::new(
+            HostProcessExecutor::new(
+                Arc::new(RuntimeDispatchProcessExecutor::new(
+                    Arc::clone(&dispatcher),
+                    ironclaw_capabilities::process_authorization_remint_port(process_runtime),
+                )),
+                self.process_sandbox_executor.clone(),
+            )
+            .with_secret_injection_store(Arc::clone(&self.secret_injection_store)),
+        );
         let result_failure_cleanup_store = Arc::clone(&lifecycle_process_store);
         let submission_lifecycle: Arc<dyn ironclaw_processes::ProcessSubmissionLifecycle> =
             lifecycle_process_store.clone();
@@ -856,6 +864,9 @@ where
         }
         if self.first_party_runtime_covers_declared_capabilities() {
             backends.push(RuntimeKind::FirstParty);
+        }
+        if self.process_sandbox_executor.is_some() {
+            backends.push(RuntimeKind::System);
         }
         backends
     }

--- a/crates/kernel/ironclaw_host_runtime/src/services/builder.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/builder.rs
@@ -518,6 +518,7 @@ where
         T: SecretStorePort + 'static,
     {
         self.component_types.secret_store = Some(ProductionComponentType::of::<T>());
+        let secret_store: Arc<dyn SecretStorePort> = secret_store;
         self.secret_store = Some(secret_store);
         self
     }
@@ -704,6 +705,11 @@ where
     where
         T: ProcessExecutor + 'static,
     {
+        self.process_sandbox_executor = Some(executor);
+        self
+    }
+
+    pub fn with_process_sandbox_executor_dyn(mut self, executor: Arc<dyn ProcessExecutor>) -> Self {
         self.process_sandbox_executor = Some(executor);
         self
     }

--- a/crates/kernel/ironclaw_host_runtime/src/services/process_executor.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/process_executor.rs
@@ -1,12 +1,25 @@
 use std::{sync::Arc, time::Instant};
 
+use crate::obligations::RuntimeSecretInjectionStore;
 use async_trait::async_trait;
 use ironclaw_capabilities::ProcessAuthorizationRemintPort;
-use ironclaw_host_api::{dispatch::CapabilityDispatcher, runtime::RuntimeKind};
+use ironclaw_host_api::{
+    action::NetworkScheme,
+    dispatch::CapabilityDispatcher,
+    http::RuntimeCredentialTarget,
+    process::{
+        CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError,
+        SandboxCommandCredential, SandboxCommandTransport,
+    },
+    runtime::RuntimeKind,
+};
 use ironclaw_observability::live_latency_started_at;
 use ironclaw_processes::{
     ProcessExecutionError, ProcessExecutionRequest, ProcessExecutionResult, ProcessExecutor,
 };
+use ironclaw_sandbox::{SandboxCommandPlan, SandboxProcessPlan, ValidatedSandboxProcessPlan};
+use secrecy::ExposeSecret;
+use serde_json::json;
 
 struct ProcessLatencyFields {
     capability_id: String,
@@ -118,6 +131,7 @@ fn trace_process_latency_error<E: ?Sized>(
 pub(super) struct HostProcessExecutor {
     dispatch_executor: Arc<dyn ProcessExecutor>,
     process_sandbox_executor: Option<Arc<dyn ProcessExecutor>>,
+    secret_injection_store: Arc<RuntimeSecretInjectionStore>,
 }
 
 impl HostProcessExecutor {
@@ -128,7 +142,78 @@ impl HostProcessExecutor {
         Self {
             dispatch_executor,
             process_sandbox_executor,
+            secret_injection_store: Arc::new(RuntimeSecretInjectionStore::new()),
         }
+    }
+
+    pub(super) fn with_secret_injection_store(
+        mut self,
+        secret_injection_store: Arc<RuntimeSecretInjectionStore>,
+    ) -> Self {
+        self.secret_injection_store = secret_injection_store;
+        self
+    }
+
+    fn resolve_sandbox_credentials(
+        &self,
+        request: &ProcessExecutionRequest,
+    ) -> Result<Vec<SandboxCommandCredential>, ProcessExecutionError> {
+        if request
+            .input
+            .get("credentials")
+            .and_then(serde_json::Value::as_array)
+            .is_none_or(Vec::is_empty)
+        {
+            return Ok(Vec::new());
+        }
+        let plan = serde_json::from_value::<SandboxProcessPlan>(request.input.clone())
+            .map_err(|_| ProcessExecutionError::new("invalid_sandbox_process_plan"))?;
+        let plan = ValidatedSandboxProcessPlan::new(plan)
+            .map_err(|_| ProcessExecutionError::new("invalid_sandbox_process_plan"))?;
+        let mut credentials = Vec::with_capacity(plan.credentials.len());
+        for binding in &plan.credentials {
+            let placeholder_env = binding.placeholder_env.clone().ok_or_else(|| {
+                ProcessExecutionError::new("sandbox_credential_placeholder_env_required")
+            })?;
+            let RuntimeCredentialTarget::Header { name, prefix } = &binding.target else {
+                return Err(ProcessExecutionError::new(
+                    "sandbox_credential_target_unsupported",
+                ));
+            };
+            let (material, authorized_binding) = self
+                .secret_injection_store
+                .take_bound(&request.scope, &request.capability_id, &binding.handle)
+                .map_err(|_| ProcessExecutionError::new("sandbox_credential_handoff_failed"))?
+                .ok_or_else(|| ProcessExecutionError::new("sandbox_credential_unavailable"))?;
+            let authorized_binding = authorized_binding.ok_or_else(|| {
+                ProcessExecutionError::new("sandbox_credential_binding_unavailable")
+            })?;
+            let audience = &authorized_binding.audience;
+            if audience.scheme != Some(NetworkScheme::Https)
+                || audience.port.is_some_and(|port| port != 443)
+                || !audience
+                    .host_pattern
+                    .eq_ignore_ascii_case(&binding.approved_host)
+                || authorized_binding.target != binding.target
+            {
+                return Err(ProcessExecutionError::new(
+                    "sandbox_credential_binding_mismatch",
+                ));
+            }
+            credentials.push(SandboxCommandCredential::new(
+                placeholder_env,
+                format!(
+                    "{}{}",
+                    ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX,
+                    uuid::Uuid::new_v4().simple()
+                ),
+                binding.approved_host.clone(),
+                name.clone(),
+                prefix.clone(),
+                material.expose_secret().to_string(),
+            ));
+        }
+        Ok(credentials)
     }
 }
 
@@ -151,7 +236,10 @@ impl ProcessExecutor for HostProcessExecutor {
                 );
                 return Err(error);
             };
-            let result = executor.execute(request).await;
+            let credentials = self.resolve_sandbox_credentials(&request)?;
+            let result = executor
+                .execute_with_credentials(request, credentials)
+                .await;
             match &result {
                 Ok(_) => {
                     trace_process_latency_ok("host_process_execute", fields.as_ref(), started_at)
@@ -177,6 +265,172 @@ impl ProcessExecutor for HostProcessExecutor {
         }
         result
     }
+}
+
+/// Executes the typed `system.process_sandbox.run` plan through the configured
+/// sandbox transport without reparsing a shell command line.
+#[derive(Clone)]
+pub struct SandboxTransportProcessExecutor {
+    transport: Arc<dyn SandboxCommandTransport>,
+}
+
+impl SandboxTransportProcessExecutor {
+    pub fn new(transport: Arc<dyn SandboxCommandTransport>) -> Self {
+        Self { transport }
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ProcessExecutionRequest,
+        command: &SandboxCommandPlan,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<CommandExecutionOutput, ProcessExecutionError> {
+        if request.cancellation.is_cancelled() {
+            return Err(ProcessExecutionError::new("sandbox_process_cancelled"));
+        }
+        let timeout_secs = command
+            .timeout_ms
+            .map(|timeout_ms| timeout_ms.div_ceil(1_000));
+        let mut extra_env = command.env.clone();
+        for credential in &credentials {
+            extra_env.insert(
+                credential.placeholder_env.clone(),
+                credential.placeholder.clone(),
+            );
+        }
+        let command_cancellation = ironclaw_host_api::process::CommandCancellationToken::new();
+        let command_request = CommandExecutionRequest {
+            scope: request.scope.clone(),
+            mounts: Some(request.mounts.clone()),
+            command: command.command.clone(),
+            args: command.args.clone(),
+            workdir: command.working_dir.clone(),
+            timeout_secs,
+            extra_env,
+            cancellation: command_cancellation.clone(),
+        };
+        let execution = async {
+            if credentials.is_empty() {
+                self.transport.run_command(command_request).await
+            } else {
+                self.transport
+                    .run_credentialed_command(command_request, credentials)
+                    .await
+            }
+        };
+        tokio::pin!(execution);
+        tokio::select! {
+            result = &mut execution => result.map_err(map_sandbox_process_error),
+            () = request.cancellation.cancelled() => {
+                command_cancellation.cancel();
+                let _ = execution.await;
+                Err(ProcessExecutionError::new("sandbox_process_cancelled"))
+            }
+        }
+    }
+}
+#[async_trait]
+impl ProcessExecutor for crate::UserSandboxProcessPort {
+    async fn execute(
+        &self,
+        request: ProcessExecutionRequest,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        SandboxTransportProcessExecutor::new(self.transport())
+            .execute(request)
+            .await
+    }
+
+    async fn execute_with_credentials(
+        &self,
+        request: ProcessExecutionRequest,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        SandboxTransportProcessExecutor::new(self.transport())
+            .execute_with_credentials(request, credentials)
+            .await
+    }
+}
+
+#[async_trait]
+impl ProcessExecutor for SandboxTransportProcessExecutor {
+    async fn execute(
+        &self,
+        request: ProcessExecutionRequest,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        self.execute_with_credentials(request, Vec::new()).await
+    }
+
+    async fn execute_with_credentials(
+        &self,
+        request: ProcessExecutionRequest,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        let plan = serde_json::from_value::<SandboxProcessPlan>(request.input.clone())
+            .map_err(|_| ProcessExecutionError::new("invalid_sandbox_process_plan"))?;
+        let plan = ValidatedSandboxProcessPlan::new(plan)
+            .map_err(|_| ProcessExecutionError::new("invalid_sandbox_process_plan"))?;
+        if plan.credentials.len() != credentials.len() {
+            return Err(ProcessExecutionError::new(
+                "sandbox_credential_handoff_mismatch",
+            ));
+        }
+
+        if let Some(install) = &plan.install {
+            let output = self
+                .execute_command(&request, &install.command, Vec::new())
+                .await?;
+            if output.exit_code != 0 {
+                return Err(ProcessExecutionError::new("sandbox_install_failed"));
+            }
+        }
+        let output = self
+            .execute_command(&request, &plan.run, credentials)
+            .await?;
+        Ok(ProcessExecutionResult {
+            output: json!({
+                "exit_code": output.exit_code,
+                "output": bounded_output(
+                    output.output,
+                    combined_output_limit(
+                        plan.run.max_stdout_bytes,
+                        plan.run.max_stderr_bytes,
+                    ),
+                ),
+                "duration_ms": output.duration.as_millis(),
+            }),
+        })
+    }
+}
+
+fn map_sandbox_process_error(error: RuntimeProcessError) -> ProcessExecutionError {
+    let kind = match error {
+        RuntimeProcessError::Timeout(_) => "sandbox_process_timeout",
+        RuntimeProcessError::Cancelled => "sandbox_process_cancelled",
+        RuntimeProcessError::ExecutionFailed(_) => "sandbox_process_execution_failed",
+    };
+    ProcessExecutionError::new(kind)
+}
+
+fn combined_output_limit(stdout: Option<u64>, stderr: Option<u64>) -> Option<u64> {
+    match (stdout, stderr) {
+        (Some(stdout), Some(stderr)) => stdout.checked_add(stderr),
+        (Some(limit), None) | (None, Some(limit)) => Some(limit),
+        (None, None) => None,
+    }
+}
+
+fn bounded_output(output: String, max_bytes: Option<u64>) -> String {
+    let Some(max_bytes) = max_bytes.and_then(|value| usize::try_from(value).ok()) else {
+        return output;
+    };
+    if output.len() <= max_bytes {
+        return output;
+    }
+    let mut boundary = max_bytes;
+    while !output.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    output[..boundary].to_string()
 }
 
 fn is_process_sandbox_request(request: &ProcessExecutionRequest) -> bool {
@@ -261,7 +515,10 @@ impl ProcessExecutor for RuntimeDispatchProcessExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    };
 
     use ironclaw_host_api::dispatch_test_support::TestDispatcher;
     use ironclaw_host_api::{
@@ -271,7 +528,8 @@ mod tests {
         },
         ids::{
             ActivityId, AgentId, CapabilityId, CorrelationId, ExtensionId, InvocationId, ProcessId,
-            ProductKind, ProjectId, ResourceReservationId, TenantId, ThreadId, UserId,
+            ProductKind, ProjectId, ResourceReservationId, SecretHandle, TenantId, ThreadId,
+            UserId,
         },
         invocation::{Actor, InvocationOrigin},
         lane::RuntimeLane,
@@ -319,6 +577,313 @@ mod tests {
                 output: json!({ "executor": self.label }),
             })
         }
+    }
+
+    #[derive(Default)]
+    struct RecordingSandboxCommandTransport {
+        requests: Mutex<Vec<CommandExecutionRequest>>,
+        credential_requests: Mutex<Vec<(CommandExecutionRequest, Vec<SandboxCommandCredential>)>>,
+    }
+
+    #[async_trait]
+    impl SandboxCommandTransport for RecordingSandboxCommandTransport {
+        async fn run_command(
+            &self,
+            request: CommandExecutionRequest,
+        ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+            self.requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(request);
+            Ok(CommandExecutionOutput {
+                output: "hello".to_string(),
+                saved_output: None,
+                exit_code: 7,
+                sandboxed: true,
+                duration: std::time::Duration::from_millis(12),
+            })
+        }
+
+        async fn run_credentialed_command(
+            &self,
+            request: CommandExecutionRequest,
+            credentials: Vec<SandboxCommandCredential>,
+        ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+            self.credential_requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push((request, credentials));
+            Ok(CommandExecutionOutput {
+                output: "credentialed".to_string(),
+                saved_output: None,
+                exit_code: 0,
+                sandboxed: true,
+                duration: std::time::Duration::from_millis(5),
+            })
+        }
+    }
+    struct CancellationAwareSandboxTransport {
+        started: Arc<tokio::sync::Notify>,
+        stopped: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl SandboxCommandTransport for CancellationAwareSandboxTransport {
+        async fn run_command(
+            &self,
+            request: CommandExecutionRequest,
+        ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+            self.started.notify_one();
+            request.cancellation.cancelled().await;
+            self.stopped.store(true, Ordering::SeqCst);
+            Err(RuntimeProcessError::Cancelled)
+        }
+    }
+
+    #[tokio::test]
+    async fn user_sandbox_process_executor_runs_validated_plan_with_direct_arguments() {
+        let transport = Arc::new(RecordingSandboxCommandTransport::default());
+        let executor = crate::UserSandboxProcessPort::new(transport.clone());
+        let mut request = sample_process_request(
+            ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID,
+            RuntimeKind::System,
+        );
+        request.input = json!({
+            "run": {
+                "command": "printf",
+                "args": ["%s", "hello"],
+                "max_stdout_bytes": 3,
+                "max_stderr_bytes": 2
+            }
+        });
+
+        let result = executor.execute(request).await.unwrap();
+
+        assert_eq!(
+            result.output,
+            json!({
+                "exit_code": 7,
+                "output": "hello",
+                "duration_ms": 12
+            })
+        );
+        let requests = transport
+            .requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].command, "printf");
+        assert_eq!(requests[0].args, ["%s", "hello"]);
+    }
+
+    #[tokio::test]
+    async fn host_process_executor_consumes_staged_credential_without_exposing_it_to_command_env() {
+        let transport = Arc::new(RecordingSandboxCommandTransport::default());
+        let sandbox = Arc::new(SandboxTransportProcessExecutor::new(transport.clone()));
+        let store = Arc::new(RuntimeSecretInjectionStore::new());
+        let mut request = sample_process_request(
+            ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID,
+            RuntimeKind::System,
+        );
+        request.input = json!({
+            "run": {
+                "command": "gh",
+                "args": ["pr", "list"],
+                "env": {"GH_TOKEN": "model-value-is-not-authority"}
+            },
+            "network": {
+                "runtime_hosts": ["api.github.com"],
+                "direct_egress_lockdown": true
+            },
+            "credentials": [{
+                "handle": "github_runtime_token",
+                "approved_host": "api.github.com",
+                "target": {
+                    "type": "header",
+                    "name": "Authorization",
+                    "prefix": "token "
+                },
+                "placeholder_env": "GH_TOKEN",
+                "placeholder_value": "model-value-is-not-authority",
+                "required": true
+            }]
+        });
+        let handle = SecretHandle::new("github_runtime_token").unwrap();
+        store
+            .insert_bound(
+                &request.scope,
+                &request.capability_id,
+                &handle,
+                ironclaw_secrets::SecretMaterial::from("github-secret"),
+                crate::obligations::RuntimeCredentialBindingPolicy {
+                    audience: ironclaw_host_api::action::NetworkTargetPattern {
+                        scheme: Some(NetworkScheme::Https),
+                        host_pattern: "api.github.com".to_string(),
+                        port: None,
+                    },
+                    target: RuntimeCredentialTarget::Header {
+                        name: "Authorization".to_string(),
+                        prefix: Some("token ".to_string()),
+                    },
+                },
+            )
+            .unwrap();
+        let executor = HostProcessExecutor::new(
+            Arc::new(RecordingProcessExecutor::new("dispatch")),
+            Some(sandbox),
+        )
+        .with_secret_injection_store(store.clone());
+
+        executor.execute(request.clone()).await.unwrap();
+
+        let calls = transport
+            .credential_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(calls.len(), 1);
+        let (command, credentials) = &calls[0];
+        assert_eq!(command.command, "gh");
+        assert_eq!(command.args, ["pr", "list"]);
+        let placeholder = command.extra_env.get("GH_TOKEN").unwrap();
+        assert!(placeholder.starts_with(ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX));
+        assert_ne!(placeholder, "model-value-is-not-authority");
+        assert_ne!(placeholder, "github-secret");
+        assert_eq!(credentials.len(), 1);
+        assert_eq!(credentials[0].placeholder, *placeholder);
+        assert_eq!(credentials[0].approved_host, "api.github.com");
+        assert_eq!(credentials[0].header_name, "Authorization");
+        assert_eq!(credentials[0].expose_secret(), "github-secret");
+        drop(calls);
+        assert!(
+            store
+                .take(&request.scope, &request.capability_id, &handle)
+                .unwrap()
+                .is_none(),
+            "the staged credential must be one-shot"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_process_executor_rejects_model_credential_binding_mismatch() {
+        let transport = Arc::new(RecordingSandboxCommandTransport::default());
+        let sandbox = Arc::new(SandboxTransportProcessExecutor::new(transport.clone()));
+        let store = Arc::new(RuntimeSecretInjectionStore::new());
+        let mut request = sample_process_request(
+            ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID,
+            RuntimeKind::System,
+        );
+        request.input = json!({
+            "run": {
+                "command": "gh",
+                "args": ["pr", "list"],
+                "env": {"GH_TOKEN": "model-value-is-not-authority"}
+            },
+            "network": {
+                "runtime_hosts": ["api.github.com"],
+                "direct_egress_lockdown": true
+            },
+            "credentials": [{
+                "handle": "github_runtime_token",
+                "approved_host": "api.github.com",
+                "target": {
+                    "type": "header",
+                    "name": "Authorization",
+                    "prefix": "Bearer "
+                },
+                "placeholder_env": "GH_TOKEN",
+                "placeholder_value": "model-value-is-not-authority",
+                "required": true
+            }]
+        });
+        let handle = SecretHandle::new("github_runtime_token").unwrap();
+        store
+            .insert_bound(
+                &request.scope,
+                &request.capability_id,
+                &handle,
+                ironclaw_secrets::SecretMaterial::from("github-secret"),
+                crate::obligations::RuntimeCredentialBindingPolicy {
+                    audience: ironclaw_host_api::action::NetworkTargetPattern {
+                        scheme: Some(NetworkScheme::Https),
+                        host_pattern: "api.github.com".to_string(),
+                        port: None,
+                    },
+                    target: RuntimeCredentialTarget::Header {
+                        name: "X-GitHub-Token".to_string(),
+                        prefix: None,
+                    },
+                },
+            )
+            .unwrap();
+        let executor = HostProcessExecutor::new(
+            Arc::new(RecordingProcessExecutor::new("dispatch")),
+            Some(sandbox),
+        )
+        .with_secret_injection_store(store);
+
+        let error = executor.execute(request).await.unwrap_err();
+
+        assert_eq!(error.kind, "sandbox_credential_binding_mismatch");
+        assert!(
+            transport
+                .credential_requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn user_sandbox_process_executor_rejects_cancelled_request_before_transport() {
+        let transport = Arc::new(RecordingSandboxCommandTransport::default());
+        let executor = crate::UserSandboxProcessPort::new(transport.clone());
+        let mut request = sample_process_request(
+            ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID,
+            RuntimeKind::System,
+        );
+        request.input = json!({"run": {"command": "true"}});
+        request.cancellation.cancel();
+
+        let error = executor.execute(request).await.unwrap_err();
+
+        assert_eq!(error.kind, "sandbox_process_cancelled");
+        assert!(
+            transport
+                .requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty()
+        );
+    }
+    #[tokio::test]
+    async fn user_sandbox_process_executor_stops_in_flight_transport_on_cancellation() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let stopped = Arc::new(AtomicBool::new(false));
+        let transport = Arc::new(CancellationAwareSandboxTransport {
+            started: Arc::clone(&started),
+            stopped: Arc::clone(&stopped),
+        });
+        let executor = crate::UserSandboxProcessPort::new(transport);
+        let mut request = sample_process_request(
+            ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID,
+            RuntimeKind::System,
+        );
+        request.input = json!({"run": {"command": "sleep", "args": ["60"]}});
+        let cancellation = request.cancellation.clone();
+        let started_wait = started.notified();
+        tokio::pin!(started_wait);
+
+        let execution = tokio::spawn(async move { executor.execute(request).await });
+        started_wait.await;
+        cancellation.cancel();
+        let error = tokio::time::timeout(std::time::Duration::from_secs(1), execution)
+            .await
+            .expect("cancelled execution must stop promptly")
+            .expect("execution task must not panic")
+            .expect_err("cancelled execution must fail");
+
+        assert_eq!(error.kind, "sandbox_process_cancelled");
+        assert!(stopped.load(Ordering::SeqCst));
     }
 
     fn dispatch_result() -> CapabilityDispatchResult {

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests.rs
@@ -805,9 +805,11 @@ async fn inherited_env_runtime_policy_selects_inherited_local_process_port() {
             scope: sample_scope(),
             mounts: None,
             command: "printf '%s' \"$HOME\"".to_string(),
+            args: Vec::new(),
             workdir: Some(workdir.path().display().to_string()),
             timeout_secs: Some(5),
             extra_env: Default::default(),
+            cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
         })
         .await
         .expect("command succeeds");
@@ -840,9 +842,11 @@ async fn scrubbed_runtime_policy_resets_managed_local_process_port_after_inherit
             scope: sample_scope(),
             mounts: None,
             command: "printf '%s' \"$HOME\"".to_string(),
+            args: Vec::new(),
             workdir: Some(workdir.path().display().to_string()),
             timeout_secs: Some(5),
             extra_env: Default::default(),
+            cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
         })
         .await
         .expect("command succeeds");

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use ironclaw_filesystem::InMemoryBackend;
 use ironclaw_host_api::{
-    decision::RuntimeCredentialAuthRequirement,
+    decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     dispatch::{DispatchError, DispatchFailureKind, RuntimeDispatchErrorKind},
     ids::{ExtensionId, RunId, SecretHandle, UserId, VendorId},
     invocation::InvocationOrigin,
@@ -428,7 +428,9 @@ async fn first_party_adapter_forwards_credential_requirements_from_auth_required
         setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth {
             scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
         },
-        requester_extension: ExtensionId::new("gmail").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("gmail").unwrap(),
+        },
         provider_scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
     };
     let descriptor = test_descriptor(RuntimeKind::FirstParty, Vec::new());

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    decision::RuntimeCredentialAuthRequirement,
+    decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     dispatch::DispatchError,
     ids::{ExtensionId, VendorId},
     resource::{ResourceEstimate, RuntimeResourceBudget},
@@ -20,7 +20,9 @@ async fn mcp_adapter_maps_executor_auth_required_to_dispatch_auth_required() {
         setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth {
             scopes: vec!["repo".to_string()],
         },
-        requester_extension: ExtensionId::new("mcp").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("mcp").unwrap(),
+        },
         provider_scopes: vec!["repo".to_string()],
     };
     let adapter = McpRuntimeAdapter::from_executor(Arc::new(AuthRequiredMcpExecutor {

--- a/crates/kernel/ironclaw_host_runtime/src/wasm_credentials.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/wasm_credentials.rs
@@ -159,6 +159,9 @@ impl RuntimeCredentialRestager {
         else {
             return Ok(());
         };
+        let consumer = ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+            extension_id: credential.requester_extension.clone(),
+        };
         let access_secret = self
             .account_resolver
             .resolve_access_secret(RuntimeCredentialAccountRequest {
@@ -166,7 +169,7 @@ impl RuntimeCredentialRestager {
                 provider,
                 setup,
                 provider_scopes: &credential.provider_scopes,
-                requester_extension: &credential.requester_extension,
+                consumer: &consumer,
             })
             .await?;
         let lease = self

--- a/crates/kernel/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
@@ -24,7 +24,7 @@ use ironclaw_host_api::{
     action::{NetworkPolicy, NetworkScheme, NetworkTargetPattern},
     audit::AuditStage,
     capability::{CapabilityDescriptor, CapabilitySet},
-    decision::{Decision, Obligation, Obligations},
+    decision::{Decision, Obligation, Obligations, RuntimeCredentialConsumer},
     dispatch::CapabilityDispatchResult,
     host_port::HostPortCatalog,
     ids::{
@@ -1463,7 +1463,9 @@ async fn inject_credential_account_once_fails_when_no_resolver_wired() {
         provider: ironclaw_host_api::ids::VendorId::new("github").unwrap(),
         setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: Vec::new(),
-        requester_extension: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        },
     }];
 
     let err = handler
@@ -1504,7 +1506,9 @@ async fn inject_credential_account_once_fails_when_resolver_returns_auth_require
         provider: ironclaw_host_api::ids::VendorId::new("github").unwrap(),
         setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: provider_scopes.clone(),
-        requester_extension: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        },
     }];
 
     let err = handler
@@ -1527,7 +1531,11 @@ async fn inject_credential_account_once_fails_when_resolver_returns_auth_require
     assert_eq!(credential_requirements.len(), 1);
     assert_eq!(credential_requirements[0].provider.as_str(), "github");
     assert_eq!(
-        credential_requirements[0].requester_extension.as_str(),
+        credential_requirements[0]
+            .consumer
+            .extension_id()
+            .expect("extension consumer")
+            .as_str(),
         "github"
     );
     assert_eq!(credential_requirements[0].provider_scopes, provider_scopes);
@@ -1568,7 +1576,9 @@ async fn inject_credential_account_once_resolves_and_stages_secret() {
         provider: ironclaw_host_api::ids::VendorId::new("github").unwrap(),
         setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: Vec::new(),
-        requester_extension: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        },
     }];
 
     handler
@@ -1622,7 +1632,9 @@ async fn inject_credential_account_once_reads_from_resolved_source_scope() {
         provider: ironclaw_host_api::ids::VendorId::new("github").unwrap(),
         setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: Vec::new(),
-        requester_extension: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        },
     }];
 
     handler
@@ -1664,7 +1676,9 @@ async fn inject_credential_account_once_maps_unknown_resolved_secret_to_auth_req
         provider: ironclaw_host_api::ids::VendorId::new("github").unwrap(),
         setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
         provider_scopes: Vec::new(),
-        requester_extension: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        },
     }];
 
     let err = handler
@@ -1687,7 +1701,11 @@ async fn inject_credential_account_once_maps_unknown_resolved_secret_to_auth_req
     assert_eq!(credential_requirements.len(), 1);
     assert_eq!(credential_requirements[0].provider.as_str(), "github");
     assert_eq!(
-        credential_requirements[0].requester_extension.as_str(),
+        credential_requirements[0]
+            .consumer
+            .extension_id()
+            .expect("extension consumer")
+            .as_str(),
         "github"
     );
 }

--- a/crates/kernel/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -15,7 +15,7 @@ use ironclaw_host_api::{
     capability::{
         CapabilityDescriptor, CapabilityGrant, CapabilitySet, EffectKind, GrantConstraints,
     },
-    decision::{Decision, Obligation, Obligations},
+    decision::{Decision, Obligation, Obligations, RuntimeCredentialConsumer},
     dispatch::CredentialStageError,
     host_port::default_host_port_catalog,
     ids::{
@@ -71,7 +71,9 @@ macro_rules! github_wasm_services_for_test {
                     setup:
                         ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
                     provider_scopes: Vec::new(),
-                    requester_extension: ExtensionId::new("github").unwrap(),
+                    consumer: RuntimeCredentialConsumer::Extension {
+                        extension_id: ExtensionId::new("github").unwrap(),
+                    },
                 },
             ])),
             ProcessServices::in_memory(),
@@ -116,7 +118,9 @@ macro_rules! google_wasm_services_for_test {
                         scopes: required_scopes.clone(),
                     },
                     provider_scopes: required_scopes.clone(),
-                    requester_extension: ExtensionId::new(package_id).unwrap(),
+                    consumer: RuntimeCredentialConsumer::Extension {
+                        extension_id: ExtensionId::new(package_id).unwrap(),
+                    },
                 },
             ])),
             ProcessServices::in_memory(),
@@ -195,7 +199,9 @@ async fn host_runtime_services_compact_github_search_preserves_pagination_and_eg
                 provider: VendorId::new("github").unwrap(),
                 setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: Vec::new(),
-                requester_extension: ExtensionId::new("github").unwrap(),
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new("github").unwrap(),
+                },
             },
         ])),
         ProcessServices::in_memory(),
@@ -385,7 +391,9 @@ async fn host_runtime_services_restages_github_product_auth_for_multi_request_wa
                 provider: VendorId::new("github").unwrap(),
                 setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: Vec::new(),
-                requester_extension: ExtensionId::new("github").unwrap(),
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new("github").unwrap(),
+                },
             },
         ])),
         ProcessServices::in_memory(),
@@ -480,7 +488,9 @@ async fn host_runtime_services_routes_google_drive_wasm_list_files_with_scoped_g
                     scopes: required_scopes.clone(),
                 },
                 provider_scopes: required_scopes.clone(),
-                requester_extension: ExtensionId::new("google-drive").unwrap(),
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new("google-drive").unwrap(),
+                },
             },
         ])),
         ProcessServices::in_memory(),
@@ -1017,7 +1027,14 @@ async fn host_runtime_services_maps_google_docs_sheets_and_slides_wasm_401_to_au
         assert_eq!(gate.credential_requirements.len(), 1);
         let requirement = &gate.credential_requirements[0];
         assert_eq!(requirement.provider, VendorId::new("google").unwrap());
-        assert_eq!(requirement.requester_extension.as_str(), package_id);
+        assert_eq!(
+            requirement
+                .consumer
+                .extension_id()
+                .expect("extension credential consumer")
+                .as_str(),
+            package_id
+        );
         assert_eq!(requirement.provider_scopes, required_scopes);
         assert_eq!(network.requests().len(), 1);
     }
@@ -1165,7 +1182,9 @@ async fn host_runtime_services_missing_github_runtime_secret_blocks_on_auth() {
                 provider: VendorId::new("github").unwrap(),
                 setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
                 provider_scopes: Vec::new(),
-                requester_extension: ExtensionId::new("github").unwrap(),
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new("github").unwrap(),
+                },
             },
         ])),
         ProcessServices::in_memory(),
@@ -1245,7 +1264,9 @@ async fn host_runtime_services_injects_personal_xoxp_token_for_slack_user_search
                     scopes: slack_user_scopes(),
                 },
                 provider_scopes: slack_user_scopes(),
-                requester_extension: ExtensionId::new("slack").unwrap(),
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new("slack").unwrap(),
+                },
             },
         ])),
         ProcessServices::in_memory(),
@@ -1359,7 +1380,9 @@ async fn host_runtime_services_missing_slack_account_blocks_slack_user_on_auth()
                     scopes: slack_user_scopes(),
                 },
                 provider_scopes: slack_user_scopes(),
-                requester_extension: ExtensionId::new("slack").unwrap(),
+                consumer: RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new("slack").unwrap(),
+                },
             },
         ])),
         ProcessServices::in_memory(),
@@ -2255,7 +2278,14 @@ impl RuntimeCredentialAccountResolver for FixedRuntimeCredentialAccountResolver 
         request: RuntimeCredentialAccountRequest<'_>,
     ) -> Result<RuntimeCredentialAccessSecret, CredentialStageError> {
         assert_eq!(request.provider.as_str(), "github");
-        assert_eq!(request.requester_extension.as_str(), "github");
+        assert_eq!(
+            request
+                .consumer
+                .extension_id()
+                .expect("extension credential consumer")
+                .as_str(),
+            "github"
+        );
         self.result
             .clone()
             .map(|handle| RuntimeCredentialAccessSecret {
@@ -2280,7 +2310,10 @@ impl RuntimeCredentialAccountResolver for FixedGoogleRuntimeCredentialAccountRes
     ) -> Result<RuntimeCredentialAccessSecret, CredentialStageError> {
         assert_eq!(request.provider.as_str(), "google");
         assert_eq!(
-            request.requester_extension,
+            request
+                .consumer
+                .extension_id()
+                .expect("extension credential consumer"),
             &self.expected_requester_extension
         );
         assert_eq!(request.provider_scopes, self.expected_scopes.as_slice());
@@ -2316,7 +2349,14 @@ impl RuntimeCredentialAccountResolver for FixedSlackRuntimeCredentialAccountReso
         request: RuntimeCredentialAccountRequest<'_>,
     ) -> Result<RuntimeCredentialAccessSecret, CredentialStageError> {
         assert_eq!(request.provider.as_str(), "slack");
-        assert_eq!(request.requester_extension.as_str(), "slack");
+        assert_eq!(
+            request
+                .consumer
+                .extension_id()
+                .expect("extension credential consumer")
+                .as_str(),
+            "slack"
+        );
         assert_eq!(request.provider_scopes, self.expected_scopes.as_slice());
         self.result
             .clone()
@@ -2969,7 +3009,9 @@ macro_rules! slack_enrichment_services_for_test {
                         scopes: $scopes,
                     },
                     provider_scopes: $scopes,
-                    requester_extension: ExtensionId::new("slack").unwrap(),
+                    consumer: RuntimeCredentialConsumer::Extension {
+                        extension_id: ExtensionId::new("slack").unwrap(),
+                    },
                 },
             ])),
             ProcessServices::in_memory(),

--- a/crates/kernel/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -7,7 +7,7 @@ use ironclaw_filesystem::{DiskFilesystem, InMemoryBackend, RootFilesystem, Scope
 use ironclaw_host_api::{
     action::{NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern},
     capability::CapabilitySet,
-    decision::Obligation,
+    decision::{Obligation, RuntimeCredentialConsumer},
     dispatch::CredentialStageError,
     http::{
         CapabilityHostHttpRequest, RuntimeCredentialInjection, RuntimeCredentialSource,
@@ -2879,7 +2879,9 @@ async fn mcp_http_client_reuses_product_auth_staged_credential_for_json_rpc_sess
                     setup:
                         ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
                     provider_scopes: Vec::new(),
-                    requester_extension: ExtensionId::new("mcp").unwrap(),
+                    consumer: RuntimeCredentialConsumer::Extension {
+                        extension_id: ExtensionId::new("mcp").unwrap(),
+                    },
                 },
             ],
         })

--- a/crates/kernel/ironclaw_processes/src/types.rs
+++ b/crates/kernel/ironclaw_processes/src/types.rs
@@ -16,6 +16,7 @@ use ironclaw_host_api::{
     },
     mount::MountView,
     path::VirtualPath,
+    process::SandboxCommandCredential,
     resource::{ResourceEstimate, ResourceReservation, ResourceScope},
     runtime::RuntimeKind,
 };
@@ -247,6 +248,22 @@ pub trait ProcessExecutor: Send + Sync {
         &self,
         request: ProcessExecutionRequest,
     ) -> Result<ProcessExecutionResult, ProcessExecutionError>;
+
+    /// Runs a process with one-shot host-staged sandbox credentials.
+    ///
+    /// Executors that do not implement the credential boundary fail closed.
+    async fn execute_with_credentials(
+        &self,
+        request: ProcessExecutionRequest,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        if !credentials.is_empty() {
+            return Err(ProcessExecutionError::new(
+                "sandbox_credentials_not_supported",
+            ));
+        }
+        self.execute(request).await
+    }
 }
 
 #[async_trait]

--- a/crates/kernel/ironclaw_turns/src/events.rs
+++ b/crates/kernel/ironclaw_turns/src/events.rs
@@ -549,7 +549,7 @@ pub(crate) fn project_turn_events(
 mod tests {
     use async_trait::async_trait;
     use ironclaw_host_api::{
-        decision::RuntimeCredentialAuthRequirement,
+        decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
         ids::{AgentId, ExtensionId, ProjectId, TenantId, ThreadId, UserId, VendorId},
     };
 
@@ -588,7 +588,9 @@ mod tests {
                 credential_requirements: vec![RuntimeCredentialAuthRequirement {
                     provider: VendorId::new("github").expect("provider"),
                     setup: Default::default(),
-                    requester_extension: ExtensionId::new("github").expect("extension"),
+                    consumer: RuntimeCredentialConsumer::Extension {
+                        extension_id: ExtensionId::new("github").expect("extension"),
+                    },
                     provider_scopes: vec!["repo".to_string()],
                 }],
             }),

--- a/crates/lanes/ironclaw_mcp/src/runtime.rs
+++ b/crates/lanes/ironclaw_mcp/src/runtime.rs
@@ -400,7 +400,9 @@ mod tests {
                 setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth {
                     scopes
                 },
-                requester_extension: ExtensionId::new("google-drive").unwrap(),
+                consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new("google-drive").unwrap(),
+                },
                 provider_scopes: vec!["https://www.googleapis.com/auth/drive.readonly".to_string()],
             }]
         );

--- a/crates/lanes/ironclaw_mcp/tests/mcp_dispatch_integration.rs
+++ b/crates/lanes/ironclaw_mcp/tests/mcp_dispatch_integration.rs
@@ -6,6 +6,7 @@ use ironclaw_extension_registry::{
     HostApiContractRegistry, ManifestSource,
 };
 use ironclaw_host_api::{
+    decision::RuntimeCredentialConsumer,
     host_port::HostPortCatalog,
     ids::{
         AgentId, CapabilityId, ExtensionId, InvocationId, MissionId, ProjectId, TenantId, ThreadId,
@@ -126,8 +127,10 @@ async fn mcp_lane_auth_failure_returns_context_and_accounts_the_provider_attempt
                 VendorId::new("github").unwrap()
             );
             assert_eq!(
-                credential_requirements[0].requester_extension,
-                ExtensionId::new("github-mcp").unwrap()
+                credential_requirements[0].consumer,
+                RuntimeCredentialConsumer::Extension {
+                    extension_id: ExtensionId::new("github-mcp").unwrap(),
+                }
             );
             assert_eq!(
                 credential_requirements[0].provider_scopes,

--- a/crates/lanes/ironclaw_sandbox/Cargo.toml
+++ b/crates/lanes/ironclaw_sandbox/Cargo.toml
@@ -27,6 +27,7 @@ ironclaw_safety = { path = "../../substrates/ironclaw_safety" }
 ironclaw_secrets = { path = "../../substrates/ironclaw_secrets" }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.11"
+secrecy = "0.10"
 serde_json = "1"
 thiserror = "2"
 tar = "0.4"

--- a/crates/lanes/ironclaw_sandbox/README.md
+++ b/crates/lanes/ironclaw_sandbox/README.md
@@ -27,9 +27,9 @@ the point of the crate.
   credentialed-run phases stay separate.
 - Execution machinery: `RebornScopedSandboxCommandTransport` (implements the
   `ironclaw_host_api::process::SandboxCommandTransport` port — contracts
-  vocabulary this lane implements and the kernel consumes),
-  `RebornSandboxConfig`, the broker/firewall/CA/identity types
-  (`sandbox_process`).
+  vocabulary this lane implements and the kernel consumes), direct executable
+  plus argument-vector dispatch, invocation cancellation, `RebornSandboxConfig`,
+  and the broker/firewall/CA/identity types (`sandbox_process`).
 - Script lane: `ScriptRuntime`, `ScriptExecutor`/`ScriptBackend`,
   `DockerScriptBackend`, `ScriptRuntimeHttpAdapter`, normalized
   request/result/error types (`script`).
@@ -122,9 +122,11 @@ explicit host broker or managed-egress binding.
 
 - **Typed plans only:** no raw container flags, host paths, environment
   inheritance, or secret material through plan input (`plan`/`validation`).
-- **Credential firewall as a staging chokepoint:** an invocation consumes only
-  the credential it was already entitled to; consumers see yes/no, never
-  material. The per-tenant CA root key never touches disk and is never
+- **Credential firewall as a staging chokepoint:** the capability kernel derives
+  each invocation's credential authority from active extension declarations,
+  then stages only handle-bound material for the sandbox transport. The command
+  receives a placeholder; only the private proxy can replace it for the approved
+  host and header. The per-tenant CA root key never touches disk and is never
   serialized to a caller.
 - **Fail closed on missing containment:** a served multi-user deployment must
   never resolve to an unsandboxed host-process backend; a missing backend

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process.rs
@@ -7,7 +7,7 @@
 //! different users to run in parallel.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Component, Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -23,7 +23,8 @@ use fs2::FileExt;
 use ironclaw_host_api::resource::ResourceScope;
 
 use ironclaw_host_api::process::{
-    CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, SandboxCommandTransport,
+    CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, SandboxCommandCredential,
+    SandboxCommandTransport,
 };
 
 mod broker;
@@ -41,6 +42,7 @@ pub(crate) mod shell_limits;
 mod user_container;
 mod worker_spec;
 
+use crate::validation::{validate_env_has_no_raw_sensitive_values, validate_env_name};
 use managed_egress::{ManagedEgressBundle, ManagedEgressConfig, ManagedEgressRuntime};
 
 // `user_key` is the shared per-user workspace and local Docker container
@@ -281,13 +283,19 @@ impl RebornSandboxConfig {
     fn command_env_for_bundle(
         &self,
         extra_env: HashMap<String, String>,
+        credentials: &[SandboxCommandCredential],
         managed: Option<&ManagedEgressRuntime>,
         bundle: Option<&ManagedEgressBundle>,
     ) -> Result<Vec<String>, RuntimeProcessError> {
         let (Some(managed), Some(bundle)) = (managed, bundle) else {
             return self.command_env(extra_env);
         };
-        let mut env = validate_env(&extra_env)?;
+        validate_credential_env(&extra_env, credentials)?;
+        let mut env = extra_env
+            .into_iter()
+            .map(|(name, value)| format!("{name}={value}"))
+            .collect::<Vec<_>>();
+        env.sort();
         broker::push_broker_env(None, self.secret_broker.as_ref(), &mut env)?;
         let mode_prefix = format!("{}=", broker::REBORN_NETWORK_MODE_ENV);
         env.retain(|entry| !entry.starts_with(&mode_prefix));
@@ -537,13 +545,17 @@ impl RebornScopedSandboxCommandTransport {
         resolved_image: &str,
         bundle: Option<&ManagedEgressBundle>,
         container_user: String,
-        binds: Vec<String>,
+        mut binds: Vec<String>,
     ) -> Result<user_container::UserContainerLaunch, RuntimeProcessError> {
         let env = self.config.command_env_for_bundle(
-            request.extra_env.clone(),
+            HashMap::new(),
+            &[],
             self.managed_egress.as_deref(),
             bundle,
         )?;
+        if let (Some(managed), Some(bundle)) = (self.managed_egress.as_deref(), bundle) {
+            binds.push(managed.user_ca_bind(bundle)?);
+        }
         let security = worker_spec::DockerWorkerSecuritySpec::new(
             self.config.managed_container_network_mode(bundle),
         );
@@ -600,6 +612,7 @@ impl RebornScopedSandboxCommandTransport {
     async fn run_command_owned(
         self,
         request: CommandExecutionRequest,
+        credentials: Vec<SandboxCommandCredential>,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
         reject_nul("sandbox command", &request.command)?;
         let user_key = RebornSandboxUserKey::from_scope(&request.scope);
@@ -611,8 +624,11 @@ impl RebornScopedSandboxCommandTransport {
         if timeout.is_zero() {
             return Err(RuntimeProcessError::Timeout(timeout));
         }
+        if request.cancellation.is_cancelled() {
+            return Err(RuntimeProcessError::Cancelled);
+        }
         user_container::exec_helper_timeout_secs(timeout)?;
-        validate_env(&request.extra_env)?;
+        validate_credential_env(&request.extra_env, &credentials)?;
         let workspace = self.prepare_workspace(&request.scope).await?;
         let container_user = self
             .config
@@ -656,6 +672,11 @@ impl RebornScopedSandboxCommandTransport {
                 managed
                     .set_invocation(bundle, &request.scope.invocation_id)
                     .await?;
+                if !credentials.is_empty() {
+                    managed
+                        .configure_credentials(&self.docker, bundle, &credentials)
+                        .await?;
+                }
             }
             let launch = self.user_container_launch_config(
                 &request,
@@ -667,7 +688,8 @@ impl RebornScopedSandboxCommandTransport {
             let container_name =
                 user_container::ensure_user_container(&self, &user_key, launch).await?;
             let exec_env = self.config.command_env_for_bundle(
-                HashMap::new(),
+                request.extra_env.clone(),
+                &credentials,
                 self.managed_egress.as_deref(),
                 bundle.as_ref(),
             )?;
@@ -693,18 +715,44 @@ impl RebornScopedSandboxCommandTransport {
                 return Err(setup_error);
             }
         };
+        if request.cancellation.is_cancelled() {
+            if let Some(managed) = self.managed_egress.as_ref()
+                && let Some(bundle) = bundle.as_ref()
+                && !credentials.is_empty()
+            {
+                managed.clear_credentials(&self.docker, bundle).await?;
+            }
+            return Err(RuntimeProcessError::Cancelled);
+        }
         let result = user_container::execute_in_user_container(
             &self,
             &user_key,
             &container_name,
-            request.command,
-            workdir,
-            exec_env,
-            timeout,
+            user_container::UserContainerCommand {
+                command: request.command,
+                args: request.args,
+                workdir,
+                env: exec_env,
+                timeout,
+                cancellation: request.cancellation,
+            },
         )
         .await;
+        let cleanup = match (self.managed_egress.as_ref(), bundle.as_ref()) {
+            (Some(managed), Some(bundle)) if !credentials.is_empty() => {
+                managed.clear_credentials(&self.docker, bundle).await
+            }
+            _ => Ok(()),
+        };
         drop(activity);
-        result
+        match (result, cleanup) {
+            (Ok(output), Ok(())) => Ok(output),
+            (Err(error), Ok(())) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+            (Err(error), Err(cleanup_error)) => Err(RuntimeProcessError::ExecutionFailed(format!(
+                "{error}; sandbox credential cleanup failed: {cleanup_error}"
+            ))),
+        }
     }
 }
 
@@ -728,10 +776,28 @@ impl SandboxCommandTransport for RebornScopedSandboxCommandTransport {
         &self,
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
-        let execution = tokio::spawn(self.clone().run_command_owned(request));
+        let execution = tokio::spawn(self.clone().run_command_owned(request, Vec::new()));
         execution.await.map_err(|error| {
             RuntimeProcessError::ExecutionFailed(format!(
                 "sandbox command execution task failed: {error}"
+            ))
+        })?
+    }
+
+    async fn run_credentialed_command(
+        &self,
+        request: CommandExecutionRequest,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        if self.managed_egress.is_none() {
+            return Err(RuntimeProcessError::ExecutionFailed(
+                "sandbox transport requires managed egress for credential bindings".to_string(),
+            ));
+        }
+        let execution = tokio::spawn(self.clone().run_command_owned(request, credentials));
+        execution.await.map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox credentialed command execution task failed: {error}"
             ))
         })?
     }
@@ -850,12 +916,65 @@ fn reject_nul(label: &str, value: &str) -> Result<(), RuntimeProcessError> {
 }
 
 fn validate_env(env: &HashMap<String, String>) -> Result<Vec<String>, RuntimeProcessError> {
-    if !env.is_empty() {
-        return Err(RuntimeProcessError::ExecutionFailed(
-            "user sandbox commands do not accept caller-provided environment variables".to_string(),
-        ));
+    validate_environment_entries(env, &[])?;
+    let mut rendered = env
+        .iter()
+        .map(|(name, value)| format!("{name}={value}"))
+        .collect::<Vec<_>>();
+    rendered.sort();
+    Ok(rendered)
+}
+
+fn validate_credential_env(
+    env: &HashMap<String, String>,
+    credentials: &[SandboxCommandCredential],
+) -> Result<(), RuntimeProcessError> {
+    let placeholders = credentials
+        .iter()
+        .map(|credential| credential.placeholder.as_str())
+        .collect::<Vec<_>>();
+    validate_environment_entries(env, &placeholders)?;
+
+    let mut names = HashSet::with_capacity(credentials.len());
+    for credential in credentials {
+        if credential.placeholder_env.is_empty()
+            || credential.placeholder_env.contains(['=', '\0'])
+            || credential.placeholder.contains('\0')
+            || !names.insert(credential.placeholder_env.as_str())
+            || !credential
+                .placeholder
+                .starts_with(ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX)
+            || env.get(&credential.placeholder_env) != Some(&credential.placeholder)
+        {
+            return Err(RuntimeProcessError::ExecutionFailed(
+                "sandbox credential placeholders must match credential bindings".to_string(),
+            ));
+        }
     }
-    Ok(Vec::new())
+    Ok(())
+}
+
+fn validate_environment_entries(
+    env: &HashMap<String, String>,
+    allowed_placeholders: &[&str],
+) -> Result<(), RuntimeProcessError> {
+    for (name, value) in env {
+        validate_env_name(name).map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox command environment is invalid: {error}"
+            ))
+        })?;
+        if value.contains('\0') {
+            return Err(RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox command environment is invalid for {name}"
+            )));
+        }
+    }
+    validate_env_has_no_raw_sensitive_values(env, allowed_placeholders).map_err(|error| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "sandbox command environment is invalid: {error}"
+        ))
+    })
 }
 
 fn validate_relative_workdir(path: &Path) -> Result<(), RuntimeProcessError> {
@@ -880,6 +999,10 @@ mod tests {
         mount::{MountGrant, MountPermissions, MountView},
         path::{MountAlias, VirtualPath},
     };
+    fn inert_docker_client() -> Docker {
+        Docker::connect_with_http("http://127.0.0.1:9", 1, bollard::API_DEFAULT_VERSION)
+            .expect("construct inert Docker test client")
+    }
 
     #[test]
     fn transport_constructor_uses_canonical_bounded_docker_connector() {
@@ -908,11 +1031,42 @@ mod tests {
 
     #[test]
     fn test_constructor_works_without_tokio_runtime() {
-        let docker = Docker::connect_with_local_defaults().expect("construct Docker client");
+        let docker = inert_docker_client();
         let _transport = test_support::transport(
             docker,
             RebornSandboxConfig::new("/tmp/reborn-sandbox-pure-constructor"),
         );
+    }
+    #[test]
+    fn command_environment_accepts_valid_non_sensitive_values() {
+        let env = HashMap::from([
+            ("RUST_LOG".to_string(), "debug".to_string()),
+            ("FEATURE_FLAG".to_string(), "enabled".to_string()),
+        ]);
+
+        assert_eq!(
+            validate_env(&env).unwrap(),
+            ["FEATURE_FLAG=enabled", "RUST_LOG=debug"]
+        );
+    }
+
+    #[test]
+    fn credential_environment_allows_benign_values_beside_bound_placeholders() {
+        let placeholder = format!("{}test", ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX);
+        let env = HashMap::from([
+            ("GH_TOKEN".to_string(), placeholder.clone()),
+            ("RUST_LOG".to_string(), "debug".to_string()),
+        ]);
+        let credentials = [SandboxCommandCredential::new(
+            "GH_TOKEN".to_string(),
+            placeholder,
+            "api.github.com".to_string(),
+            "Authorization".to_string(),
+            Some("token ".to_string()),
+            "secret".to_string(),
+        )];
+
+        validate_credential_env(&env, &credentials).unwrap();
     }
 
     #[tokio::test]
@@ -1017,14 +1171,36 @@ mod tests {
     }
 
     #[test]
-    fn validate_env_rejects_all_caller_environment_injection() {
-        let error = validate_env(&HashMap::from([(
-            "PLACEHOLDER".to_string(),
-            "value".to_string(),
-        )]))
-        .unwrap_err();
-        assert!(error.to_string().contains("caller-provided environment"));
-        assert_eq!(validate_env(&HashMap::new()).unwrap(), Vec::<String>::new());
+    fn validate_credential_env_accepts_valid_caller_values_and_bound_placeholders() {
+        let caller_env = HashMap::from([("FEATURE_FLAG".to_string(), "enabled".to_string())]);
+        assert_eq!(validate_credential_env(&caller_env, &[]), Ok(()));
+        assert_eq!(validate_credential_env(&HashMap::new(), &[]), Ok(()));
+
+        let placeholder = format!("{}test", ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX);
+        let credential = SandboxCommandCredential::new(
+            "GH_TOKEN".to_string(),
+            placeholder.clone(),
+            "api.github.com".to_string(),
+            "Authorization".to_string(),
+            Some("Bearer ".to_string()),
+            "real-secret".to_string(),
+        );
+        let bound_env = HashMap::from([("GH_TOKEN".to_string(), placeholder.clone())]);
+        assert_eq!(
+            validate_credential_env(&bound_env, std::slice::from_ref(&credential)),
+            Ok(())
+        );
+
+        let wrong_placeholder =
+            HashMap::from([("GH_TOKEN".to_string(), "caller-value".to_string())]);
+        assert!(
+            validate_credential_env(&wrong_placeholder, std::slice::from_ref(&credential)).is_err()
+        );
+        let extra_env = HashMap::from([
+            ("GH_TOKEN".to_string(), placeholder),
+            ("UNBOUND".to_string(), "value".to_string()),
+        ]);
+        assert_eq!(validate_credential_env(&extra_env, &[credential]), Ok(()));
     }
 
     #[test]
@@ -1098,15 +1274,13 @@ mod tests {
             .with_secret_broker_url("https://broker.internal/secrets")
             .unwrap();
         for key in broker::RESERVED_BROKER_ENV_KEYS {
-            let error = config
-                .command_env(HashMap::from([(
-                    (*key).to_string(),
-                    "caller-controlled".to_string(),
-                )]))
-                .unwrap_err();
-
             assert!(
-                format!("{error}").contains("caller-provided environment"),
+                config
+                    .command_env(HashMap::from([(
+                        (*key).to_string(),
+                        "caller-controlled".to_string(),
+                    )]))
+                    .is_err(),
                 "{key}"
             );
         }
@@ -1138,8 +1312,7 @@ mod tests {
             .unwrap()
             .with_secret_broker_unix_socket(&secret_socket)
             .unwrap();
-        let transport =
-            test_support::transport(Docker::connect_with_local_defaults().unwrap(), config);
+        let transport = test_support::transport(inert_docker_client(), config);
         // Config-shape tests inject an immutable identity directly; only the
         // real run path resolves the configured reference through Docker.
         let container_user = transport
@@ -1165,9 +1338,11 @@ mod tests {
                     scope: sandbox_scope(),
                     mounts: None,
                     command: "true".to_string(),
+                    args: Vec::new(),
                     workdir: None,
                     timeout_secs: Some(1),
                     extra_env: HashMap::new(),
+                    cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
                 },
                 "sha256:test-worker",
                 None,
@@ -1250,9 +1425,11 @@ mod tests {
                 scope: sandbox_scope(),
                 mounts: None,
                 command: "true".to_string(),
+                args: Vec::new(),
                 workdir: None,
                 timeout_secs: Some(86_401),
                 extra_env: HashMap::new(),
+                cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
             })
             .await
             .unwrap_err();
@@ -1263,7 +1440,7 @@ mod tests {
     #[tokio::test]
     async fn run_command_rejects_unconfigured_scoped_mount_before_container_create() {
         let temp = tempfile::tempdir().unwrap();
-        let docker = Docker::connect_with_local_defaults().unwrap();
+        let docker = inert_docker_client();
         let transport = test_support::transport(
             docker,
             RebornSandboxConfig::new(temp.path().join("workspaces")),
@@ -1280,9 +1457,11 @@ mod tests {
                 scope: sandbox_scope(),
                 mounts: Some(mounts),
                 command: "true".to_string(),
+                args: Vec::new(),
                 workdir: None,
                 timeout_secs: Some(1),
                 extra_env: HashMap::new(),
+                cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
             })
             .await
             .unwrap_err();

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/attribution_tests.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/attribution_tests.rs
@@ -586,9 +586,11 @@ async fn real_docker_resolves_a_production_user_container() {
         scope,
         mounts: None,
         command: "true".to_string(),
+        args: Vec::new(),
         workdir: Some("/workspace".to_string()),
         timeout_secs: Some(30),
         extra_env: HashMap::new(),
+        cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
     };
     let command_output =
         ironclaw_host_api::process::SandboxCommandTransport::run_command(&transport, command)

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/ca.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/ca.rs
@@ -4,10 +4,9 @@
 //! Generates a root key/cert pair in memory at construction and signs
 //! short-lived leaf certificates for the older host-mediated credential
 //! firewall path. The public root certificate can be installed in an
-//! untrusted user container. This module never serializes or exports the root
-//! private key.
-//!
-//! Managed egress uses the upstream proxy's own leaf issuance instead.
+//! untrusted user container. Managed egress may serialize the root key only
+//! into its proxy-private material directory so the trusted proxy can issue
+//! leaves; the key is never exposed to the user container or logs.
 
 use std::{
     collections::HashMap,
@@ -19,6 +18,7 @@ use rcgen::{
     BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
     KeyUsagePurpose,
 };
+use secrecy::SecretString;
 use time::{Duration as CertValidityDuration, OffsetDateTime};
 
 use ironclaw_host_api::process::RuntimeProcessError;
@@ -190,14 +190,18 @@ impl SandboxCertificateAuthority {
         })
     }
 
-    /// The CA's public trust anchor — the only artifact of this CA meant
-    /// to reach a container (read-only bind-mount + `SSL_CERT_FILE` and
-    /// friends is W5's remaining trust-distribution work). Contains no
-    /// private key material; see this module's
-    /// `root_certificate_pem_never_contains_key_material` test.
-    #[allow(dead_code)] // consumed by W6; not wired yet
+    /// The CA's public trust anchor. Managed egress binds this file read-only
+    /// into the user container and points common TLS clients at it.
     pub(crate) fn root_certificate_pem(&self) -> &str {
         &self.root_cert_pem
+    }
+
+    /// The signing key consumed only by the trusted proxy sidecar.
+    ///
+    /// Wrapping the serialized value keeps debug output redacted and zeroizes
+    /// the allocation when the caller finishes writing its private material.
+    pub(crate) fn proxy_private_key_pem(&self) -> SecretString {
+        SecretString::new(self.issuer.key().serialize_pem().into_boxed_str())
     }
 
     /// Returns a leaf certificate for `host`: a live cached one if present,

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/managed_egress.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/managed_egress.rs
@@ -5,12 +5,14 @@ use std::{
     time::Duration,
 };
 
-use super::{registry, user_key::RebornSandboxUserKey, worker_spec};
+use super::{
+    ca::SandboxCertificateAuthority, registry, user_key::RebornSandboxUserKey, worker_spec,
+};
 use bollard::{
     Docker,
     container::{
         Config, CreateContainerOptions, InspectContainerOptions, ListContainersOptions,
-        LogsOptions, RemoveContainerOptions, StartContainerOptions,
+        LogsOptions, RemoveContainerOptions, RestartContainerOptions, StartContainerOptions,
     },
     image::CreateImageOptions,
     models::{HealthConfig, HealthStatusEnum, HostConfig, HostConfigLogConfig},
@@ -24,8 +26,9 @@ use ironclaw_common::env_helpers::env_or_override;
 use ironclaw_host_api::{
     action::NetworkPolicy,
     ids::{InvocationId, TenantId, UserId},
-    process::RuntimeProcessError,
+    process::{RuntimeProcessError, SandboxCommandCredential},
 };
+use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
 pub(super) const PROXY_LABEL_PREFIX: &str = "ironclaw.proxy";
 pub(super) const NETWORK_LABEL_PREFIX: &str = "ironclaw.network";
@@ -35,6 +38,9 @@ pub(super) const PROXY_IMAGE_ENV: &str = "IRONCLAW_REBORN_SANDBOX_PROXY_IMAGE";
 const PROXY_CONFIG_PATH: &str = "/run/ironclaw-proxy/proxy.yaml";
 const PROXY_MATERIAL_ROOT: &str = "/run/ironclaw-proxy";
 const PROXY_INVOCATION_ID_PATH: &str = "/run/ironclaw-proxy/invocation-id";
+const PROXY_CA_CERT_PATH: &str = "/run/ironclaw-proxy/ca.crt";
+const PROXY_CA_KEY_PATH: &str = "/run/ironclaw-proxy/ca.key";
+pub(super) const USER_PROXY_CA_PATH: &str = "/run/ironclaw/egress-ca.crt";
 const SHARED_UPSTREAM_NETWORK_NAME: &str = "ironclaw-reborn-sandbox-upstream";
 const SHARED_UPSTREAM_LABEL_ROLE: &str = "ironclaw.network.role";
 const SHARED_UPSTREAM_ROLE: &str = "shared-proxy-upstream-v1";
@@ -77,6 +83,7 @@ pub(super) struct ManagedEgressConfig {
     proxy_image: String,
     policy: NetworkPolicy,
     material_root: PathBuf,
+    ca: Arc<SandboxCertificateAuthority>,
 }
 
 impl ManagedEgressConfig {
@@ -97,10 +104,12 @@ impl ManagedEgressConfig {
         }
         reject_wildcard_targets(&policy)?;
         let proxy_image = configured_proxy_image()?;
+        let ca = Arc::new(SandboxCertificateAuthority::generate()?);
         Ok(Self {
             proxy_image,
             policy,
             material_root,
+            ca,
         })
     }
 }
@@ -170,6 +179,7 @@ pub(super) struct ManagedEgressRuntime {
     proxy_image: String,
     policy: NetworkPolicy,
     posture: String,
+    ca: Arc<SandboxCertificateAuthority>,
     material_root: PathBuf,
     upstream_gate: tokio::sync::Mutex<()>,
 }
@@ -190,6 +200,7 @@ pub(super) struct ManagedEgressBundle {
     pub(super) proxy_ip: String,
     proxy_host: String,
     pub(super) posture: String,
+    pub(super) ca_cert_path: PathBuf,
     invocation_id_path: PathBuf,
 }
 
@@ -208,12 +219,17 @@ impl ManagedEgressRuntime {
         let proxy_image = resolve_proxy_image(docker, &config.proxy_image).await?;
         let material_root = config.material_root;
         create_material_directory(&material_root, 0o711).await?;
-        let posture = proxy_posture(&proxy_image, &config.policy, &material_root)?;
+        let posture = proxy_posture(
+            &proxy_image,
+            &config.policy,
+            config.ca.root_certificate_pem().as_bytes(),
+        )?;
         Ok(Arc::new(Self {
             proxy_image,
             policy: config.policy,
             posture,
             material_root,
+            ca: config.ca,
             upstream_gate: tokio::sync::Mutex::new(()),
         }))
     }
@@ -256,6 +272,12 @@ impl ManagedEgressRuntime {
         let upstream_network_name = SHARED_UPSTREAM_NETWORK_NAME;
         let proxy_material_root = self.material_root.join(&proxy_name);
         create_material_directory(&proxy_material_root, 0o711).await?;
+        let ca_cert_path = proxy_material_root.join("ca.crt");
+        let ca_key_path = proxy_material_root.join("ca.key");
+        write_atomic_material_file(&ca_cert_path, self.ca.root_certificate_pem().as_bytes())
+            .await?;
+        let ca_key = self.ca.proxy_private_key_pem();
+        write_atomic_private_material_file(&ca_key_path, ca_key.expose_secret().as_bytes()).await?;
         let invocation_id_path = proxy_material_root.join("invocation-id");
         if !tokio::fs::try_exists(&invocation_id_path)
             .await
@@ -398,6 +420,7 @@ impl ManagedEgressRuntime {
             proxy_host: proxy_name,
             posture: self.posture.clone(),
             invocation_id_path,
+            ca_cert_path,
         })
     }
 
@@ -415,6 +438,61 @@ impl ManagedEgressRuntime {
         // Attribution metadata must remain readable across that boundary.
         let invocation_id = invocation_id.to_string();
         write_atomic_material_file(&bundle.invocation_id_path, invocation_id.as_bytes()).await
+    }
+    pub(super) async fn configure_credentials(
+        &self,
+        docker: &Docker,
+        bundle: &ManagedEgressBundle,
+        credentials: &[SandboxCommandCredential],
+    ) -> Result<(), RuntimeProcessError> {
+        let material_root = bundle.ca_cert_path.parent().ok_or_else(|| {
+            RuntimeProcessError::ExecutionFailed(
+                "sandbox proxy credential material path has no parent".to_string(),
+            )
+        })?;
+        remove_credential_material(material_root).await?;
+        let mut rendered = Vec::with_capacity(credentials.len());
+        for (index, credential) in credentials.iter().enumerate() {
+            if !self.policy.allowed_targets.iter().any(|target| {
+                target
+                    .host_pattern
+                    .eq_ignore_ascii_case(&credential.approved_host)
+            }) {
+                return Err(RuntimeProcessError::ExecutionFailed(
+                    "sandbox credential host is outside the approved network policy".to_string(),
+                ));
+            }
+            let filename = format!("credential-{index}.secret");
+            let host_path = material_root.join(&filename);
+            let header_prefix = credential.header_prefix.as_deref().unwrap_or_default();
+            let authorized_value = format!("{header_prefix}{}", credential.expose_secret());
+            write_atomic_private_material_file(&host_path, authorized_value.as_bytes()).await?;
+            rendered.push(ProxyCredentialConfig {
+                source_path: format!("{PROXY_MATERIAL_ROOT}/{filename}"),
+                approved_host: credential.approved_host.clone(),
+                target_header: credential.header_name.clone(),
+                placeholder_value: format!("{header_prefix}{}", credential.placeholder),
+            });
+        }
+        let config = render_proxy_config_inner(&self.policy, &bundle.proxy_ip, true, &rendered)?;
+        write_atomic_material_file(&material_root.join("proxy.yaml"), config.as_bytes()).await?;
+        restart_proxy_container(docker, &bundle.proxy_host).await
+    }
+
+    pub(super) async fn clear_credentials(
+        &self,
+        docker: &Docker,
+        bundle: &ManagedEgressBundle,
+    ) -> Result<(), RuntimeProcessError> {
+        let material_root = bundle.ca_cert_path.parent().ok_or_else(|| {
+            RuntimeProcessError::ExecutionFailed(
+                "sandbox proxy credential material path has no parent".to_string(),
+            )
+        })?;
+        let config = render_proxy_config_with_ca(&self.policy, &bundle.proxy_ip)?;
+        write_atomic_material_file(&material_root.join("proxy.yaml"), config.as_bytes()).await?;
+        restart_proxy_container(docker, &bundle.proxy_host).await?;
+        remove_credential_material(material_root).await
     }
 
     async fn create_proxy(
@@ -542,7 +620,7 @@ impl ManagedEgressRuntime {
                 return Err(error);
             }
         };
-        let proxy_config = render_proxy_config(&self.policy, &proxy_ip)?;
+        let proxy_config = render_proxy_config_with_ca(&self.policy, &proxy_ip)?;
         if let Err(error) =
             write_atomic_material_file(&proxy_config_path, proxy_config.as_bytes()).await
         {
@@ -558,6 +636,13 @@ impl ManagedEgressRuntime {
         }
         Ok(proxy_ip)
     }
+    pub(super) fn user_ca_bind(
+        &self,
+        bundle: &ManagedEgressBundle,
+    ) -> Result<String, RuntimeProcessError> {
+        docker_readonly_bind(&bundle.ca_cert_path, USER_PROXY_CA_PATH)
+    }
+
     pub(super) fn user_environment(
         &self,
         bundle: &ManagedEgressBundle,
@@ -577,6 +662,10 @@ impl ManagedEgressRuntime {
             ("https_proxy", proxy_url.as_str()),
             ("HTTP_PROXY", proxy_url.as_str()),
             ("HTTPS_PROXY", proxy_url.as_str()),
+            ("SSL_CERT_FILE", USER_PROXY_CA_PATH),
+            ("NODE_EXTRA_CA_CERTS", USER_PROXY_CA_PATH),
+            ("REQUESTS_CA_BUNDLE", USER_PROXY_CA_PATH),
+            ("CURL_CA_BUNDLE", USER_PROXY_CA_PATH),
             ("NO_PROXY", ""),
             ("no_proxy", ""),
         ]
@@ -1003,6 +1092,54 @@ fn proxy_is_ready(inspected: &bollard::models::ContainerInspectResponse) -> bool
         )
 }
 
+async fn restart_proxy_container(docker: &Docker, name: &str) -> Result<(), RuntimeProcessError> {
+    docker
+        .restart_container(name, Some(RestartContainerOptions { t: 10 }))
+        .await
+        .map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox proxy credential reload failed: {error}"
+            ))
+        })?;
+    if let Err(error) = wait_proxy_ready(docker, name).await {
+        let detail = proxy_failure_detail(docker, name).await;
+        return Err(RuntimeProcessError::ExecutionFailed(format!(
+            "{error}{detail}"
+        )));
+    }
+    Ok(())
+}
+
+async fn remove_credential_material(
+    material_root: &std::path::Path,
+) -> Result<(), RuntimeProcessError> {
+    let mut entries = tokio::fs::read_dir(material_root).await.map_err(|error| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "sandbox proxy credential material scan failed: {error}"
+        ))
+    })?;
+    while let Some(entry) = entries.next_entry().await.map_err(|error| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "sandbox proxy credential material scan failed: {error}"
+        ))
+    })? {
+        let filename = entry.file_name();
+        if filename
+            .to_str()
+            .is_some_and(|name| name.starts_with("credential-") && name.ends_with(".secret"))
+        {
+            tokio::fs::remove_file(entry.path())
+                .await
+                .map_err(|error| {
+                    RuntimeProcessError::ExecutionFailed(format!(
+                        "sandbox proxy credential material cleanup failed: {error}"
+                    ))
+                })?;
+        }
+    }
+    Ok(())
+}
+
 async fn start_proxy_container(docker: &Docker, name: &str) -> Result<(), RuntimeProcessError> {
     docker
         .start_container(name, None::<StartContainerOptions<String>>)
@@ -1168,7 +1305,7 @@ fn reject_wildcard_targets(policy: &NetworkPolicy) -> Result<(), RuntimeProcessE
 pub(super) fn proxy_posture(
     proxy_image: &str,
     policy: &NetworkPolicy,
-    material_root: &std::path::Path,
+    ca_certificate: &[u8],
 ) -> Result<String, RuntimeProcessError> {
     let policy_json = serde_json::to_vec(policy).map_err(|error| {
         RuntimeProcessError::ExecutionFailed(format!(
@@ -1176,18 +1313,41 @@ pub(super) fn proxy_posture(
         ))
     })?;
     let mut hasher = Sha256::new();
-    hasher.update(b"ironclaw-managed-egress-v3\0");
+    hasher.update(b"ironclaw-managed-egress-v4\0");
     hasher.update(proxy_image.as_bytes());
     hasher.update([0]);
-    hasher.update(material_root.as_os_str().as_encoded_bytes());
+    hasher.update(ca_certificate);
     hasher.update([0]);
     hasher.update(policy_json);
     Ok(hex::encode(hasher.finalize()))
 }
 
+struct ProxyCredentialConfig {
+    source_path: String,
+    approved_host: String,
+    target_header: String,
+    placeholder_value: String,
+}
+
 pub(super) fn render_proxy_config(
     policy: &NetworkPolicy,
     proxy_ip: &str,
+) -> Result<String, RuntimeProcessError> {
+    render_proxy_config_inner(policy, proxy_ip, false, &[])
+}
+
+fn render_proxy_config_with_ca(
+    policy: &NetworkPolicy,
+    proxy_ip: &str,
+) -> Result<String, RuntimeProcessError> {
+    render_proxy_config_inner(policy, proxy_ip, true, &[])
+}
+
+fn render_proxy_config_inner(
+    policy: &NetworkPolicy,
+    proxy_ip: &str,
+    intercept_tls: bool,
+    credentials: &[ProxyCredentialConfig],
 ) -> Result<String, RuntimeProcessError> {
     if policy.allowed_targets.is_empty() || !policy.deny_private_ip_ranges {
         return Err(RuntimeProcessError::ExecutionFailed(
@@ -1228,16 +1388,65 @@ pub(super) fn render_proxy_config(
         config.push_str(cidr);
         config.push('\n');
     }
-    config.push_str("tls:\n  mode: \"sni-only\"\ntransforms:\n  - name: secrets\n    config:\n      secrets:\n        - source:\n            type: file\n            path: \"");
-    config.push_str(PROXY_INVOCATION_ID_PATH);
-    config.push_str("\"\n            ttl: \"-1ns\"\n            failure_ttl: \"1ms\"\n          rules:\n            - host: \"*\"\n          inject:\n            header: \"X-Ironclaw-Invocation-Id\"\n            require: true\n  - name: annotate\n    config:\n      annotations:\n        - rules:\n            - host: \"*\"\n          headers: [\"X-Ironclaw-Invocation-Id\"]\n  - name: header_allowlist\n    config:\n      headers: [\"Authorization\", \"Content-Type\", \"Accept\", \"User-Agent\", \"Range\", \"If-None-Match\", \"If-Modified-Since\"]\n  - name: allowlist\n    config:\n      domains:\n");
+    if intercept_tls {
+        config.push_str("tls:\n  ca_cert: \"");
+        config.push_str(PROXY_CA_CERT_PATH);
+        config.push_str("\"\n  ca_key: \"");
+        config.push_str(PROXY_CA_KEY_PATH);
+        config.push_str("\"\n");
+    } else {
+        config.push_str("tls:\n  mode: \"sni-only\"\n");
+    }
+    config.push_str("transforms:\n  - name: allowlist\n    config:\n      domains:\n");
     for target in &policy.allowed_targets {
         let quoted = serde_json::to_string(&target.host_pattern).map_err(proxy_config_error)?;
         config.push_str("        - ");
         config.push_str(&quoted);
         config.push('\n');
     }
-    config.push_str("log:\n  level: info\n");
+    config.push_str("  - name: header_allowlist\n    config:\n      headers: [\"Authorization\", \"Content-Type\", \"Accept\", \"User-Agent\", \"Range\", \"If-None-Match\", \"If-Modified-Since\"");
+    let mut allowed_headers = [
+        "authorization",
+        "content-type",
+        "accept",
+        "user-agent",
+        "range",
+        "if-none-match",
+        "if-modified-since",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect::<HashSet<_>>();
+    for credential in credentials {
+        let normalized = credential.target_header.to_ascii_lowercase();
+        if allowed_headers.insert(normalized) {
+            config.push_str(", ");
+            config.push_str(
+                &serde_json::to_string(&credential.target_header).map_err(proxy_config_error)?,
+            );
+        }
+    }
+    config.push_str("]\n  - name: secrets\n    config:\n      secrets:\n        - source:\n            type: file\n            path: \"");
+    config.push_str(PROXY_INVOCATION_ID_PATH);
+    config.push_str("\"\n            ttl: \"-1ns\"\n            failure_ttl: \"1ms\"\n          rules:\n            - host: \"*\"\n          inject:\n            header: \"X-Ironclaw-Invocation-Id\"\n            require: true\n");
+    for credential in credentials {
+        let source = serde_json::to_string(&credential.source_path).map_err(proxy_config_error)?;
+        let host = serde_json::to_string(&credential.approved_host).map_err(proxy_config_error)?;
+        let header =
+            serde_json::to_string(&credential.target_header).map_err(proxy_config_error)?;
+        let proxy_value =
+            serde_json::to_string(&credential.placeholder_value).map_err(proxy_config_error)?;
+        config.push_str("        - source:\n            type: file\n            path: ");
+        config.push_str(&source);
+        config.push_str("\n            ttl: \"-1ns\"\n            failure_ttl: \"1ms\"\n          replace:\n            proxy_value: ");
+        config.push_str(&proxy_value);
+        config.push_str("\n            match_headers: [");
+        config.push_str(&header);
+        config.push_str("]\n            require: true\n          rules:\n            - host: ");
+        config.push_str(&host);
+        config.push_str("\n              methods: [\"GET\", \"POST\", \"PUT\", \"PATCH\", \"DELETE\", \"HEAD\", \"OPTIONS\"]\n              paths: [\"/*\"]\n");
+    }
+    config.push_str("  - name: annotate\n    config:\n      annotations:\n        - rules:\n            - host: \"*\"\n          headers: [\"X-Ironclaw-Invocation-Id\"]\nlog:\n  level: info\n");
     Ok(config)
 }
 
@@ -1273,6 +1482,21 @@ async fn write_atomic_material_file(
     path: &std::path::Path,
     contents: &[u8],
 ) -> Result<(), RuntimeProcessError> {
+    write_atomic_material_file_with_mode(path, contents, 0o644).await
+}
+
+async fn write_atomic_private_material_file(
+    path: &std::path::Path,
+    contents: &[u8],
+) -> Result<(), RuntimeProcessError> {
+    write_atomic_material_file_with_mode(path, contents, 0o600).await
+}
+
+async fn write_atomic_material_file_with_mode(
+    path: &std::path::Path,
+    contents: &[u8],
+    mode: u32,
+) -> Result<(), RuntimeProcessError> {
     let path = path.to_path_buf();
     let contents = contents.to_vec();
     tokio::task::spawn_blocking(move || {
@@ -1293,7 +1517,7 @@ async fn write_atomic_material_file(
             use std::os::unix::fs::PermissionsExt as _;
             temporary
                 .as_file()
-                .set_permissions(std::fs::Permissions::from_mode(0o644))
+                .set_permissions(std::fs::Permissions::from_mode(mode))
                 .map_err(|error| {
                     RuntimeProcessError::ExecutionFailed(format!(
                         "sandbox managed-egress material permissions failed: {error}"
@@ -1486,6 +1710,42 @@ mod tests {
     }
 
     #[test]
+    fn credential_renderer_binds_secret_source_to_exact_host_and_header() {
+        let credentials = [ProxyCredentialConfig {
+            source_path: "/run/ironclaw-proxy/credential-0.secret".to_string(),
+            approved_host: "github.com".to_string(),
+            target_header: "Authorization".to_string(),
+            placeholder_value: "Bearer icsbx_test_placeholder".to_string(),
+        }];
+
+        let rendered =
+            render_proxy_config_inner(&policy(), "172.28.10.2", true, &credentials).unwrap();
+
+        assert!(rendered.contains("ca_cert: \"/run/ironclaw-proxy/ca.crt\""));
+        assert!(rendered.contains("path: \"/run/ironclaw-proxy/credential-0.secret\""));
+        assert!(
+            rendered
+                .contains("replace:\n            proxy_value: \"Bearer icsbx_test_placeholder\"")
+        );
+        assert!(rendered.contains("- host: \"github.com\""));
+        assert!(rendered.contains("match_headers: [\"Authorization\"]"));
+        assert!(!rendered.contains("RAW_SECRET_SENTINEL"));
+        assert!(rendered.contains("paths: [\"/*\"]"));
+        assert!(rendered.contains(
+            "methods: [\"GET\", \"POST\", \"PUT\", \"PATCH\", \"DELETE\", \"HEAD\", \"OPTIONS\"]"
+        ));
+        let header_allowlist = rendered
+            .lines()
+            .find(|line| line.trim_start().starts_with("headers:"))
+            .expect("header allowlist is rendered");
+        assert_eq!(
+            header_allowlist.matches("\"Authorization\"").count(),
+            1,
+            "a credential header already in the base allowlist must not be duplicated"
+        );
+    }
+
+    #[test]
     fn proxy_image_override_requires_a_full_sha256_digest() {
         let _guard = lock_env();
         remove_runtime_env(PROXY_IMAGE_ENV);
@@ -1545,17 +1805,11 @@ mod tests {
     }
 
     #[test]
-    fn posture_binds_image_policy_and_material_root() {
+    fn posture_binds_image_policy_and_deployment_identity() {
         let image = "sha256:proxy-image";
-        let base = proxy_posture(image, &policy(), std::path::Path::new("/a")).unwrap();
-        assert_eq!(
-            base,
-            proxy_posture(image, &policy(), std::path::Path::new("/a")).unwrap()
-        );
-        assert_ne!(
-            base,
-            proxy_posture(image, &policy(), std::path::Path::new("/b")).unwrap()
-        );
+        let base = proxy_posture(image, &policy(), b"ca-a").unwrap();
+        assert_eq!(base, proxy_posture(image, &policy(), b"ca-a").unwrap());
+        assert_ne!(base, proxy_posture(image, &policy(), b"ca-b").unwrap());
     }
 
     #[tokio::test]

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway.rs
@@ -117,7 +117,7 @@ drain_proxy_audit() {
     rm -f "$audit_append" "$audit_capture"
     return 1
   fi
-  cat "$audit_append" >> "$audit_log"
+  cat "$audit_append" >> "$audit_log" || return 1
   chmod 600 "$audit_log"
   rm -f "$audit_append" "$audit_capture"
   if [ -n "$last_record" ]; then

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway.rs
@@ -273,7 +273,7 @@ impl RailwayPreviewSandboxConfig {
         let proxy_posture = super::managed_egress::proxy_posture(
             &proxy_image,
             &policy,
-            std::path::Path::new("/run/ironclaw-reborn-proxy"),
+            b"/run/ironclaw-reborn-proxy",
         )?;
         let proxy_config_template =
             super::managed_egress::render_proxy_config(&policy, RAILWAY_PROXY_IP_TOKEN)?;
@@ -664,8 +664,22 @@ impl RailwayPreviewSandboxTransport {
         invocation: RailwayCliInvocation,
         deadline: Instant,
     ) -> Result<RailwayCliOutput, RuntimeProcessError> {
+        self.execute_cli_cancellable(
+            invocation,
+            deadline,
+            ironclaw_host_api::process::CommandCancellationToken::new(),
+        )
+        .await
+    }
+
+    async fn execute_cli_cancellable(
+        &self,
+        invocation: RailwayCliInvocation,
+        deadline: Instant,
+        cancellation: ironclaw_host_api::process::CommandCancellationToken,
+    ) -> Result<RailwayCliOutput, RuntimeProcessError> {
         self.cli
-            .execute(invocation, deadline_remaining(deadline)?)
+            .execute_cancellable(invocation, deadline_remaining(deadline)?, cancellation)
             .await
     }
 }
@@ -678,6 +692,9 @@ impl SandboxCommandTransport for RailwayPreviewSandboxTransport {
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
         reject_request_environment(&request)?;
         reject_nul("command", &request.command)?;
+        for argument in &request.args {
+            reject_nul("command argument", argument)?;
+        }
         let workdir = validated_workdir(request.workdir.as_deref())?;
         let timeout = request_timeout(request.timeout_secs);
         let output_limit = DEFAULT_OUTPUT_LIMIT;
@@ -722,7 +739,7 @@ impl SandboxCommandTransport for RailwayPreviewSandboxTransport {
         // without first retrying a checkpoint.
         state.checkpoint_current = false;
         let output = self
-            .execute_cli(
+            .execute_cli_cancellable(
                 RailwayCliInvocation::new(
                     self.config.cli_path.clone(),
                     RailwayCliOperation::ExecuteSandboxCommand,
@@ -735,12 +752,14 @@ impl SandboxCommandTransport for RailwayPreviewSandboxTransport {
                             &railway_workspace_path(&key),
                             &workdir,
                             &request.command,
+                            &request.args,
                             &request.scope.invocation_id,
                         ),
                     ),
                     output_limit,
                 ),
                 deadline,
+                request.cancellation.clone(),
             )
             .await;
         let output = match output {
@@ -895,6 +914,15 @@ trait RailwayCli: Send + Sync {
         invocation: RailwayCliInvocation,
         timeout: Duration,
     ) -> Result<RailwayCliOutput, RuntimeProcessError>;
+
+    async fn execute_cancellable(
+        &self,
+        invocation: RailwayCliInvocation,
+        timeout: Duration,
+        _cancellation: ironclaw_host_api::process::CommandCancellationToken,
+    ) -> Result<RailwayCliOutput, RuntimeProcessError> {
+        self.execute(invocation, timeout).await
+    }
 }
 
 #[derive(Debug)]
@@ -1004,6 +1032,20 @@ impl RailwayCli for SystemRailwayCli {
         invocation: RailwayCliInvocation,
         timeout: Duration,
     ) -> Result<RailwayCliOutput, RuntimeProcessError> {
+        self.execute_cancellable(
+            invocation,
+            timeout,
+            ironclaw_host_api::process::CommandCancellationToken::new(),
+        )
+        .await
+    }
+
+    async fn execute_cancellable(
+        &self,
+        invocation: RailwayCliInvocation,
+        timeout: Duration,
+        cancellation: ironclaw_host_api::process::CommandCancellationToken,
+    ) -> Result<RailwayCliOutput, RuntimeProcessError> {
         let environment = railway_cli_environment()?;
         let cli_home = PrivateRailwayCliHome::create().await?;
         let operation = invocation.operation;
@@ -1015,7 +1057,8 @@ impl RailwayCli for SystemRailwayCli {
             .env("HOME", cli_home.path()?)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
         let mut child = match command.spawn() {
             Ok(child) => child,
             Err(error) => {
@@ -1028,52 +1071,60 @@ impl RailwayCli for SystemRailwayCli {
         };
         let stdout = child.stdout.take();
         let stderr = child.stderr.take();
-        let result = tokio::time::timeout(timeout, async {
-            let stdout = async {
-                match stdout {
-                    Some(stream) => read_stream_bounded(stream, invocation.output_limit).await,
-                    None => Ok(String::new()),
+        let result = {
+            let timed_run = tokio::time::timeout(timeout, async {
+                let stdout = async {
+                    match stdout {
+                        Some(stream) => read_stream_bounded(stream, invocation.output_limit).await,
+                        None => Ok(String::new()),
+                    }
+                };
+                let stderr = async {
+                    match stderr {
+                        Some(stream) => read_stream_bounded(stream, invocation.output_limit).await,
+                        None => Ok(String::new()),
+                    }
+                };
+                let (stdout, stderr, status) = tokio::join!(stdout, stderr, child.wait());
+                let status = status.map_err(|error| {
+                    tracing::error!(?error, "trusted Railway CLI process wait failed");
+                    RuntimeProcessError::ExecutionFailed(
+                        "Railway preview CLI command did not complete".to_string(),
+                    )
+                })?;
+                let stdout = stdout?;
+                let stderr = stderr?;
+                if !status.success() {
+                    return Err(railway_cli_status_error(
+                        operation,
+                        status.code(),
+                        &stderr,
+                        &environment,
+                        timeout,
+                    ));
                 }
-            };
-            let stderr = async {
-                match stderr {
-                    Some(stream) => read_stream_bounded(stream, invocation.output_limit).await,
-                    None => Ok(String::new()),
-                }
-            };
-            let (stdout, stderr, status) = tokio::join!(stdout, stderr, child.wait());
-            let status = status.map_err(|error| {
-                tracing::error!(?error, "trusted Railway CLI process wait failed");
-                RuntimeProcessError::ExecutionFailed(
-                    "Railway preview CLI command did not complete".to_string(),
-                )
-            })?;
-            let stdout = stdout?;
-            let stderr = stderr?;
-            if !status.success() {
-                return Err(railway_cli_status_error(
-                    operation,
-                    status.code(),
-                    &stderr,
-                    &environment,
-                    timeout,
-                ));
-            }
-            Ok(RailwayCliOutput { stdout, stderr })
-        })
-        .await;
-        let result = match result {
-            Ok(result) => result,
-            Err(_) => {
-                if let Err(error) = child.kill().await {
-                    tracing::debug!(?error, "best-effort Railway CLI termination failed");
-                }
-                if let Err(error) = child.wait().await {
-                    tracing::debug!(?error, "best-effort Railway CLI reap failed");
-                }
-                Err(RuntimeProcessError::Timeout(timeout))
+                Ok(RailwayCliOutput { stdout, stderr })
+            });
+            tokio::pin!(timed_run);
+            tokio::select! {
+                outcome = &mut timed_run => match outcome {
+                    Ok(result) => result,
+                    Err(_) => Err(RuntimeProcessError::Timeout(timeout)),
+                },
+                () = cancellation.cancelled() => Err(RuntimeProcessError::Cancelled),
             }
         };
+        if matches!(
+            &result,
+            Err(RuntimeProcessError::Timeout(_) | RuntimeProcessError::Cancelled)
+        ) {
+            if let Err(error) = child.kill().await {
+                tracing::debug!(?error, "best-effort Railway CLI termination failed");
+            }
+            if let Err(error) = child.wait().await {
+                tracing::debug!(?error, "best-effort Railway CLI reap failed");
+            }
+        }
         cli_home.cleanup().await;
         result
     }
@@ -1252,6 +1303,7 @@ fn ephemeral_worker_argv(
     railway_workspace: &str,
     workdir: &str,
     model_command: &str,
+    model_args: &[String],
     invocation_id: &ironclaw_host_api::ids::InvocationId,
 ) -> Vec<String> {
     let mut worker = vec!["--rm".into()];
@@ -1264,10 +1316,9 @@ fn ephemeral_worker_argv(
         "--memory".into(),
         "512m".into(),
         config.worker_image.clone(),
-        "sh".into(),
-        "-c".into(),
         model_command.into(),
     ]);
+    worker.extend(model_args.iter().cloned());
     let mut args = vec![
         "sh".into(),
         "-c".into(),

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway/tests.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway/tests.rs
@@ -694,7 +694,9 @@ async fn ephemeral_worker_uses_managed_proxy_and_hardened_private_network() {
             && RAILWAY_MANAGED_EGRESS_WRAPPER
                 .contains("for audit_file in \"$material\"/audit/proxy.log*; do")
             && RAILWAY_MANAGED_EGRESS_WRAPPER
-                .contains("if [ \"$audit_total\" -gt 268435456 ]; then"),
+                .contains("if [ \"$audit_total\" -gt 268435456 ]; then")
+            && RAILWAY_MANAGED_EGRESS_WRAPPER
+                .contains("cat \"$audit_append\" >> \"$audit_log\" || return 1"),
         "Railway audit append must fail closed before aggregate retained evidence exceeds 256 MiB"
     );
     assert!(

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway/tests.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway/tests.rs
@@ -2,9 +2,11 @@ use std::{
     collections::{BTreeSet, HashMap},
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
+
+use ironclaw_common::env_helpers::lock_env;
 
 use ironclaw_host_api::{
     ids::{AgentId, InvocationId, TenantId, UserId},
@@ -28,6 +30,8 @@ struct FakeRailwayCli {
     failed_checkpoint_creates: AtomicUsize,
     failed_destroys: AtomicUsize,
     malformed_checkpoint_lists: AtomicUsize,
+    block_worker_exec: AtomicBool,
+    worker_started: tokio::sync::Notify,
     checkpoint_timeouts: Mutex<Vec<Duration>>,
     delay: Option<Duration>,
 }
@@ -47,6 +51,8 @@ impl FakeRailwayCli {
             failed_checkpoint_creates: AtomicUsize::new(0),
             failed_destroys: AtomicUsize::new(0),
             malformed_checkpoint_lists: AtomicUsize::new(0),
+            block_worker_exec: AtomicBool::new(false),
+            worker_started: tokio::sync::Notify::new(),
             checkpoint_timeouts: Mutex::new(Vec::new()),
             delay: None,
         }
@@ -73,6 +79,10 @@ impl FakeRailwayCli {
 
     fn fail_next_worker_exec(&self) {
         self.failed_worker_execs.store(1, Ordering::SeqCst);
+    }
+
+    fn block_next_worker_exec(&self) {
+        self.block_worker_exec.store(true, Ordering::SeqCst);
     }
 
     fn malform_next_worker_output(&self) {
@@ -239,9 +249,27 @@ impl RailwayCli for FakeRailwayCli {
             stderr: String::new(),
         })
     }
+
+    async fn execute_cancellable(
+        &self,
+        invocation: RailwayCliInvocation,
+        timeout: Duration,
+        cancellation: ironclaw_host_api::process::CommandCancellationToken,
+    ) -> Result<RailwayCliOutput, RuntimeProcessError> {
+        if invocation.args.iter().any(|arg| arg == OUTER_EXEC_WRAPPER)
+            && self.block_worker_exec.swap(false, Ordering::SeqCst)
+        {
+            self.invocations.lock().await.push(invocation);
+            self.worker_started.notify_one();
+            cancellation.cancelled().await;
+            return Err(RuntimeProcessError::Cancelled);
+        }
+        self.execute(invocation, timeout).await
+    }
 }
 
 fn config() -> RailwayPreviewSandboxConfig {
+    let _guard = lock_env();
     RailwayPreviewSandboxConfig::new("project-id", "environment-id").unwrap()
 }
 
@@ -258,9 +286,11 @@ fn request(tenant: &str, user: &str, command: &str) -> CommandExecutionRequest {
         },
         mounts: None,
         command: command.into(),
+        args: Vec::new(),
         workdir: None,
         timeout_secs: Some(10),
         extra_env: HashMap::new(),
+        cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
     }
 }
 
@@ -825,6 +855,42 @@ async fn failed_remote_worker_is_destroyed_before_return_and_reprovisioned() {
         .await
         .unwrap();
     assert_eq!(count_creates(&cli.invocations().await), 2);
+}
+
+#[tokio::test]
+async fn cancelled_remote_worker_is_destroyed_before_return() {
+    let cli = Arc::new(FakeRailwayCli::new());
+    cli.block_next_worker_exec();
+    let transport = Arc::new(RailwayPreviewSandboxTransport::with_cli(
+        config(),
+        cli.clone(),
+    ));
+    let command = request("tenant", "cancelled-user", "sleep");
+    let cancellation = command.cancellation.clone();
+    let worker_started = cli.worker_started.notified();
+    tokio::pin!(worker_started);
+
+    let execution = tokio::spawn({
+        let transport = Arc::clone(&transport);
+        async move { transport.run_command(command).await }
+    });
+    worker_started.await;
+    cancellation.cancel();
+    let error = tokio::time::timeout(Duration::from_secs(1), execution)
+        .await
+        .expect("cancelled Railway execution must stop promptly")
+        .expect("Railway execution task must not panic")
+        .expect_err("cancelled Railway execution must fail");
+
+    assert_eq!(error, RuntimeProcessError::Cancelled);
+    let invocations = cli.invocations().await;
+    assert!(invocations.iter().any(|call| {
+        call.args.starts_with(&["sandbox".into(), "destroy".into()])
+            && call
+                .args
+                .windows(2)
+                .any(|pair| pair == ["--id", "sandbox-1"])
+    }));
 }
 
 #[tokio::test]

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/user_container.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/user_container.rs
@@ -225,6 +225,15 @@ pub(super) fn exec_helper_timeout_secs(timeout: Duration) -> Result<u64, Runtime
     Ok(seconds)
 }
 
+pub(super) struct UserContainerCommand {
+    pub(super) command: String,
+    pub(super) args: Vec<String>,
+    pub(super) workdir: ContainerWorkdir,
+    pub(super) env: Vec<String>,
+    pub(super) timeout: Duration,
+    pub(super) cancellation: ironclaw_host_api::process::CommandCancellationToken,
+}
+
 /// Executes a command while its user's lifecycle gate is held.
 ///
 /// The caller must retain that gate through any error or timeout recycle.
@@ -232,14 +241,20 @@ pub(super) async fn execute_in_user_container(
     transport: &RebornScopedSandboxCommandTransport,
     key: &RebornSandboxUserKey,
     container_name: &str,
-    command: String,
-    workdir: ContainerWorkdir,
-    env: Vec<String>,
-    timeout: Duration,
+    command: UserContainerCommand,
 ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+    let UserContainerCommand {
+        command,
+        args,
+        workdir,
+        env,
+        timeout,
+        cancellation,
+    } = command;
     let started_at = Instant::now();
     let helper_timeout_secs = exec_helper_timeout_secs(timeout)?;
     let outcome_nonce = uuid::Uuid::new_v4().to_string();
+    let helper_argv = exec_helper_argv(helper_timeout_secs, outcome_nonce.clone(), command, args);
     let created = transport
         .docker
         .create_exec(
@@ -249,12 +264,7 @@ pub(super) async fn execute_in_user_container(
                 attach_stdout: Some(true),
                 attach_stderr: Some(true),
                 tty: Some(false),
-                cmd: Some(vec![
-                    EXEC_HELPER.to_string(),
-                    helper_timeout_secs.to_string(),
-                    outcome_nonce.clone(),
-                    command,
-                ]),
+                cmd: Some(helper_argv),
                 privileged: Some(false),
                 working_dir: Some(workdir.into_string()),
                 env: Some(env),
@@ -348,18 +358,41 @@ pub(super) async fn execute_in_user_container(
         }
     };
 
-    match tokio::time::timeout(timeout.saturating_add(HOST_TIMEOUT_GRACE), run).await {
-        Ok(Ok(output)) => Ok(output),
-        Ok(Err(error @ RuntimeProcessError::Timeout(_))) => Err(error),
-        Ok(Err(error)) => {
+    let timed_run = tokio::time::timeout(timeout.saturating_add(HOST_TIMEOUT_GRACE), run);
+    tokio::pin!(timed_run);
+    tokio::select! {
+        outcome = &mut timed_run => match outcome {
+            Ok(Ok(output)) => Ok(output),
+            Ok(Err(error @ RuntimeProcessError::Timeout(_))) => Err(error),
+            Ok(Err(error)) => {
+                recycle_untrusted_user_container(transport, key, container_name).await;
+                Err(error)
+            }
+            Err(_) => {
+                recycle_untrusted_user_container(transport, key, container_name).await;
+                Err(RuntimeProcessError::Timeout(timeout))
+            }
+        },
+        () = cancellation.cancelled() => {
             recycle_untrusted_user_container(transport, key, container_name).await;
-            Err(error)
-        }
-        Err(_) => {
-            recycle_untrusted_user_container(transport, key, container_name).await;
-            Err(RuntimeProcessError::Timeout(timeout))
+            Err(RuntimeProcessError::Cancelled)
         }
     }
+}
+fn exec_helper_argv(
+    timeout_secs: u64,
+    outcome_nonce: String,
+    command: String,
+    args: Vec<String>,
+) -> Vec<String> {
+    let mut helper_argv = vec![
+        EXEC_HELPER.to_string(),
+        timeout_secs.to_string(),
+        outcome_nonce,
+        command,
+    ];
+    helper_argv.extend(args);
+    helper_argv
 }
 
 /// Recycles a container that cannot safely accept another command.
@@ -885,6 +918,18 @@ mod tests {
         assert!(output.contains("command wrote"));
         assert!(!output.ends_with("timeout\n"));
         assert!(parse_exec_outcome_trailer("ordinary output", nonce).is_err());
+    }
+    #[test]
+    fn zero_argument_commands_remain_direct_executable_invocations() {
+        assert_eq!(
+            exec_helper_argv(
+                30,
+                "nonce".to_string(),
+                "true;unexpected-command".to_string(),
+                Vec::new(),
+            ),
+            [EXEC_HELPER, "30", "nonce", "true;unexpected-command",]
+        );
     }
 
     #[test]

--- a/crates/lanes/ironclaw_sandbox/tests/railway_sandbox_live.rs
+++ b/crates/lanes/ironclaw_sandbox/tests/railway_sandbox_live.rs
@@ -23,9 +23,11 @@ fn request(scope: &ResourceScope, command: impl Into<String>) -> CommandExecutio
         scope: scope.clone(),
         mounts: None,
         command: command.into(),
+        args: Vec::new(),
         workdir: Some("/workspace".to_string()),
         timeout_secs: Some(300),
         extra_env: HashMap::new(),
+        cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
     }
 }
 

--- a/crates/lanes/ironclaw_sandbox/tests/support/user_sandbox_live.rs
+++ b/crates/lanes/ironclaw_sandbox/tests/support/user_sandbox_live.rs
@@ -41,9 +41,11 @@ pub(crate) fn request(scope: ResourceScope, command: impl Into<String>) -> Comma
         scope,
         mounts: None,
         command: command.into(),
+        args: Vec::new(),
         workdir: Some("/workspace".to_string()),
         timeout_secs: Some(60),
         extra_env: HashMap::new(),
+        cancellation: ironclaw_host_api::process::CommandCancellationToken::new(),
     }
 }
 

--- a/crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live.rs
+++ b/crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live.rs
@@ -4,7 +4,7 @@ use std::{process::Command, sync::Arc, time::Duration};
 
 use ironclaw_host_api::{
     ids::InvocationId,
-    process::{RuntimeProcessError, SandboxCommandTransport},
+    process::{RuntimeProcessError, SandboxCommandCredential, SandboxCommandTransport},
 };
 use ironclaw_sandbox::{RebornSandboxConfig, RebornScopedSandboxCommandTransport};
 

--- a/crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live/extra.rs
+++ b/crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live/extra.rs
@@ -805,6 +805,92 @@ async fn different_users_receive_distinct_private_networks_and_proxies() {
 }
 
 #[tokio::test]
+#[ignore = "requires Docker, public Internet access, and IRONCLAW_TEST_GITHUB_TOKEN"]
+async fn github_cli_uses_proxy_bound_placeholder_without_exposing_real_token() {
+    let Some((_image, _serial)) =
+        docker_worker_and_proxy_images("sandbox GitHub credential canary").await
+    else {
+        return;
+    };
+    let Ok(token) = std::env::var("IRONCLAW_TEST_GITHUB_TOKEN") else {
+        eprintln!("SKIP: GitHub credential canary — IRONCLAW_TEST_GITHUB_TOKEN is unset");
+        return;
+    };
+    assert!(!token.is_empty(), "GitHub canary token must not be empty");
+
+    let scope = TestScope::unique("github-credential");
+    let temp = docker_visible_tempdir();
+    let mut cleanup = DockerCleanup::with_scopes([scope.clone()]);
+    let transport = RebornScopedSandboxCommandTransport::connect(
+        RebornSandboxConfig::new(temp.path().join("sandbox-workspaces"))
+            .with_managed_egress_proxy()
+            .expect("managed egress policy is valid"),
+    )
+    .await
+    .expect("Docker transport connects");
+    let placeholder = format!(
+        "{}{}",
+        ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX,
+        InvocationId::new()
+    );
+    let mut command = request(scope.resource_scope(), "gh");
+    command.args = vec![
+        "pr".to_string(),
+        "list".to_string(),
+        "--repo".to_string(),
+        "nearai/ironclaw".to_string(),
+        "--limit".to_string(),
+        "1".to_string(),
+        "--json".to_string(),
+        "number".to_string(),
+    ];
+    command
+        .extra_env
+        .insert("GH_TOKEN".to_string(), placeholder.clone());
+    let result = transport
+        .run_credentialed_command(
+            command,
+            vec![SandboxCommandCredential::new(
+                "GH_TOKEN".to_string(),
+                placeholder,
+                "api.github.com".to_string(),
+                "Authorization".to_string(),
+                Some("token ".to_string()),
+                token.clone(),
+            )],
+        )
+        .await
+        .expect("credentialed gh command reaches GitHub through the proxy");
+
+    assert_eq!(result.exit_code, 0, "gh command failed: {}", result.output);
+    assert!(serde_json::from_str::<serde_json::Value>(&result.output).is_ok());
+    assert!(!result.output.contains(&token));
+    let container = cleanup.capture(&scope);
+    let inspect = docker_command(&[
+        "container",
+        "inspect",
+        "--format",
+        "{{json .Config.Env}}",
+        &container.id,
+    ]);
+    assert!(inspect.status.success());
+    assert!(!String::from_utf8_lossy(&inspect.stdout).contains(&token));
+    let proxy_mount_probe = docker_command(&[
+        "container",
+        "exec",
+        &container.id,
+        "test",
+        "!",
+        "-e",
+        "/run/ironclaw-proxy",
+    ]);
+    assert!(
+        proxy_mount_probe.status.success(),
+        "proxy credential material must not be mounted in the command container"
+    );
+}
+
+#[tokio::test]
 #[ignore = "requires public DNS and Internet access; run as a live egress canary"]
 async fn sandbox_profile_allows_allowlisted_https_through_proxy() {
     let Some((_image, _serial)) = docker_worker_and_proxy_images("sandbox egress canary").await

--- a/crates/loop/ironclaw_loop_host/src/capability_port/tests/runtime_lifecycle_tests.rs
+++ b/crates/loop/ironclaw_loop_host/src/capability_port/tests/runtime_lifecycle_tests.rs
@@ -9,7 +9,7 @@ use std::{
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    decision::RuntimeCredentialAuthRequirement,
+    decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     dispatch::CapabilityDisplayOutputPreview,
     ids::{ApprovalRequestId, CapabilityId, ExtensionId, ProcessId, VendorId},
     resolution::{Blocked, Resolution},
@@ -568,7 +568,9 @@ async fn runtime_auth_gate_forwards_credential_requirements() {
     let requirement = RuntimeCredentialAuthRequirement {
         provider: VendorId::new("github").unwrap(),
         setup: Default::default(),
-        requester_extension: provider_id.clone(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: provider_id.clone(),
+        },
         provider_scopes: Vec::new(),
     };
     let port = runtime_capability_port(

--- a/crates/product/ironclaw_assistant/src/blocked_auth_resume.rs
+++ b/crates/product/ironclaw_assistant/src/blocked_auth_resume.rs
@@ -359,7 +359,9 @@ mod tests {
         RuntimeCredentialAuthRequirement {
             provider: VendorId::new("slack").expect("provider id"),
             setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
-            requester_extension: ExtensionId::new("slack").expect("extension id"),
+            consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("slack").expect("extension id"),
+            },
             provider_scopes: Vec::new(),
         }
     }
@@ -368,7 +370,9 @@ mod tests {
         RuntimeCredentialAuthRequirement {
             provider: VendorId::new("google").expect("provider id"),
             setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
-            requester_extension: ExtensionId::new("gmail").expect("extension id"),
+            consumer: ironclaw_host_api::decision::RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("gmail").expect("extension id"),
+            },
             provider_scopes: Vec::new(),
         }
     }

--- a/crates/product/ironclaw_assistant/src/projection/tests/turn_stream_auth.rs
+++ b/crates/product/ironclaw_assistant/src/projection/tests/turn_stream_auth.rs
@@ -4,7 +4,8 @@ use ironclaw_auth::product_prompt::{AuthChallengeProvider, AuthChallengeView};
 use ironclaw_auth::{AuthProviderId, OAuthAuthorizationUrl};
 use ironclaw_extension_contracts::auth_prompt::AuthPromptChallengeKind;
 use ironclaw_host_api::{
-    capability::RuntimeCredentialAccountSetup, decision::RuntimeCredentialAuthRequirement,
+    capability::RuntimeCredentialAccountSetup,
+    decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     ids::VendorId,
 };
 
@@ -209,7 +210,9 @@ async fn product_event_stream_projects_pairing_prompt_connection_context() {
     let credential_requirements = vec![RuntimeCredentialAuthRequirement {
         provider: VendorId::new("telegram").unwrap(),
         setup: RuntimeCredentialAccountSetup::Pairing,
-        requester_extension: ExtensionId::new("telegram").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("telegram").unwrap(),
+        },
         provider_scopes: Vec::new(),
     }];
     let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
@@ -337,7 +340,9 @@ async fn product_event_stream_uses_credential_requirement_for_manual_token_auth_
     let credential_requirements = vec![RuntimeCredentialAuthRequirement {
         provider: VendorId::new("github").unwrap(),
         setup: Default::default(),
-        requester_extension: ExtensionId::new("github").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("github").unwrap(),
+        },
         provider_scopes: Vec::new(),
     }];
     let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
@@ -431,7 +436,9 @@ async fn product_event_stream_keeps_retired_channel_pairing_requirement_generic(
     let credential_requirements = vec![RuntimeCredentialAuthRequirement {
         provider: VendorId::new("slack").unwrap(),
         setup: RuntimeCredentialAccountSetup::Retired,
-        requester_extension: ExtensionId::new("slack").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("slack").unwrap(),
+        },
         provider_scopes: Vec::new(),
     }];
     let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
@@ -520,7 +527,9 @@ async fn product_event_stream_keeps_oauth_requirement_as_oauth_prompt_without_ur
         setup: RuntimeCredentialAccountSetup::OAuth {
             scopes: vec!["https://www.googleapis.com/auth/calendar.readonly".to_string()],
         },
-        requester_extension: ExtensionId::new("google-calendar").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("google-calendar").unwrap(),
+        },
         provider_scopes: vec!["https://www.googleapis.com/auth/calendar.readonly".to_string()],
     }];
     let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
@@ -700,7 +709,9 @@ async fn product_event_stream_creates_vendor_oauth_prompt_for_runtime_credential
         setup: ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth {
             scopes: vec!["items:read".to_string()],
         },
-        requester_extension: ExtensionId::new("vendorco-tools").unwrap(),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("vendorco-tools").unwrap(),
+        },
         provider_scopes: vec!["items:read".to_string()],
     }];
 

--- a/crates/product/ironclaw_assistant/tests/extension_account_setup_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/extension_account_setup_contract.rs
@@ -7,7 +7,7 @@ use ironclaw_assistant::{
 };
 use ironclaw_host_api::{
     capability::RuntimeCredentialAccountSetup,
-    decision::RuntimeCredentialAuthRequirement,
+    decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     ids::{ExtensionId, UserId, VendorId},
 };
 use ironclaw_product_contracts::account_setup::{
@@ -48,7 +48,7 @@ fn descriptor_with_display_name(
         auth_requirement: RuntimeCredentialAuthRequirement {
             provider: VendorId::new(extension).expect("valid provider id"),
             setup: RuntimeCredentialAccountSetup::Pairing,
-            requester_extension: extension_id,
+            consumer: RuntimeCredentialConsumer::Extension { extension_id },
             provider_scopes: Vec::new(),
         },
         connection_requirement,

--- a/crates/product/ironclaw_assistant/tests/prompt_projection_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/prompt_projection_contract.rs
@@ -10,7 +10,7 @@ use ironclaw_extension_contracts::auth_prompt::AuthPromptChallengeKind;
 use ironclaw_host_api::turn::{TurnGateRef, TurnRunId, TurnScope};
 use ironclaw_host_api::{
     capability::RuntimeCredentialAccountSetup,
-    decision::RuntimeCredentialAuthRequirement,
+    decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
     ids::{ExtensionId, TenantId, ThreadId, UserId, VendorId},
 };
 use ironclaw_product_contracts::prompt_source::BlockedAuthPromptRequest;
@@ -81,7 +81,9 @@ async fn auth_prompt_enrichment_accepts_the_owned_view_without_a_crossing_reques
         setup: RuntimeCredentialAccountSetup::OAuth {
             scopes: vec!["repo:read".to_string()],
         },
-        requester_extension: ExtensionId::new("github").expect("extension"),
+        consumer: RuntimeCredentialConsumer::Extension {
+            extension_id: ExtensionId::new("github").expect("extension"),
+        },
         provider_scopes: vec!["repo:read".to_string()],
     }];
     let challenge = OAuthChallenge {

--- a/crates/product/ironclaw_webui/src/product_auth/mod.rs
+++ b/crates/product/ironclaw_webui/src/product_auth/mod.rs
@@ -1970,7 +1970,7 @@ mod tests {
     };
     use ironclaw_host_api::{
         action::NetworkMethod,
-        decision::RuntimeCredentialAuthRequirement,
+        decision::{RuntimeCredentialAuthRequirement, RuntimeCredentialConsumer},
         http::{RuntimeHttpEgress, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse},
         ids::{SecretHandle, VendorId},
     };
@@ -3348,7 +3348,9 @@ mod tests {
         let requirements = vec![RuntimeCredentialAuthRequirement {
             provider: VendorId::new("vendorco").expect("provider"),
             setup: Default::default(),
-            requester_extension: ExtensionId::new("vendorco-tools").expect("extension"),
+            consumer: RuntimeCredentialConsumer::Extension {
+                extension_id: ExtensionId::new("vendorco-tools").expect("extension"),
+            },
             provider_scopes: vec!["items:read".to_string()],
         }];
 

--- a/docker/sandbox/ironclaw-exec
+++ b/docker/sandbox/ironclaw-exec
@@ -18,14 +18,14 @@ PR_SET_CHILD_SUBREAPER = 36
 
 def usage() -> "NoReturn":
     print(
-        "usage: ironclaw-exec <timeout-seconds> <outcome-nonce> <command>",
+        "usage: ironclaw-exec <timeout-seconds> <outcome-nonce> <command> [arg ...]",
         file=sys.stderr,
     )
     raise SystemExit(64)
 
 
-def parse_args() -> tuple[int, str, str]:
-    if len(sys.argv) != 4:
+def parse_args() -> tuple[int, str, list[str]]:
+    if len(sys.argv) < 4:
         usage()
     try:
         timeout = int(sys.argv[1], 10)
@@ -36,7 +36,7 @@ def parse_args() -> tuple[int, str, str]:
     nonce = sys.argv[2]
     if not nonce or any(char not in "0123456789abcdef-" for char in nonce):
         usage()
-    return timeout, nonce, sys.argv[3]
+    return timeout, nonce, sys.argv[3:]
 
 
 def make_subreaper() -> None:
@@ -147,7 +147,7 @@ def main() -> int:
         return 70
 
     process = subprocess.Popen(
-        ["sh", "-c", command],
+        command,
         stdin=subprocess.DEVNULL,
         start_new_session=True,
     )

--- a/tests/integration/hosted_mcp_registration.rs
+++ b/tests/integration/hosted_mcp_registration.rs
@@ -2168,7 +2168,7 @@ async fn oauth_registration_discovers_standard_metadata_then_hands_off_to_generi
         &provider_vendor,
         ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
         &[],
-        &requester,
+        Some(&requester),
     )
     .expect("runtime credential request");
     let account = services
@@ -2960,7 +2960,7 @@ async fn oauth_empty_catalog_after_callback_retains_account_and_stays_installed(
         &provider_vendor,
         ironclaw_host_api::capability::RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
         &[],
-        &requester,
+        Some(&requester),
     )
     .expect("runtime credential request");
     let account = services

--- a/tests/integration/support/doubles/fixed_runtime_credential_account_resolver.rs
+++ b/tests/integration/support/doubles/fixed_runtime_credential_account_resolver.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
-use ironclaw_host_api::{dispatch::CredentialStageError, ids::SecretHandle};
+use ironclaw_host_api::{
+    decision::RuntimeCredentialConsumer, dispatch::CredentialStageError, ids::SecretHandle,
+};
 use ironclaw_host_runtime::{
     RuntimeCredentialAccessSecret, RuntimeCredentialAccountRequest,
     RuntimeCredentialAccountResolver,
@@ -17,7 +19,11 @@ impl RuntimeCredentialAccountResolver for FixedRuntimeCredentialAccountResolver 
         request: RuntimeCredentialAccountRequest<'_>,
     ) -> Result<RuntimeCredentialAccessSecret, CredentialStageError> {
         assert_eq!(request.provider.as_str(), "github");
-        assert_eq!(request.requester_extension.as_str(), "github");
+        assert!(matches!(
+            request.consumer,
+            RuntimeCredentialConsumer::Extension { extension_id }
+                if extension_id.as_str() == "github"
+        ));
         self.result
             .clone()
             .map(|handle| RuntimeCredentialAccessSecret {

--- a/tests/integration/support/doubles/github_harness_authorizer.rs
+++ b/tests/integration/support/doubles/github_harness_authorizer.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use ironclaw_authorization::TrustAwareCapabilityDispatchAuthorizer;
 use ironclaw_host_api::{
     capability::CapabilityDescriptor,
-    decision::{Decision, Obligation, Obligations},
+    decision::{Decision, Obligation, Obligations, RuntimeCredentialConsumer},
     ids::{ExtensionId, SecretHandle, VendorId},
     resource::ResourceEstimate,
     scope::ExecutionContext,
@@ -29,7 +29,9 @@ impl GithubHarnessAuthorizer {
                     setup:
                         ironclaw_host_api::capability::RuntimeCredentialAccountSetup::ManualToken,
                     provider_scopes: Vec::new(),
-                    requester_extension: ExtensionId::new("github")?,
+                    consumer: RuntimeCredentialConsumer::Extension {
+                        extension_id: ExtensionId::new("github")?,
+                    },
                 },
             ])?,
         })


### PR DESCRIPTION
## Summary

- Add direct executable plus argument-vector sandbox execution with cancellation support.
- Resolve GitHub credentials from active extension declarations and stage opaque, invocation-scoped material through the host runtime.
- Replace sandbox placeholders only inside the managed egress proxy; raw tokens do not enter command arguments, environment, plans, logs, or audit records.
- Persist redacted credential-consumption audit evidence and add Docker/live, authorization, expiry, failure, and leak-negative coverage.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Closes #7732

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: host API, capabilities, authorization, host runtime, sandbox, and architecture suites
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (not applicable: no crate-level integration feature covers this path)
- [x] Manual testing: Docker GitHub credential canary executed successfully before the local Docker daemon became unavailable; the final rerun then skipped explicitly because no daemon was reachable
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Test Strategy

User behavior: A sandboxed `gh` command can authenticate without receiving the real token in argv or environment.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: typed argv/cancellation, credential staging, authorization obligations, expiry, audit redaction, and proxy substitution.
- Reborn integration: host-runtime process executor and composition wiring tests.
- Recorded fixture: Not applicable: deterministic Rust contracts cover this path.
- Browser E2E: Not applicable: no browser surface changed.
- Backend or runtime: sandbox, host-runtime, and architecture suites.
- Live canary: Docker sandbox invokes `gh` through the managed proxy with a fake GitHub-shaped token and proves raw-token non-exposure.

What the tests prove: Approved credential authority is derived from host declarations, staged by handle, consumed once, redacted in durable audit records, and exposed only as proxy-side header replacement.

Commands run:
- `cargo test -p ironclaw_host_api --all-targets`
- `cargo test -p ironclaw_capabilities --all-targets`
- `cargo test -p ironclaw_authorization --all-targets`
- `cargo test -p ironclaw_host_runtime --all-targets`
- `cargo test -p ironclaw_sandbox --lib`
- `cargo test -p ironclaw_architecture_tests --all-targets`
- `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- `cargo test`

## Security Impact

Adds a host-mediated credential path for sandboxed processes. Credentials remain host-side, are authorized against active extension metadata, are bound to approved host/header targets, expire, and are redacted from plans, output, errors, and durable audit events.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: host API types are constructed by authorization, host runtime, and the sandbox lane.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. Not applicable to this process path.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic.
- [x] Driver/operator-visible errors have stable class semantics.
- [x] Sandbox/native/host names accurately describe trust boundary.

## Database Impact

No schema or migration changes. Durable audit records reuse the existing event/journal storage path.

## Blast Radius

Host API process contracts, capability authorization, host-runtime obligation staging, sandbox Docker/Railway transports, managed egress proxy configuration, composition wiring, and affected test doubles.

## Rollback Plan

Revert `2f00d11e2b` and `524a0baf99`. The prior Step 2 managed-egress behavior remains the baseline.

## Review Follow-Through

The no-mistakes review identified unresolved design questions around crash-safe proxy credential revocation, persistent approvals for invocation-selected credentials, Railway credential support, and dynamic preflight ordering. These are called out for focused maintainer review rather than hidden as complete.

---

**Review track**: C