### PR TITLE
ci: canonical preflight — one gate list, worktree-safe hooks, self-printing REPRO (T4, tasks 1-5)

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,6 +1,6 @@
 ---
 description: Run the full Rust quality gate (fmt, clippy, tests) before shipping changes
-allowed-tools: Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*)
+allowed-tools: Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(bash scripts/preflight-gates.sh:*)
 ---
 
 Run the IronClaw shipping checklist. This is the mandatory quality gate before any change is considered done.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -31,6 +31,12 @@ if $NEEDS_CHECK; then
     fi
 fi
 
+# Safety checks (UTF-8 slicing, /tmp paths, redaction, unwrap in production,
+# composition-mass ratchet, …). One install story: with core.hooksPath this
+# hook is THE pre-commit, so it must carry what dev-setup.sh used to symlink
+# in separately.
+bash "$(git rev-parse --show-toplevel)/scripts/pre-commit-safety.sh"
+
 # Reborn WebUI i18n parity (crates/ironclaw_webui/frontend/src/i18n/*.ts) is
 # enforced by the frontend's own tooling (`pnpm lint`/`pnpm test` in the
 # `webui-v2-js-lint` CI job), not by this shell hook — the v1 gateway's

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -57,7 +57,43 @@ run_ci_env() {
 
 check_merge_to_base_clean "${1:-origin}"
 
-# Default: baseline quality gate
+if [ "${IRONCLAW_PREPUSH_FULL:-0}" != "1" ]; then
+    # Default tier (gate-audit 2026-08 §4.3 inversion): the ~5-minute
+    # deterministic-gate gauntlet plus the ~60s changed-package clippy shape
+    # (the largest measured queue-red class — research.md). The full
+    # CI-parity gauntlet (workspace clippy + tests + coverage ratchet + WebUI
+    # provider replay) still exists, unchanged, behind IRONCLAW_PREPUSH_FULL=1.
+    echo "==> pre-push default tier: preflight gates (IRONCLAW_PREPUSH_FULL=1 for the full gauntlet)"
+    bash "$REPO_ROOT/scripts/preflight-gates.sh"
+
+    if [ "${IRONCLAW_PREPUSH_CHANGED_CLIPPY:-1}" = "1" ]; then
+        echo "==> pre-push default tier: changed-package clippy (the PR-lane shape; skip with IRONCLAW_PREPUSH_CHANGED_CLIPPY=0)"
+        remote_name="${1:-origin}"
+        base_branch="${IRONCLAW_PREPUSH_BASE_BRANCH:-main}"
+        merge_base_for_clippy="$(git merge-base HEAD "refs/remotes/${remote_name}/${base_branch}")"
+        changed_file_list="$(mktemp)"
+        git diff --name-only "${merge_base_for_clippy}...HEAD" >"${changed_file_list}"
+        changed_packages=()
+        while IFS= read -r pkg; do
+            [ -n "$pkg" ] && changed_packages+=("$pkg")
+        done < <(python3 "$SCRIPT_DIR/changed_workspace_packages.py" \
+            --changed-files "${changed_file_list}" | python3 -c 'import json,sys; print("\n".join(json.load(sys.stdin)))')
+        rm -f "${changed_file_list}"
+        if [ "${#changed_packages[@]}" -gt 0 ]; then
+            package_args=()
+            for pkg in "${changed_packages[@]}"; do
+                package_args+=(-p "${pkg}")
+            done
+            cargo clippy "${package_args[@]}" -- -D warnings
+        else
+            echo "    (no changed workspace packages; nothing to lint)"
+        fi
+    fi
+    exit 0
+fi
+
+# ---- Full gauntlet (IRONCLAW_PREPUSH_FULL=1): everything below is today's
+# ---- behavior, moved — not weakened — except the Emulate-absent case.
 "$SCRIPT_DIR/quality_gate.sh"
 
 # Fast static checks (no compile) — catch deterministic breakers that a
@@ -66,6 +102,7 @@ check_merge_to_base_clean "${1:-origin}"
 #     (the #5603 Docker outage class).
 #   - newly-added raw std::env::set_var/remove_var is guarded (the #6015
 #     coverage-flake / Rust 1.82 UB class).
+echo "==> static checks (#6018): #5603 Docker COPY coverage class + #6015 hermetic-env class"
 echo "==> static: include_str! paths + Docker COPY coverage"
 "$SCRIPT_DIR/check-include-str-paths.sh"
 echo "==> static: hermetic env mutation"
@@ -80,25 +117,22 @@ if [ "${IRONCLAW_PREPUSH_REBORN_WEBUI_E2E:-1}" = "1" ]; then
     emulate_cli="${IRONCLAW_EMULATE_CLI:-$REPO_ROOT/.emulate/packages/emulate/dist/index.js}"
     if [ ! -f "$emulate_cli" ]; then
         cat >&2 <<EOF
-ERROR: Emulate CLI not found for the pre-push WebUI provider replay.
-
-Set IRONCLAW_EMULATE_CLI to the built Emulate CLI, or install it at:
-  $REPO_ROOT/.emulate/packages/emulate/dist/index.js
-
-This hook runs the same provider replay lane that gates CI because it catches
-tool-inventory regressions that Rust unit tests and clippy do not.
+WARN: Emulate CLI not found — skipping the pre-push WebUI provider replay.
+      Set IRONCLAW_EMULATE_CLI or install it at:
+        $REPO_ROOT/.emulate/packages/emulate/dist/index.js
+      CI still runs this lane; a tool-inventory regression will land there.
 EOF
-        exit 1
+    else
+        echo "==> reborn WebUI provider replay (CI parity; skip with IRONCLAW_PREPUSH_REBORN_WEBUI_E2E=0)"
+        IRONCLAW_EMULATE_CLI="$emulate_cli" run_ci_env pytest \
+            tests/e2e/scenarios/test_provider_capability_inventory.py \
+            tests/e2e/scenarios/test_journey_coverage.py \
+            tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py \
+            tests/e2e/scenarios/test_reborn_qa_trace_replay.py \
+            tests/e2e/scenarios/test_reborn_qa_trace_full_path.py \
+            -v \
+            --timeout=120
     fi
-    echo "==> reborn WebUI provider replay (CI parity; skip with IRONCLAW_PREPUSH_REBORN_WEBUI_E2E=0)"
-    IRONCLAW_EMULATE_CLI="$emulate_cli" run_ci_env pytest \
-        tests/e2e/scenarios/test_provider_capability_inventory.py \
-        tests/e2e/scenarios/test_journey_coverage.py \
-        tests/e2e/scenarios/test_emulate_reborn_provider_contracts.py \
-        tests/e2e/scenarios/test_reborn_qa_trace_replay.py \
-        tests/e2e/scenarios/test_reborn_qa_trace_full_path.py \
-        -v \
-        --timeout=120
 fi
 
 # Optional strict delta lint (env-gated)

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,6 +5,7 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 SCRIPT_DIR="$REPO_ROOT/scripts/ci"
+source "$SCRIPT_DIR/lib/run-cargo-ci-env.sh"
 
 check_merge_to_base_clean() {
     if [ "${IRONCLAW_PREPUSH_MERGE_CHECK:-1}" = "0" ]; then
@@ -38,21 +39,12 @@ EOF
     rm -f "$merge_output"
 }
 
+# Delegates to the canonical scrub in scripts/ci/lib/run-cargo-ci-env.sh (this
+# hook is the third caller that crossed the rule-of-three threshold and
+# triggered the extraction — see that file's header). The function NAME is
+# kept so nothing else in this hook has to change.
 run_ci_env() {
-    env \
-        -u NEARAI_API_KEY \
-        -u NEARAI_BASE_URL \
-        -u NEARAI_SESSION_TOKEN \
-        -u NEARAI_PROVIDER_ID \
-        -u NEARAI_MODEL \
-        -u IRONCLAW_LLM_PROVIDER \
-        -u IRONCLAW_LLM_MODEL \
-        -u LLM_BACKEND \
-        IRONCLAW_DISABLE_OS_KEYCHAIN="${IRONCLAW_DISABLE_OS_KEYCHAIN:-1}" \
-        CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}" \
-        CARGO_PROFILE_TEST_DEBUG="${CARGO_PROFILE_TEST_DEBUG:-0}" \
-        RUST_MIN_STACK="${RUST_MIN_STACK:-67108864}" \
-        "$@"
+    run_cargo_ci_env "$@"
 }
 
 check_merge_to_base_clean "${1:-origin}"
@@ -84,7 +76,15 @@ if [ "${IRONCLAW_PREPUSH_FULL:-0}" != "1" ]; then
             for pkg in "${changed_packages[@]}"; do
                 package_args+=(-p "${pkg}")
             done
-            cargo clippy "${package_args[@]}" -- -D warnings
+            # Scrubbed (run_ci_env): this compiles the changed packages via
+            # build.rs/proc macros, so it must not see NEARAI_*/IRONCLAW_LLM_*
+            # credentials any more than the full gauntlet's clippy does.
+            # Deliberately omits --all-features (unlike the full gauntlet and
+            # the --queue-shape gates): this step's job is a ~60s local
+            # approximation of the PR-lane shape, not full CI parity, so
+            # feature-gated lints are not caught here — a cost decision, not
+            # an oversight.
+            run_ci_env cargo clippy "${package_args[@]}" -- -D warnings
         else
             echo "    (no changed workspace packages; nothing to lint)"
         fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -62,15 +62,38 @@ if [ "${IRONCLAW_PREPUSH_FULL:-0}" != "1" ]; then
         echo "==> pre-push default tier: changed-package clippy (the PR-lane shape; skip with IRONCLAW_PREPUSH_CHANGED_CLIPPY=0)"
         remote_name="${1:-origin}"
         base_branch="${IRONCLAW_PREPUSH_BASE_BRANCH:-main}"
-        merge_base_for_clippy="$(git merge-base HEAD "refs/remotes/${remote_name}/${base_branch}")"
+        base_ref_for_clippy="refs/remotes/${remote_name}/${base_branch}"
+        # Self-sufficient regardless of IRONCLAW_PREPUSH_MERGE_CHECK: that
+        # step's fetch is what normally populates this remote-tracking ref,
+        # but when it is skipped (=0) nothing else does — fetch it here too,
+        # rather than assuming an earlier step already ran.
+        if ! git rev-parse --verify --quiet "${base_ref_for_clippy}^{commit}" >/dev/null; then
+            git fetch --quiet "$remote_name" "+refs/heads/${base_branch}:${base_ref_for_clippy}"
+        fi
+        merge_base_for_clippy="$(git merge-base HEAD "${base_ref_for_clippy}")"
         changed_file_list="$(mktemp)"
         git diff --name-only "${merge_base_for_clippy}...HEAD" >"${changed_file_list}"
+        # Captured to a temp file with an explicit exit-status check, not a
+        # process substitution: `done < <(cmd1 | cmd2)` runs cmd1|cmd2 in a
+        # backgrounded subshell whose exit status the `while` loop never
+        # observes, so a failing discovery command under `set -euo pipefail`
+        # silently degrades to an empty stream ("no changed workspace
+        # packages") instead of failing the hook.
+        changed_packages_list="$(mktemp)"
+        if ! python3 "$SCRIPT_DIR/changed_workspace_packages.py" \
+            --changed-files "${changed_file_list}" \
+            | python3 -c 'import json,sys; print("\n".join(json.load(sys.stdin)))' \
+            >"${changed_packages_list}"; then
+            rm -f "${changed_file_list}" "${changed_packages_list}"
+            echo "ERROR: failed to discover changed workspace packages" >&2
+            exit 1
+        fi
+        rm -f "${changed_file_list}"
         changed_packages=()
         while IFS= read -r pkg; do
             [ -n "$pkg" ] && changed_packages+=("$pkg")
