### PR TITLE
feat(sandbox): mediate GitHub CLI credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5086,6 +5086,7 @@ dependencies = [
  "libc",
  "rcgen",
  "rust_decimal_macros",
+ "secrecy",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Dockerfile.sandbox-worker
+++ b/Dockerfile.sandbox-worker
@@ -7,6 +7,7 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
+        gh \
         jq \
         nodejs \
         npm \
@@ -20,8 +21,8 @@ RUN groupadd --gid 1000 sandbox \
 COPY --chmod=0755 docker/sandbox/ironclaw-exec \
     docker/sandbox/ironclaw-sandbox-idle \
     /usr/local/bin/
-
-ENV HOME=/home/sandbox
+ENV HOME=/home/sandbox \
+    GH_CONFIG_DIR=/workspace/.config/gh
 WORKDIR /workspace
 USER 1000:1000
 

--- a/crates/app/ironclaw_composition/src/factory.rs
+++ b/crates/app/ironclaw_composition/src/factory.rs
@@ -161,7 +161,7 @@ use ironclaw_host_runtime::{
 };
 use ironclaw_host_runtime::{
     builtin_first_party_handlers_with_trigger_services_for_process_backend,
-    builtin_first_party_package_for_process_backend,
+    builtin_first_party_package_for_process_backend, user_sandbox_process_package,
 };
 use ironclaw_identity::projects::ProjectRepository;
 use ironclaw_identity::projects::RebornProjectService;
@@ -1212,6 +1212,17 @@ fn production_builtin_extension_registry(
         .map_err(|error| RebornBuildError::InvalidConfig {
             reason: format!("built-in first-party registry is invalid: {error}"),
         })?;
+    if process_backend == ProcessBackendKind::UserSandbox {
+        registry
+            .insert(user_sandbox_process_package().map_err(|error| {
+                RebornBuildError::InvalidConfig {
+                    reason: format!("user sandbox process package is invalid: {error}"),
+                }
+            })?)
+            .map_err(|error| RebornBuildError::InvalidConfig {
+                reason: format!("user sandbox process registry is invalid: {error}"),
+            })?;
+    }
     insert_bound_memory_package(&mut registry, memory_package)?;
     Ok(registry)
 }

--- a/crates/app/ironclaw_composition/src/factory/production_backend_assembly.rs
+++ b/crates/app/ironclaw_composition/src/factory/production_backend_assembly.rs
@@ -712,7 +712,9 @@ pub(super) async fn build_backend_production(
     };
     let user_sandbox_process_port = match &production_wiring.runtime_process_binding {
         RebornRuntimeProcessBinding::None => None,
-        RebornRuntimeProcessBinding::UserSandbox { process_port } => Some(Arc::clone(process_port)),
+        RebornRuntimeProcessBinding::UserSandbox { process_port, .. } => {
+            Some(Arc::clone(process_port))
+        }
     };
     let services = apply_production_runtime_process_binding(
         services,

--- a/crates/app/ironclaw_composition/src/factory/runtime_lane_assembly.rs
+++ b/crates/app/ironclaw_composition/src/factory/runtime_lane_assembly.rs
@@ -123,8 +123,11 @@ where
 {
     match binding {
         RebornRuntimeProcessBinding::None => services,
-        RebornRuntimeProcessBinding::UserSandbox { process_port } => {
-            services.with_production_user_sandbox_process_port(process_port)
-        }
+        RebornRuntimeProcessBinding::UserSandbox {
+            process_port,
+            process_executor,
+        } => services
+            .with_production_user_sandbox_process_port(process_port)
+            .with_process_sandbox_executor_dyn(process_executor),
     }
 }

--- a/crates/app/ironclaw_composition/src/input.rs
+++ b/crates/app/ironclaw_composition/src/input.rs
@@ -16,6 +16,7 @@ use ironclaw_host_runtime::memory_binding::MemoryBindingPolicy;
 #[cfg(any(test, feature = "test-support"))]
 use ironclaw_network::NetworkHttpEgress;
 use ironclaw_processes::ProcessConcurrencyLimits;
+use ironclaw_processes::ProcessExecutor;
 use ironclaw_trust::HostTrustPolicy;
 use ironclaw_turns::TurnRunWakeNotifier;
 use secrecy::SecretString;
@@ -105,13 +106,25 @@ pub(crate) struct OAuthDcrCallbackConfig {
     pub(crate) callback_origin: String,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
 pub enum RebornRuntimeProcessBinding {
     #[default]
     None,
     UserSandbox {
         process_port: Arc<UserSandboxProcessPort>,
+        process_executor: Arc<dyn ProcessExecutor>,
     },
+}
+
+impl std::fmt::Debug for RebornRuntimeProcessBinding {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => formatter.write_str("RebornRuntimeProcessBinding::None"),
+            Self::UserSandbox { .. } => formatter
+                .debug_struct("RebornRuntimeProcessBinding::UserSandbox")
+                .finish_non_exhaustive(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -140,7 +153,11 @@ impl RebornRuntimeProcessBinding {
     }
 
     pub fn user_sandbox(process_port: Arc<UserSandboxProcessPort>) -> Self {
-        Self::UserSandbox { process_port }
+        let process_executor: Arc<dyn ProcessExecutor> = process_port.clone();
+        Self::UserSandbox {
+            process_port,
+            process_executor,
+        }
     }
 
     pub(crate) fn validate_for_production_policy(

--- a/crates/contracts/ironclaw_host_api/src/decision.rs
+++ b/crates/contracts/ironclaw_host_api/src/decision.rs
@@ -68,6 +68,19 @@ pub enum Obligation {
         provider_scopes: Vec<String>,
         requester_extension: ExtensionId,
     },
+    InjectSandboxCredentialAccountOnce {
+        handle: SecretHandle,
+        provider: VendorId,
+        #[serde(default)]
+        setup: RuntimeCredentialAccountSetup,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        provider_scopes: Vec<String>,
+        requester_extension: ExtensionId,
+        #[serde(default)]
+        required: bool,
+        audience: crate::action::NetworkTargetPattern,
+        target: crate::http::RuntimeCredentialTarget,
+    },
     FirstPartyCredentialStagedViaHostPort {
         capability_id: CapabilityId,
     },
@@ -93,6 +106,19 @@ impl Obligation {
                 setup,
                 provider_scopes,
                 requester_extension,
+                ..
+            } => Some(RuntimeCredentialAuthRequirement {
+                provider: provider.clone(),
+                setup: setup.clone(),
+                requester_extension: requester_extension.clone(),
+                provider_scopes: provider_scopes.clone(),
+            }),
+            Obligation::InjectSandboxCredentialAccountOnce {
+                provider,
+                setup,
+                provider_scopes,
+                requester_extension,
+                required: true,
                 ..
             } => Some(RuntimeCredentialAuthRequirement {
                 provider: provider.clone(),
@@ -240,8 +266,9 @@ fn normalize_multi_inject<'a>(
 
 fn extract_inject_handle(obligation: &Obligation, kind: &ObligationKind) -> SecretHandle {
     match obligation {
-        Obligation::InjectSecretOnce { handle } => handle.clone(),
-        Obligation::InjectCredentialAccountOnce { handle, .. } => handle.clone(),
+        Obligation::InjectSecretOnce { handle }
+        | Obligation::InjectCredentialAccountOnce { handle, .. }
+        | Obligation::InjectSandboxCredentialAccountOnce { handle, .. } => handle.clone(),
         _ => unreachable!("extract_inject_handle called for {kind:?}"),
     }
 }
@@ -265,7 +292,10 @@ impl Obligation {
             Self::ReserveResources { .. } => ObligationKind::ReserveResources,
             Self::UseScopedMounts { .. } => ObligationKind::UseScopedMounts,
             Self::InjectSecretOnce { .. } => ObligationKind::InjectSecretOnce,
-            Self::InjectCredentialAccountOnce { .. } => ObligationKind::InjectCredentialAccountOnce,
+            Self::InjectCredentialAccountOnce { .. }
+            | Self::InjectSandboxCredentialAccountOnce { .. } => {
+                ObligationKind::InjectCredentialAccountOnce
+            }
             Self::FirstPartyCredentialStagedViaHostPort { .. } => {
                 ObligationKind::FirstPartyCredentialStagedViaHostPort
             }

--- a/crates/contracts/ironclaw_host_api/src/process.rs
+++ b/crates/contracts/ironclaw_host_api/src/process.rs
@@ -38,7 +38,7 @@ pub enum SavedCommandOutputSanitization {
     Blocked,
 }
 
-/// Placement-neutral command request handed to the selected process port.
+/// Placement-neutral shell command request handed to the selected process port.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandExecutionRequest {
     pub scope: ResourceScope,
@@ -49,6 +49,28 @@ pub struct CommandExecutionRequest {
     pub extra_env: HashMap<String, String>,
 }
 
+/// A validated executable plus argument vector. This request is separate from
+/// [`CommandExecutionRequest`] so existing shell transports cannot accidentally
+/// reinterpret a credentialed command as shell syntax.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectSandboxCommandRequest {
+    pub scope: ResourceScope,
+    pub mounts: Option<MountView>,
+    pub executable: String,
+    pub args: Vec<String>,
+    pub workdir: Option<String>,
+    pub timeout_secs: Option<u64>,
+    pub extra_env: HashMap<String, String>,
+}
+
+impl DirectSandboxCommandRequest {
+    pub fn argv(&self) -> Vec<&str> {
+        std::iter::once(self.executable.as_str())
+            .chain(self.args.iter().map(String::as_str))
+            .collect()
+    }
+}
+
 /// Process-port command result normalized for capability handlers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandExecutionOutput {
@@ -57,6 +79,55 @@ pub struct CommandExecutionOutput {
     pub exit_code: i64,
     pub sandboxed: bool,
     pub duration: Duration,
+}
+
+/// One invocation-scoped credential binding handed only to the sandbox
+/// transport. The command receives `placeholder`; only the proxy-side
+/// transport may expose `secret`.
+#[derive(Clone)]
+pub struct SandboxCommandCredential {
+    pub placeholder_env: String,
+    pub placeholder: String,
+    pub approved_host: String,
+    pub header_name: String,
+    pub header_prefix: Option<String>,
+    secret: zeroize::Zeroizing<String>,
+}
+
+impl SandboxCommandCredential {
+    pub fn new(
+        placeholder_env: String,
+        placeholder: String,
+        approved_host: String,
+        header_name: String,
+        header_prefix: Option<String>,
+        secret: String,
+    ) -> Self {
+        Self {
+            placeholder_env,
+            placeholder,
+            approved_host,
+            header_name,
+            header_prefix,
+            secret: zeroize::Zeroizing::new(secret),
+        }
+    }
+
+    pub fn expose_secret(&self) -> &str {
+        self.secret.as_str()
+    }
+}
+
+impl std::fmt::Debug for SandboxCommandCredential {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SandboxCommandCredential")
+            .field("placeholder_env", &self.placeholder_env)
+            .field("approved_host", &self.approved_host)
+            .field("header_name", &self.header_name)
+            .field("header_prefix", &self.header_prefix)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Stable redacted process-port failure.
@@ -84,10 +155,47 @@ pub trait SandboxCommandTransport: Send + Sync {
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError>;
 
+    async fn run_credentialed_direct_command(
+        &self,
+        _request: DirectSandboxCommandRequest,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        let reason = if credentials.is_empty() {
+            "sandbox transport does not support direct-argv execution"
+        } else {
+            "sandbox transport does not support credential bindings"
+        };
+        Err(RuntimeProcessError::ExecutionFailed(reason.to_string()))
+    }
+
     /// Release remote resources owned by this transport after command
     /// producers have stopped. Local transports may keep the default no-op;
     /// remote transports override this with idempotent provider cleanup.
     async fn shutdown(&self) -> Result<(), RuntimeProcessError> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_request_preserves_argument_boundaries() {
+        let request = DirectSandboxCommandRequest {
+            scope: ResourceScope::system(),
+            mounts: None,
+            executable: "printf".to_string(),
+            args: vec!["%s".to_string(), "one; echo injected".to_string()],
+            workdir: None,
+            timeout_secs: None,
+            extra_env: HashMap::new(),
+        };
+
+        assert_eq!(
+            request.argv(),
+            ["printf", "%s", "one; echo injected"],
+            "the credentialed process boundary must never reinterpret arguments as shell syntax"
+        );
     }
 }

--- a/crates/kernel/ironclaw_authorization/src/lib.rs
+++ b/crates/kernel/ironclaw_authorization/src/lib.rs
@@ -1097,10 +1097,23 @@ fn obligations_for_grant(
                     }
                 }
                 RuntimeCredentialRequirementSource::ProductAuthAccount { provider, setup } => {
-                    // Mirror SecretHandle: only mandate the obligation when the credential is
-                    // required. An optional product-auth credential is skipped rather than
-                    // injected so that a missing account does not hard-fail dispatch.
-                    if credential.required {
+                    if descriptor.id.as_str()
+                        == ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID
+                    {
+                        obligations.push(Obligation::InjectSandboxCredentialAccountOnce {
+                            handle: credential.handle.clone(),
+                            provider: provider.clone(),
+                            setup: setup.clone(),
+                            provider_scopes: credential.provider_scopes.clone(),
+                            requester_extension: ironclaw_host_api::ids::ExtensionId::new(
+                                provider.as_str(),
+                            )
+                            .ok()?,
+                            required: credential.required,
+                            audience: credential.audience.clone(),
+                            target: credential.target.clone(),
+                        });
+                    } else if credential.required {
                         obligations.push(Obligation::InjectCredentialAccountOnce {
                             handle: credential.handle.clone(),
                             provider: provider.clone(),

--- a/crates/kernel/ironclaw_capabilities/src/host/approval_resume.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/approval_resume.rs
@@ -185,7 +185,7 @@ where
             });
         }
 
-        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+        let Some(base_descriptor) = self.registry.get_capability(&request.capability_id) else {
             fail_invocation_if_configured(
                 Some(invocation_state),
                 &scope,
@@ -196,6 +196,22 @@ where
             return Err(CapabilityInvocationError::UnknownCapability {
                 capability: request.capability_id,
             });
+        };
+        let descriptor = match self
+            .enrich_invocation_descriptor(base_descriptor, &request.capability_id, &request.input)
+            .await
+        {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                fail_invocation_if_configured(
+                    Some(invocation_state),
+                    &scope,
+                    invocation_id,
+                    "AuthorizationDenied",
+                )
+                .await;
+                return Err(error);
+            }
         };
 
         let Some(lease) = matching_approval_lease(
@@ -237,7 +253,7 @@ where
             estimate: request.estimate,
             input: request.input,
             authorized_context,
-            descriptor,
+            descriptor: &descriptor,
             lease_state: ResumedLeaseState::PendingClaim(PendingClaimAfterAuth {
                 leases: capability_leases,
                 grant_id,

--- a/crates/kernel/ironclaw_capabilities/src/host/auth_resume.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/auth_resume.rs
@@ -125,7 +125,7 @@ where
         // touching the lease at all — preventing a one-shot lease from being
         // permanently stranded in `Claimed`/`Dispatching` when the capability
         // was unregistered between the original invocation and this resume.
-        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+        let Some(base_descriptor) = self.registry.get_capability(&request.capability_id) else {
             fail_invocation_if_configured(
                 Some(invocation_state),
                 &scope,
@@ -136,6 +136,22 @@ where
             return Err(CapabilityInvocationError::UnknownCapability {
                 capability: request.capability_id,
             });
+        };
+        let descriptor = match self
+            .enrich_invocation_descriptor(base_descriptor, &request.capability_id, &request.input)
+            .await
+        {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                fail_invocation_if_configured(
+                    Some(invocation_state),
+                    &scope,
+                    invocation_id,
+                    "AuthorizationDenied",
+                )
+                .await;
+                return Err(error);
+            }
         };
 
         // When the invocation previously passed an approval gate, validate and
@@ -378,7 +394,7 @@ where
             estimate: request.estimate,
             input: request.input,
             authorized_context,
-            descriptor,
+            descriptor: &descriptor,
             lease_state: match approval_lease_to_consume {
                 Some((leases, lease)) => ResumedLeaseState::AlreadyClaimed(leases, Box::new(lease)),
                 None => ResumedLeaseState::NoPriorLease,

--- a/crates/kernel/ironclaw_capabilities/src/host/authorize.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/authorize.rs
@@ -67,6 +67,27 @@ where
             )),
         }
     }
+    pub(super) async fn enrich_invocation_descriptor(
+        &self,
+        descriptor: &CapabilityDescriptor,
+        capability_id: &CapabilityId,
+        input: &serde_json::Value,
+    ) -> Result<CapabilityDescriptor, CapabilityInvocationError> {
+        let mut descriptor = descriptor.clone();
+        let invocation_credentials = self
+            .policy_facts
+            .invocation_runtime_credentials(capability_id, input)
+            .await
+            .map_err(|detail| CapabilityInvocationError::AuthorizationDenied {
+                capability: capability_id.clone(),
+                reason: DenyReason::PolicyDenied,
+                detail: Some(detail),
+            })?;
+        descriptor
+            .runtime_credentials
+            .extend(invocation_credentials);
+        Ok(descriptor)
+    }
 
     /// Persistent-approval fold (§5.2.7/§5.3.2): a prior scoped approval may
     /// already authorize this invocation. Relocated from host_runtime's former
@@ -194,12 +215,15 @@ where
         // fingerprint above nor `invocation_state.start` below needs the descriptor, so
         // hoisting this lookup is safe; everything from `start` onward keeps its
         // original order (the credential pre-flight still runs after `start`).
-        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+        let Some(base_descriptor) = self.registry.get_capability(&request.capability_id) else {
             debug!("capability invocation failed before authorization: unknown capability");
             return Err(CapabilityInvocationError::UnknownCapability {
                 capability: request.capability_id.clone(),
             });
         };
+        let descriptor = self
+            .enrich_invocation_descriptor(base_descriptor, &request.capability_id, &request.input)
+            .await?;
 
         if let Some(invocation_state) = self.invocation_state {
             invocation_state
@@ -233,7 +257,7 @@ where
                 return Err(error);
             }
         };
-        if let Err(error) = self.enforce_runtime_policy(descriptor) {
+        if let Err(error) = self.enforce_runtime_policy(&descriptor) {
             apply_invocation_state_transition_if_configured(
                 self.invocation_state,
                 &scope,
@@ -287,7 +311,7 @@ where
         let frozen_deadline = self
             .apply_persistent_approval(
                 &mut authorize_context,
-                descriptor,
+                &descriptor,
                 &request.capability_id,
                 &request.estimate,
                 &trust_decision,
@@ -299,7 +323,7 @@ where
             .authorizer
             .authorize_dispatch_with_trust(
                 &authorize_context,
-                descriptor,
+                &descriptor,
                 &request.estimate,
                 &trust_decision,
             )
@@ -347,7 +371,7 @@ where
                     &request.capability_id,
                     &request.estimate,
                     &request.input,
-                    descriptor,
+                    &descriptor,
                     &obligation_outcome,
                     frozen_deadline,
                 );

--- a/crates/kernel/ironclaw_capabilities/src/host/spawn.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/spawn.rs
@@ -233,11 +233,14 @@ where
         // Resolve the descriptor BEFORE starting a invocation record (see `authorize`):
         // an unknown capability short-circuits without creating a invocation record, so
         // no `fail_invocation_if_configured` is needed here.
-        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+        let Some(base_descriptor) = self.registry.get_capability(&request.capability_id) else {
             return Err(CapabilityInvocationError::UnknownCapability {
                 capability: request.capability_id.clone(),
             });
         };
+        let descriptor = self
+            .enrich_invocation_descriptor(base_descriptor, &request.capability_id, &request.input)
+            .await?;
 
         if let Some(invocation_state) = self.invocation_state {
             invocation_state
@@ -268,7 +271,7 @@ where
                 return Err(error);
             }
         };
-        if let Err(error) = self.enforce_runtime_policy(descriptor) {
+        if let Err(error) = self.enforce_runtime_policy(&descriptor) {
             apply_invocation_state_transition_if_configured(
                 self.invocation_state,
                 &scope,
@@ -317,7 +320,7 @@ where
         let frozen_deadline = self
             .apply_persistent_approval(
                 &mut authorize_context,
-                descriptor,
+                &descriptor,
                 &request.capability_id,
                 &request.estimate,
                 &trust_decision,
@@ -329,7 +332,7 @@ where
             .authorizer
             .authorize_spawn_with_trust(
                 &authorize_context,
-                descriptor,
+                &descriptor,
                 &request.estimate,
                 &trust_decision,
             )
@@ -366,7 +369,7 @@ where
                     &request.capability_id,
                     &request.estimate,
                     &request.input,
-                    descriptor,
+                    &descriptor,
                     &obligation_outcome,
                     frozen_deadline,
                 );

--- a/crates/kernel/ironclaw_capabilities/src/host/spawn_resume.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/spawn_resume.rs
@@ -190,7 +190,7 @@ where
             });
         }
 
-        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+        let Some(base_descriptor) = self.registry.get_capability(&request.capability_id) else {
             fail_invocation_if_configured(
                 Some(invocation_state),
                 &scope,
@@ -201,6 +201,22 @@ where
             return Err(CapabilityInvocationError::UnknownCapability {
                 capability: request.capability_id,
             });
+        };
+        let descriptor = match self
+            .enrich_invocation_descriptor(base_descriptor, &request.capability_id, &request.input)
+            .await
+        {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                fail_invocation_if_configured(
+                    Some(invocation_state),
+                    &scope,
+                    invocation_id,
+                    "AuthorizationDenied",
+                )
+                .await;
+                return Err(error);
+            }
         };
 
         let Some(lease) = matching_approval_lease(
@@ -247,7 +263,7 @@ where
             .authorizer
             .authorize_spawn_with_trust(
                 &authorized_context,
-                descriptor,
+                &descriptor,
                 &request.estimate,
                 &trust_decision,
             )
@@ -360,7 +376,7 @@ where
             &request.capability_id,
             &request.estimate,
             &request.input,
-            descriptor,
+            &descriptor,
             &obligation_outcome,
             claimed_lease.grant.constraints.expires_at,
         );

--- a/crates/kernel/ironclaw_capabilities/src/host/tests.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/tests.rs
@@ -228,6 +228,37 @@ impl HostPolicyFacts for SatisfiedPolicyFacts {
         Vec::new()
     }
 }
+struct InvocationCredentialPolicyFacts {
+    requirement: ironclaw_host_api::capability::RuntimeCredentialRequirement,
+}
+
+#[async_trait::async_trait]
+impl HostPolicyFacts for InvocationCredentialPolicyFacts {
+    async fn invocation_runtime_credentials(
+        &self,
+        _capability_id: &CapabilityId,
+        _input: &serde_json::Value,
+    ) -> Result<Vec<ironclaw_host_api::capability::RuntimeCredentialRequirement>, String> {
+        Ok(vec![self.requirement.clone()])
+    }
+
+    async fn credential_presence(
+        &self,
+        _capability_id: &CapabilityId,
+        _scope: &ResourceScope,
+    ) -> CredentialPresence {
+        CredentialPresence::Satisfied
+    }
+
+    async fn persistent_grants(
+        &self,
+        _capability_id: &CapabilityId,
+        _context: &ExecutionContext,
+        _action: crate::ports::PolicyAction,
+    ) -> Vec<ironclaw_host_api::capability::CapabilityGrant> {
+        Vec::new()
+    }
+}
 
 // Returns a single persistent grant carrying `expiry`. With `AllowAuthorizer`
 // the persistent-approval probe adopts it, so its `expires_at` becomes the
@@ -477,6 +508,74 @@ async fn authorize_allow_path_seals_authorized_with_lane_and_invocation() {
     // No frozen fact → the bounded default TTL from authorize-time.
     assert!(authorized.deadline() >= before + WITNESS_DEFAULT_TTL);
     assert!(authorized.deadline() <= after + WITNESS_DEFAULT_TTL);
+}
+#[tokio::test]
+async fn invocation_credentials_enrich_only_the_authorized_descriptor_snapshot() {
+    use ironclaw_host_api::{
+        action::{NetworkScheme, NetworkTargetPattern},
+        capability::{RuntimeCredentialRequirement, RuntimeCredentialRequirementSource},
+        http::RuntimeCredentialTarget,
+    };
+
+    let registry = echo_registry();
+    let dispatcher =
+        ironclaw_host_api::dispatch_test_support::TestDispatcher::responding(|req, _| {
+            Err(DispatchError::UnknownCapability {
+                capability: req.invocation.capability.clone(),
+            })
+        });
+    let authorizer = AllowAuthorizer;
+    let trust_policy = StaticTrustPolicy;
+    let runtime_policy = permissive_runtime_policy();
+    let policy_facts = InvocationCredentialPolicyFacts {
+        requirement: RuntimeCredentialRequirement {
+            handle: SecretHandle::new("fixture_runtime_token").unwrap(),
+            source: RuntimeCredentialRequirementSource::ProductAuthAccount {
+                provider: VendorId::new("fixture-vendor").unwrap(),
+                setup: RuntimeCredentialAccountSetup::ManualToken,
+            },
+            provider_scopes: Vec::new(),
+            audience: NetworkTargetPattern {
+                scheme: Some(NetworkScheme::Https),
+                host_pattern: "api.example.com".to_string(),
+                port: None,
+            },
+            target: RuntimeCredentialTarget::Header {
+                name: "Authorization".to_string(),
+                prefix: Some("token ".to_string()),
+            },
+            required: true,
+        },
+    };
+    let host = CapabilityHost::new(
+        &registry,
+        &dispatcher,
+        &authorizer,
+        &trust_policy,
+        &runtime_policy,
+        &policy_facts,
+    );
+    let capability_id = CapabilityId::new("echo.say").unwrap();
+    let base = registry.get_capability(&capability_id).unwrap();
+
+    let enriched = host
+        .enrich_invocation_descriptor(base, &capability_id, &serde_json::json!({"message": "hi"}))
+        .await
+        .unwrap();
+
+    assert_eq!(enriched.runtime_credentials.len(), 1);
+    assert_eq!(
+        enriched.runtime_credentials[0].handle.as_str(),
+        "fixture_runtime_token"
+    );
+    assert!(
+        registry
+            .get_capability(&capability_id)
+            .unwrap()
+            .runtime_credentials
+            .is_empty(),
+        "per-invocation authority must not mutate the shared registry descriptor"
+    );
 }
 
 // When a persistent grant carrying an `expires_at` is adopted in the fold, the

--- a/crates/kernel/ironclaw_capabilities/src/ports.rs
+++ b/crates/kernel/ironclaw_capabilities/src/ports.rs
@@ -25,12 +25,13 @@
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    capability::CapabilityGrant,
+    capability::{CapabilityGrant, RuntimeCredentialRequirement},
     decision::RuntimeCredentialAuthRequirement,
     ids::{CapabilityId, SecretHandle},
     resource::ResourceScope,
     scope::ExecutionContext,
 };
+use serde_json::Value;
 
 /// Presence of a capability's required credentials, read from the host secret
 /// store. A *fact*, not a decision.
@@ -68,7 +69,19 @@ pub enum PolicyAction {
 /// Host-mediated policy facts consumed by `authorize()`. **Facts only** — this
 /// port never decides; the kernel maps each fact into the sealed verdict.
 #[async_trait]
+
 pub trait HostPolicyFacts: Send + Sync {
+    /// Resolve invocation-selected credential requirements from host-owned
+    /// declarations. The returned facts are folded into a per-invocation
+    /// descriptor before policy runs; callers cannot declare credential
+    /// authority through model input alone.
+    async fn invocation_runtime_credentials(
+        &self,
+        _capability_id: &CapabilityId,
+        _input: &Value,
+    ) -> Result<Vec<RuntimeCredentialRequirement>, String> {
+        Ok(Vec::new())
+    }
     /// Whether the capability's required credentials are present for `scope`.
     ///
     /// Presence only — the pre-flight exists solely to order the auth gate ahead

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -35,7 +35,10 @@ use ironclaw_extension_support::coding::{
     CodingCapabilityError, CodingCapabilityKind, CodingCapabilityRequest, CodingCapabilityState,
 };
 use ironclaw_host_api::{
-    capability::{EffectKind, OriginGateMatrix, OriginGatePolicy, PermissionMode},
+    capability::{
+        EffectKind, OriginGateMatrix, OriginGatePolicy, PROCESS_SANDBOX_CAPABILITY_ID,
+        PermissionMode,
+    },
     capability_profile::CapabilityProfileSchemaRef,
     dispatch::RuntimeDispatchErrorKind,
     error::HostApiError,
@@ -276,6 +279,44 @@ pub fn builtin_first_party_package_for_process_backend(
     let mut package = builtin_first_party_package()?;
     restrict_package_for_process_backend(&mut package, process_backend)?;
     Ok(package)
+}
+
+pub fn user_sandbox_process_package() -> Result<ExtensionPackage, ExtensionError> {
+    ExtensionPackage::from_manifest(
+        ExtensionManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION.to_string(),
+            id: ExtensionId::new("system.process_sandbox")?,
+            name: "User sandbox process".to_string(),
+            version: "0.1.0".to_string(),
+            description: "Host-mediated direct-argument user sandbox execution".to_string(),
+            source: ManifestSource::HostBundled,
+            requested_trust: RequestedTrustClass::SystemRequested,
+            descriptor_trust_default: TrustClass::Sandbox,
+            runtime: ExtensionRuntime::System {
+                service: "process_sandbox".to_string(),
+            },
+            host_apis: Vec::new(),
+            host_api_surfaces: Vec::new(),
+            capabilities: vec![user_sandbox_process_manifest()?],
+            hooks: Vec::new(),
+        },
+        VirtualPath::new("/system/extensions/system.process_sandbox")?,
+    )
+}
+
+fn user_sandbox_process_manifest() -> Result<CapabilityManifest, ExtensionError> {
+    first_party_capability_manifest(
+        PROCESS_SANDBOX_CAPABILITY_ID,
+        "Run a direct-argument process in the isolated user sandbox",
+        vec![
+            EffectKind::DispatchCapability,
+            EffectKind::SpawnProcess,
+            EffectKind::UseSecret,
+            EffectKind::ExecuteCode,
+        ],
+        PermissionMode::Ask,
+        None,
+    )
 }
 
 fn restrict_package_for_process_backend(
@@ -1020,4 +1061,28 @@ fn coding_capability_metadata(capability_id: &str) -> Option<CodingCapabilityMet
         .iter()
         .copied()
         .find(|metadata| metadata.id == capability_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_sandbox_package_exposes_isolated_process_without_generic_network_privilege() {
+        let package = user_sandbox_process_package().unwrap();
+        let descriptor = package
+            .capabilities
+            .iter()
+            .find(|descriptor| descriptor.id.as_str() == PROCESS_SANDBOX_CAPABILITY_ID)
+            .expect("user-sandbox package must expose the direct-argument process capability");
+
+        assert!(descriptor.effects.contains(&EffectKind::UseSecret));
+        assert_eq!(descriptor.default_permission, PermissionMode::Ask);
+        assert!(!descriptor.effects.contains(&EffectKind::Network));
+        assert!(
+            descriptor.runtime_credentials.is_empty(),
+            "credential authority is resolved per invocation from extension declarations"
+        );
+        assert!(descriptor.network_targets.is_empty());
+    }
 }

--- a/crates/kernel/ironclaw_host_runtime/src/lib.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/lib.rs
@@ -115,6 +115,7 @@ pub use first_party_tools::{
     memory_invocation_for_request, memory_tool_profiles, normalize_memory_tool_input,
     register_memory_tool_handler, register_native_memory_tools,
     register_outbound_deliver_first_party_handler, register_reply_attachment_first_party_handler,
+    user_sandbox_process_package,
 };
 #[cfg(any(test, feature = "test-support"))]
 pub use first_party_tools::{
@@ -149,7 +150,7 @@ pub use services::{
     ProductAuthCredentialStageError, ProductAuthProviderRuntimePorts,
     ProductionEventStoreWiringError, ProductionWiringComponent, ProductionWiringConfig,
     ProductionWiringIssue, ProductionWiringIssueKind, ProductionWiringReport,
-    RegisteredRuntimeHealth,
+    RegisteredRuntimeHealth, SandboxTransportProcessExecutor,
 };
 pub use surface::{VisibleCapability, VisibleCapabilityAccess};
 /// Stable, validated idempotency key supplied by upper turn/loop services.

--- a/crates/kernel/ironclaw_host_runtime/src/obligations/handler.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/obligations/handler.rs
@@ -25,7 +25,7 @@ use ironclaw_host_api::{
     capability::{EffectKind, RuntimeCredentialAccountSetup},
     decision::{Obligation, RuntimeCredentialAuthRequirement},
     dispatch::{CapabilityDispatchResult, CredentialStageError},
-    ids::{AuditEventId, CapabilityId, ExtensionId, SecretHandle, VendorId},
+    ids::{AuditEventId, CapabilityId, SecretHandle, VendorId},
     mount::MountView,
     resource::{
         ResourceCeiling, ResourceEstimate, ResourceReservation, ResourceScope, ResourceUsage,
@@ -39,7 +39,7 @@ use secrecy::ExposeSecret;
 
 use super::staged_handoffs::{
     NetworkObligationPolicyStore, RuntimeCredentialAccountRequest,
-    RuntimeCredentialAccountResolver, RuntimeSecretInjectionStore,
+    RuntimeCredentialAccountResolver, RuntimeCredentialBindingPolicy, RuntimeSecretInjectionStore,
 };
 
 /// Built-in obligation handler for the current host-runtime slice.
@@ -300,7 +300,14 @@ impl BuiltinObligationHandler {
             return Ok(());
         }
         let Some(resolver) = &self.credential_account_resolver else {
-            return Err(secret_obligation_failed());
+            return if account_obligations
+                .iter()
+                .all(|obligation| !obligation.required)
+            {
+                Ok(())
+            } else {
+                Err(secret_obligation_failed())
+            };
         };
         let Some(secret_store) = &self.secret_store else {
             return Err(secret_obligation_failed());
@@ -310,7 +317,7 @@ impl BuiltinObligationHandler {
         };
 
         for obligation in account_obligations {
-            let access_secret = resolver
+            let access_secret = match resolver
                 .resolve_access_secret(RuntimeCredentialAccountRequest {
                     scope: &request.context.resource_scope,
                     provider: obligation.provider,
@@ -319,25 +326,41 @@ impl BuiltinObligationHandler {
                     requester_extension: obligation.requester_extension,
                 })
                 .await
-                .map_err(|error| {
-                    credential_stage_error_to_obligation_error(error, Some(&obligation))
-                })?;
+            {
+                Ok(access_secret) => access_secret,
+                Err(CredentialStageError::AuthRequired) if !obligation.required => continue,
+                Err(error) => {
+                    return Err(credential_stage_error_to_obligation_error(
+                        error,
+                        Some(&obligation),
+                    ));
+                }
+            };
             // Retrieve and stage the resolved credential under the obligation's injection handle.
             // The access_secret names the material in the secret store; obligation.handle is
             // the slot name the WASM guest expects.
-            stage_credential_material(
+            if let Err(error) = stage_credential_material(
                 secret_store.as_ref(),
                 secret_injections,
-                &access_secret.scope,
-                &request.context.resource_scope,
-                request.capability_id,
-                &access_secret.handle,
-                obligation.handle,
+                CredentialMaterialStage {
+                    source_scope: &access_secret.scope,
+                    target_scope: &request.context.resource_scope,
+                    capability_id: request.capability_id,
+                    source: &access_secret.handle,
+                    target: obligation.handle,
+                    binding: obligation.binding.clone(),
+                },
             )
             .await
-            .map_err(|error| {
-                credential_stage_error_to_obligation_error(error, Some(&obligation))
-            })?;
+            {
+                if error == CredentialStageError::AuthRequired && !obligation.required {
+                    continue;
+                }
+                return Err(credential_stage_error_to_obligation_error(
+                    error,
+                    Some(&obligation),
+                ));
+            }
         }
 
         Ok(())
@@ -718,6 +741,7 @@ fn obligation_supported(phase: CapabilityObligationPhase, obligation: &Obligatio
         | Obligation::ApplyNetworkPolicy { .. }
         | Obligation::FirstPartyCredentialStagedViaHostPort { .. }
         | Obligation::InjectCredentialAccountOnce { .. }
+        | Obligation::InjectSandboxCredentialAccountOnce { .. }
         | Obligation::InjectSecretOnce { .. }
         | Obligation::ReserveResources { .. }
         | Obligation::UseScopedMounts { .. } => true,
@@ -747,7 +771,9 @@ struct CredentialAccountInjectionObligation<'a> {
     provider: &'a VendorId,
     setup: &'a RuntimeCredentialAccountSetup,
     provider_scopes: &'a [String],
-    requester_extension: &'a ExtensionId,
+    requester_extension: &'a ironclaw_host_api::ids::ExtensionId,
+    required: bool,
+    binding: Option<RuntimeCredentialBindingPolicy>,
 }
 
 fn credential_account_injection_obligations(
@@ -768,6 +794,29 @@ fn credential_account_injection_obligations(
                 setup,
                 provider_scopes,
                 requester_extension,
+                required: true,
+                binding: None,
+            }),
+            Obligation::InjectSandboxCredentialAccountOnce {
+                handle,
+                provider,
+                setup,
+                provider_scopes,
+                requester_extension,
+                required,
+                audience,
+                target,
+            } => Some(CredentialAccountInjectionObligation {
+                handle,
+                provider,
+                setup,
+                provider_scopes,
+                requester_extension,
+                required: *required,
+                binding: Some(RuntimeCredentialBindingPolicy {
+                    audience: audience.clone(),
+                    target: target.clone(),
+                }),
             }),
             _ => None,
         })
@@ -779,7 +828,8 @@ fn staged_secret_injection_handles(obligations: &[Obligation]) -> Vec<SecretHand
         .iter()
         .filter_map(|obligation| match obligation {
             Obligation::InjectSecretOnce { handle }
-            | Obligation::InjectCredentialAccountOnce { handle, .. } => Some(handle.clone()),
+            | Obligation::InjectCredentialAccountOnce { handle, .. }
+            | Obligation::InjectSandboxCredentialAccountOnce { handle, .. } => Some(handle.clone()),
             _ => None,
         })
         .collect()
@@ -812,50 +862,44 @@ fn credential_stage_error_to_obligation_error(
     }
 }
 
-/// Retrieve `source` from the secret store and stage the material under `target`
-/// in the injection store for the given capability invocation.
-///
-/// Used when the secret store key (`source`) differs from the runtime injection slot
-/// (`target`) — for example, when a product-auth account's backing secret is resolved
-/// to a concrete handle before being injected under the WASM guest's declared slot name.
-/// Lease → consume → insert the staged credential material.
-///
+struct CredentialMaterialStage<'a> {
+    source_scope: &'a ResourceScope,
+    target_scope: &'a ResourceScope,
+    capability_id: &'a CapabilityId,
+    source: &'a SecretHandle,
+    target: &'a SecretHandle,
+    binding: Option<RuntimeCredentialBindingPolicy>,
+}
+
 /// Mirrors [`crate::services::ProductAuthProviderRuntimePorts::stage_secret_once`]
-/// so the WASM `InjectCredentialAccountOnce` path and the first-party stager path
-/// (e.g. `ProductAuthRuntimeGsuiteCredentialStager`) share identical lease/consume
-/// semantics and `CredentialStageError` mapping. `SecretStoreError` variants for
-/// unknown/expired/revoked/consumed material map to
-/// [`CredentialStageError::AuthRequired`] via [`crate::services::stage_secret_error`];
-/// other failures map to [`CredentialStageError::Backend`].
+/// so account credentials use the same lease/consume semantics and error mapping.
 async fn stage_credential_material(
     secret_store: &dyn SecretStorePort,
     secret_injections: &RuntimeSecretInjectionStore,
-    source_scope: &ResourceScope,
-    target_scope: &ResourceScope,
-    capability_id: &CapabilityId,
-    source: &SecretHandle,
-    target: &SecretHandle,
+    stage: CredentialMaterialStage<'_>,
 ) -> Result<(), CredentialStageError> {
+    let CredentialMaterialStage {
+        source_scope,
+        target_scope,
+        capability_id,
+        source,
+        target,
+        binding,
+    } = stage;
     let lease = secret_store
         .lease_once(source_scope, source)
         .await
-        .map_err(|e| {
-            tracing::debug!(err = %e, "stage_credential_material: lease_once failed");
-            crate::services::stage_secret_error(e)
+        .map_err(|error| {
+            tracing::debug!(%error, "stage_credential_material: lease_once failed");
+            crate::services::stage_secret_error(error)
         })?;
     let secret = secret_store
         .consume(source_scope, lease.id)
         .await
-        .map_err(|e| {
-            tracing::debug!(err = %e, "stage_credential_material: consume failed");
-            crate::services::stage_secret_error(e)
+        .map_err(|error| {
+            tracing::debug!(%error, "stage_credential_material: consume failed");
+            crate::services::stage_secret_error(error)
         })?;
-    // A "Configured" account whose resolved material is empty cannot
-    // authenticate anything; staging it would only let the guest fail later
-    // with an opaque `operation_failed` (e.g. an ironhub tool probing
-    // `secret-exists` sees an unusable slot and reports "API key not
-    // configured" as a generic domain failure). Surface the typed re-auth
-    // signal at authorization time instead so the model can act on it.
     if secret.expose_secret().is_empty() {
         tracing::debug!(
             handle = %target.as_str(),
@@ -863,12 +907,16 @@ async fn stage_credential_material(
         );
         return Err(CredentialStageError::AuthRequired);
     }
-    secret_injections
-        .insert(target_scope, capability_id, target, secret)
-        .map_err(|e| {
-            tracing::debug!(err = %e, "stage_credential_material: insert failed");
-            CredentialStageError::Backend
-        })
+    let inserted = match binding {
+        Some(binding) => {
+            secret_injections.insert_bound(target_scope, capability_id, target, secret, binding)
+        }
+        None => secret_injections.insert(target_scope, capability_id, target, secret),
+    };
+    inserted.map_err(|error| {
+        tracing::debug!(%error, "stage_credential_material: insert failed");
+        CredentialStageError::Backend
+    })
 }
 
 fn network_policy_obligation(
@@ -1264,7 +1312,10 @@ fn obligation_label(obligation: &Obligation) -> Option<&'static str> {
         Obligation::RedactOutput => Some("redact_output"),
         Obligation::ApplyNetworkPolicy { .. } => Some("apply_network_policy"),
         Obligation::InjectSecretOnce { .. } => Some("inject_secret_once"),
-        Obligation::InjectCredentialAccountOnce { .. } => Some("inject_credential_account_once"),
+        Obligation::InjectCredentialAccountOnce { .. }
+        | Obligation::InjectSandboxCredentialAccountOnce { .. } => {
+            Some("inject_credential_account_once")
+        }
         Obligation::FirstPartyCredentialStagedViaHostPort { .. } => {
             Some("first_party_credential_staged_via_host_port")
         }

--- a/crates/kernel/ironclaw_host_runtime/src/obligations/mod.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/obligations/mod.rs
@@ -43,6 +43,8 @@ pub use staged_handoffs::{
 };
 
 pub(crate) use handler::secret_owner_scope;
+#[cfg(test)]
+pub(crate) use staged_handoffs::RuntimeCredentialBindingPolicy;
 pub(crate) use staged_handoffs::{
     NetworkObligationPolicyStore, RuntimeSecretInjectionStore, SharedSecretStore,
 };

--- a/crates/kernel/ironclaw_host_runtime/src/obligations/staged_handoffs.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/obligations/staged_handoffs.rs
@@ -18,9 +18,10 @@ use std::{
 use async_trait::async_trait;
 use ironclaw_host_api::{
     Timestamp,
-    action::NetworkPolicy,
+    action::{NetworkPolicy, NetworkTargetPattern},
     capability::RuntimeCredentialAccountSetup,
     dispatch::CredentialStageError,
+    http::RuntimeCredentialTarget,
     ids::{CapabilityId, ExtensionId, SecretHandle, VendorId},
     resource::ResourceScope,
 };
@@ -79,9 +80,15 @@ struct RuntimeSecretInjectionState {
     secrets: Mutex<HashMap<RuntimeSecretInjectionKey, RuntimeSecretInjectionEntry>>,
     ttl: Duration,
 }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeCredentialBindingPolicy {
+    pub audience: NetworkTargetPattern,
+    pub target: RuntimeCredentialTarget,
+}
 
 struct RuntimeSecretInjectionEntry {
     material: SecretMaterial,
+    binding: Option<RuntimeCredentialBindingPolicy>,
     expires_at: Instant,
 }
 
@@ -106,6 +113,28 @@ impl RuntimeSecretInjectionStore {
         handle: &SecretHandle,
         material: SecretMaterial,
     ) -> Result<(), RuntimeSecretInjectionStoreError> {
+        self.insert_inner(scope, capability_id, handle, material, None)
+    }
+
+    pub(crate) fn insert_bound(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+        material: SecretMaterial,
+        binding: RuntimeCredentialBindingPolicy,
+    ) -> Result<(), RuntimeSecretInjectionStoreError> {
+        self.insert_inner(scope, capability_id, handle, material, Some(binding))
+    }
+
+    fn insert_inner(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+        material: SecretMaterial,
+        binding: Option<RuntimeCredentialBindingPolicy>,
+    ) -> Result<(), RuntimeSecretInjectionStoreError> {
         let now = Instant::now();
         let expires_at = now.checked_add(self.state.ttl).unwrap_or(now);
         let mut secrets = self.lock()?;
@@ -114,6 +143,7 @@ impl RuntimeSecretInjectionStore {
             RuntimeSecretInjectionKey::new(scope, capability_id, handle),
             RuntimeSecretInjectionEntry {
                 material,
+                binding,
                 expires_at,
             },
         );
@@ -136,6 +166,26 @@ impl RuntimeSecretInjectionStore {
                 handle,
             ))
             .map(|entry| entry.material))
+    }
+    pub(crate) fn take_bound(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+    ) -> Result<
+        Option<(SecretMaterial, Option<RuntimeCredentialBindingPolicy>)>,
+        RuntimeSecretInjectionStoreError,
+    > {
+        let now = Instant::now();
+        let mut secrets = self.lock()?;
+        prune_expired_entries(&mut secrets, now);
+        Ok(secrets
+            .remove(&RuntimeSecretInjectionKey::new(
+                scope,
+                capability_id,
+                handle,
+            ))
+            .map(|entry| (entry.material, entry.binding)))
     }
 
     pub(crate) fn clone_material(

--- a/crates/kernel/ironclaw_host_runtime/src/obligations/tests.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/obligations/tests.rs
@@ -165,6 +165,103 @@ async fn builtin_obligation_handler_satisfy_release_preserves_staged_handoffs() 
     );
 }
 
+#[derive(Debug)]
+struct SandboxCredentialResolver {
+    source_scope: ResourceScope,
+    source_handle: SecretHandle,
+}
+
+#[async_trait::async_trait]
+impl RuntimeCredentialAccountResolver for SandboxCredentialResolver {
+    async fn resolve_access_secret(
+        &self,
+        request: RuntimeCredentialAccountRequest<'_>,
+    ) -> Result<RuntimeCredentialAccessSecret, ironclaw_host_api::dispatch::CredentialStageError>
+    {
+        assert_eq!(request.requester_extension.as_str(), "github");
+        assert_eq!(request.provider.as_str(), "github");
+        Ok(RuntimeCredentialAccessSecret {
+            scope: self.source_scope.clone(),
+            handle: self.source_handle.clone(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn sandbox_credential_obligation_stages_bound_material_for_process_executor() {
+    let secret_store = Arc::new(SecretStore::ephemeral());
+    let secret_injections = Arc::new(RuntimeSecretInjectionStore::new());
+    let context = execution_context();
+    let capability_id =
+        CapabilityId::new(ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID).unwrap();
+    let source_handle = SecretHandle::new("github_access_token").unwrap();
+    let injection_handle = SecretHandle::new("github_runtime_token").unwrap();
+    secret_store
+        .put(
+            context.resource_scope.clone(),
+            source_handle.clone(),
+            SecretMaterial::from("github-secret"),
+            None,
+        )
+        .await
+        .unwrap();
+    let services = BuiltinObligationServices::with_handoff_stores(
+        Arc::new(InMemoryAuditSink::new()),
+        Arc::new(NetworkObligationPolicyStore::new()),
+        secret_store,
+        secret_injections.clone(),
+        Arc::new(InMemoryResourceGovernor::new()),
+    )
+    .with_credential_account_resolver(Arc::new(SandboxCredentialResolver {
+        source_scope: context.resource_scope.clone(),
+        source_handle,
+    }));
+    let audience = NetworkTargetPattern {
+        scheme: Some(NetworkScheme::Https),
+        host_pattern: "api.github.com".to_string(),
+        port: None,
+    };
+    let target = ironclaw_host_api::http::RuntimeCredentialTarget::Header {
+        name: "Authorization".to_string(),
+        prefix: Some("token ".to_string()),
+    };
+    let obligations = vec![Obligation::InjectSandboxCredentialAccountOnce {
+        handle: injection_handle.clone(),
+        provider: ironclaw_host_api::ids::VendorId::new("github").unwrap(),
+        setup: Default::default(),
+        provider_scopes: Vec::new(),
+        requester_extension: ironclaw_host_api::ids::ExtensionId::new("github").unwrap(),
+        required: true,
+        audience: audience.clone(),
+        target: target.clone(),
+    }];
+
+    services
+        .obligation_handler()
+        .satisfy(CapabilityObligationRequest {
+            phase: CapabilityObligationPhase::Invoke,
+            context: &context,
+            capability_id: &capability_id,
+            estimate: &ResourceEstimate::default(),
+            obligations: &obligations,
+        })
+        .await
+        .unwrap();
+
+    let (material, binding) = secret_injections
+        .take_bound(&context.resource_scope, &capability_id, &injection_handle)
+        .unwrap()
+        .expect("sandbox credential must be staged");
+    assert_eq!(
+        secrecy::ExposeSecret::expose_secret(&material),
+        "github-secret"
+    );
+    assert_eq!(
+        binding,
+        Some(RuntimeCredentialBindingPolicy { audience, target })
+    );
+}
+
 // #5459 tenant-shared credential resolution: a caller's own secret wins;
 // otherwise the tenant-shared admin-managed scope; otherwise absent.
 #[tokio::test]

--- a/crates/kernel/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/process_port.rs
@@ -94,6 +94,9 @@ impl UserSandboxProcessPort {
     pub fn new(transport: std::sync::Arc<dyn SandboxCommandTransport>) -> Self {
         Self { transport }
     }
+    pub(crate) fn transport(&self) -> std::sync::Arc<dyn SandboxCommandTransport> {
+        self.transport.clone()
+    }
 
     pub async fn shutdown(&self) -> Result<(), RuntimeProcessError> {
         self.transport.shutdown().await

--- a/crates/kernel/ironclaw_host_runtime/src/production.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/production.rs
@@ -29,9 +29,12 @@ use ironclaw_capabilities::{
 };
 use ironclaw_extension_registry::{ExtensionRegistry, SharedExtensionRegistry};
 use ironclaw_filesystem::RootFilesystem;
-use ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID;
 use ironclaw_host_api::{
     approval::sha256_digest_token,
+    capability::{
+        PROCESS_SANDBOX_CAPABILITY_ID, RuntimeCredentialRequirement,
+        RuntimeCredentialRequirementSource,
+    },
     decision::{DenyReason, RuntimeCredentialAuthRequirement},
     dispatch::{CapabilityDispatcher, provider_diagnostic_model_cause},
     ids::{ApprovalRequestId, CapabilityId, InvocationId, SecretHandle},
@@ -1037,6 +1040,68 @@ impl DefaultHostRuntime {
     }
 }
 
+fn resolve_invocation_runtime_credentials(
+    registry: &ExtensionRegistry,
+    capability_id: &CapabilityId,
+    input: &serde_json::Value,
+) -> Result<Vec<RuntimeCredentialRequirement>, String> {
+    if capability_id.as_str() != PROCESS_SANDBOX_CAPABILITY_ID {
+        return Ok(Vec::new());
+    }
+
+    let plan = serde_json::from_value::<SandboxProcessPlan>(input.clone())
+        .map_err(|error| format!("sandbox credential request is invalid: {error}"))?;
+    let plan = ValidatedSandboxProcessPlan::new(plan)
+        .map_err(|error| format!("sandbox credential request is invalid: {error}"))?;
+    let mut resolved = Vec::with_capacity(plan.credentials.len());
+
+    for binding in &plan.credentials {
+        let mut matched: Option<RuntimeCredentialRequirement> = None;
+        for declared in registry
+            .capabilities()
+            .flat_map(|descriptor| descriptor.runtime_credentials.iter())
+        {
+            if declared.handle != binding.handle
+                || !matches!(
+                    declared.source,
+                    RuntimeCredentialRequirementSource::ProductAuthAccount { .. }
+                )
+                || !declared
+                    .audience
+                    .host_pattern
+                    .eq_ignore_ascii_case(&binding.approved_host)
+                || declared.target != binding.target
+                || declared.required != binding.required
+            {
+                continue;
+            }
+
+            if let Some(existing) = &matched
+                && (existing.source != declared.source
+                    || existing.provider_scopes != declared.provider_scopes
+                    || existing.audience != declared.audience)
+            {
+                return Err(format!(
+                    "sandbox credential handle '{}' has conflicting host declarations",
+                    binding.handle
+                ));
+            }
+
+            matched = Some(declared.clone());
+        }
+
+        let Some(requirement) = matched else {
+            return Err(format!(
+                "sandbox credential handle '{}' is not declared for host '{}'",
+                binding.handle, binding.approved_host
+            ));
+        };
+        resolved.push(requirement);
+    }
+
+    Ok(resolved)
+}
+
 /// `DefaultHostRuntime` is the sole production implementor of the kernel's
 /// [`ironclaw_capabilities::HostPolicyFacts`] port (§5.3.2/§9). It surfaces
 /// host-mediated policy *facts* — never a verdict — that the capability kernel's
@@ -1047,10 +1112,18 @@ impl DefaultHostRuntime {
 /// - [`persistent_grants`](DefaultHostRuntime::persistent_grants) surfaces the
 ///   active persistent-approval grants (via the same scope × grantee fan-out the
 ///   former `apply_persistent_approval_policy` used). The kernel's `authorize()`
-///   fold owns the re-authorize loop that reads it and adopts the first grant
-///   that flips the decision to `Allow`.
+///   fold owns the re-authorize loop that reads it, adopts the first grant that
+///   flips the decision to `Allow`.
 #[async_trait]
 impl ironclaw_capabilities::HostPolicyFacts for DefaultHostRuntime {
+    async fn invocation_runtime_credentials(
+        &self,
+        capability_id: &CapabilityId,
+        input: &serde_json::Value,
+    ) -> Result<Vec<RuntimeCredentialRequirement>, String> {
+        let registry = self.registry.snapshot();
+        resolve_invocation_runtime_credentials(&registry, capability_id, input)
+    }
     async fn credential_presence(
         &self,
         capability_id: &CapabilityId,
@@ -1405,7 +1478,7 @@ fn stable_auth_gate_id(
             // `GateRecordAlreadyExists` and silently keeps the stale record, so
             // the runner reloads and renders the wrong authentication flow.
             format!(
-                "credential={}:{}:setup={}:{}",
+                "credential={}:extension:{}:setup={}:{}",
                 requirement.provider.as_str(),
                 requirement.requester_extension.as_str(),
                 stable_setup_token(&requirement.setup),
@@ -2648,16 +2721,8 @@ mod tests {
             "NetworkDenied must not be in the quiet-retry set"
         );
     }
-    // ─── capability_credential_requirements unit tests ──────────────────────────
-    //
-    // These were previously integration tests in host_runtime_services_contract.rs
-    // that called the function via `ironclaw_host_runtime::capability_credential_requirements`.
-    // They are kept here as unit tests because the function is now `pub(crate)`,
-    // making it invisible to external test binaries. Coverage is equivalent.
 
-    fn build_descriptor_for_manifest(
-        manifest_toml: &str,
-    ) -> ironclaw_host_api::capability::CapabilityDescriptor {
+    fn build_registry_for_manifest(manifest_toml: &str) -> ExtensionRegistry {
         let manifest = ExtensionManifest::parse(
             manifest_toml,
             ManifestSource::InstalledLocal,
@@ -2665,13 +2730,22 @@ mod tests {
             &capability_provider_contracts(),
         )
         .expect("manifest must parse");
-        let cap_id = manifest.capabilities[0].id.clone();
         let root =
             VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
         let package = ExtensionPackage::from_manifest(manifest, root).expect("package must build");
         let mut registry = ExtensionRegistry::new();
         registry.insert(package).unwrap();
-        registry.get_capability(&cap_id).unwrap().clone()
+        registry
+    }
+
+    fn build_descriptor_for_manifest(
+        manifest_toml: &str,
+    ) -> ironclaw_host_api::capability::CapabilityDescriptor {
+        build_registry_for_manifest(manifest_toml)
+            .capabilities()
+            .next()
+            .expect("fixture package must declare a capability")
+            .clone()
     }
 
     /// `capability_credential_requirements` must return exactly the required
@@ -2870,6 +2944,125 @@ required = true
             !credential_requirements.is_empty(),
             "a required product_auth_account credential must still surface in credential_requirements"
         );
+    }
+    fn sandbox_credential_registry() -> ExtensionRegistry {
+        const MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "credential-fixture"
+name = "Credential Fixture"
+version = "0.1.0"
+description = "Fixture with a product-auth runtime credential"
+trust = "untrusted"
+
+[runtime]
+kind = "script"
+runner = "sandboxed_process"
+command = "echo"
+args = []
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "credential-fixture.call"
+description = "Call the fixture provider"
+effects = ["dispatch_capability", "use_secret"]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/test/input.v1.json"
+output_schema_ref = "schemas/test/output.v1.json"
+prompt_doc_ref = "prompts/test.md"
+
+[[capability_provider.tools.capabilities.runtime_credentials]]
+handle = "fixture_runtime_token"
+source = { type = "product_auth_account", provider = "fixture-vendor" }
+audience = { scheme = "https", host_pattern = "api.example.com" }
+target = { type = "header", name = "authorization", prefix = "Bearer " }
+required = true
+"#;
+        build_registry_for_manifest(MANIFEST)
+    }
+
+    fn sandbox_credential_input(host: &str) -> serde_json::Value {
+        serde_json::json!({
+            "run": {
+                "command": "provider-cli",
+                "args": [],
+                "env": {
+                    "PROVIDER_TOKEN": "icsbx_test_placeholder"
+                }
+            },
+            "network": {
+                "runtime_hosts": [host],
+                "direct_egress_lockdown": true
+            },
+            "credentials": [{
+                "handle": "fixture_runtime_token",
+                "approved_host": host,
+                "target": {
+                    "type": "header",
+                    "name": "authorization",
+                    "prefix": "Bearer "
+                },
+                "placeholder_env": "PROVIDER_TOKEN",
+                "placeholder_value": "icsbx_test_placeholder",
+                "required": true
+            }]
+        })
+    }
+
+    #[test]
+    fn sandbox_invocation_credentials_resolve_from_extension_authority() {
+        let requirements = resolve_invocation_runtime_credentials(
+            &sandbox_credential_registry(),
+            &CapabilityId::new(PROCESS_SANDBOX_CAPABILITY_ID).unwrap(),
+            &sandbox_credential_input("api.example.com"),
+        )
+        .expect("declared sandbox credential resolves");
+
+        assert_eq!(requirements.len(), 1);
+        assert_eq!(requirements[0].handle.as_str(), "fixture_runtime_token");
+        assert!(requirements[0].required);
+        assert!(matches!(
+            &requirements[0].source,
+            RuntimeCredentialRequirementSource::ProductAuthAccount { provider, .. }
+                if provider.as_str() == "fixture-vendor"
+        ));
+        assert!(matches!(
+            &requirements[0].target,
+            ironclaw_host_api::http::RuntimeCredentialTarget::Header { name, prefix }
+                if name == "authorization" && prefix.as_deref() == Some("Bearer ")
+        ));
+    }
+
+    #[test]
+    fn sandbox_invocation_credentials_reject_undeclared_host() {
+        let error = resolve_invocation_runtime_credentials(
+            &sandbox_credential_registry(),
+            &CapabilityId::new(PROCESS_SANDBOX_CAPABILITY_ID).unwrap(),
+            &sandbox_credential_input("other.example.com"),
+        )
+        .expect_err("an undeclared credential audience must fail closed");
+
+        assert!(error.contains("is not declared for host"));
+    }
+
+    #[test]
+    fn sandbox_invocation_credentials_reject_undeclared_header_binding() {
+        let mut input = sandbox_credential_input("api.example.com");
+        input["credentials"][0]["target"]["name"] = serde_json::json!("X-GitHub-Token");
+
+        let error = resolve_invocation_runtime_credentials(
+            &sandbox_credential_registry(),
+            &CapabilityId::new(PROCESS_SANDBOX_CAPABILITY_ID).unwrap(),
+            &input,
+        )
+        .expect_err("a model-selected credential header must fail closed");
+
+        assert!(error.contains("is not declared for host"));
     }
 
     #[test]

--- a/crates/kernel/ironclaw_host_runtime/src/services.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services.rs
@@ -7,6 +7,7 @@
 //! lifecycle, and runtime execution semantics remain in their owning crates.
 
 mod process_executor;
+pub use process_executor::SandboxTransportProcessExecutor;
 
 use std::sync::{Arc, Mutex};
 
@@ -717,13 +718,16 @@ where
         }
         let dispatcher: Arc<dyn CapabilityDispatcher> = Arc::new(self.runtime_dispatcher());
         let process_runtime = self.process_services.process_runtime();
-        let process_executor = Arc::new(HostProcessExecutor::new(
-            Arc::new(RuntimeDispatchProcessExecutor::new(
-                Arc::clone(&dispatcher),
-                ironclaw_capabilities::process_authorization_remint_port(process_runtime),
-            )),
-            self.process_sandbox_executor.clone(),
-        ));
+        let process_executor = Arc::new(
+            HostProcessExecutor::new(
+                Arc::new(RuntimeDispatchProcessExecutor::new(
+                    Arc::clone(&dispatcher),
+                    ironclaw_capabilities::process_authorization_remint_port(process_runtime),
+                )),
+                self.process_sandbox_executor.clone(),
+            )
+            .with_secret_injection_store(Arc::clone(&self.secret_injection_store)),
+        );
         let result_failure_cleanup_store = Arc::clone(&lifecycle_process_store);
         let submission_lifecycle: Arc<dyn ironclaw_processes::ProcessSubmissionLifecycle> =
             lifecycle_process_store.clone();

--- a/crates/kernel/ironclaw_host_runtime/src/services/builder.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/builder.rs
@@ -518,6 +518,7 @@ where
         T: SecretStorePort + 'static,
     {
         self.component_types.secret_store = Some(ProductionComponentType::of::<T>());
+        let secret_store: Arc<dyn SecretStorePort> = secret_store;
         self.secret_store = Some(secret_store);
         self
     }
@@ -704,6 +705,11 @@ where
     where
         T: ProcessExecutor + 'static,
     {
+        self.process_sandbox_executor = Some(executor);
+        self
+    }
+
+    pub fn with_process_sandbox_executor_dyn(mut self, executor: Arc<dyn ProcessExecutor>) -> Self {
         self.process_sandbox_executor = Some(executor);
         self
     }

--- a/crates/kernel/ironclaw_host_runtime/src/services/process_executor.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/process_executor.rs
@@ -1,12 +1,25 @@
 use std::{sync::Arc, time::Instant};
 
+use crate::obligations::RuntimeSecretInjectionStore;
 use async_trait::async_trait;
 use ironclaw_capabilities::ProcessAuthorizationRemintPort;
-use ironclaw_host_api::{dispatch::CapabilityDispatcher, runtime::RuntimeKind};
+use ironclaw_host_api::{
+    action::NetworkScheme,
+    dispatch::CapabilityDispatcher,
+    http::RuntimeCredentialTarget,
+    process::{
+        CommandExecutionOutput, DirectSandboxCommandRequest, RuntimeProcessError,
+        SandboxCommandCredential, SandboxCommandTransport,
+    },
+    runtime::RuntimeKind,
+};
 use ironclaw_observability::live_latency_started_at;
 use ironclaw_processes::{
     ProcessExecutionError, ProcessExecutionRequest, ProcessExecutionResult, ProcessExecutor,
 };
+use ironclaw_sandbox::{SandboxCommandPlan, SandboxProcessPlan, ValidatedSandboxProcessPlan};
+use secrecy::ExposeSecret;
+use serde_json::json;
 
 struct ProcessLatencyFields {
     capability_id: String,
@@ -118,6 +131,7 @@ fn trace_process_latency_error<E: ?Sized>(
 pub(super) struct HostProcessExecutor {
     dispatch_executor: Arc<dyn ProcessExecutor>,
     process_sandbox_executor: Option<Arc<dyn ProcessExecutor>>,
+    secret_injection_store: Arc<RuntimeSecretInjectionStore>,
 }
 
 impl HostProcessExecutor {
@@ -128,7 +142,78 @@ impl HostProcessExecutor {
         Self {
             dispatch_executor,
             process_sandbox_executor,
+            secret_injection_store: Arc::new(RuntimeSecretInjectionStore::new()),
         }
+    }
+
+    pub(super) fn with_secret_injection_store(
+        mut self,
+        secret_injection_store: Arc<RuntimeSecretInjectionStore>,
+    ) -> Self {
+        self.secret_injection_store = secret_injection_store;
+        self
+    }
+
+    fn resolve_sandbox_credentials(
+        &self,
+        request: &ProcessExecutionRequest,
+    ) -> Result<Vec<SandboxCommandCredential>, ProcessExecutionError> {
+        if request
+            .input
+            .get("credentials")
+            .and_then(serde_json::Value::as_array)
+            .is_none_or(Vec::is_empty)
+        {
+            return Ok(Vec::new());
+        }
+        let plan = serde_json::from_value::<SandboxProcessPlan>(request.input.clone())
+            .map_err(|_| ProcessExecutionError::new("invalid_sandbox_process_plan"))?;
+        let plan = ValidatedSandboxProcessPlan::new(plan)
+            .map_err(|_| ProcessExecutionError::new("invalid_sandbox_process_plan"))?;
+        let mut credentials = Vec::with_capacity(plan.credentials.len());
+        for binding in &plan.credentials {
+            let placeholder_env = binding.placeholder_env.clone().ok_or_else(|| {
+                ProcessExecutionError::new("sandbox_credential_placeholder_env_required")
+            })?;
+            let RuntimeCredentialTarget::Header { name, prefix } = &binding.target else {
+                return Err(ProcessExecutionError::new(
+                    "sandbox_credential_target_unsupported",
+                ));
+            };
+            let (material, authorized_binding) = self
+                .secret_injection_store
+                .take_bound(&request.scope, &request.capability_id, &binding.handle)
+                .map_err(|_| ProcessExecutionError::new("sandbox_credential_handoff_failed"))?
+                .ok_or_else(|| ProcessExecutionError::new("sandbox_credential_unavailable"))?;
+            let authorized_binding = authorized_binding.ok_or_else(|| {
+                ProcessExecutionError::new("sandbox_credential_binding_unavailable")
+            })?;
+            let audience = &authorized_binding.audience;
+            if audience.scheme != Some(NetworkScheme::Https)
+                || audience.port.is_some_and(|port| port != 443)
+                || !audience
+                    .host_pattern
+                    .eq_ignore_ascii_case(&binding.approved_host)
+                || authorized_binding.target != binding.target
+            {
+                return Err(ProcessExecutionError::new(
+                    "sandbox_credential_binding_mismatch",
+                ));
+            }
+            credentials.push(SandboxCommandCredential::new(
+                placeholder_env,
+                format!(
+                    "{}{}",
+                    ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX,
+                    uuid::Uuid::new_v4().simple()
+                ),
+                binding.approved_host.clone(),
+                name.clone(),
+                prefix.clone(),
+                material.expose_secret().to_string(),
+            ));
+        }
+        Ok(credentials)
     }
 }
 
@@ -151,7 +236,10 @@ impl ProcessExecutor for HostProcessExecutor {
                 );
                 return Err(error);
             };
-            let result = executor.execute(request).await;
+            let credentials = self.resolve_sandbox_credentials(&request)?;
+            let result = executor
+                .execute_with_credentials(request, credentials)
+                .await;
             match &result {
                 Ok(_) => {
                     trace_process_latency_ok("host_process_execute", fields.as_ref(), started_at)
@@ -177,6 +265,155 @@ impl ProcessExecutor for HostProcessExecutor {
         }
         result
     }
+}
+
+/// Executes the typed `system.process_sandbox.run` plan through the configured
+/// sandbox transport without reparsing a shell command line.
+#[derive(Clone)]
+pub struct SandboxTransportProcessExecutor {
+    transport: Arc<dyn SandboxCommandTransport>,
+}
+
+impl SandboxTransportProcessExecutor {
+    pub fn new(transport: Arc<dyn SandboxCommandTransport>) -> Self {
+        Self { transport }
+    }
+
+    async fn execute_command(
+        &self,
+        request: &ProcessExecutionRequest,
+        command: &SandboxCommandPlan,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<CommandExecutionOutput, ProcessExecutionError> {
+        if request.cancellation.is_cancelled() {
+            return Err(ProcessExecutionError::new("sandbox_process_cancelled"));
+        }
+        let timeout_secs = command
+            .timeout_ms
+            .map(|timeout_ms| timeout_ms.div_ceil(1_000));
+        let mut extra_env = command.env.clone();
+        for credential in &credentials {
+            extra_env.insert(
+                credential.placeholder_env.clone(),
+                credential.placeholder.clone(),
+            );
+        }
+        let command_request = DirectSandboxCommandRequest {
+            scope: request.scope.clone(),
+            mounts: Some(request.mounts.clone()),
+            executable: command.command.clone(),
+            args: command.args.clone(),
+            workdir: command.working_dir.clone(),
+            timeout_secs,
+            extra_env,
+        };
+        self.transport
+            .run_credentialed_direct_command(command_request, credentials)
+            .await
+            .map_err(map_sandbox_process_error)
+    }
+}
+#[async_trait]
+impl ProcessExecutor for crate::UserSandboxProcessPort {
+    async fn execute(
+        &self,
+        request: ProcessExecutionRequest,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        SandboxTransportProcessExecutor::new(self.transport())
+            .execute(request)
+            .await
+    }
+
+    async fn execute_with_credentials(
+        &self,
+        request: ProcessExecutionRequest,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        SandboxTransportProcessExecutor::new(self.transport())
+            .execute_with_credentials(request, credentials)
+            .await
+    }
+}
+
+#[async_trait]
+impl ProcessExecutor for SandboxTransportProcessExecutor {
+    async fn execute(
+        &self,
+        request: ProcessExecutionRequest,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        self.execute_with_credentials(request, Vec::new()).await
+    }
+
+    async fn execute_with_credentials(
+        &self,
+        request: ProcessExecutionRequest,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        let plan = serde_json::from_value::<SandboxProcessPlan>(request.input.clone())
+            .map_err(|_| ProcessExecutionError::new("invalid_sandbox_process_plan"))?;
+        let plan = ValidatedSandboxProcessPlan::new(plan)
+            .map_err(|_| ProcessExecutionError::new("invalid_sandbox_process_plan"))?;
+        if plan.credentials.len() != credentials.len() {
+            return Err(ProcessExecutionError::new(
+                "sandbox_credential_handoff_mismatch",
+            ));
+        }
+
+        if let Some(install) = &plan.install {
+            let output = self
+                .execute_command(&request, &install.command, Vec::new())
+                .await?;
+            if output.exit_code != 0 {
+                return Err(ProcessExecutionError::new("sandbox_install_failed"));
+            }
+        }
+        let output = self
+            .execute_command(&request, &plan.run, credentials)
+            .await?;
+        Ok(ProcessExecutionResult {
+            output: json!({
+                "exit_code": output.exit_code,
+                "output": bounded_output(
+                    output.output,
+                    combined_output_limit(
+                        plan.run.max_stdout_bytes,
+                        plan.run.max_stderr_bytes,
+                    ),
+                ),
+                "duration_ms": output.duration.as_millis(),
+            }),
+        })
+    }
+}
+
+fn map_sandbox_process_error(error: RuntimeProcessError) -> ProcessExecutionError {
+    let kind = match error {
+        RuntimeProcessError::Timeout(_) => "sandbox_process_timeout",
+        RuntimeProcessError::ExecutionFailed(_) => "sandbox_process_execution_failed",
+    };
+    ProcessExecutionError::new(kind)
+}
+
+fn combined_output_limit(stdout: Option<u64>, stderr: Option<u64>) -> Option<u64> {
+    match (stdout, stderr) {
+        (Some(stdout), Some(stderr)) => stdout.checked_add(stderr),
+        (Some(limit), None) | (None, Some(limit)) => Some(limit),
+        (None, None) => None,
+    }
+}
+
+fn bounded_output(output: String, max_bytes: Option<u64>) -> String {
+    let Some(max_bytes) = max_bytes.and_then(|value| usize::try_from(value).ok()) else {
+        return output;
+    };
+    if output.len() <= max_bytes {
+        return output;
+    }
+    let mut boundary = max_bytes;
+    while !output.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    output[..boundary].to_string()
 }
 
 fn is_process_sandbox_request(request: &ProcessExecutionRequest) -> bool {
@@ -271,7 +508,8 @@ mod tests {
         },
         ids::{
             ActivityId, AgentId, CapabilityId, CorrelationId, ExtensionId, InvocationId, ProcessId,
-            ProductKind, ProjectId, ResourceReservationId, TenantId, ThreadId, UserId,
+            ProductKind, ProjectId, ResourceReservationId, SecretHandle, TenantId, ThreadId,
+            UserId,
         },
         invocation::{Actor, InvocationOrigin},
         lane::RuntimeLane,
@@ -319,6 +557,266 @@ mod tests {
                 output: json!({ "executor": self.label }),
             })
         }
+    }
+
+    #[derive(Default)]
+    struct RecordingSandboxCommandTransport {
+        direct_requests: Mutex<Vec<(DirectSandboxCommandRequest, Vec<SandboxCommandCredential>)>>,
+    }
+
+    #[async_trait]
+    impl SandboxCommandTransport for RecordingSandboxCommandTransport {
+        async fn run_command(
+            &self,
+            _request: ironclaw_host_api::process::CommandExecutionRequest,
+        ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+            Err(RuntimeProcessError::ExecutionFailed(
+                "legacy command execution is not used by the sandbox process executor".to_string(),
+            ))
+        }
+
+        async fn run_credentialed_direct_command(
+            &self,
+            request: DirectSandboxCommandRequest,
+            credentials: Vec<SandboxCommandCredential>,
+        ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+            let credentialed = !credentials.is_empty();
+            self.direct_requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push((request, credentials));
+            Ok(CommandExecutionOutput {
+                output: if credentialed {
+                    "credentialed".to_string()
+                } else {
+                    "hello".to_string()
+                },
+                saved_output: None,
+                exit_code: if credentialed { 0 } else { 7 },
+                sandboxed: true,
+                duration: if credentialed {
+                    std::time::Duration::from_millis(5)
+                } else {
+                    std::time::Duration::from_millis(12)
+                },
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn user_sandbox_process_executor_runs_validated_plan_with_direct_arguments() {
+        let transport = Arc::new(RecordingSandboxCommandTransport::default());
+        let executor = SandboxTransportProcessExecutor::new(transport.clone());
+        let mut request = sample_process_request(
+            ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID,
+            RuntimeKind::System,
+        );
+        request.input = json!({
+            "run": {
+                "command": "printf",
+                "args": ["%s", "hello"],
+                "max_stdout_bytes": 3,
+                "max_stderr_bytes": 2
+            }
+        });
+
+        let result = executor.execute(request).await.unwrap();
+
+        assert_eq!(
+            result.output,
+            json!({
+                "exit_code": 7,
+                "output": "hello",
+                "duration_ms": 12
+            })
+        );
+        let requests = transport
+            .direct_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].0.executable, "printf");
+        assert_eq!(requests[0].0.args, ["%s", "hello"]);
+    }
+
+    #[tokio::test]
+    async fn host_process_executor_consumes_staged_credential_without_exposing_it_to_command_env() {
+        let transport = Arc::new(RecordingSandboxCommandTransport::default());
+        let sandbox = Arc::new(SandboxTransportProcessExecutor::new(transport.clone()));
+        let store = Arc::new(RuntimeSecretInjectionStore::new());
+        let mut request = sample_process_request(
+            ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID,
+            RuntimeKind::System,
+        );
+        request.input = json!({
+            "run": {
+                "command": "gh",
+                "args": ["pr", "list"],
+                "env": {"GH_TOKEN": "model-value-is-not-authority"}
+            },
+            "network": {
+                "runtime_hosts": ["api.github.com"],
+                "direct_egress_lockdown": true
+            },
+            "credentials": [{
+                "handle": "github_runtime_token",
+                "approved_host": "api.github.com",
+                "target": {
+                    "type": "header",
+                    "name": "Authorization",
+                    "prefix": "token "
+                },
+                "placeholder_env": "GH_TOKEN",
+                "placeholder_value": "model-value-is-not-authority",
+                "required": true
+            }]
+        });
+        let handle = SecretHandle::new("github_runtime_token").unwrap();
+        store
+            .insert_bound(
+                &request.scope,
+                &request.capability_id,
+                &handle,
+                ironclaw_secrets::SecretMaterial::from("github-secret"),
+                crate::obligations::RuntimeCredentialBindingPolicy {
+                    audience: ironclaw_host_api::action::NetworkTargetPattern {
+                        scheme: Some(NetworkScheme::Https),
+                        host_pattern: "api.github.com".to_string(),
+                        port: None,
+                    },
+                    target: RuntimeCredentialTarget::Header {
+                        name: "Authorization".to_string(),
+                        prefix: Some("token ".to_string()),
+                    },
+                },
+            )
+            .unwrap();
+        let executor = HostProcessExecutor::new(
+            Arc::new(RecordingProcessExecutor::new("dispatch")),
+            Some(sandbox),
+        )
+        .with_secret_injection_store(store.clone());
+
+        executor.execute(request.clone()).await.unwrap();
+
+        let calls = transport
+            .direct_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(calls.len(), 1);
+        let (command, credentials) = &calls[0];
+        assert_eq!(command.executable, "gh");
+        assert_eq!(command.args, ["pr", "list"]);
+        let placeholder = command.extra_env.get("GH_TOKEN").unwrap();
+        assert!(placeholder.starts_with(ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX));
+        assert_ne!(placeholder, "model-value-is-not-authority");
+        assert_ne!(placeholder, "github-secret");
+        assert_eq!(credentials.len(), 1);
+        assert_eq!(credentials[0].placeholder, *placeholder);
+        assert_eq!(credentials[0].approved_host, "api.github.com");
+        assert_eq!(credentials[0].header_name, "Authorization");
+        assert_eq!(credentials[0].expose_secret(), "github-secret");
+        drop(calls);
+        assert!(
+            store
+                .take(&request.scope, &request.capability_id, &handle)
+                .unwrap()
+                .is_none(),
+            "the staged credential must be one-shot"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_process_executor_rejects_model_credential_binding_mismatch() {
+        let transport = Arc::new(RecordingSandboxCommandTransport::default());
+        let sandbox = Arc::new(SandboxTransportProcessExecutor::new(transport.clone()));
+        let store = Arc::new(RuntimeSecretInjectionStore::new());
+        let mut request = sample_process_request(
+            ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID,
+            RuntimeKind::System,
+        );
+        request.input = json!({
+            "run": {
+                "command": "gh",
+                "args": ["pr", "list"],
+                "env": {"GH_TOKEN": "model-value-is-not-authority"}
+            },
+            "network": {
+                "runtime_hosts": ["api.github.com"],
+                "direct_egress_lockdown": true
+            },
+            "credentials": [{
+                "handle": "github_runtime_token",
+                "approved_host": "api.github.com",
+                "target": {
+                    "type": "header",
+                    "name": "Authorization",
+                    "prefix": "Bearer "
+                },
+                "placeholder_env": "GH_TOKEN",
+                "placeholder_value": "model-value-is-not-authority",
+                "required": true
+            }]
+        });
+        let handle = SecretHandle::new("github_runtime_token").unwrap();
+        store
+            .insert_bound(
+                &request.scope,
+                &request.capability_id,
+                &handle,
+                ironclaw_secrets::SecretMaterial::from("github-secret"),
+                crate::obligations::RuntimeCredentialBindingPolicy {
+                    audience: ironclaw_host_api::action::NetworkTargetPattern {
+                        scheme: Some(NetworkScheme::Https),
+                        host_pattern: "api.github.com".to_string(),
+                        port: None,
+                    },
+                    target: RuntimeCredentialTarget::Header {
+                        name: "X-GitHub-Token".to_string(),
+                        prefix: None,
+                    },
+                },
+            )
+            .unwrap();
+        let executor = HostProcessExecutor::new(
+            Arc::new(RecordingProcessExecutor::new("dispatch")),
+            Some(sandbox),
+        )
+        .with_secret_injection_store(store);
+
+        let error = executor.execute(request).await.unwrap_err();
+
+        assert_eq!(error.kind, "sandbox_credential_binding_mismatch");
+        assert!(
+            transport
+                .direct_requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn sandbox_process_executor_rejects_cancelled_request_before_transport() {
+        let transport = Arc::new(RecordingSandboxCommandTransport::default());
+        let executor = SandboxTransportProcessExecutor::new(transport.clone());
+        let mut request = sample_process_request(
+            ironclaw_host_api::capability::PROCESS_SANDBOX_CAPABILITY_ID,
+            RuntimeKind::System,
+        );
+        request.input = json!({"run": {"command": "true"}});
+        request.cancellation.cancel();
+
+        let error = executor.execute(request).await.unwrap_err();
+
+        assert_eq!(error.kind, "sandbox_process_cancelled");
+        assert!(
+            transport
+                .direct_requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty()
+        );
     }
 
     fn dispatch_result() -> CapabilityDispatchResult {

--- a/crates/kernel/ironclaw_processes/src/types.rs
+++ b/crates/kernel/ironclaw_processes/src/types.rs
@@ -16,6 +16,7 @@ use ironclaw_host_api::{
     },
     mount::MountView,
     path::VirtualPath,
+    process::SandboxCommandCredential,
     resource::{ResourceEstimate, ResourceReservation, ResourceScope},
     runtime::RuntimeKind,
 };
@@ -247,6 +248,22 @@ pub trait ProcessExecutor: Send + Sync {
         &self,
         request: ProcessExecutionRequest,
     ) -> Result<ProcessExecutionResult, ProcessExecutionError>;
+
+    /// Runs a process with one-shot host-staged sandbox credentials.
+    ///
+    /// Executors that do not implement the credential boundary fail closed.
+    async fn execute_with_credentials(
+        &self,
+        request: ProcessExecutionRequest,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        if !credentials.is_empty() {
+            return Err(ProcessExecutionError::new(
+                "sandbox_credentials_not_supported",
+            ));
+        }
+        self.execute(request).await
+    }
 }
 
 #[async_trait]

--- a/crates/lanes/ironclaw_sandbox/Cargo.toml
+++ b/crates/lanes/ironclaw_sandbox/Cargo.toml
@@ -27,6 +27,7 @@ ironclaw_safety = { path = "../../substrates/ironclaw_safety" }
 ironclaw_secrets = { path = "../../substrates/ironclaw_secrets" }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.11"
+secrecy = "0.10"
 serde_json = "1"
 thiserror = "2"
 tar = "0.4"

--- a/crates/lanes/ironclaw_sandbox/README.md
+++ b/crates/lanes/ironclaw_sandbox/README.md
@@ -27,9 +27,9 @@ the point of the crate.
   credentialed-run phases stay separate.
 - Execution machinery: `RebornScopedSandboxCommandTransport` (implements the
   `ironclaw_host_api::process::SandboxCommandTransport` port — contracts
-  vocabulary this lane implements and the kernel consumes),
-  `RebornSandboxConfig`, the broker/firewall/CA/identity types
-  (`sandbox_process`).
+  vocabulary this lane implements and the kernel consumes), direct executable
+  plus argument-vector dispatch, invocation cancellation, `RebornSandboxConfig`,
+  and the broker/firewall/CA/identity types (`sandbox_process`).
 - Script lane: `ScriptRuntime`, `ScriptExecutor`/`ScriptBackend`,
   `DockerScriptBackend`, `ScriptRuntimeHttpAdapter`, normalized
   request/result/error types (`script`).
@@ -122,9 +122,11 @@ explicit host broker or managed-egress binding.
 
 - **Typed plans only:** no raw container flags, host paths, environment
   inheritance, or secret material through plan input (`plan`/`validation`).
-- **Credential firewall as a staging chokepoint:** an invocation consumes only
-  the credential it was already entitled to; consumers see yes/no, never
-  material. The per-tenant CA root key never touches disk and is never
+- **Credential firewall as a staging chokepoint:** the capability kernel derives
+  each invocation's credential authority from active extension declarations,
+  then stages only handle-bound material for the sandbox transport. The command
+  receives a placeholder; only the private proxy can replace it for the approved
+  host and header. The per-tenant CA root key never touches disk and is never
   serialized to a caller.
 - **Fail closed on missing containment:** a served multi-user deployment must
   never resolve to an unsandboxed host-process backend; a missing backend

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process.rs
@@ -7,7 +7,7 @@
 //! different users to run in parallel.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Component, Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -20,10 +20,12 @@ use bollard::{
     models::{HostConfig, HostConfigLogConfig},
 };
 use fs2::FileExt;
-use ironclaw_host_api::resource::ResourceScope;
-
-use ironclaw_host_api::process::{
-    CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, SandboxCommandTransport,
+use ironclaw_host_api::{
+    process::{
+        CommandExecutionOutput, CommandExecutionRequest, DirectSandboxCommandRequest,
+        RuntimeProcessError, SandboxCommandCredential, SandboxCommandTransport,
+    },
+    resource::ResourceScope,
 };
 
 mod broker;
@@ -41,6 +43,7 @@ pub(crate) mod shell_limits;
 mod user_container;
 mod worker_spec;
 
+use crate::validation::{validate_env_has_no_raw_sensitive_values, validate_env_name};
 use managed_egress::{ManagedEgressBundle, ManagedEgressConfig, ManagedEgressRuntime};
 
 // `user_key` is the shared per-user workspace and local Docker container
@@ -281,13 +284,19 @@ impl RebornSandboxConfig {
     fn command_env_for_bundle(
         &self,
         extra_env: HashMap<String, String>,
+        credentials: &[SandboxCommandCredential],
         managed: Option<&ManagedEgressRuntime>,
         bundle: Option<&ManagedEgressBundle>,
     ) -> Result<Vec<String>, RuntimeProcessError> {
         let (Some(managed), Some(bundle)) = (managed, bundle) else {
             return self.command_env(extra_env);
         };
-        let mut env = validate_env(&extra_env)?;
+        validate_credential_env(&extra_env, credentials)?;
+        let mut env = extra_env
+            .into_iter()
+            .map(|(name, value)| format!("{name}={value}"))
+            .collect::<Vec<_>>();
+        env.sort();
         broker::push_broker_env(None, self.secret_broker.as_ref(), &mut env)?;
         let mode_prefix = format!("{}=", broker::REBORN_NETWORK_MODE_ENV);
         env.retain(|entry| !entry.starts_with(&mode_prefix));
@@ -374,6 +383,43 @@ pub struct RebornScopedSandboxCommandTransport {
     managed_egress: Option<Arc<ManagedEgressRuntime>>,
     sweeper: Arc<user_container::UserContainerSweeper>,
     _owner_lock: Arc<LocalDockerOwnerLock>,
+}
+struct SandboxExecutionRequest {
+    scope: ResourceScope,
+    mounts: Option<ironclaw_host_api::mount::MountView>,
+    executable: String,
+    args: Vec<String>,
+    workdir: Option<String>,
+    timeout_secs: Option<u64>,
+    extra_env: HashMap<String, String>,
+}
+
+impl From<CommandExecutionRequest> for SandboxExecutionRequest {
+    fn from(request: CommandExecutionRequest) -> Self {
+        Self {
+            scope: request.scope,
+            mounts: request.mounts,
+            executable: "sh".to_string(),
+            args: vec!["-c".to_string(), request.command],
+            workdir: request.workdir,
+            timeout_secs: request.timeout_secs,
+            extra_env: request.extra_env,
+        }
+    }
+}
+
+impl From<DirectSandboxCommandRequest> for SandboxExecutionRequest {
+    fn from(request: DirectSandboxCommandRequest) -> Self {
+        Self {
+            scope: request.scope,
+            mounts: request.mounts,
+            executable: request.executable,
+            args: request.args,
+            workdir: request.workdir,
+            timeout_secs: request.timeout_secs,
+            extra_env: request.extra_env,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -533,17 +579,21 @@ impl RebornScopedSandboxCommandTransport {
 
     fn user_container_launch_config(
         &self,
-        request: &CommandExecutionRequest,
+        scope: &ResourceScope,
         resolved_image: &str,
         bundle: Option<&ManagedEgressBundle>,
         container_user: String,
-        binds: Vec<String>,
+        mut binds: Vec<String>,
     ) -> Result<user_container::UserContainerLaunch, RuntimeProcessError> {
         let env = self.config.command_env_for_bundle(
-            request.extra_env.clone(),
+            HashMap::new(),
+            &[],
             self.managed_egress.as_deref(),
             bundle,
         )?;
+        if let (Some(managed), Some(bundle)) = (self.managed_egress.as_deref(), bundle) {
+            binds.push(managed.user_ca_bind(bundle)?);
+        }
         let security = worker_spec::DockerWorkerSecuritySpec::new(
             self.config.managed_container_network_mode(bundle),
         );
@@ -557,8 +607,8 @@ impl RebornScopedSandboxCommandTransport {
         );
         let labels = registry::build_user_container_launch_labels(
             user_container::LABEL_PREFIX,
-            &request.scope.tenant_id,
-            &request.scope.user_id,
+            &scope.tenant_id,
+            &scope.user_id,
             resolved_image,
             &posture,
         );
@@ -599,9 +649,10 @@ impl RebornScopedSandboxCommandTransport {
 
     async fn run_command_owned(
         self,
-        request: CommandExecutionRequest,
+        request: SandboxExecutionRequest,
+        credentials: Vec<SandboxCommandCredential>,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
-        reject_nul("sandbox command", &request.command)?;
+        reject_nul("sandbox executable", &request.executable)?;
         let user_key = RebornSandboxUserKey::from_scope(&request.scope);
         let workdir = Self::resolve_container_workdir(request.workdir.as_deref())?;
         let timeout = request
@@ -611,8 +662,11 @@ impl RebornScopedSandboxCommandTransport {
         if timeout.is_zero() {
             return Err(RuntimeProcessError::Timeout(timeout));
         }
+        for argument in &request.args {
+            reject_nul("sandbox command argument", argument)?;
+        }
         user_container::exec_helper_timeout_secs(timeout)?;
-        validate_env(&request.extra_env)?;
+        validate_credential_env(&request.extra_env, &credentials)?;
         let workspace = self.prepare_workspace(&request.scope).await?;
         let container_user = self
             .config
@@ -656,9 +710,14 @@ impl RebornScopedSandboxCommandTransport {
                 managed
                     .set_invocation(bundle, &request.scope.invocation_id)
                     .await?;
+                if !credentials.is_empty() {
+                    managed
+                        .configure_credentials(&self.docker, bundle, &credentials)
+                        .await?;
+                }
             }
             let launch = self.user_container_launch_config(
-                &request,
+                &request.scope,
                 &resolved_image,
                 bundle.as_ref(),
                 container_user,
@@ -667,7 +726,8 @@ impl RebornScopedSandboxCommandTransport {
             let container_name =
                 user_container::ensure_user_container(&self, &user_key, launch).await?;
             let exec_env = self.config.command_env_for_bundle(
-                HashMap::new(),
+                request.extra_env.clone(),
+                &credentials,
                 self.managed_egress.as_deref(),
                 bundle.as_ref(),
             )?;
@@ -697,14 +757,30 @@ impl RebornScopedSandboxCommandTransport {
             &self,
             &user_key,
             &container_name,
-            request.command,
-            workdir,
-            exec_env,
-            timeout,
+            user_container::UserContainerCommand {
+                command: request.executable,
+                args: request.args,
+                workdir,
+                env: exec_env,
+                timeout,
+            },
         )
         .await;
+        let cleanup = match (self.managed_egress.as_ref(), bundle.as_ref()) {
+            (Some(managed), Some(bundle)) if !credentials.is_empty() => {
+                managed.clear_credentials(&self.docker, bundle).await
+            }
+            _ => Ok(()),
+        };
         drop(activity);
-        result
+        match (result, cleanup) {
+            (Ok(output), Ok(())) => Ok(output),
+            (Err(error), Ok(())) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+            (Err(error), Err(cleanup_error)) => Err(RuntimeProcessError::ExecutionFailed(format!(
+                "{error}; sandbox credential cleanup failed: {cleanup_error}"
+            ))),
+        }
     }
 }
 
@@ -728,10 +804,34 @@ impl SandboxCommandTransport for RebornScopedSandboxCommandTransport {
         &self,
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
-        let execution = tokio::spawn(self.clone().run_command_owned(request));
+        let execution = tokio::spawn(
+            self.clone()
+                .run_command_owned(SandboxExecutionRequest::from(request), Vec::new()),
+        );
         execution.await.map_err(|error| {
             RuntimeProcessError::ExecutionFailed(format!(
                 "sandbox command execution task failed: {error}"
+            ))
+        })?
+    }
+
+    async fn run_credentialed_direct_command(
+        &self,
+        request: DirectSandboxCommandRequest,
+        credentials: Vec<SandboxCommandCredential>,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        if self.managed_egress.is_none() {
+            return Err(RuntimeProcessError::ExecutionFailed(
+                "sandbox transport requires managed egress for credential bindings".to_string(),
+            ));
+        }
+        let execution = tokio::spawn(
+            self.clone()
+                .run_command_owned(SandboxExecutionRequest::from(request), credentials),
+        );
+        execution.await.map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox credentialed command execution task failed: {error}"
             ))
         })?
     }
@@ -850,12 +950,65 @@ fn reject_nul(label: &str, value: &str) -> Result<(), RuntimeProcessError> {
 }
 
 fn validate_env(env: &HashMap<String, String>) -> Result<Vec<String>, RuntimeProcessError> {
-    if !env.is_empty() {
-        return Err(RuntimeProcessError::ExecutionFailed(
-            "user sandbox commands do not accept caller-provided environment variables".to_string(),
-        ));
+    validate_environment_entries(env, &[])?;
+    let mut rendered = env
+        .iter()
+        .map(|(name, value)| format!("{name}={value}"))
+        .collect::<Vec<_>>();
+    rendered.sort();
+    Ok(rendered)
+}
+
+fn validate_credential_env(
+    env: &HashMap<String, String>,
+    credentials: &[SandboxCommandCredential],
+) -> Result<(), RuntimeProcessError> {
+    let placeholders = credentials
+        .iter()
+        .map(|credential| credential.placeholder.as_str())
+        .collect::<Vec<_>>();
+    validate_environment_entries(env, &placeholders)?;
+
+    let mut names = HashSet::with_capacity(credentials.len());
+    for credential in credentials {
+        if credential.placeholder_env.is_empty()
+            || credential.placeholder_env.contains(['=', '\0'])
+            || credential.placeholder.contains('\0')
+            || !names.insert(credential.placeholder_env.as_str())
+            || !credential
+                .placeholder
+                .starts_with(ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX)
+            || env.get(&credential.placeholder_env) != Some(&credential.placeholder)
+        {
+            return Err(RuntimeProcessError::ExecutionFailed(
+                "sandbox credential placeholders must match credential bindings".to_string(),
+            ));
+        }
     }
-    Ok(Vec::new())
+    Ok(())
+}
+
+fn validate_environment_entries(
+    env: &HashMap<String, String>,
+    allowed_placeholders: &[&str],
+) -> Result<(), RuntimeProcessError> {
+    for (name, value) in env {
+        validate_env_name(name).map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox command environment is invalid: {error}"
+            ))
+        })?;
+        if value.contains('\0') {
+            return Err(RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox command environment is invalid for {name}"
+            )));
+        }
+    }
+    validate_env_has_no_raw_sensitive_values(env, allowed_placeholders).map_err(|error| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "sandbox command environment is invalid: {error}"
+        ))
+    })
 }
 
 fn validate_relative_workdir(path: &Path) -> Result<(), RuntimeProcessError> {
@@ -880,6 +1033,10 @@ mod tests {
         mount::{MountGrant, MountPermissions, MountView},
         path::{MountAlias, VirtualPath},
     };
+    fn inert_docker_client() -> Docker {
+        Docker::connect_with_http("http://127.0.0.1:9", 1, bollard::API_DEFAULT_VERSION)
+            .expect("construct inert Docker test client")
+    }
 
     #[test]
     fn transport_constructor_uses_canonical_bounded_docker_connector() {
@@ -908,11 +1065,42 @@ mod tests {
 
     #[test]
     fn test_constructor_works_without_tokio_runtime() {
-        let docker = Docker::connect_with_local_defaults().expect("construct Docker client");
+        let docker = inert_docker_client();
         let _transport = test_support::transport(
             docker,
             RebornSandboxConfig::new("/tmp/reborn-sandbox-pure-constructor"),
         );
+    }
+    #[test]
+    fn command_environment_accepts_valid_non_sensitive_values() {
+        let env = HashMap::from([
+            ("RUST_LOG".to_string(), "debug".to_string()),
+            ("FEATURE_FLAG".to_string(), "enabled".to_string()),
+        ]);
+
+        assert_eq!(
+            validate_env(&env).unwrap(),
+            ["FEATURE_FLAG=enabled", "RUST_LOG=debug"]
+        );
+    }
+
+    #[test]
+    fn credential_environment_allows_benign_values_beside_bound_placeholders() {
+        let placeholder = format!("{}test", ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX);
+        let env = HashMap::from([
+            ("GH_TOKEN".to_string(), placeholder.clone()),
+            ("RUST_LOG".to_string(), "debug".to_string()),
+        ]);
+        let credentials = [SandboxCommandCredential::new(
+            "GH_TOKEN".to_string(),
+            placeholder,
+            "api.github.com".to_string(),
+            "Authorization".to_string(),
+            Some("token ".to_string()),
+            "secret".to_string(),
+        )];
+
+        validate_credential_env(&env, &credentials).unwrap();
     }
 
     #[tokio::test]
@@ -1017,14 +1205,36 @@ mod tests {
     }
 
     #[test]
-    fn validate_env_rejects_all_caller_environment_injection() {
-        let error = validate_env(&HashMap::from([(
-            "PLACEHOLDER".to_string(),
-            "value".to_string(),
-        )]))
-        .unwrap_err();
-        assert!(error.to_string().contains("caller-provided environment"));
-        assert_eq!(validate_env(&HashMap::new()).unwrap(), Vec::<String>::new());
+    fn validate_credential_env_accepts_valid_caller_values_and_bound_placeholders() {
+        let caller_env = HashMap::from([("FEATURE_FLAG".to_string(), "enabled".to_string())]);
+        assert_eq!(validate_credential_env(&caller_env, &[]), Ok(()));
+        assert_eq!(validate_credential_env(&HashMap::new(), &[]), Ok(()));
+
+        let placeholder = format!("{}test", ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX);
+        let credential = SandboxCommandCredential::new(
+            "GH_TOKEN".to_string(),
+            placeholder.clone(),
+            "api.github.com".to_string(),
+            "Authorization".to_string(),
+            Some("Bearer ".to_string()),
+            "real-secret".to_string(),
+        );
+        let bound_env = HashMap::from([("GH_TOKEN".to_string(), placeholder.clone())]);
+        assert_eq!(
+            validate_credential_env(&bound_env, std::slice::from_ref(&credential)),
+            Ok(())
+        );
+
+        let wrong_placeholder =
+            HashMap::from([("GH_TOKEN".to_string(), "caller-value".to_string())]);
+        assert!(
+            validate_credential_env(&wrong_placeholder, std::slice::from_ref(&credential)).is_err()
+        );
+        let extra_env = HashMap::from([
+            ("GH_TOKEN".to_string(), placeholder),
+            ("UNBOUND".to_string(), "value".to_string()),
+        ]);
+        assert_eq!(validate_credential_env(&extra_env, &[credential]), Ok(()));
     }
 
     #[test]
@@ -1098,15 +1308,13 @@ mod tests {
             .with_secret_broker_url("https://broker.internal/secrets")
             .unwrap();
         for key in broker::RESERVED_BROKER_ENV_KEYS {
-            let error = config
-                .command_env(HashMap::from([(
-                    (*key).to_string(),
-                    "caller-controlled".to_string(),
-                )]))
-                .unwrap_err();
-
             assert!(
-                format!("{error}").contains("caller-provided environment"),
+                config
+                    .command_env(HashMap::from([(
+                        (*key).to_string(),
+                        "caller-controlled".to_string(),
+                    )]))
+                    .is_err(),
                 "{key}"
             );
         }
@@ -1138,8 +1346,7 @@ mod tests {
             .unwrap()
             .with_secret_broker_unix_socket(&secret_socket)
             .unwrap();
-        let transport =
-            test_support::transport(Docker::connect_with_local_defaults().unwrap(), config);
+        let transport = test_support::transport(inert_docker_client(), config);
         // Config-shape tests inject an immutable identity directly; only the
         // real run path resolves the configured reference through Docker.
         let container_user = transport
@@ -1161,14 +1368,7 @@ mod tests {
         binds.sort();
         let launch = transport
             .user_container_launch_config(
-                &CommandExecutionRequest {
-                    scope: sandbox_scope(),
-                    mounts: None,
-                    command: "true".to_string(),
-                    workdir: None,
-                    timeout_secs: Some(1),
-                    extra_env: HashMap::new(),
-                },
+                &sandbox_scope(),
                 "sha256:test-worker",
                 None,
                 container_user,
@@ -1263,7 +1463,7 @@ mod tests {
     #[tokio::test]
     async fn run_command_rejects_unconfigured_scoped_mount_before_container_create() {
         let temp = tempfile::tempdir().unwrap();
-        let docker = Docker::connect_with_local_defaults().unwrap();
+        let docker = inert_docker_client();
         let transport = test_support::transport(
             docker,
             RebornSandboxConfig::new(temp.path().join("workspaces")),

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/ca.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/ca.rs
@@ -4,10 +4,9 @@
 //! Generates a root key/cert pair in memory at construction and signs
 //! short-lived leaf certificates for the older host-mediated credential
 //! firewall path. The public root certificate can be installed in an
-//! untrusted user container. This module never serializes or exports the root
-//! private key.
-//!
-//! Managed egress uses the upstream proxy's own leaf issuance instead.
+//! untrusted user container. Managed egress may serialize the root key only
+//! into its proxy-private material directory so the trusted proxy can issue
+//! leaves; the key is never exposed to the user container or logs.
 
 use std::{
     collections::HashMap,
@@ -19,6 +18,7 @@ use rcgen::{
     BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
     KeyUsagePurpose,
 };
+use secrecy::SecretString;
 use time::{Duration as CertValidityDuration, OffsetDateTime};
 
 use ironclaw_host_api::process::RuntimeProcessError;
@@ -190,14 +190,18 @@ impl SandboxCertificateAuthority {
         })
     }
 
-    /// The CA's public trust anchor — the only artifact of this CA meant
-    /// to reach a container (read-only bind-mount + `SSL_CERT_FILE` and
-    /// friends is W5's remaining trust-distribution work). Contains no
-    /// private key material; see this module's
-    /// `root_certificate_pem_never_contains_key_material` test.
-    #[allow(dead_code)] // consumed by W6; not wired yet
+    /// The CA's public trust anchor. Managed egress binds this file read-only
+    /// into the user container and points common TLS clients at it.
     pub(crate) fn root_certificate_pem(&self) -> &str {
         &self.root_cert_pem
+    }
+
+    /// The signing key consumed only by the trusted proxy sidecar.
+    ///
+    /// Wrapping the serialized value keeps debug output redacted and zeroizes
+    /// the allocation when the caller finishes writing its private material.
+    pub(crate) fn proxy_private_key_pem(&self) -> SecretString {
+        SecretString::new(self.issuer.key().serialize_pem().into_boxed_str())
     }
 
     /// Returns a leaf certificate for `host`: a live cached one if present,

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/managed_egress.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/managed_egress.rs
@@ -5,12 +5,14 @@ use std::{
     time::Duration,
 };
 
-use super::{registry, user_key::RebornSandboxUserKey, worker_spec};
+use super::{
+    ca::SandboxCertificateAuthority, registry, user_key::RebornSandboxUserKey, worker_spec,
+};
 use bollard::{
     Docker,
     container::{
         Config, CreateContainerOptions, InspectContainerOptions, ListContainersOptions,
-        LogsOptions, RemoveContainerOptions, StartContainerOptions,
+        LogsOptions, RemoveContainerOptions, RestartContainerOptions, StartContainerOptions,
     },
     image::CreateImageOptions,
     models::{HealthConfig, HealthStatusEnum, HostConfig, HostConfigLogConfig},
@@ -24,8 +26,9 @@ use ironclaw_common::env_helpers::env_or_override;
 use ironclaw_host_api::{
     action::NetworkPolicy,
     ids::{InvocationId, TenantId, UserId},
-    process::RuntimeProcessError,
+    process::{RuntimeProcessError, SandboxCommandCredential},
 };
+use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
 pub(super) const PROXY_LABEL_PREFIX: &str = "ironclaw.proxy";
 pub(super) const NETWORK_LABEL_PREFIX: &str = "ironclaw.network";
@@ -35,6 +38,9 @@ pub(super) const PROXY_IMAGE_ENV: &str = "IRONCLAW_REBORN_SANDBOX_PROXY_IMAGE";
 const PROXY_CONFIG_PATH: &str = "/run/ironclaw-proxy/proxy.yaml";
 const PROXY_MATERIAL_ROOT: &str = "/run/ironclaw-proxy";
 const PROXY_INVOCATION_ID_PATH: &str = "/run/ironclaw-proxy/invocation-id";
+const PROXY_CA_CERT_PATH: &str = "/run/ironclaw-proxy/ca.crt";
+const PROXY_CA_KEY_PATH: &str = "/run/ironclaw-proxy/ca.key";
+pub(super) const USER_PROXY_CA_PATH: &str = "/run/ironclaw/egress-ca.crt";
 const SHARED_UPSTREAM_NETWORK_NAME: &str = "ironclaw-reborn-sandbox-upstream";
 const SHARED_UPSTREAM_LABEL_ROLE: &str = "ironclaw.network.role";
 const SHARED_UPSTREAM_ROLE: &str = "shared-proxy-upstream-v1";
@@ -77,6 +83,7 @@ pub(super) struct ManagedEgressConfig {
     proxy_image: String,
     policy: NetworkPolicy,
     material_root: PathBuf,
+    ca: Arc<SandboxCertificateAuthority>,
 }
 
 impl ManagedEgressConfig {
@@ -97,10 +104,12 @@ impl ManagedEgressConfig {
         }
         reject_wildcard_targets(&policy)?;
         let proxy_image = configured_proxy_image()?;
+        let ca = Arc::new(SandboxCertificateAuthority::generate()?);
         Ok(Self {
             proxy_image,
             policy,
             material_root,
+            ca,
         })
     }
 }
@@ -170,6 +179,7 @@ pub(super) struct ManagedEgressRuntime {
     proxy_image: String,
     policy: NetworkPolicy,
     posture: String,
+    ca: Arc<SandboxCertificateAuthority>,
     material_root: PathBuf,
     upstream_gate: tokio::sync::Mutex<()>,
 }
@@ -190,6 +200,7 @@ pub(super) struct ManagedEgressBundle {
     pub(super) proxy_ip: String,
     proxy_host: String,
     pub(super) posture: String,
+    pub(super) ca_cert_path: PathBuf,
     invocation_id_path: PathBuf,
 }
 
@@ -208,12 +219,17 @@ impl ManagedEgressRuntime {
         let proxy_image = resolve_proxy_image(docker, &config.proxy_image).await?;
         let material_root = config.material_root;
         create_material_directory(&material_root, 0o711).await?;
-        let posture = proxy_posture(&proxy_image, &config.policy, &material_root)?;
+        let posture = proxy_posture(
+            &proxy_image,
+            &config.policy,
+            config.ca.root_certificate_pem().as_bytes(),
+        )?;
         Ok(Arc::new(Self {
             proxy_image,
             policy: config.policy,
             posture,
             material_root,
+            ca: config.ca,
             upstream_gate: tokio::sync::Mutex::new(()),
         }))
     }
@@ -256,6 +272,12 @@ impl ManagedEgressRuntime {
         let upstream_network_name = SHARED_UPSTREAM_NETWORK_NAME;
         let proxy_material_root = self.material_root.join(&proxy_name);
         create_material_directory(&proxy_material_root, 0o711).await?;
+        let ca_cert_path = proxy_material_root.join("ca.crt");
+        let ca_key_path = proxy_material_root.join("ca.key");
+        write_atomic_material_file(&ca_cert_path, self.ca.root_certificate_pem().as_bytes())
+            .await?;
+        let ca_key = self.ca.proxy_private_key_pem();
+        write_atomic_private_material_file(&ca_key_path, ca_key.expose_secret().as_bytes()).await?;
         let invocation_id_path = proxy_material_root.join("invocation-id");
         if !tokio::fs::try_exists(&invocation_id_path)
             .await
@@ -398,6 +420,7 @@ impl ManagedEgressRuntime {
             proxy_host: proxy_name,
             posture: self.posture.clone(),
             invocation_id_path,
+            ca_cert_path,
         })
     }
 
@@ -415,6 +438,61 @@ impl ManagedEgressRuntime {
         // Attribution metadata must remain readable across that boundary.
         let invocation_id = invocation_id.to_string();
         write_atomic_material_file(&bundle.invocation_id_path, invocation_id.as_bytes()).await
+    }
+    pub(super) async fn configure_credentials(
+        &self,
+        docker: &Docker,
+        bundle: &ManagedEgressBundle,
+        credentials: &[SandboxCommandCredential],
+    ) -> Result<(), RuntimeProcessError> {
+        let material_root = bundle.ca_cert_path.parent().ok_or_else(|| {
+            RuntimeProcessError::ExecutionFailed(
+                "sandbox proxy credential material path has no parent".to_string(),
+            )
+        })?;
+        remove_credential_material(material_root).await?;
+        let mut rendered = Vec::with_capacity(credentials.len());
+        for (index, credential) in credentials.iter().enumerate() {
+            if !self.policy.allowed_targets.iter().any(|target| {
+                target
+                    .host_pattern
+                    .eq_ignore_ascii_case(&credential.approved_host)
+            }) {
+                return Err(RuntimeProcessError::ExecutionFailed(
+                    "sandbox credential host is outside the approved network policy".to_string(),
+                ));
+            }
+            let filename = format!("credential-{index}.secret");
+            let host_path = material_root.join(&filename);
+            let header_prefix = credential.header_prefix.as_deref().unwrap_or_default();
+            let authorized_value = format!("{header_prefix}{}", credential.expose_secret());
+            write_atomic_private_material_file(&host_path, authorized_value.as_bytes()).await?;
+            rendered.push(ProxyCredentialConfig {
+                source_path: format!("{PROXY_MATERIAL_ROOT}/{filename}"),
+                approved_host: credential.approved_host.clone(),
+                target_header: credential.header_name.clone(),
+                placeholder_value: format!("{header_prefix}{}", credential.placeholder),
+            });
+        }
+        let config = render_proxy_config_inner(&self.policy, &bundle.proxy_ip, true, &rendered)?;
+        write_atomic_material_file(&material_root.join("proxy.yaml"), config.as_bytes()).await?;
+        restart_proxy_container(docker, &bundle.proxy_host).await
+    }
+
+    pub(super) async fn clear_credentials(
+        &self,
+        docker: &Docker,
+        bundle: &ManagedEgressBundle,
+    ) -> Result<(), RuntimeProcessError> {
+        let material_root = bundle.ca_cert_path.parent().ok_or_else(|| {
+            RuntimeProcessError::ExecutionFailed(
+                "sandbox proxy credential material path has no parent".to_string(),
+            )
+        })?;
+        let config = render_proxy_config_with_ca(&self.policy, &bundle.proxy_ip)?;
+        write_atomic_material_file(&material_root.join("proxy.yaml"), config.as_bytes()).await?;
+        restart_proxy_container(docker, &bundle.proxy_host).await?;
+        remove_credential_material(material_root).await
     }
 
     async fn create_proxy(
@@ -542,7 +620,7 @@ impl ManagedEgressRuntime {
                 return Err(error);
             }
         };
-        let proxy_config = render_proxy_config(&self.policy, &proxy_ip)?;
+        let proxy_config = render_proxy_config_with_ca(&self.policy, &proxy_ip)?;
         if let Err(error) =
             write_atomic_material_file(&proxy_config_path, proxy_config.as_bytes()).await
         {
@@ -558,6 +636,13 @@ impl ManagedEgressRuntime {
         }
         Ok(proxy_ip)
     }
+    pub(super) fn user_ca_bind(
+        &self,
+        bundle: &ManagedEgressBundle,
+    ) -> Result<String, RuntimeProcessError> {
+        docker_readonly_bind(&bundle.ca_cert_path, USER_PROXY_CA_PATH)
+    }
+
     pub(super) fn user_environment(
         &self,
         bundle: &ManagedEgressBundle,
@@ -577,6 +662,10 @@ impl ManagedEgressRuntime {
             ("https_proxy", proxy_url.as_str()),
             ("HTTP_PROXY", proxy_url.as_str()),
             ("HTTPS_PROXY", proxy_url.as_str()),
+            ("SSL_CERT_FILE", USER_PROXY_CA_PATH),
+            ("NODE_EXTRA_CA_CERTS", USER_PROXY_CA_PATH),
+            ("REQUESTS_CA_BUNDLE", USER_PROXY_CA_PATH),
+            ("CURL_CA_BUNDLE", USER_PROXY_CA_PATH),
             ("NO_PROXY", ""),
             ("no_proxy", ""),
         ]
@@ -1003,6 +1092,54 @@ fn proxy_is_ready(inspected: &bollard::models::ContainerInspectResponse) -> bool
         )
 }
 
+async fn restart_proxy_container(docker: &Docker, name: &str) -> Result<(), RuntimeProcessError> {
+    docker
+        .restart_container(name, Some(RestartContainerOptions { t: 10 }))
+        .await
+        .map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox proxy credential reload failed: {error}"
+            ))
+        })?;
+    if let Err(error) = wait_proxy_ready(docker, name).await {
+        let detail = proxy_failure_detail(docker, name).await;
+        return Err(RuntimeProcessError::ExecutionFailed(format!(
+            "{error}{detail}"
+        )));
+    }
+    Ok(())
+}
+
+async fn remove_credential_material(
+    material_root: &std::path::Path,
+) -> Result<(), RuntimeProcessError> {
+    let mut entries = tokio::fs::read_dir(material_root).await.map_err(|error| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "sandbox proxy credential material scan failed: {error}"
+        ))
+    })?;
+    while let Some(entry) = entries.next_entry().await.map_err(|error| {
+        RuntimeProcessError::ExecutionFailed(format!(
+            "sandbox proxy credential material scan failed: {error}"
+        ))
+    })? {
+        let filename = entry.file_name();
+        if filename
+            .to_str()
+            .is_some_and(|name| name.starts_with("credential-") && name.ends_with(".secret"))
+        {
+            tokio::fs::remove_file(entry.path())
+                .await
+                .map_err(|error| {
+                    RuntimeProcessError::ExecutionFailed(format!(
+                        "sandbox proxy credential material cleanup failed: {error}"
+                    ))
+                })?;
+        }
+    }
+    Ok(())
+}
+
 async fn start_proxy_container(docker: &Docker, name: &str) -> Result<(), RuntimeProcessError> {
     docker
         .start_container(name, None::<StartContainerOptions<String>>)
@@ -1168,7 +1305,7 @@ fn reject_wildcard_targets(policy: &NetworkPolicy) -> Result<(), RuntimeProcessE
 pub(super) fn proxy_posture(
     proxy_image: &str,
     policy: &NetworkPolicy,
-    material_root: &std::path::Path,
+    ca_certificate: &[u8],
 ) -> Result<String, RuntimeProcessError> {
     let policy_json = serde_json::to_vec(policy).map_err(|error| {
         RuntimeProcessError::ExecutionFailed(format!(
@@ -1176,18 +1313,41 @@ pub(super) fn proxy_posture(
         ))
     })?;
     let mut hasher = Sha256::new();
-    hasher.update(b"ironclaw-managed-egress-v3\0");
+    hasher.update(b"ironclaw-managed-egress-v4\0");
     hasher.update(proxy_image.as_bytes());
     hasher.update([0]);
-    hasher.update(material_root.as_os_str().as_encoded_bytes());
+    hasher.update(ca_certificate);
     hasher.update([0]);
     hasher.update(policy_json);
     Ok(hex::encode(hasher.finalize()))
 }
 
+struct ProxyCredentialConfig {
+    source_path: String,
+    approved_host: String,
+    target_header: String,
+    placeholder_value: String,
+}
+
 pub(super) fn render_proxy_config(
     policy: &NetworkPolicy,
     proxy_ip: &str,
+) -> Result<String, RuntimeProcessError> {
+    render_proxy_config_inner(policy, proxy_ip, false, &[])
+}
+
+fn render_proxy_config_with_ca(
+    policy: &NetworkPolicy,
+    proxy_ip: &str,
+) -> Result<String, RuntimeProcessError> {
+    render_proxy_config_inner(policy, proxy_ip, true, &[])
+}
+
+fn render_proxy_config_inner(
+    policy: &NetworkPolicy,
+    proxy_ip: &str,
+    intercept_tls: bool,
+    credentials: &[ProxyCredentialConfig],
 ) -> Result<String, RuntimeProcessError> {
     if policy.allowed_targets.is_empty() || !policy.deny_private_ip_ranges {
         return Err(RuntimeProcessError::ExecutionFailed(
@@ -1228,16 +1388,65 @@ pub(super) fn render_proxy_config(
         config.push_str(cidr);
         config.push('\n');
     }
-    config.push_str("tls:\n  mode: \"sni-only\"\ntransforms:\n  - name: secrets\n    config:\n      secrets:\n        - source:\n            type: file\n            path: \"");
-    config.push_str(PROXY_INVOCATION_ID_PATH);
-    config.push_str("\"\n            ttl: \"-1ns\"\n            failure_ttl: \"1ms\"\n          rules:\n            - host: \"*\"\n          inject:\n            header: \"X-Ironclaw-Invocation-Id\"\n            require: true\n  - name: annotate\n    config:\n      annotations:\n        - rules:\n            - host: \"*\"\n          headers: [\"X-Ironclaw-Invocation-Id\"]\n  - name: header_allowlist\n    config:\n      headers: [\"Authorization\", \"Content-Type\", \"Accept\", \"User-Agent\", \"Range\", \"If-None-Match\", \"If-Modified-Since\"]\n  - name: allowlist\n    config:\n      domains:\n");
+    if intercept_tls {
+        config.push_str("tls:\n  ca_cert: \"");
+        config.push_str(PROXY_CA_CERT_PATH);
+        config.push_str("\"\n  ca_key: \"");
+        config.push_str(PROXY_CA_KEY_PATH);
+        config.push_str("\"\n");
+    } else {
+        config.push_str("tls:\n  mode: \"sni-only\"\n");
+    }
+    config.push_str("transforms:\n  - name: allowlist\n    config:\n      domains:\n");
     for target in &policy.allowed_targets {
         let quoted = serde_json::to_string(&target.host_pattern).map_err(proxy_config_error)?;
         config.push_str("        - ");
         config.push_str(&quoted);
         config.push('\n');
     }
-    config.push_str("log:\n  level: info\n");
+    config.push_str("  - name: header_allowlist\n    config:\n      headers: [\"Authorization\", \"Content-Type\", \"Accept\", \"User-Agent\", \"Range\", \"If-None-Match\", \"If-Modified-Since\"");
+    let mut allowed_headers = [
+        "authorization",
+        "content-type",
+        "accept",
+        "user-agent",
+        "range",
+        "if-none-match",
+        "if-modified-since",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect::<HashSet<_>>();
+    for credential in credentials {
+        let normalized = credential.target_header.to_ascii_lowercase();
+        if allowed_headers.insert(normalized) {
+            config.push_str(", ");
+            config.push_str(
+                &serde_json::to_string(&credential.target_header).map_err(proxy_config_error)?,
+            );
+        }
+    }
+    config.push_str("]\n  - name: secrets\n    config:\n      secrets:\n        - source:\n            type: file\n            path: \"");
+    config.push_str(PROXY_INVOCATION_ID_PATH);
+    config.push_str("\"\n            ttl: \"-1ns\"\n            failure_ttl: \"1ms\"\n          rules:\n            - host: \"*\"\n          inject:\n            header: \"X-Ironclaw-Invocation-Id\"\n            require: true\n");
+    for credential in credentials {
+        let source = serde_json::to_string(&credential.source_path).map_err(proxy_config_error)?;
+        let host = serde_json::to_string(&credential.approved_host).map_err(proxy_config_error)?;
+        let header =
+            serde_json::to_string(&credential.target_header).map_err(proxy_config_error)?;
+        let proxy_value =
+            serde_json::to_string(&credential.placeholder_value).map_err(proxy_config_error)?;
+        config.push_str("        - source:\n            type: file\n            path: ");
+        config.push_str(&source);
+        config.push_str("\n            ttl: \"-1ns\"\n            failure_ttl: \"1ms\"\n          replace:\n            proxy_value: ");
+        config.push_str(&proxy_value);
+        config.push_str("\n            match_headers: [");
+        config.push_str(&header);
+        config.push_str("]\n            require: true\n          rules:\n            - host: ");
+        config.push_str(&host);
+        config.push_str("\n              methods: [\"GET\", \"POST\", \"PUT\", \"PATCH\", \"DELETE\", \"HEAD\", \"OPTIONS\"]\n              paths: [\"/*\"]\n");
+    }
+    config.push_str("  - name: annotate\n    config:\n      annotations:\n        - rules:\n            - host: \"*\"\n          headers: [\"X-Ironclaw-Invocation-Id\"]\nlog:\n  level: info\n");
     Ok(config)
 }
 
@@ -1273,6 +1482,21 @@ async fn write_atomic_material_file(
     path: &std::path::Path,
     contents: &[u8],
 ) -> Result<(), RuntimeProcessError> {
+    write_atomic_material_file_with_mode(path, contents, 0o644).await
+}
+
+async fn write_atomic_private_material_file(
+    path: &std::path::Path,
+    contents: &[u8],
+) -> Result<(), RuntimeProcessError> {
+    write_atomic_material_file_with_mode(path, contents, 0o600).await
+}
+
+async fn write_atomic_material_file_with_mode(
+    path: &std::path::Path,
+    contents: &[u8],
+    mode: u32,
+) -> Result<(), RuntimeProcessError> {
     let path = path.to_path_buf();
     let contents = contents.to_vec();
     tokio::task::spawn_blocking(move || {
@@ -1293,7 +1517,7 @@ async fn write_atomic_material_file(
             use std::os::unix::fs::PermissionsExt as _;
             temporary
                 .as_file()
-                .set_permissions(std::fs::Permissions::from_mode(0o644))
+                .set_permissions(std::fs::Permissions::from_mode(mode))
                 .map_err(|error| {
                     RuntimeProcessError::ExecutionFailed(format!(
                         "sandbox managed-egress material permissions failed: {error}"
@@ -1486,6 +1710,42 @@ mod tests {
     }
 
     #[test]
+    fn credential_renderer_binds_secret_source_to_exact_host_and_header() {
+        let credentials = [ProxyCredentialConfig {
+            source_path: "/run/ironclaw-proxy/credential-0.secret".to_string(),
+            approved_host: "github.com".to_string(),
+            target_header: "Authorization".to_string(),
+            placeholder_value: "Bearer icsbx_test_placeholder".to_string(),
+        }];
+
+        let rendered =
+            render_proxy_config_inner(&policy(), "172.28.10.2", true, &credentials).unwrap();
+
+        assert!(rendered.contains("ca_cert: \"/run/ironclaw-proxy/ca.crt\""));
+        assert!(rendered.contains("path: \"/run/ironclaw-proxy/credential-0.secret\""));
+        assert!(
+            rendered
+                .contains("replace:\n            proxy_value: \"Bearer icsbx_test_placeholder\"")
+        );
+        assert!(rendered.contains("- host: \"github.com\""));
+        assert!(rendered.contains("match_headers: [\"Authorization\"]"));
+        assert!(!rendered.contains("RAW_SECRET_SENTINEL"));
+        assert!(rendered.contains("paths: [\"/*\"]"));
+        assert!(rendered.contains(
+            "methods: [\"GET\", \"POST\", \"PUT\", \"PATCH\", \"DELETE\", \"HEAD\", \"OPTIONS\"]"
+        ));
+        let header_allowlist = rendered
+            .lines()
+            .find(|line| line.trim_start().starts_with("headers:"))
+            .expect("header allowlist is rendered");
+        assert_eq!(
+            header_allowlist.matches("\"Authorization\"").count(),
+            1,
+            "a credential header already in the base allowlist must not be duplicated"
+        );
+    }
+
+    #[test]
     fn proxy_image_override_requires_a_full_sha256_digest() {
         let _guard = lock_env();
         remove_runtime_env(PROXY_IMAGE_ENV);
@@ -1545,17 +1805,11 @@ mod tests {
     }
 
     #[test]
-    fn posture_binds_image_policy_and_material_root() {
+    fn posture_binds_image_policy_and_deployment_identity() {
         let image = "sha256:proxy-image";
-        let base = proxy_posture(image, &policy(), std::path::Path::new("/a")).unwrap();
-        assert_eq!(
-            base,
-            proxy_posture(image, &policy(), std::path::Path::new("/a")).unwrap()
-        );
-        assert_ne!(
-            base,
-            proxy_posture(image, &policy(), std::path::Path::new("/b")).unwrap()
-        );
+        let base = proxy_posture(image, &policy(), b"ca-a").unwrap();
+        assert_eq!(base, proxy_posture(image, &policy(), b"ca-a").unwrap());
+        assert_ne!(base, proxy_posture(image, &policy(), b"ca-b").unwrap());
     }
 
     #[tokio::test]

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/railway.rs
@@ -273,7 +273,7 @@ impl RailwayPreviewSandboxConfig {
         let proxy_posture = super::managed_egress::proxy_posture(
             &proxy_image,
             &policy,
-            std::path::Path::new("/run/ironclaw-reborn-proxy"),
+            b"railway-preview-sni-only",
         )?;
         let proxy_config_template =
             super::managed_egress::render_proxy_config(&policy, RAILWAY_PROXY_IP_TOKEN)?;

--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/user_container.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/user_container.rs
@@ -225,6 +225,14 @@ pub(super) fn exec_helper_timeout_secs(timeout: Duration) -> Result<u64, Runtime
     Ok(seconds)
 }
 
+pub(super) struct UserContainerCommand {
+    pub(super) command: String,
+    pub(super) args: Vec<String>,
+    pub(super) workdir: ContainerWorkdir,
+    pub(super) env: Vec<String>,
+    pub(super) timeout: Duration,
+}
+
 /// Executes a command while its user's lifecycle gate is held.
 ///
 /// The caller must retain that gate through any error or timeout recycle.
@@ -232,14 +240,19 @@ pub(super) async fn execute_in_user_container(
     transport: &RebornScopedSandboxCommandTransport,
     key: &RebornSandboxUserKey,
     container_name: &str,
-    command: String,
-    workdir: ContainerWorkdir,
-    env: Vec<String>,
-    timeout: Duration,
+    command: UserContainerCommand,
 ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+    let UserContainerCommand {
+        command,
+        args,
+        workdir,
+        env,
+        timeout,
+    } = command;
     let started_at = Instant::now();
     let helper_timeout_secs = exec_helper_timeout_secs(timeout)?;
     let outcome_nonce = uuid::Uuid::new_v4().to_string();
+    let helper_argv = exec_helper_argv(helper_timeout_secs, outcome_nonce.clone(), command, args);
     let created = transport
         .docker
         .create_exec(
@@ -249,12 +262,7 @@ pub(super) async fn execute_in_user_container(
                 attach_stdout: Some(true),
                 attach_stderr: Some(true),
                 tty: Some(false),
-                cmd: Some(vec![
-                    EXEC_HELPER.to_string(),
-                    helper_timeout_secs.to_string(),
-                    outcome_nonce.clone(),
-                    command,
-                ]),
+                cmd: Some(helper_argv),
                 privileged: Some(false),
                 working_dir: Some(workdir.into_string()),
                 env: Some(env),
@@ -360,6 +368,21 @@ pub(super) async fn execute_in_user_container(
             Err(RuntimeProcessError::Timeout(timeout))
         }
     }
+}
+fn exec_helper_argv(
+    timeout_secs: u64,
+    outcome_nonce: String,
+    command: String,
+    args: Vec<String>,
+) -> Vec<String> {
+    let mut helper_argv = vec![
+        EXEC_HELPER.to_string(),
+        timeout_secs.to_string(),
+        outcome_nonce,
+        command,
+    ];
+    helper_argv.extend(args);
+    helper_argv
 }
 
 /// Recycles a container that cannot safely accept another command.
@@ -885,6 +908,18 @@ mod tests {
         assert!(output.contains("command wrote"));
         assert!(!output.ends_with("timeout\n"));
         assert!(parse_exec_outcome_trailer("ordinary output", nonce).is_err());
+    }
+    #[test]
+    fn zero_argument_commands_remain_direct_executable_invocations() {
+        assert_eq!(
+            exec_helper_argv(
+                30,
+                "nonce".to_string(),
+                "true;unexpected-command".to_string(),
+                Vec::new(),
+            ),
+            [EXEC_HELPER, "30", "nonce", "true;unexpected-command",]
+        );
     }
 
     #[test]

--- a/crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live.rs
+++ b/crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live.rs
@@ -1,10 +1,13 @@
 //! Real-Docker proof for persistent per-user containers and workspaces.
 
-use std::{process::Command, sync::Arc, time::Duration};
+use std::{collections::HashMap, process::Command, sync::Arc, time::Duration};
 
 use ironclaw_host_api::{
     ids::InvocationId,
-    process::{RuntimeProcessError, SandboxCommandTransport},
+    process::{
+        DirectSandboxCommandRequest, RuntimeProcessError, SandboxCommandCredential,
+        SandboxCommandTransport,
+    },
 };
 use ironclaw_sandbox::{RebornSandboxConfig, RebornScopedSandboxCommandTransport};
 

--- a/crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live/extra.rs
+++ b/crates/lanes/ironclaw_sandbox/tests/user_sandbox_docker_live/extra.rs
@@ -805,6 +805,96 @@ async fn different_users_receive_distinct_private_networks_and_proxies() {
 }
 
 #[tokio::test]
+#[ignore = "requires Docker, public Internet access, and IRONCLAW_TEST_GITHUB_TOKEN"]
+async fn github_cli_uses_proxy_bound_placeholder_without_exposing_real_token() {
+    let Some((_image, _serial)) =
+        docker_worker_and_proxy_images("sandbox GitHub credential canary").await
+    else {
+        return;
+    };
+    let Ok(token) = std::env::var("IRONCLAW_TEST_GITHUB_TOKEN") else {
+        eprintln!("SKIP: GitHub credential canary — IRONCLAW_TEST_GITHUB_TOKEN is unset");
+        return;
+    };
+    assert!(!token.is_empty(), "GitHub canary token must not be empty");
+
+    let scope = TestScope::unique("github-credential");
+    let temp = docker_visible_tempdir();
+    let mut cleanup = DockerCleanup::with_scopes([scope.clone()]);
+    let transport = RebornScopedSandboxCommandTransport::connect(
+        RebornSandboxConfig::new(temp.path().join("sandbox-workspaces"))
+            .with_managed_egress_proxy()
+            .expect("managed egress policy is valid"),
+    )
+    .await
+    .expect("Docker transport connects");
+    let placeholder = format!(
+        "{}{}",
+        ironclaw_secrets::CREDENTIAL_PLACEHOLDER_PREFIX,
+        InvocationId::new()
+    );
+    let command = DirectSandboxCommandRequest {
+        scope: scope.resource_scope(),
+        mounts: None,
+        executable: "gh".to_string(),
+        args: vec![
+            "pr".to_string(),
+            "list".to_string(),
+            "--repo".to_string(),
+            "nearai/ironclaw".to_string(),
+            "--limit".to_string(),
+            "1".to_string(),
+            "--json".to_string(),
+            "number".to_string(),
+        ],
+        workdir: None,
+        timeout_secs: Some(60),
+        extra_env: HashMap::from([("GH_TOKEN".to_string(), placeholder.clone())]),
+    };
+    let result = transport
+        .run_credentialed_direct_command(
+            command,
+            vec![SandboxCommandCredential::new(
+                "GH_TOKEN".to_string(),
+                placeholder,
+                "api.github.com".to_string(),
+                "Authorization".to_string(),
+                Some("Bearer ".to_string()),
+                token.clone(),
+            )],
+        )
+        .await
+        .expect("credentialed gh command reaches GitHub through the proxy");
+
+    assert_eq!(result.exit_code, 0, "gh command failed: {}", result.output);
+    assert!(serde_json::from_str::<serde_json::Value>(&result.output).is_ok());
+    assert!(!result.output.contains(&token));
+    let container = cleanup.capture(&scope);
+    let inspect = docker_command(&[
+        "container",
+        "inspect",
+        "--format",
+        "{{json .Config.Env}}",
+        &container.id,
+    ]);
+    assert!(inspect.status.success());
+    assert!(!String::from_utf8_lossy(&inspect.stdout).contains(&token));
+    let proxy_mount_probe = docker_command(&[
+        "container",
+        "exec",
+        &container.id,
+        "test",
+        "!",
+        "-e",
+        "/run/ironclaw-proxy",
+    ]);
+    assert!(
+        proxy_mount_probe.status.success(),
+        "proxy credential material must not be mounted in the command container"
+    );
+}
+
+#[tokio::test]
 #[ignore = "requires public DNS and Internet access; run as a live egress canary"]
 async fn sandbox_profile_allows_allowlisted_https_through_proxy() {
     let Some((_image, _serial)) = docker_worker_and_proxy_images("sandbox egress canary").await

--- a/docker/sandbox/ironclaw-exec
+++ b/docker/sandbox/ironclaw-exec
@@ -18,14 +18,14 @@ PR_SET_CHILD_SUBREAPER = 36
 
 def usage() -> "NoReturn":
     print(
-        "usage: ironclaw-exec <timeout-seconds> <outcome-nonce> <command>",
+        "usage: ironclaw-exec <timeout-seconds> <outcome-nonce> <executable> [arg ...]",
         file=sys.stderr,
     )
     raise SystemExit(64)
 
 
-def parse_args() -> tuple[int, str, str]:
-    if len(sys.argv) != 4:
+def parse_args() -> tuple[int, str, list[str]]:
+    if len(sys.argv) < 4:
         usage()
     try:
         timeout = int(sys.argv[1], 10)
@@ -36,7 +36,7 @@ def parse_args() -> tuple[int, str, str]:
     nonce = sys.argv[2]
     if not nonce or any(char not in "0123456789abcdef-" for char in nonce):
         usage()
-    return timeout, nonce, sys.argv[3]
+    return timeout, nonce, sys.argv[3:]
 
 
 def make_subreaper() -> None:
@@ -139,7 +139,7 @@ def cleanup_processes(root_pid: int | None) -> None:
 
 
 def main() -> int:
-    timeout, nonce, command = parse_args()
+    timeout, nonce, argv = parse_args()
     try:
         make_subreaper()
     except OSError as error:
@@ -147,7 +147,7 @@ def main() -> int:
         return 70
 
     process = subprocess.Popen(
-        ["sh", "-c", command],
+        argv,
         stdin=subprocess.DEVNULL,
         start_new_session=True,
     )


### PR DESCRIPTION
## Summary

- Add a dedicated direct-executable plus argument-vector sandbox process path for `system.process_sandbox.run`.
- Resolve GitHub credential authority from active extension declarations, stage one-shot material after authorization/approval, and expose only an invocation placeholder to `gh`.
- Configure the existing per-user `ironsh/iron-proxy` sidecar to replace that placeholder only for the declared HTTPS host and header.
- Add credential expiry, redaction, binding, zero-argument, and Docker canary coverage.

Closes #7732

## Change Type

- [x] New feature
- [ ] Bug fix
- [ ] Refactor-only
- [ ] Documentation
- [x] CI / Infrastructure
- [x] Security
- [ ] Dependencies

## Validation

- [x] `cargo fmt --check`
- [x] Focused credential resolver, process executor, descriptor enrichment, proxy renderer, argument-boundary, and zero-argument tests
- [x] Python syntax compile for `docker/sandbox/ironclaw-exec`
- [ ] Full owning-crate suites (local run exhausted disk while compiling the workspace; CI is the source of truth)
- [ ] Docker GitHub credential canary (requires Docker plus `IRONCLAW_TEST_GITHUB_TOKEN`; CI/manual lane)

## Test Strategy

Unit/contract coverage pins:

1. declared GitHub credential resolution and undeclared host/header rejection;
2. `PermissionMode::Ask` on the sandbox capability and existing denied-approval no-dispatch contracts;
3. one-shot staged credential expiry/removal;
4. no raw token in command environment, debug/model surfaces, or command output;
5. exact host and header injection in the proxy transform;
6. direct zero-argument and argument-boundary execution.

The ignored live Docker canary runs `gh pr list --repo nearai/ironclaw` through the per-user proxy and checks the real token is absent from output and container environment.

## Data / Config / Compatibility

- No schema or migration changes.
- No new user-facing config or generic environment/installer framework.
- Existing shell execution keeps `sh -c`; only the credentialed path uses direct argv execution.
- The sandbox worker image adds the GitHub CLI and a standard CA bundle path.

## Blast Radius

Sandbox process execution, capability authorization/obligation staging, composition wiring, and managed egress proxy configuration. Non-sandbox process backends and non-credentialed shell calls retain their existing paths.

## Rollback Plan

Revert commit `873b6daf8e`. This removes the dedicated capability registration, dynamic credential handoff, direct argv transport, and proxy credential transform together; no persisted schema requires rollback.

## Review track

C — security/runtime boundary change. Focus review on declaration-derived authority, approval ordering, one-shot secret consumption, exact host/header binding, and raw-token containment.