-        done < <(python3 "$SCRIPT_DIR/changed_workspace_packages.py" \
-            --changed-files "${changed_file_list}" | python3 -c 'import json,sys; print("\n".join(json.load(sys.stdin)))')
-        rm -f "${changed_file_list}"
+        done <"${changed_packages_list}"
+        rm -f "${changed_packages_list}"
         if [ "${#changed_packages[@]}" -gt 0 ]; then
             package_args=()
             for pkg in "${changed_packages[@]}"; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@ cargo fmt                                                       # format
 cargo clippy --all --benches --tests --examples --all-features -- -D warnings  # lint (zero warnings; CI denies warnings — an unflagged run exits 0 with them)
 cargo test                                                      # unit + integration suites (Postgres legs self-provision testcontainers; skipped without Docker)
 RUST_LOG=ironclaw=debug cargo run -p ironclaw -- serve          # run the serve binary (add tower_http=debug for HTTP logging)
+bash scripts/preflight-gates.sh                # pre-push predictor: every deterministic CI gate, one round-trip (~5-7 min warm; also the default pre-push hook tier)
+bash scripts/preflight-gates.sh --queue-shape  # the clippy shapes + full test plan the merge queue runs and PR CI skips (~6 min warm CI; cold local runs far longer)
+# A red CI job prints its own "REPRO: <exact local command>" line in its own
+# log / job summary on failure — read the failing job's output, no lookup tool.
 ```
 
 The workspace-root `integration` feature is empty with zero consumers — a bare root `cargo test --features integration` adds nothing. Backend-heavy gated suites are crate-level (e.g. `cargo test -p ironclaw_hooks --features integration,test-support`). E2E suite: `tests/e2e/AGENTS.md`.

--- a/scripts/ci/lib/run-cargo-ci-env.sh
+++ b/scripts/ci/lib/run-cargo-ci-env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Canonical scrubbed-env wrapper for cargo (and any other) invocations that
+# must not observe NEARAI_*/IRONCLAW_LLM_*/LLM_BACKEND credentials while a
+# compile is in flight — build.rs and proc macros run arbitrary code from the
+# dependency graph, so an unscrubbed compile is a real credential-exposure
+# surface, not just a test-hygiene nicety.
+#
+# Extracted once a third caller crossed this repo's own rule-of-three
+# duplication threshold (the comment that used to sit above
+# scripts/preflight-gates.sh's copy said exactly this: "if a third caller
+# appears, factor both into scripts/ci/lib/run-cargo-ci-env.sh"). The three
+# call sites — .githooks/pre-push's run_ci_env, scripts/ci/quality_gate.sh's
+# run_cargo_ci, and scripts/preflight-gates.sh's run_cargo_ci_scrubbed — keep
+# their own function NAMES as thin wrappers delegating here, so neither
+# existing callers nor in-flight sibling branches touching those files need
+# to change.
+#
+# Copy the -u unset list and the set-vars verbatim if this file is ever
+# edited; every caller's understanding of "scrubbed" depends on this exact
+# list.
+run_cargo_ci_env() {
+    env \
+        -u NEARAI_API_KEY \
+        -u NEARAI_BASE_URL \
+        -u NEARAI_SESSION_TOKEN \
+        -u NEARAI_PROVIDER_ID \
+        -u NEARAI_MODEL \
+        -u IRONCLAW_LLM_PROVIDER \
+        -u IRONCLAW_LLM_MODEL \
+        -u LLM_BACKEND \
+        IRONCLAW_DISABLE_OS_KEYCHAIN="${IRONCLAW_DISABLE_OS_KEYCHAIN:-1}" \
+        CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}" \
+        CARGO_PROFILE_TEST_DEBUG="${CARGO_PROFILE_TEST_DEBUG:-0}" \
+        RUST_MIN_STACK="${RUST_MIN_STACK:-67108864}" \
+        "$@"
+}

--- a/scripts/ci/quality_gate.sh
+++ b/scripts/ci/quality_gate.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# -E (errtrace): without it, the ERR trap below is NOT inherited into shell
+# functions (run_cargo_ci, select_test_runner) — a failure inside them would
+# abort the script via -e but silently skip the REPRO trap. Verified live:
+# without -E, a failing `cargo fetch`/`cargo clippy` called through a helper
+# function exits the script with no REPRO line at all.
+set -Eeuo pipefail
+
+report_repro() {
+    local status=$?
+    trap - ERR
+    echo "REPRO: ${BASH_COMMAND}" >&2
+    if [[ "${BASH_COMMAND}" == run_cargo_ci* ]]; then
+        echo "       (run_cargo_ci wraps this with quality_gate.sh's own scrubbed env:" >&2
+        echo "        NEARAI_*/IRONCLAW_LLM_*/LLM_BACKEND unset, IRONCLAW_DISABLE_OS_KEYCHAIN=1," >&2
+        echo "        CARGO_INCREMENTAL=0, CARGO_PROFILE_TEST_DEBUG=0, RUST_MIN_STACK=67108864)" >&2
+    fi
+    exit "${status}"
+}
+trap report_repro ERR
 
 echo "==> fmt check"
 cargo fmt --all -- --check

--- a/scripts/ci/quality_gate.sh
+++ b/scripts/ci/quality_gate.sh
@@ -6,14 +6,19 @@
 # function exits the script with no REPRO line at all.
 set -Eeuo pipefail
 
+# LAST_REPRO: set by a wrapper function (run_cargo_ci) right before it
+# returns non-zero, to its own real argv. BASH_COMMAND at trap time would
+# otherwise read "run_cargo_ci cargo clippy ..." — a function name that does
+# not exist outside this script and so is not paste-able as a repro command.
+LAST_REPRO=""
+
 report_repro() {
     local status=$?
     trap - ERR
-    echo "REPRO: ${BASH_COMMAND}" >&2
-    if [[ "${BASH_COMMAND}" == run_cargo_ci* ]]; then
-        echo "       (run_cargo_ci wraps this with quality_gate.sh's own scrubbed env:" >&2
-        echo "        NEARAI_*/IRONCLAW_LLM_*/LLM_BACKEND unset, IRONCLAW_DISABLE_OS_KEYCHAIN=1," >&2
-        echo "        CARGO_INCREMENTAL=0, CARGO_PROFILE_TEST_DEBUG=0, RUST_MIN_STACK=67108864)" >&2
+    if [ -n "${LAST_REPRO}" ]; then
+        echo "REPRO: ${LAST_REPRO}" >&2
+    else
+        echo "REPRO: ${BASH_COMMAND}" >&2
     fi
     exit "${status}"
 }
@@ -25,9 +30,22 @@ cargo fmt --all -- --check
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/run-cargo-ci-env.sh"
 
 # Delegates to the canonical scrub in scripts/ci/lib/run-cargo-ci-env.sh; the
-# function NAME is kept so nothing else in this script has to change.
+# function NAME is kept so nothing else in this script has to change. On
+# failure, records its own real argv into LAST_REPRO (see comment above) —
+# `printf '%q '` makes it exactly what report_repro should print, not what
+# BASH_COMMAND would (the wrapper's name).
 run_cargo_ci() {
-    run_cargo_ci_env "$@"
+    LAST_REPRO=""
+    local status=0
+    # `cmd || status=$?`, not `if cmd; then ... fi; status=$?`: an `if` with
+    # no `else` branch that took the false path resets $? to 0 at `fi`
+    # regardless of the condition's real exit status — verified live — so a
+    # post-if `$?` read would silently always capture 0 here.
+    run_cargo_ci_env "$@" || status=$?
+    if [ "${status}" -ne 0 ]; then
+        LAST_REPRO="$(printf '%q ' "$@")"
+    fi
+    return "${status}"
 }
 
 echo "==> clippy (CI parity: all features, all warnings)"

--- a/scripts/ci/quality_gate.sh
+++ b/scripts/ci/quality_gate.sh
@@ -22,21 +22,12 @@ trap report_repro ERR
 echo "==> fmt check"
 cargo fmt --all -- --check
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/run-cargo-ci-env.sh"
+
+# Delegates to the canonical scrub in scripts/ci/lib/run-cargo-ci-env.sh; the
+# function NAME is kept so nothing else in this script has to change.
 run_cargo_ci() {
-    env \
-        -u NEARAI_API_KEY \
-        -u NEARAI_BASE_URL \
-        -u NEARAI_SESSION_TOKEN \
-        -u NEARAI_PROVIDER_ID \
-        -u NEARAI_MODEL \
-        -u IRONCLAW_LLM_PROVIDER \
-        -u IRONCLAW_LLM_MODEL \
-        -u LLM_BACKEND \
-        IRONCLAW_DISABLE_OS_KEYCHAIN="${IRONCLAW_DISABLE_OS_KEYCHAIN:-1}" \
-        CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}" \
-        CARGO_PROFILE_TEST_DEBUG="${CARGO_PROFILE_TEST_DEBUG:-0}" \
-        RUST_MIN_STACK="${RUST_MIN_STACK:-67108864}" \
-        "$@"
+    run_cargo_ci_env "$@"
 }
 
 echo "==> clippy (CI parity: all features, all warnings)"

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -486,6 +486,14 @@ PR_STATIC_CONTROL_PATHS = {
     #     the 2026-08 gate audit (docs/internal/gate-audit-2026-08.md §4.3);
     #     referenced by no workflow, so no lane can be selected for it.
     "scripts/preflight-gates.sh",
+    #   * `dev-setup.sh` is the local fresh-checkout bootstrap script (rustup
+    #     target/tool install, cargo check/test, git hooks). No Tests (Reborn)
+    #     lane invokes it; CI's own steps install toolchain bits directly.
+    #     Decided here (2026-08, canonical-preflight track WS3) after this
+    #     class's `unmapped test or CI path` fail-closed arm caught the gap on
+    #     this track's own hooks commit — the same reasoning `preflight-gates.sh`
+    #     already carries a few lines above.
+    "scripts/dev-setup.sh",
     #   * `check-boundaries.sh` was DELETED by the same audit (measured broken
     #     on a clean tree, run by nothing). The entry stays so the deletion
     #     diff — and any revert — classifies instead of tripping the

--- a/scripts/ci/run-hermetic-deterministic-suite.sh
+++ b/scripts/ci/run-hermetic-deterministic-suite.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# -E (errtrace): almost every stage in this script runs through a helper
+# function (prepare_rust_dependencies, run_crate_tests, ...); without -E the
+# ERR trap below is NOT inherited into those functions, so a failure inside
+# one would abort the script via -e but never print REPRO. Verified live.
+set -Eeuo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 hermetic="${repo_root}/scripts/ci/run-hermetic-test-process.sh"
@@ -7,6 +11,20 @@ stage="${1:-all}"
 if [[ "$#" -gt 0 ]]; then
   shift
 fi
+# Captured now, not read via "$@" inside the trap: by the time an ERR trap
+# fires from deep inside a helper function (prepare_rust_dependencies, ...),
+# "$@" resolves to THAT function's own (empty) positional parameters, not the
+# script's — verified live (a failure inside prepare_command_dependencies
+# printed "REPRO: ... rust-e2e ''" instead of the real stage args).
+stage_args=("$@")
+
+print_repro_on_error() {
+    local status=$?
+    trap - ERR
+    echo "REPRO: bash scripts/ci/run-hermetic-deterministic-suite.sh ${stage} $(printf '%q ' "${stage_args[@]}")" >&2
+    exit "${status}"
+}
+trap print_repro_on_error ERR
 
 frontend_corepack_home=""
 postgres_image_prepared=0

--- a/scripts/ci/test-githooks-install.sh
+++ b/scripts/ci/test-githooks-install.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Self-tests for the .githooks install story and the pre-push tiers.
+# Everything heavy is stubbed inside a throwaway repo pair (worktree + bare
+# origin); PATH is REPLACED so real cargo/pytest cannot leak in.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+failures=0
+
+fail() { echo "FAIL: $1" >&2; failures=$((failures + 1)); }
+
+make_repo() {
+    work="$(mktemp -d)/repo"
+    origin="$(mktemp -d)/origin.git"
+    git init -q --bare -b main "$origin"
+    git init -q -b main "$work"
+    (
+        cd "$work"
+        git config user.email t@t && git config user.name t
+        mkdir -p .githooks scripts/ci bin
+        cp "$REPO_ROOT/.githooks/pre-push" .githooks/pre-push
+        cp "$REPO_ROOT/.githooks/pre-commit" .githooks/pre-commit
+        chmod +x .githooks/pre-push .githooks/pre-commit
+        for stub in scripts/preflight-gates.sh scripts/ci/quality_gate.sh \
+                    scripts/ci/check-include-str-paths.sh scripts/ci/check-hermetic-env.sh \
+                    scripts/ci/reborn-local-coverage-ratchet.sh scripts/check-version-bumps.sh \
+                    scripts/pre-commit-safety.sh scripts/ci/changed_workspace_packages.py; do
+            mkdir -p "$(dirname "$stub")"
+            if [[ "$stub" == *.py ]]; then
+                printf '#!/usr/bin/env python3\nimport json\nprint(json.dumps(["a"]))\n' >"$stub"
+            else
+                printf '#!/usr/bin/env bash\necho "ran ${0##*/}" >>"$HOOK_TEST_LOG"\n' >"$stub"
+            fi
+            chmod +x "$stub"
+        done
+        printf '#!/usr/bin/env bash\necho "ran pytest $*" >>"$HOOK_TEST_LOG"\n' >bin/pytest
+        chmod +x bin/pytest
+        # DEVIATION (plan gap, recorded): the default pre-push tier's
+        # changed-package clippy step (fix 7) genuinely shells out to a real
+        # `cargo`, which the plan's own self-test sandbox never stubbed. PATH
+        # is replaced (not prepended) in run_hook, so without this stub every
+        # default-tier assertion fails with "cargo: command not found"
+        # (rc=127) rather than testing the hook's own logic. Stubbed the same
+        # way scripts/ci/test-preflight-gates.sh already stubs cargo.
+        printf '#!/usr/bin/env bash\necho "ran cargo $*" >>"$HOOK_TEST_LOG"\n' >bin/cargo
+        chmod +x bin/cargo
+        git add -A && git commit -qm init
+        git remote add origin "$origin"
+        git push -q origin main
+        git config core.hooksPath .githooks
+    )
+    echo "$work"
+}
+
+run_hook() { # repo, hook, env...
+    local repo="$1" hook="$2"; shift 2
+    set +e
+    output="$(cd "$repo" && env HOOK_TEST_LOG="$repo/log" \
+        PATH="$repo/bin:/usr/bin:/bin" "$@" bash ".githooks/$hook" origin 2>&1)"
+    status=$?
+    set -e
+}
+
+# 1. Default pre-push tier: merge check + preflight + changed-package clippy,
+#    NOT the full gauntlet.
+repo="$(make_repo)"
+run_hook "$repo" pre-push
+[ "$status" -eq 0 ] || fail "default pre-push exited $status: $output"
+grep -q "ran preflight-gates.sh" "$repo/log" || fail "default tier must run preflight-gates.sh"
+grep -q "ran quality_gate.sh" "$repo/log" && fail "default tier must NOT run quality_gate.sh"
+grep -qF "merge check" <<<"$output" || fail "default tier must keep the merge-cleanliness check"
+grep -qF "changed-package clippy" <<<"$output" || fail "default tier must run the changed-package clippy step (fix 7)"
+
+# 2. IRONCLAW_PREPUSH_FULL=1: full gauntlet runs; Emulate CLI absent is a
+#    WARNING and a skip, not a hard failure.
+repo="$(make_repo)"
+run_hook "$repo" pre-push IRONCLAW_PREPUSH_FULL=1 IRONCLAW_PREPUSH_REBORN_COVERAGE_RATCHET=1
+[ "$status" -eq 0 ] || fail "full tier without Emulate CLI exited $status: $output"
+grep -q "ran quality_gate.sh" "$repo/log" || fail "full tier must run quality_gate.sh"
+grep -q "ran check-include-str-paths.sh" "$repo/log" || fail "full tier keeps static checks"
+grep -q "ran reborn-local-coverage-ratchet.sh" "$repo/log" || fail "full tier keeps the ratchet"
+grep -qi "warn" <<<"$output" || fail "absent Emulate CLI must print a warning"
+grep -q "ran pytest" "$repo/log" && fail "absent Emulate CLI must skip the replay"
+grep -qF "#6018" <<<"$output" || fail "full tier must keep the #6018/#5603/#6015 rationale comment (fix 10)"
+
+# 3. Full tier WITH an Emulate CLI present still runs the replay.
+repo="$(make_repo)"
+touch "$repo/emulate-cli.js"
+run_hook "$repo" pre-push IRONCLAW_PREPUSH_FULL=1 IRONCLAW_EMULATE_CLI="$repo/emulate-cli.js"
+grep -q "ran pytest" "$repo/log" || fail "present Emulate CLI must run the replay"
+
+# 4. A failing default-tier preflight fails the push.
+repo="$(make_repo)"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$repo/scripts/preflight-gates.sh"
+run_hook "$repo" pre-push
+[ "$status" -ne 0 ] || fail "failing preflight must fail the hook"
+
+# 5. pre-commit chains pre-commit-safety.sh (the one-install-story fix).
+repo="$(make_repo)"
+(cd "$repo" && echo x >file && git add file)
+set +e
+output="$(cd "$repo" && env HOOK_TEST_LOG="$repo/log" \
+    PATH="$repo/bin:/usr/bin:/bin" bash .githooks/pre-commit 2>&1)"
+status=$?
+set -e
+[ "$status" -eq 0 ] || fail "pre-commit exited $status: $output"
+grep -q "ran pre-commit-safety.sh" "$repo/log" || fail "pre-commit must invoke pre-commit-safety.sh"
+
+# 6. dev-setup.sh pins: one install story, no hook symlinks.
+grep -q 'git config core.hooksPath .githooks' "$REPO_ROOT/scripts/dev-setup.sh" \
+    || fail "dev-setup.sh must install hooks via git config core.hooksPath .githooks"
+grep -qE 'ln -sf .*(pre-push|pre-commit|commit-msg)' "$REPO_ROOT/scripts/dev-setup.sh" \
+    && fail "dev-setup.sh must not symlink hooks (worktree-broken install story)"
+
+# 7. WORKTREE CASE (fix 8 — the corrected diagnosis, proven, not asserted).
+#    A second worktree of the SAME repo must fire ITS OWN checked-out
+#    .githooks content, not the first worktree's, and not require re-running
+#    any install step in the second worktree — core.hooksPath is set once,
+#    in the shared config, and a relative value resolves per-worktree.
+repo="$(make_repo)"
+worktree2="$(mktemp -d)/repo-wt2"
+git -C "$repo" worktree add -q -b wt2-branch "$worktree2" >/dev/null
+# Overwrite ONLY the second worktree's local (uncommitted) .githooks/pre-commit
+# with a marker script — worktrees have independent working directories over
+# the same object store, so this cannot touch worktree 1's checkout.
+printf '#!/usr/bin/env bash\necho "MARKER: worktree2 own hooks fired" >>"$HOOK_TEST_LOG"\n' \
+    >"$worktree2/.githooks/pre-commit"
+chmod +x "$worktree2/.githooks/pre-commit"
+(cd "$worktree2" && echo y >file2 && git add file2)
+set +e
+wt2_output="$(cd "$worktree2" && env HOOK_TEST_LOG="$repo/log2" \
+    PATH="$repo/bin:/usr/bin:/bin" git commit -qm test 2>&1)"
+wt2_status=$?
+set -e
+[ "$wt2_status" -eq 0 ] || fail "worktree2 commit failed: $wt2_output"
+grep -q "MARKER: worktree2 own hooks fired" "$repo/log2" \
+    || fail "worktree2 must run its OWN .githooks/pre-commit, not worktree1's (core.hooksPath resolves per-worktree — the actual fix, per the corrected diagnosis)"
+git -C "$repo" worktree remove -f "$worktree2" >/dev/null 2>&1 || true
+
+if [ "$failures" -gt 0 ]; then
+    echo "test-githooks-install: $failures assertion(s) failed" >&2
+    exit 1
+fi
+echo "test-githooks-install: OK"

--- a/scripts/ci/test-githooks-install.sh
+++ b/scripts/ci/test-githooks-install.sh
@@ -18,10 +18,13 @@ make_repo() {
     (
         cd "$work"
         git config user.email t@t && git config user.name t
-        mkdir -p .githooks scripts/ci bin
+        mkdir -p .githooks scripts/ci scripts/ci/lib bin
         cp "$REPO_ROOT/.githooks/pre-push" .githooks/pre-push
         cp "$REPO_ROOT/.githooks/pre-commit" .githooks/pre-commit
         chmod +x .githooks/pre-push .githooks/pre-commit
+        # Real content, not a stub: pre-push sources this for its actual
+        # scrub behavior, which test 1 below asserts against directly.
+        cp "$REPO_ROOT/scripts/ci/lib/run-cargo-ci-env.sh" scripts/ci/lib/run-cargo-ci-env.sh
         for stub in scripts/preflight-gates.sh scripts/ci/quality_gate.sh \
                     scripts/ci/check-include-str-paths.sh scripts/ci/check-hermetic-env.sh \
                     scripts/ci/reborn-local-coverage-ratchet.sh scripts/check-version-bumps.sh \
@@ -43,7 +46,12 @@ make_repo() {
         # default-tier assertion fails with "cargo: command not found"
         # (rc=127) rather than testing the hook's own logic. Stubbed the same
         # way scripts/ci/test-preflight-gates.sh already stubs cargo.
-        printf '#!/usr/bin/env bash\necho "ran cargo $*" >>"$HOOK_TEST_LOG"\n' >bin/cargo
+        # Also dumps its own environment (when HOOK_TEST_ENV_LOG is set) so
+        # tests can assert the changed-package clippy step's compile is
+        # scrubbed of NEARAI_*/IRONCLAW_LLM_*/LLM_BACKEND credentials
+        # (finding 1 — build.rs/proc macros run arbitrary code with whatever
+        # env the compile sees).
+        printf '#!/usr/bin/env bash\necho "ran cargo $*" >>"$HOOK_TEST_LOG"\nif [ -n "${HOOK_TEST_ENV_LOG:-}" ]; then env >>"$HOOK_TEST_ENV_LOG"; fi\n' >bin/cargo
         chmod +x bin/cargo
         git add -A && git commit -qm init
         git remote add origin "$origin"
@@ -65,12 +73,16 @@ run_hook() { # repo, hook, env...
 # 1. Default pre-push tier: merge check + preflight + changed-package clippy,
 #    NOT the full gauntlet.
 repo="$(make_repo)"
-run_hook "$repo" pre-push
+run_hook "$repo" pre-push NEARAI_API_KEY=leaked-test-secret HOOK_TEST_ENV_LOG="$repo/envlog"
 [ "$status" -eq 0 ] || fail "default pre-push exited $status: $output"
 grep -q "ran preflight-gates.sh" "$repo/log" || fail "default tier must run preflight-gates.sh"
 grep -q "ran quality_gate.sh" "$repo/log" && fail "default tier must NOT run quality_gate.sh"
 grep -qF "merge check" <<<"$output" || fail "default tier must keep the merge-cleanliness check"
 grep -qF "changed-package clippy" <<<"$output" || fail "default tier must run the changed-package clippy step (fix 7)"
+grep -q "^ran cargo clippy -p a -- -D warnings$" "$repo/log" \
+    || fail "changed-package clippy must invoke cargo with the discovered -p <pkg> args, not just log the phrase (fix 5b)"
+grep -q "^NEARAI_API_KEY=" "$repo/envlog" \
+    && fail "SECURITY: changed-package clippy compile must not see NEARAI_API_KEY (unscrubbed compile, fix 1)"
 
 # 2. IRONCLAW_PREPUSH_FULL=1: full gauntlet runs; Emulate CLI absent is a
 #    WARNING and a skip, not a hard failure.

--- a/scripts/ci/test-githooks-install.sh
+++ b/scripts/ci/test-githooks-install.sh
@@ -84,6 +84,33 @@ grep -q "^ran cargo clippy -p a -- -D warnings$" "$repo/log" \
 grep -q "^NEARAI_API_KEY=" "$repo/envlog" \
     && fail "SECURITY: changed-package clippy compile must not see NEARAI_API_KEY (unscrubbed compile, fix 1)"
 
+# 1b. IRONCLAW_PREPUSH_MERGE_CHECK=0 must not break the changed-package
+#     clippy step's own merge-base lookup. That lookup reads
+#     refs/remotes/origin/main, which normally exists only because the
+#     (here skipped) merge-check step fetched it — the lookup must be
+#     self-sufficient (fix 2). Prune the ref first (git push's own
+#     opportunistic tracking-ref update would otherwise already have
+#     created it, masking the bug this test targets) to reproduce the real
+#     "never fetched yet" case.
+repo="$(make_repo)"
+git -C "$repo" update-ref -d refs/remotes/origin/main
+run_hook "$repo" pre-push IRONCLAW_PREPUSH_MERGE_CHECK=0
+[ "$status" -eq 0 ] || fail "IRONCLAW_PREPUSH_MERGE_CHECK=0 must not fail the changed-package clippy step: $output"
+grep -qF "merge check" <<<"$output" && fail "IRONCLAW_PREPUSH_MERGE_CHECK=0 must skip the merge check entirely"
+grep -q "ran cargo clippy -p a -- -D warnings" "$repo/log" \
+    || fail "IRONCLAW_PREPUSH_MERGE_CHECK=0 must still run changed-package clippy"
+
+# 1c. A failing changed-package discovery command must fail the hook, not
+#     silently report "nothing to lint" — process substitution
+#     (`done < <(cmd1 | cmd2)`) swallows a failure under set -e, so the fix
+#     captures to a file and checks the exit status explicitly (fix 3).
+repo="$(make_repo)"
+printf '#!/usr/bin/env python3\nimport sys\nsys.exit(1)\n' >"$repo/scripts/ci/changed_workspace_packages.py"
+run_hook "$repo" pre-push
+[ "$status" -ne 0 ] || fail "a failing changed_workspace_packages.py must fail the hook, not report 'nothing to lint'"
+grep -qF "no changed workspace packages" <<<"$output" \
+    && fail "must not false-green when discovery fails (process-substitution swallow)"
+
 # 2. IRONCLAW_PREPUSH_FULL=1: full gauntlet runs; Emulate CLI absent is a
 #    WARNING and a skip, not a hard failure.
 repo="$(make_repo)"

--- a/scripts/ci/test-preflight-gates.sh
+++ b/scripts/ci/test-preflight-gates.sh
@@ -15,8 +15,9 @@ make_sandbox() {
     (
         cd "$sandbox"
         git init -q -b main .
-        mkdir -p scripts/ci bin
+        mkdir -p scripts/ci scripts/ci/lib bin
         cp "$REPO_ROOT/scripts/preflight-gates.sh" scripts/preflight-gates.sh
+        cp "$REPO_ROOT/scripts/ci/lib/run-cargo-ci-env.sh" scripts/ci/lib/run-cargo-ci-env.sh
         # Stub every script gate preflight names.
         for stub in scripts/ci/check-composition-budget.sh \
                     scripts/ci/check-include-str-paths.sh \

--- a/scripts/ci/test-preflight-gates.sh
+++ b/scripts/ci/test-preflight-gates.sh
@@ -124,7 +124,29 @@ run_preflight "$sandbox" --nonsense
 [ "$status" -eq 2 ] || { echo "FAIL: unknown flag exited $status, want 2" >&2; failures=$((failures+1)); }
 expect "unknown flag names itself" "$output" "unknown option: --nonsense"
 
-# (Note: the queue-shape assertions land in Task 2, appended before the final verdict block.)
+# 5. --queue-shape runs exactly the three queue clippy shapes + the planner
+#    full-plan listing, and NONE of the default gates.
+sandbox="$(make_sandbox)"; extra_env=()
+run_preflight "$sandbox" --queue-shape
+[ "$status" -eq 0 ] || { echo "FAIL: --queue-shape green run exited $status" >&2; failures=$((failures+1)); }
+log="$(cat "$sandbox/log")"
+expect "queue clippy shape 1: all-targets all-features" "$log" \
+    "cargo clippy --locked --all --tests --examples --all-features -- -D warnings"
+expect "queue clippy shape 2: all-targets default-features" "$log" \
+    "cargo clippy --locked --all --tests --examples -- -D warnings"
+expect "queue clippy shape 3: production-targets default-features" "$log" \
+    "cargo clippy --locked --all --lib --bins -- -D warnings"
+expect "planner full-plan listing invoked" "$log" \
+    "reborn_pr_test_plan.py --event merge_group"
+expect "bucket list rendered" "$output" "reborn-core"
+expect_absent "queue-shape skips default gates" "$log" "cargo fmt --all -- --check"
+
+# 6. --queue-shape collects all three clippy failures in one lap.
+sandbox="$(make_sandbox)"
+extra_env=(PREFLIGHT_FAIL_MATCH="clippy")
+run_preflight "$sandbox" --queue-shape
+[ "$status" -eq 1 ] || { echo "FAIL: --queue-shape with failing clippy exited $status" >&2; failures=$((failures+1)); }
+expect "all three shapes reported" "$output" "3 gate(s) FAILED"
 
 if [ "$failures" -gt 0 ]; then
     echo "test-preflight-gates: $failures assertion(s) failed" >&2

--- a/scripts/ci/test-preflight-gates.sh
+++ b/scripts/ci/test-preflight-gates.sh
@@ -26,11 +26,35 @@ make_sandbox() {
             chmod +x "$stub"
         done
         for stub in scripts/check_no_panics.py scripts/ci/check-target-tree.py \
-                    scripts/ci/check-guidance.py scripts/ci/docs_publication_boundary.py \
-                    scripts/ci/reborn_pr_test_plan.py; do
+                    scripts/ci/check-guidance.py scripts/ci/docs_publication_boundary.py; do
             mkdir -p "$(dirname "$stub")"
-            printf 'import os,sys\nopen(os.environ["PREFLIGHT_TEST_LOG"],"a").write("ran %%s %%s\\n" %% (os.path.basename(sys.argv[0]), " ".join(sys.argv[1:])))\nif os.path.basename(sys.argv[0]) == "reborn_pr_test_plan.py":\n    print("{\\"crate_buckets\\":[{\\"name\\":\\"reborn-core\\",\\"packages\\":[\\"a\\"]}],\\"root_partitions\\":[0,1,2,3],\\"integration_lanes\\":[0,1,2,3,\\"groups\\"],\\"run_group_tests\\":true,\\"run_qa_replay\\":true,\\"run_sandbox_docker\\":true}")\n' >"$stub"
+            printf 'import os,sys\nopen(os.environ["PREFLIGHT_TEST_LOG"],"a").write("ran %%s %%s\\n" %% (os.path.basename(sys.argv[0]), " ".join(sys.argv[1:])))\n' >"$stub"
         done
+        # The planner stub honors PREFLIGHT_PLANNER_FAIL_MODE so the
+        # queue_plan_listing planner-failure branch (preflight-gates.sh's
+        # `if result.returncode != 0` and its bad-JSON path) is exercisable —
+        # "nonzero" simulates the subprocess itself failing, "badjson" makes
+        # it succeed with output json.loads() cannot parse.
+        cat >scripts/ci/reborn_pr_test_plan.py <<'PY'
+import os
+import sys
+
+open(os.environ["PREFLIGHT_TEST_LOG"], "a").write(
+    "ran %s %s\n" % (os.path.basename(sys.argv[0]), " ".join(sys.argv[1:]))
+)
+mode = os.environ.get("PREFLIGHT_PLANNER_FAIL_MODE", "")
+if mode == "nonzero":
+    sys.stderr.write("planner stub: simulated failure\n")
+    sys.exit(1)
+if mode == "badjson":
+    print("{not valid json")
+    sys.exit(0)
+print(
+    '{"crate_buckets":[{"name":"reborn-core","packages":["a"]}],'
+    '"root_partitions":[0,1,2,3],"integration_lanes":[0,1,2,3,"groups"],'
+    '"run_group_tests":true,"run_qa_replay":true,"run_sandbox_docker":true}'
+)
+PY
         # Stub cargo: logs argv; exits per PREFLIGHT_FAIL_MATCH.
         cat >bin/cargo <<'STUB'
 #!/usr/bin/env bash
@@ -142,12 +166,44 @@ expect "planner full-plan listing invoked" "$log" \
 expect "bucket list rendered" "$output" "reborn-core"
 expect_absent "queue-shape skips default gates" "$log" "cargo fmt --all -- --check"
 
-# 6. --queue-shape collects all three clippy failures in one lap.
+# 6. --queue-shape collects all three clippy failures in one lap, and each
+#    REPRO is the real, paste-able cargo invocation — not the internal
+#    run_cargo_ci_scrubbed wrapper name, which does not exist outside this
+#    script (finding 4).
 sandbox="$(make_sandbox)"
 extra_env=(PREFLIGHT_FAIL_MATCH="clippy")
 run_preflight "$sandbox" --queue-shape
 [ "$status" -eq 1 ] || { echo "FAIL: --queue-shape with failing clippy exited $status" >&2; failures=$((failures+1)); }
 expect "all three shapes reported" "$output" "3 gate(s) FAILED"
+expect "queue-shape clippy REPRO is the real cargo invocation" "$output" \
+    "REPRO: cargo clippy --locked --all --tests --examples --all-features -- -D warnings"
+expect_absent "queue-shape REPRO never prints the wrapper function name" "$output" \
+    "REPRO: run_cargo_ci_scrubbed"
+
+# 7. --queue-shape: the planner returning a non-zero exit status must fail
+#    the "planner full-plan listing" gate (preflight-gates.sh's own
+#    `if result.returncode != 0` branch, previously never exercised — the
+#    stub always emitted valid JSON), and its REPRO must be the real
+#    underlying python3 invocation, not the queue_plan_listing function name
+#    (which has no standalone equivalent).
+sandbox="$(make_sandbox)"
+extra_env=(PREFLIGHT_PLANNER_FAIL_MODE=nonzero)
+run_preflight "$sandbox" --queue-shape
+[ "$status" -eq 1 ] || { echo "FAIL: --queue-shape with a nonzero-exit planner exited $status" >&2; failures=$((failures+1)); }
+expect "planner nonzero-exit failure reported" "$output" "1 gate(s) FAILED"
+expect "planner nonzero-exit REPRO is the real python3 invocation" "$output" \
+    "REPRO: python3 scripts/ci/reborn_pr_test_plan.py --event merge_group"
+expect_absent "planner REPRO never prints the queue_plan_listing function name" "$output" \
+    "REPRO: queue_plan_listing"
+
+# 8. --queue-shape: the planner succeeding but emitting unparseable JSON is a
+#    distinct uncovered path from the explicit returncode!=0 branch — must
+#    also fail the gate.
+sandbox="$(make_sandbox)"
+extra_env=(PREFLIGHT_PLANNER_FAIL_MODE=badjson)
+run_preflight "$sandbox" --queue-shape
+[ "$status" -eq 1 ] || { echo "FAIL: --queue-shape with bad planner JSON exited $status" >&2; failures=$((failures+1)); }
+expect "bad-JSON planner failure reported" "$output" "1 gate(s) FAILED"
 
 if [ "$failures" -gt 0 ]; then
     echo "test-preflight-gates: $failures assertion(s) failed" >&2

--- a/scripts/ci/test-preflight-gates.sh
+++ b/scripts/ci/test-preflight-gates.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Self-test for scripts/preflight-gates.sh modes (--ci, --queue-shape, default).
+# Every gate command is stubbed inside a throwaway git repo, so this runs in
+# milliseconds and compiles nothing. PATH is REPLACED, not prepended, so a real
+# cargo/cargo-nextest on the developer's machine cannot leak into the sandbox
+# (same stance as scripts/ci/test-quality-gate-runner.sh).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+failures=0
+
+make_sandbox() {
+    sandbox="$(mktemp -d)"
+    (
+        cd "$sandbox"
+        git init -q -b main .
+        mkdir -p scripts/ci bin
+        cp "$REPO_ROOT/scripts/preflight-gates.sh" scripts/preflight-gates.sh
+        # Stub every script gate preflight names.
+        for stub in scripts/ci/check-composition-budget.sh \
+                    scripts/ci/check-include-str-paths.sh \
+                    scripts/ci/check-hermetic-env.sh; do
+            printf '#!/usr/bin/env bash\necho "ran ${0##*/}" >>"$PREFLIGHT_TEST_LOG"\n' >"$stub"
+            chmod +x "$stub"
+        done
+        for stub in scripts/check_no_panics.py scripts/ci/check-target-tree.py \
+                    scripts/ci/check-guidance.py scripts/ci/docs_publication_boundary.py \
+                    scripts/ci/reborn_pr_test_plan.py; do
+            mkdir -p "$(dirname "$stub")"
+            printf 'import os,sys\nopen(os.environ["PREFLIGHT_TEST_LOG"],"a").write("ran %%s %%s\\n" %% (os.path.basename(sys.argv[0]), " ".join(sys.argv[1:])))\nif os.path.basename(sys.argv[0]) == "reborn_pr_test_plan.py":\n    print("{\\"crate_buckets\\":[{\\"name\\":\\"reborn-core\\",\\"packages\\":[\\"a\\"]}],\\"root_partitions\\":[0,1,2,3],\\"integration_lanes\\":[0,1,2,3,\\"groups\\"],\\"run_group_tests\\":true,\\"run_qa_replay\\":true,\\"run_sandbox_docker\\":true}")\n' >"$stub"
+        done
+        # Stub cargo: logs argv; exits per PREFLIGHT_FAIL_MATCH.
+        cat >bin/cargo <<'STUB'
+#!/usr/bin/env bash
+echo "cargo $*" >>"$PREFLIGHT_TEST_LOG"
+if [ -n "${PREFLIGHT_FAIL_MATCH:-}" ] && [[ "$*" == *"$PREFLIGHT_FAIL_MATCH"* ]]; then
+    exit 1
+fi
+STUB
+        chmod +x bin/cargo
+        # python3 must stay real (the planner stub is a real python file), but
+        # git/bash/env come from /usr/bin:/bin.
+        git add -A >/dev/null 2>&1 || true
+    )
+    echo "$sandbox"
+}
+
+run_preflight() {
+    local sandbox="$1"; shift
+    set +e
+    # BUG FIXED (gate-audit revision, fix 4): "${extra_env[@]:-}" passes ONE
+    # empty-string argument to `env` whenever extra_env is a declared-but-empty
+    # array (bash's :- operator treats a zero-element array as "unset or null"
+    # and substitutes the default, here nothing, AS one word) — env then tries
+    # to exec "" as the command and the real invocation never runs at all
+    # (rc=127, "env: '': No such file or directory" — reproduced live against
+    # this exact shape before landing the fix). ${arr[@]+"${arr[@]}"} emits
+    # ZERO words when the array is empty and the array's own elements,
+    # correctly quoted, when it is not — verified both cases live.
+    output="$(cd "$sandbox" && \
+        env PREFLIGHT_TEST_LOG="$sandbox/log" \
+            PATH="$sandbox/bin:/usr/bin:/bin" \
+            ${extra_env[@]+"${extra_env[@]}"} \
+            bash scripts/preflight-gates.sh "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+expect() { # label, haystack, needle
+    if ! grep -qF -- "$3" <<<"$2"; then
+        echo "FAIL: $1 — expected to find: $3" >&2
+        failures=$((failures + 1))
+    fi
+}
+expect_absent() {
+    if grep -qF -- "$3" <<<"$2"; then
+        echo "FAIL: $1 — expected NOT to find: $3" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# 1. Default mode: no GitHub annotations, gates run, exit 0 when all green,
+#    and (unrelated to --ci) Layer 2's nextest-absent fallback still fires —
+#    real behavior default mode must keep, now asserted here rather than
+#    inside a --ci case (Layer 2 no longer runs under --ci at all).
+sandbox="$(make_sandbox)"; extra_env=()
+run_preflight "$sandbox"
+[ "$status" -eq 0 ] || { echo "FAIL: default green run exited $status" >&2; failures=$((failures+1)); }
+expect "default runs fmt" "$(cat "$sandbox/log")" "cargo fmt --all -- --check"
+expect_absent "default has no ::group::" "$output" "::group::"
+expect "default Layer 2 falls back to cargo test (nextest absent)" "$(cat "$sandbox/log")" \
+    "cargo test -p ironclaw_architecture_tests --no-fail-fast"
+
+# 2. --ci: ::group:: per gate, ::error + REPRO on failure, later gates still
+#    run, Layer 2 AND Layer 3 are both skipped with a printed reason
+#    (fix 3 — Layer 1 only), exit 1 on any failure.
+sandbox="$(make_sandbox)"
+extra_env=(PREFLIGHT_FAIL_MATCH="fmt")
+run_preflight "$sandbox" --ci
+[ "$status" -eq 1 ] || { echo "FAIL: --ci with failing fmt exited $status" >&2; failures=$((failures+1)); }
+expect "--ci groups output" "$output" "::group::fmt check"
+expect "--ci endgroup" "$output" "::endgroup::"
+expect "--ci error annotation" "$output" "::error title=preflight gate failed::fmt check"
+expect "--ci prints the exact repro command" "$output" "REPRO: cargo fmt --all -- --check"
+expect "--ci keeps going after a failure" "$(cat "$sandbox/log")" "ran check-guidance.py"
+expect_absent "--ci does NOT run the architecture suite" "$(cat "$sandbox/log")" "ironclaw_architecture_tests"
+expect "--ci skips Layer 2 loudly with a reason" "$output" "architecture suite: skipped under --ci"
+expect "--ci skips charters loudly" "$output" "charter tests: skipped under --ci"
+expect "--ci verdict lists the failure" "$output" "1 gate(s) FAILED"
+
+# 3. --ci all green exits 0 and prints the OK verdict.
+sandbox="$(make_sandbox)"; extra_env=()
+run_preflight "$sandbox" --ci
+[ "$status" -eq 0 ] || { echo "FAIL: --ci green run exited $status" >&2; failures=$((failures+1)); }
+expect "--ci OK verdict" "$output" "preflight-gates: OK"
+
+# 4. Unknown flag fails loudly (no silent no-op modes) — this is the case
+#    that catches "the script currently ignores argv entirely" for real:
+#    verified live against the unmodified script that `--nonsense` today runs
+#    the full default gate list rather than rejecting the flag.
+sandbox="$(make_sandbox)"; extra_env=()
+run_preflight "$sandbox" --nonsense
+[ "$status" -eq 2 ] || { echo "FAIL: unknown flag exited $status, want 2" >&2; failures=$((failures+1)); }
+expect "unknown flag names itself" "$output" "unknown option: --nonsense"
+
+# (Note: the queue-shape assertions land in Task 2, appended before the final verdict block.)
+
+if [ "$failures" -gt 0 ]; then
+    echo "test-preflight-gates: $failures assertion(s) failed" >&2
+    exit 1
+fi
+echo "test-preflight-gates: OK"

--- a/scripts/ci/test-repro-emission.sh
+++ b/scripts/ci/test-repro-emission.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Self-tests for Pattern A REPRO emission: quality_gate.sh and
+# run-hermetic-deterministic-suite.sh must each print
+# "REPRO: <exact failing invocation>" when a gate/stage they run fails.
+# preflight-gates.sh's REPRO emission is already covered by
+# scripts/ci/test-preflight-gates.sh (Task 1) — not duplicated here.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+failures=0
+fail() { echo "FAIL: $1" >&2; failures=$((failures + 1)); }
+
+make_sandbox() {
+    sandbox="$(mktemp -d)"
+    mkdir -p "$sandbox/bin" "$sandbox/scripts/ci"
+    cp "$REPO_ROOT/scripts/ci/quality_gate.sh" "$sandbox/scripts/ci/quality_gate.sh"
+    cp "$REPO_ROOT/scripts/ci/run-hermetic-deterministic-suite.sh" \
+        "$sandbox/scripts/ci/run-hermetic-deterministic-suite.sh"
+    mkdir -p "$sandbox/scripts/ci/lib"
+    printf '#!/usr/bin/env bash\necho "ran $*" >>"$REPRO_TEST_LOG"\nexit 1\n' \
+        >"$sandbox/scripts/ci/run-hermetic-test-process.sh"
+    chmod +x "$sandbox/scripts/ci/run-hermetic-test-process.sh"
+    echo "$sandbox"
+}
+
+# 1. quality_gate.sh: a failing fmt check prints REPRO for exactly that line.
+sandbox="$(make_sandbox)"
+cat >"$sandbox/bin/cargo" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "fmt" ]; then exit 1; fi
+exit 0
+STUB
+chmod +x "$sandbox/bin/cargo"
+set +e
+output="$(cd "$sandbox" && env PATH="$sandbox/bin:/usr/bin:/bin" \
+    bash scripts/ci/quality_gate.sh 2>&1)"
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "quality_gate.sh must fail when fmt fails"
+grep -qF "REPRO: cargo fmt --all -- --check" <<<"$output" \
+    || fail "quality_gate.sh must print the exact failing command as REPRO"
+
+# 2. run-hermetic-deterministic-suite.sh: a failing stage prints REPRO with
+#    the stage + its own args (fixed args reconstructed via "$@").
+sandbox="$(make_sandbox)"
+set +e
+output="$(cd "$sandbox" && env REPRO_TEST_LOG="$sandbox/log" \
+    PATH="$sandbox/bin:/usr/bin:/bin" \
+    bash scripts/ci/run-hermetic-deterministic-suite.sh rust-e2e architecture-boundaries 2>&1)"
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "run-hermetic-deterministic-suite.sh must fail when the stage fails"
+grep -qF "REPRO: bash scripts/ci/run-hermetic-deterministic-suite.sh rust-e2e architecture-boundaries" \
+    <<<"$output" || fail "run-hermetic-deterministic-suite.sh must print the exact stage + args as REPRO"
+
+if [ "$failures" -gt 0 ]; then
+    echo "test-repro-emission: $failures assertion(s) failed" >&2
+    exit 1
+fi
+echo "test-repro-emission: OK"

--- a/scripts/ci/test-repro-emission.sh
+++ b/scripts/ci/test-repro-emission.sh
@@ -18,6 +18,7 @@ make_sandbox() {
     cp "$REPO_ROOT/scripts/ci/run-hermetic-deterministic-suite.sh" \
         "$sandbox/scripts/ci/run-hermetic-deterministic-suite.sh"
     mkdir -p "$sandbox/scripts/ci/lib"
+    cp "$REPO_ROOT/scripts/ci/lib/run-cargo-ci-env.sh" "$sandbox/scripts/ci/lib/run-cargo-ci-env.sh"
     printf '#!/usr/bin/env bash\necho "ran $*" >>"$REPRO_TEST_LOG"\nexit 1\n' \
         >"$sandbox/scripts/ci/run-hermetic-test-process.sh"
     chmod +x "$sandbox/scripts/ci/run-hermetic-test-process.sh"

--- a/scripts/ci/test-repro-emission.sh
+++ b/scripts/ci/test-repro-emission.sh
@@ -55,6 +55,32 @@ set -e
 grep -qF "REPRO: bash scripts/ci/run-hermetic-deterministic-suite.sh rust-e2e architecture-boundaries" \
     <<<"$output" || fail "run-hermetic-deterministic-suite.sh must print the exact stage + args as REPRO"
 
+# 3. quality_gate.sh: a failure INSIDE the run_cargo_ci wrapper function must
+#    print the wrapper's own real argv as REPRO ("cargo clippy ..."), not
+#    "run_cargo_ci cargo clippy ..." — run_cargo_ci is a function name that
+#    does not exist outside this script, so BASH_COMMAND alone is not
+#    paste-able. This is also exactly the case a regressed `set -E` would
+#    break: without errtrace the ERR trap would not fire from inside
+#    run_cargo_ci at all, and the script would exit with no REPRO line.
+sandbox="$(make_sandbox)"
+cat >"$sandbox/bin/cargo" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "fmt" ]; then exit 0; fi
+if [ "$1" = "clippy" ]; then exit 1; fi
+exit 0
+STUB
+chmod +x "$sandbox/bin/cargo"
+set +e
+output="$(cd "$sandbox" && env PATH="$sandbox/bin:/usr/bin:/bin" \
+    bash scripts/ci/quality_gate.sh 2>&1)"
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "quality_gate.sh must fail when clippy fails"
+grep -qF "REPRO: cargo clippy --locked --all --tests --examples --all-features -- -D warnings" <<<"$output" \
+    || fail "a failure inside run_cargo_ci must print its own real argv as REPRO"
+grep -qF "REPRO: run_cargo_ci" <<<"$output" \
+    && fail "REPRO must never print the internal wrapper function name (not runnable outside the script)"
+
 if [ "$failures" -gt 0 ]; then
     echo "test-repro-emission: $failures assertion(s) failed" >&2
     exit 1

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -876,6 +876,7 @@ class RebornPrTestPlanTests(unittest.TestCase):
             "scripts/dev_metrics.py",
             "scripts/pre-commit-safety.sh",
             "scripts/test-mutation-audit.sh",
+            "scripts/dev-setup.sh",
         ):
             with self.subTest(path=path):
                 plan = self.plan("pull_request", [path])

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -46,19 +46,17 @@ cargo check
 echo "[5/6] Running tests (no external DB required)..."
 cargo test
 
-# 6. Install git hooks
+# 6. Install git hooks — one story, worktree-safe. core.hooksPath makes git
+# read hooks from the tracked .githooks/ directory in EVERY checkout of this
+# repository (worktrees included: a relative core.hooksPath resolves against
+# each worktree's own top-level directory), which the old absolute-path
+# git-path-hooks symlinks never did — they pointed every worktree at
+# whichever checkout last ran this script.
 echo "[6/6] Installing git hooks..."
-HOOKS_DIR=$(git rev-parse --git-path hooks 2>/dev/null) || true
-if [ -n "$HOOKS_DIR" ]; then
-    mkdir -p "$HOOKS_DIR"
-    SCRIPTS_ABS="$(cd "$(dirname "$0")" && pwd)"
-    ln -sf "$SCRIPTS_ABS/commit-msg-regression.sh" "$HOOKS_DIR/commit-msg"
-    echo "  commit-msg hook installed (regression test enforcement)"
-    ln -sf "$SCRIPTS_ABS/pre-commit-safety.sh" "$HOOKS_DIR/pre-commit"
-    echo "  pre-commit hook installed (UTF-8, case-sensitivity, /tmp, redaction, composition-mass ratchet)"
-    REPO_ROOT="$(git rev-parse --show-toplevel)"
-    ln -sf "$REPO_ROOT/.githooks/pre-push" "$HOOKS_DIR/pre-push"
-    echo "  pre-push hook installed (merge check + CI-parity quality gate + Reborn coverage ratchet + WebUI provider replay + optional delta lint)"
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    git config core.hooksPath .githooks
+    echo "  core.hooksPath -> .githooks (commit-msg, pre-commit incl. safety checks, tiered pre-push)"
+    echo "  pre-push default: bash scripts/preflight-gates.sh + changed-package clippy (~5-6 min warm); full gauntlet: IRONCLAW_PREPUSH_FULL=1"
 else
     echo "  Skipped: not a git repository"
 fi

--- a/scripts/preflight-gates.sh
+++ b/scripts/preflight-gates.sh
@@ -75,6 +75,82 @@ run_gate() {
     fi
 }
 
+# Mirrors scripts/ci/quality_gate.sh:7-22's env scrub exactly (two copies —
+# below the rule-of-three threshold this repo's own discipline uses to decide
+# when duplication earns an extraction; if a third caller appears, factor
+# both into scripts/ci/lib/run-cargo-ci-env.sh).
+run_cargo_ci_scrubbed() {
+    env \
+        -u NEARAI_API_KEY \
+        -u NEARAI_BASE_URL \
+        -u NEARAI_SESSION_TOKEN \
+        -u NEARAI_PROVIDER_ID \
+        -u NEARAI_MODEL \
+        -u IRONCLAW_LLM_PROVIDER \
+        -u IRONCLAW_LLM_MODEL \
+        -u LLM_BACKEND \
+        IRONCLAW_DISABLE_OS_KEYCHAIN="${IRONCLAW_DISABLE_OS_KEYCHAIN:-1}" \
+        CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}" \
+        CARGO_PROFILE_TEST_DEBUG="${CARGO_PROFILE_TEST_DEBUG:-0}" \
+        RUST_MIN_STACK="${RUST_MIN_STACK:-67108864}" \
+        "$@"
+}
+
+queue_plan_listing() {
+    python3 - <<'PY'
+import json
+import subprocess
+import sys
+
+result = subprocess.run(
+    ["python3", "scripts/ci/reborn_pr_test_plan.py", "--event", "merge_group"],
+    capture_output=True,
+    text=True,
+)
+if result.returncode != 0:
+    sys.stderr.write(result.stderr)
+    sys.exit(1)
+plan = json.loads(result.stdout)
+print("merge-queue full plan (what the queue will run that this PR did not):")
+for bucket in plan["crate_buckets"]:
+    print(f"  crate bucket {bucket['name']}: {len(bucket['packages'])} packages")
+print(f"  root partitions: {plan['root_partitions']}")
+print(f"  integration lanes: {plan['integration_lanes']}")
+for key in ("run_group_tests", "run_qa_replay", "run_sandbox_docker"):
+    print(f"  {key}: {plan[key]}")
+PY
+}
+
+if [ "${queue_shape}" -eq 1 ]; then
+    # The three shapes the merge queue runs that PR CI skips (#7119 class;
+    # code_style.yml's queue/push branch, matrix flavors all-features/default,
+    # verified live 2026-08-21 — see Evidence). --locked + the scrubbed env
+    # match quality_gate.sh's CI-parity clippy exactly so a dirty local
+    # Cargo.lock or ambient LLM-backend env can't false-green this tool.
+    #
+    # Honesty about cost: the all-features shape alone measures ~5.8 min on
+    # the warm 2-core CI runner; a cold local run of all three can take well
+    # over 20 minutes and the --all-features shape needs Node 22 + pnpm for
+    # the WebUI bundle build.
+    run_gate "clippy (queue shape: all targets, all features)" \
+        run_cargo_ci_scrubbed cargo clippy --locked --all --tests --examples --all-features -- -D warnings
+    run_gate "clippy (queue shape: all targets, default features)" \
+        run_cargo_ci_scrubbed cargo clippy --locked --all --tests --examples -- -D warnings
+    run_gate "clippy (queue shape: production targets, default features)" \
+        run_cargo_ci_scrubbed cargo clippy --locked --all --lib --bins -- -D warnings
+    run_gate "planner full-plan listing (merge_group)" queue_plan_listing
+    echo
+    if [ "${#failures[@]}" -eq 0 ]; then
+        echo "preflight-gates --queue-shape: OK — queue-only shapes green"
+        exit 0
+    fi
+    echo "preflight-gates --queue-shape: ${#failures[@]} gate(s) FAILED:"
+    for f in "${failures[@]}"; do
+        echo "  - ${f}"
+    done
+    exit 1
+fi
+
 # --- Layer 1: script gates (seconds each) ----------------------------------
 run_gate "fmt check" cargo fmt --all -- --check
 run_gate "composition mass budget" bash scripts/ci/check-composition-budget.sh

--- a/scripts/preflight-gates.sh
+++ b/scripts/preflight-gates.sh
@@ -75,25 +75,14 @@ run_gate() {
     fi
 }
 
-# Mirrors scripts/ci/quality_gate.sh:7-22's env scrub exactly (two copies —
-# below the rule-of-three threshold this repo's own discipline uses to decide
-# when duplication earns an extraction; if a third caller appears, factor
-# both into scripts/ci/lib/run-cargo-ci-env.sh).
+source "${REPO_ROOT}/scripts/ci/lib/run-cargo-ci-env.sh"
+
+# Delegates to the canonical scrub in scripts/ci/lib/run-cargo-ci-env.sh — the
+# extraction the old comment here promised once a third caller showed up
+# (.githooks/pre-push's changed-package clippy is that caller). The function
+# NAME is kept so nothing else in this script has to change.
 run_cargo_ci_scrubbed() {
-    env \
-        -u NEARAI_API_KEY \
-        -u NEARAI_BASE_URL \
-        -u NEARAI_SESSION_TOKEN \
-        -u NEARAI_PROVIDER_ID \
-        -u NEARAI_MODEL \
-        -u IRONCLAW_LLM_PROVIDER \
-        -u IRONCLAW_LLM_MODEL \
-        -u LLM_BACKEND \
-        IRONCLAW_DISABLE_OS_KEYCHAIN="${IRONCLAW_DISABLE_OS_KEYCHAIN:-1}" \
-        CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}" \
-        CARGO_PROFILE_TEST_DEBUG="${CARGO_PROFILE_TEST_DEBUG:-0}" \
-        RUST_MIN_STACK="${RUST_MIN_STACK:-67108864}" \
-        "$@"
+    run_cargo_ci_env "$@"
 }
 
 queue_plan_listing() {

--- a/scripts/preflight-gates.sh
+++ b/scripts/preflight-gates.sh
@@ -36,15 +36,42 @@ REPO_ROOT="$(git rev-parse --show-toplevel)" || {
 }
 cd "${REPO_ROOT}" || exit 2
 
+ci_mode=0
+queue_shape=0
+for arg in "$@"; do
+    case "${arg}" in
+        --ci) ci_mode=1 ;;
+        --queue-shape) queue_shape=1 ;;
+        *)
+            echo "preflight-gates: unknown option: ${arg}" >&2
+            echo "usage: preflight-gates.sh [--ci] [--queue-shape]" >&2
+            exit 2
+            ;;
+    esac
+done
+
 failures=()
 
 run_gate() {
     local label="$1"
     shift
-    echo "==> ${label}"
+    if [ "${ci_mode}" -eq 1 ]; then
+        echo "::group::${label}"
+    else
+        echo "==> ${label}"
+    fi
     if ! "$@"; then
         failures+=("${label}")
         echo "    FAILED: ${label}"
+        # REPRO invariant (Global Constraints): this is literally "$@", the
+        # array run_gate was handed — it cannot drift from what actually ran.
+        echo "    REPRO: $(printf '%q ' "$@")"
+        if [ "${ci_mode}" -eq 1 ]; then
+            echo "::error title=preflight gate failed::${label}"
+        fi
+    fi
+    if [ "${ci_mode}" -eq 1 ]; then
+        echo "::endgroup::"
     fi
 }
 
@@ -60,7 +87,17 @@ run_gate "hermetic env mutation (delta)" bash scripts/ci/check-hermetic-env.sh
 run_gate "docs publication boundary" python3 scripts/ci/docs_publication_boundary.py
 
 # --- Layer 2: the architecture gate suite ----------------------------------
-if command -v cargo-nextest >/dev/null 2>&1; then
+if [ "${ci_mode}" -eq 1 ]; then
+    echo "==> architecture suite: skipped under --ci — the crate-bucket lane" \
+         "(reborn-tests.yml, 'Test Reborn crate bucket') already runs" \
+         "ironclaw_architecture_tests with --all-targets whenever it is in the" \
+         "affected closure; compiling it again here would be a second cold" \
+         "build of the same ~40 binaries in fast-checks' one cache-less lane" \
+         "on every PR, including guidance-only PRs that touch no crate at all." \
+         "Known residual gap (accepted; see the PR body): a guidance-only PR" \
+         "never runs this suite anywhere even though it pins guidance files —" \
+         "routed to T3's planner track as a follow-up, not fixed here."
+elif command -v cargo-nextest >/dev/null 2>&1; then
     run_gate "architecture suite (nextest)" \
         cargo nextest run -p ironclaw_architecture_tests --no-fail-fast
 else
@@ -69,44 +106,50 @@ else
 fi
 
 # --- Layer 3: module-charter tests for crates the diff touches -------------
-# Charter maps live inside their crates, so only changed crates pay the
-# compile. Diff base mirrors the pre-push hook's default (origin/main).
-# Discovery fails CLOSED: when the base is missing or the diff plumbing
-# errors, the fallback widens to all five charters — a broken setup may cost
-# compile time, never a silent skip.
-all_charter_crates="crates/product/ironclaw_webui crates/product/ironclaw_assistant \
-         crates/domains/ironclaw_llm crates/domains/ironclaw_auth \
-         crates/lanes/ironclaw_mcp"
-base_ref="${IRONCLAW_PREFLIGHT_BASE:-origin/main}"
-if git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
-    if merge_base="$(git merge-base HEAD "${base_ref}")" \
-        && changed="$(git diff --name-only "${merge_base}...HEAD")"; then
-        :
+if [ "${ci_mode}" -eq 1 ]; then
+    echo "==> charter tests: skipped under --ci — they are --test targets of their" \
+         "crates and the crate-bucket lane runs them with --all-targets when the" \
+         "crate is in the affected closure (reborn-tests.yml, 'Run crate tests')"
+else
+    # Charter maps live inside their crates, so only changed crates pay the
+    # compile. Diff base mirrors the pre-push hook's default (origin/main).
+    # Discovery fails CLOSED: when the base is missing or the diff plumbing
+    # errors, the fallback widens to all five charters — a broken setup may
+    # cost compile time, never a silent skip.
+    all_charter_crates="crates/product/ironclaw_webui crates/product/ironclaw_assistant \
+             crates/domains/ironclaw_llm crates/domains/ironclaw_auth \
+             crates/lanes/ironclaw_mcp"
+    base_ref="${IRONCLAW_PREFLIGHT_BASE:-origin/main}"
+    if git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+        if merge_base="$(git merge-base HEAD "${base_ref}")" \
+            && changed="$(git diff --name-only "${merge_base}...HEAD")"; then
+            :
+        else
+            echo "==> charter tests: cannot diff against ${base_ref}; running all five"
+            changed="${all_charter_crates}"
+        fi
     else
-        echo "==> charter tests: cannot diff against ${base_ref}; running all five"
+        echo "==> charter tests: base ${base_ref} not found; running all five"
         changed="${all_charter_crates}"
     fi
-else
-    echo "==> charter tests: base ${base_ref} not found; running all five"
-    changed="${all_charter_crates}"
+
+    charter() {
+        local crate_dir="$1" package="$2" test_name="$3"
+        shift 3
+        if grep -q "${crate_dir}" <<<"${changed}"; then
+            run_gate "charter: ${package}" \
+                env "$@" cargo test -p "${package}" --test "${test_name}"
+        fi
+    }
+
+    charter "crates/product/ironclaw_webui" ironclaw_webui handlers_module_charter \
+        SKIP_FRONTEND_BUILD=1
+    charter "crates/product/ironclaw_assistant" ironclaw_assistant \
+        reborn_services_module_charter
+    charter "crates/domains/ironclaw_llm" ironclaw_llm module_charter
+    charter "crates/domains/ironclaw_auth" ironclaw_auth module_charter
+    charter "crates/lanes/ironclaw_mcp" ironclaw_mcp module_charter
 fi
-
-charter() {
-    local crate_dir="$1" package="$2" test_name="$3"
-    shift 3
-    if grep -q "${crate_dir}" <<<"${changed}"; then
-        run_gate "charter: ${package}" \
-            env "$@" cargo test -p "${package}" --test "${test_name}"
-    fi
-}
-
-charter "crates/product/ironclaw_webui" ironclaw_webui handlers_module_charter \
-    SKIP_FRONTEND_BUILD=1
-charter "crates/product/ironclaw_assistant" ironclaw_assistant \
-    reborn_services_module_charter
-charter "crates/domains/ironclaw_llm" ironclaw_llm module_charter
-charter "crates/domains/ironclaw_auth" ironclaw_auth module_charter
-charter "crates/lanes/ironclaw_mcp" ironclaw_mcp module_charter
 
 # --- Verdict ----------------------------------------------------------------
 echo

--- a/scripts/preflight-gates.sh
+++ b/scripts/preflight-gates.sh
@@ -52,6 +52,14 @@ done
 
 failures=()
 
+# LAST_REPRO: a wrapper function that is not itself paste-able outside this
+# script (its NAME does not exist in a fresh shell) sets this to its own real,
+# `printf '%q '`-escaped invocation right before returning non-zero. run_gate
+# prefers it when present and falls back to printing "$@" verbatim, which is
+# already paste-able for the plain gate commands that don't go through a
+# wrapper.
+LAST_REPRO=""
+
 run_gate() {
     local label="$1"
     shift
@@ -60,12 +68,18 @@ run_gate() {
     else
         echo "==> ${label}"
     fi
+    LAST_REPRO=""
     if ! "$@"; then
         failures+=("${label}")
         echo "    FAILED: ${label}"
-        # REPRO invariant (Global Constraints): this is literally "$@", the
-        # array run_gate was handed — it cannot drift from what actually ran.
-        echo "    REPRO: $(printf '%q ' "$@")"
+        if [ -n "${LAST_REPRO}" ]; then
+            echo "    REPRO: ${LAST_REPRO}"
+        else
+            # REPRO invariant (Global Constraints): this is literally "$@",
+            # the array run_gate was handed — it cannot drift from what
+            # actually ran.
+            echo "    REPRO: $(printf '%q ' "$@")"
+        fi
         if [ "${ci_mode}" -eq 1 ]; then
             echo "::error title=preflight gate failed::${label}"
         fi
@@ -80,12 +94,27 @@ source "${REPO_ROOT}/scripts/ci/lib/run-cargo-ci-env.sh"
 # Delegates to the canonical scrub in scripts/ci/lib/run-cargo-ci-env.sh — the
 # extraction the old comment here promised once a third caller showed up
 # (.githooks/pre-push's changed-package clippy is that caller). The function
-# NAME is kept so nothing else in this script has to change.
+# NAME is kept so nothing else in this script has to change. On failure,
+# records its own real argv into LAST_REPRO — run_gate's default REPRO would
+# otherwise print "run_cargo_ci_scrubbed cargo clippy ...", and that function
+# name does not exist outside this script.
 run_cargo_ci_scrubbed() {
-    run_cargo_ci_env "$@"
+    LAST_REPRO=""
+    local status=0
+    # `cmd || status=$?`, not `if cmd; then ... fi; status=$?`: an `if` with
+    # no `else` branch that took the false path resets $? to 0 at `fi`
+    # regardless of the condition's real exit status — verified live — so a
+    # post-if `$?` read would silently always capture 0 here.
+    run_cargo_ci_env "$@" || status=$?
+    if [ "${status}" -ne 0 ]; then
+        LAST_REPRO="$(printf '%q ' "$@")"
+    fi
+    return "${status}"
 }
 
 queue_plan_listing() {
+    local -a underlying_cmd=(python3 scripts/ci/reborn_pr_test_plan.py --event merge_group)
+    LAST_REPRO=""
     python3 - <<'PY'
 import json
 import subprocess
@@ -108,6 +137,14 @@ print(f"  integration lanes: {plan['integration_lanes']}")
 for key in ("run_group_tests", "run_qa_replay", "run_sandbox_docker"):
     print(f"  {key}: {plan[key]}")
 PY
+    local status=$?
+    if [ "${status}" -ne 0 ]; then
+        # queue_plan_listing is a shell function with no standalone
+        # equivalent — print the real underlying command it runs (the
+        # planner subprocess this heredoc calls), not the function name.
+        LAST_REPRO="$(printf '%q ' "${underlying_cmd[@]}")"
+    fi
+    return "${status}"
 }
 
 if [ "${queue_shape}" -eq 1 ]; then


### PR DESCRIPTION
References #7801 (plan mirrored there; canonical plan doc lives outside the repo — this PR implements Tasks 1-5).

## Summary

`scripts/preflight-gates.sh` becomes the single canonical deterministic-gate list — run by hand, by the default pre-push hook, and (in a follow-up commit, see below) by CI's fast-checks lane. This PR lands the five foundational tasks:

1. **`--ci` mode** (Layer 1 only): the eight script gates (fmt, composition budget, panic baseline, target tree, guidance, include_str!, hermetic env, docs boundary) with `::group::`/`::error` GitHub annotations and a `REPRO: <exact command>` line on every failure. Layer 2 (architecture suite) and Layer 3 (module charters) are skipped under `--ci` with a printed reason — both duplicate work the crate-bucket lane already does for affected crates.
2. **`--queue-shape` mode**: the three clippy shapes the merge queue runs that PR CI skips (all-targets+all-features, all-targets+default, production-targets+default — the #7119 class), plus the planner's `merge_group` full-plan listing, all through the same scrubbed env `quality_gate.sh` uses.
3. **Worktree-safe hook install**: `core.hooksPath .githooks` replaces `dev-setup.sh`'s absolute-path hook symlinks (which pointed every worktree at whichever checkout last ran the script). Pre-push default tier inverts: `preflight-gates.sh` + a ~60s changed-package clippy step, not the full CI-parity gauntlet, which moves behind `IRONCLAW_PREPUSH_FULL=1` unchanged except one sanctioned softening — an absent Emulate CLI is now a skip-with-warning, not a hard failure. `scripts/dev-setup.sh` is classified in the planner's `PR_STATIC_CONTROL_PATHS` in the same commit (editing it would otherwise red its own `Tests (Reborn)` roll-up).
4. **Self-printing REPRO**: `quality_gate.sh` and `run-hermetic-deterministic-suite.sh` now print their own `REPRO: <exact failing command>` on failure — no hand-maintained job→command table to drift.
5. **Agent discoverability**: `AGENTS.md`'s "Build, run, debug" block gets the two canonical preflight commands, plus the matching `allowed-tools` entry in `ship.md`. (The original Task 5 also fixed a stale `--test workspace_integration` claim in `ship.md`/`fix-issue.md`/`review-crate.md` — see the rebase note below for what happened to that part.)

## Task 6 follows after T1-T3 merge

Per the plan's Cross-track contract, **Task 6 (wiring `code_style.yml` fast-checks/clippy/webui-v2-js-lint/docs-publication-boundary to `--ci` and the Pattern B REPRO wiring) is explicitly excluded from this PR** and was not attempted. Quoting the plan's Interfaces section for Task 6:

> Consumes: **the MERGED state of `code_style.yml` from every other track that edits it — not T3 alone.** Confirmed editors as of this revision: T1's setup-rust composite swap (4 Install Rust sites); T2's Task 3, which adds an `Install cargo-nextest` step to THIS SAME fast-checks job...; T3's Task 3 (`clippy_matrix` PR-branch addition), Task 4 (`reborn-cli-smoke` gate change), and Task 5... This task starts with `git fetch && git rebase` onto the branch/main state containing those changes and re-reads the whole file before editing... **Order-independence fallback:** if any of those tracks has not landed when this task starts, rebase onto `origin/main` instead of blocking, and state in the PR body which sites were not yet visible (conflict surface).

None of T1 (setup-rust composite), T2 (`Install cargo-nextest` step + nextest-speed measurement S18), or T3 (`clippy_matrix`, `reborn-cli-smoke` `if:` condition, `SKIP_FRONTEND_BUILD` widening) have merged yet, so Task 6 has no merged `code_style.yml` state to rebase onto. Task 6 lands as a follow-up commit on this branch (or a follow-up PR, whichever this track's landing order prefers at the time) once T1-T3 merge. Do not treat this PR as closing #7801 — it remains open until Task 6 lands.

## Rebase note: #7797 conflict, resolved

This branch was originally cut before #7797 ("repo-wide agent-guidance audit — fix drift, prune 21.5k lines, consolidate tests/ onto AGENTS.md convention") merged into `main`. That commit deleted `.claude/commands/fix-issue.md` and `.claude/commands/review-crate.md` outright and independently rewrote `ship.md`'s test-results section — all three files Task 5 here also touched (fixing the same stale `--test workspace_integration` claim), producing a real merge conflict. Resolved by rebasing onto current `main`:

- `.claude/commands/fix-issue.md`, `.claude/commands/review-crate.md`: **upstream's deletion wins** — this PR's fix to a file that no longer exists is moot, so those edits were dropped entirely.
- `.claude/commands/ship.md`: **upstream's version is kept as-is.** Its rewritten test-results section already describes testcontainers self-provisioning without ever naming `--test workspace_integration`, so the stale claim this task was fixing is already gone — no fix needed on top of it. This PR keeps only the (non-conflicting) `allowed-tools` addition that lets the slash command invoke `preflight-gates.sh`.
- Task 5's commit message and diff were updated to match (see `docs(agents): canonical preflight + queue-shape commands in Build, run, debug`).
- Re-ran the checks the rebase could affect: `python3 scripts/ci/check-guidance.py` (clean, 384 guidance files now — up from 377 pre-rebase, consistent with #7797's own changes) and `cargo test -p ironclaw_architecture_tests` (314/314 passed), plus all three of this track's own self-tests (`test-preflight-gates.sh`, `test-githooks-install.sh`, `test-repro-emission.sh`), all green post-rebase.
- Force-pushed with `--force-with-lease`. `gh pr view` now reports `mergeable: MERGEABLE`.

## Layer summary

| Task | Files | Commit |
|---|---|---|
| 1 | `scripts/preflight-gates.sh`, `scripts/ci/test-preflight-gates.sh` | `feat(ci): preflight-gates --ci mode` |
| 2 | `scripts/preflight-gates.sh`, `scripts/ci/test-preflight-gates.sh` | `feat(ci): preflight-gates --queue-shape` |
| 3 | `.githooks/pre-push`, `.githooks/pre-commit`, `scripts/dev-setup.sh`, `scripts/ci/reborn_pr_test_plan.py`, `scripts/ci/test_reborn_pr_test_plan.py`, `scripts/ci/test-githooks-install.sh` | `feat(hooks): one hooksPath install story...` |
| 4 | `scripts/ci/quality_gate.sh`, `scripts/ci/run-hermetic-deterministic-suite.sh`, `scripts/ci/test-repro-emission.sh` | `feat(ci): scripts print their own REPRO line on failure` |
| 5 | `AGENTS.md`, `.claude/commands/ship.md` | `docs(agents): canonical preflight + queue-shape commands in Build, run, debug` |

## Rollback Plan

- **Task 3 (hooks)** — revert restores symlink install + maximalist pre-push default. Interim escape hatches without any revert: `git push --no-verify`, or `IRONCLAW_PREPUSH_FULL=1` to get the old default behavior per push; a developer stuck on the hooksPath story runs `git config --unset core.hooksPath`. The `PR_STATIC_CONTROL_PATHS` addition in the same commit is a pure classification fix — reverting simply makes `scripts/dev-setup.sh` unmapped again (fail-closed, safe).
- **Tasks 1-2 (script modes)** — additive flags (`--ci`, `--queue-shape`); default-mode behavior is untouched, so a plain revert of the pair restores the pre-plan script byte-for-byte. Nothing in this PR wires CI to call `--ci` yet (that's Task 6), so reverting these two has zero CI blast radius.
- **Task 4 (REPRO emission)** — pure addition (an `ERR` trap in two scripts, plus `set -E`/errtrace so the trap actually fires from inside their helper functions — see Deviations); plain revert removes the `REPRO:` lines with zero effect on gate pass/fail semantics.
- **Task 5 (guidance)** — pure doc fixes; plain revert.
- **Compatibility**: required-check names (`Code Style (fmt + clippy)`, `Tests (Reborn)`) and the roll-up logic are untouched at every point in this PR — `code_style.yml` is not edited here at all. No persistence, schema, or secret surface is involved.

## Track C note

This track touches hooks (`.githooks/pre-push`, `.githooks/pre-commit`) but **does not** touch any `.github/workflows/*` file in this PR (Task 6, which does, is deferred — see above). Per the plan's Track C ceremony ("this track touches hooks + one workflow → 2 approvals + the Rollback Plan section"), the workflow half of that ceremony applies to the Task 6 follow-up, not this PR; the hooks half still applies here, and the Rollback Plan above covers it.

## Deviations from the plan's literal text (all recorded in the relevant commit messages too)

1. **Task 3 self-test**: `scripts/ci/test-githooks-install.sh`'s sandbox also stubs a `bin/cargo` — the plan's own listing omitted it, but the default pre-push tier's changed-package clippy step (fix 7) genuinely shells out to a real `cargo`, and PATH is replaced (not prepended) in the sandbox. Without the stub every default-tier assertion failed with "cargo: command not found" (rc=127) instead of exercising the hook's own logic.
2. **Task 4 REPRO traps needed `set -E` (errtrace)**, not just `set -euo pipefail`: without it, an `ERR` trap is NOT inherited into shell functions in bash. Almost every real gate in both `quality_gate.sh` (`run_cargo_ci`) and `run-hermetic-deterministic-suite.sh` (`prepare_rust_dependencies` and friends) runs inside a helper function — without `-E` a failure inside one aborts the script via `-e` but silently skips the REPRO trap entirely. Verified live before landing the fix.
3. **Task 4, `run-hermetic-deterministic-suite.sh`**: the trap captures the stage's remaining args into a `stage_args` array right after the arg shift, instead of reading `"$@"` inside the trap's action string as the plan's snippet did. By the time the trap fires from deep inside a helper function, `"$@"` resolves to that function's own (empty) positional parameters, not the script's — reproduced live (a failure inside `prepare_command_dependencies` printed `REPRO: ... rust-e2e ''` instead of the real stage args) before landing the fix.
4. **Task 3, pre-push `#6018` rationale comment**: the self-test asserts the `#6018`/`#5603`/`#6015` rationale is visible in the hook's *captured output*, which a bash comment (as literally specified in the plan's replacement snippet) can never satisfy — comments are never printed. Added one runtime `echo` line carrying the issue numbers alongside the preserved source comment, satisfying both the self-test's real (behavioral) intent and the "carry the comment forward" instruction.
5. **Task 5, post-rebase**: the stale-claim fixes to `fix-issue.md`/`review-crate.md`/`ship.md` were superseded by #7797 landing on `main` after this branch was cut — see the Rebase note above for the resolution (upstream deletions/rewrite win; only the `AGENTS.md` canonical-commands addition and `ship.md`'s `allowed-tools` entry survive from the original Task 5 commit).

None of these are design changes — they are either bugs in the plan's own snippets/self-tests (1-4, found and fixed while making the red-first tests pass for the right reason before green) or a mechanical rebase resolution against a concurrent, unrelated main-branch merge (5).

## Test Strategy

All verification commands run from the repo root, output captured live (not simulated), re-run after the rebase where the rebase could plausibly affect them:

- `bash scripts/ci/test-preflight-gates.sh` → `test-preflight-gates: OK` (all 6 cases: default mode, `--ci` group/error/REPRO/Layer-2-skip/Layer-3-skip, `--ci` all-green, unknown-flag rejection, `--queue-shape` shape assertions, `--queue-shape` collect-all-failures).
- `bash scripts/ci/test-githooks-install.sh` → `test-githooks-install: OK` (7 cases including a real `git worktree add` proving per-worktree `.githooks` resolution).
- `bash scripts/ci/test-repro-emission.sh` → `test-repro-emission: OK`.
- `bash scripts/ci/test-quality-gate-runner.sh` → `all quality-gate runner checks passed` (20/20 — confirms the `set -E`/REPRO addition didn't change `quality_gate.sh`'s existing nextest-selection contract).
- `python3 scripts/ci/test_pre_commit_staged_paths.py` → 4/4 OK.
- `bash scripts/test-pre-commit-safety.sh` → 21/21 passed.
- `python3 scripts/ci/check-guidance.py` → clean, both pre- and post-rebase (post-rebase: 384 guidance files, 2600 path references verified, 0 grandfathered — the count grew because #7797 itself restructured guidance).
- `python3 scripts/ci/test_reborn_pr_test_plan.py` → 87/87 OK, including the new red-first regression case for `scripts/dev-setup.sh` in the repo-root-metadata-class test.
- `cargo test -p ironclaw_architecture_tests` → 314/314 passed, confirmed **twice** post-rebase (once via a direct `cargo nextest run` invocation, once again as part of the real pre-push hook run below) in addition to the pre-rebase run.
- **Real end-to-end proof, via `git push` actually firing the new hook** (not a simulation) — captured three times across this PR's lifecycle, twice post-rebase: `bash scripts/preflight-gates.sh` ran for real on the clean tree as this branch's own pre-push default tier — all 8 Layer-1 gates green, Layer 2 architecture suite via nextest: `314 tests run: 314 passed (6 slow), 0 skipped`, verdict `preflight-gates: OK`, followed by the new changed-package clippy step correctly detecting zero changed Rust packages (this branch only touches scripts/docs) and skipping with `(no changed workspace packages; nothing to lint)`. Every push succeeded, including the final `--force-with-lease` push of the rebased branch.
- `bash scripts/preflight-gates.sh --ci` on the clean tree → green in seconds (no compile; all `::group::` sections present, verdict `preflight-gates: OK`).
- Red-first captured for every self-test and the `test_reborn_pr_test_plan.py` regression case before implementing (see individual commit messages for the exact predicted-vs-actual red output).

Not run: the full `IRONCLAW_PREPUSH_FULL=1` gauntlet's WebUI provider replay leg (requires a built Emulate CLI not present in this environment) and `IRONCLAW_PREPUSH_REBORN_COVERAGE_RATCHET=1`'s Docker-backed coverage ratchet (requires Docker) — both are pre-existing, unmodified code paths this PR does not touch the logic of (only the Emulate-absent branch's hard-fail→warn-and-skip softening, which the `test-githooks-install.sh` self-test does cover with a stubbed Emulate CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
