### PR TITLE
ci: PR/queue check convergence — planner drift guard, default-features clippy on PRs (T3)

### DIFF
--- a/.claude/rules/review-discipline.md
+++ b/.claude/rules/review-discipline.md
@@ -31,12 +31,18 @@ regression-check exemption rather than silently omitting coverage.
 - **Feature matrix, not just `--all-features`:** `--all-features` cannot catch
   feature-gated dead code — a `#[cfg(feature = "x")]`-only caller makes its
   helper *live* under `--all-features` and *dead* (a `-D warnings` error)
-  everywhere the feature is off. **PR CI runs only the slim `all-features` lane;
-  the broader `default` lane runs post-merge**, so this class can break `main`
-  after a green PR. If you add or move a `#[cfg(feature = ...)]` gate, or touch
-  a helper only reachable through one, run the relevant feature lanes locally
-  before merging (see "Required checks"). When you gate the only caller(s) of a
-  helper behind a feature, gate the helper's definition with the same `#[cfg]`.
+  everywhere the feature is off. As of `9d074f84a`, **PR CI also lints the
+  changed packages with default features** (`cargo clippy -p <changed> --lib
+  --bins -- -D warnings`, no `--all-features`), so this class surfaces on the
+  PR when the gate lives in a package you touched directly. The
+  **workspace-wide** default sweep (`cargo clippy --all --lib --bins`) — which
+  also catches a crate that only transitively depends on your changed set —
+  still runs post-merge only, so a gate whose fallout lands in an untouched
+  dependency can still break `main` after a green PR. If you add or move a
+  `#[cfg(feature = ...)]` gate, or touch a helper only reachable through one,
+  run the relevant feature lanes locally before merging (see "Required
+  checks"). When you gate the only caller(s) of a helper behind a feature,
+  gate the helper's definition with the same `#[cfg]`.
 - **UTF-8:** never byte-slice user or external strings with `&value[..n]`.
   Use `char_indices()`, `chars()`, or an `is_char_boundary()`-checked boundary.
   Search changed Rust files for suspicious `[..` slicing.
@@ -71,9 +77,11 @@ Workspace-wide zero-warning clippy:
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-Feature matrix — reproduces the post-merge `Code Style` gate that PR CI skips
-(it only runs the `all-features` lane). Run both whenever a change adds, moves,
-or relies on a `#[cfg(feature = ...)]` gate:
+Feature matrix — reproduces the post-merge, **workspace-wide** `Code Style`
+default-features gate. PR CI itself now lints your *changed* packages with
+default features too (`9d074f84a`), but only the post-merge sweep also covers
+an untouched package that merely depends on your changed set. Run both
+whenever a change adds, moves, or relies on a `#[cfg(feature = ...)]` gate:
 
 ```bash
 cargo clippy --all --tests --examples -- -D warnings                              # default

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -79,9 +79,13 @@ PRs do not compile an unchanged workspace solely for linting. Root
 `Cargo.toml` and `Cargo.lock` changes lint every workspace package because
 their dependency and feature impact is workspace-wide. Merge queue and main
 lint the full workspace, add test and example targets, and run the
-default-feature matrix. Code Style's CLI Rust smoke and Reborn E2E's
-four Rust groups run on merge queue and main, where they validate the
-exhaustive merged state, but do not repeat those contracts on PR runners. The release-binary
+default-feature matrix. Code Style's CLI Rust smoke runs on pull requests
+too, scoped by `has_reborn_cli`, and unconditionally on merge queue and main,
+where it validates the exhaustive merged state. Reborn E2E's four Rust
+groups still run only on merge queue and main, validating the exhaustive
+merged state without repeating that contract on PR runners — see "Known
+accepted gaps" for the re-sampling plan that gates scoping them to PRs too.
+The release-binary
 smoke harness self-test remains in Code Style's fast deterministic job on every
 code PR. Reborn E2E continues to build the real product binary and run all
 browser/provider lanes on pull requests.
@@ -363,5 +367,15 @@ points, including their existing optional DIND dispatch. The manual
   `changes` jobs) are curated allowlists. Adding a new crate or test directory
   requires updating them, or the queue's scoped checks silently narrow. Keep
   `reborn-e2e.yml`'s `changes` regex in sync with its `paths:` filters.
+- **Reborn E2E's four `rust-reborn` groups are not scoped to a PR's diff**,
+  on either pull_request or merge_group — they run exhaustively on merge
+  queue and main only. Deriving a group→package mapping from
+  `scripts/reborn-e2e-rust.sh` to scope either side was investigated and
+  deferred rather than built as a second, fragile bash-parsing fork: land
+  the planner drift-guard fixes first, re-sample merge_group `rust-reborn`
+  failures over ~2 weeks, and if a residual under-selection class remains,
+  design the derivation once (a `LIST_ONLY=1` script mode, a shared TOML
+  manifest, or a static hand-maintained regex mirroring `has_reborn_cli`) —
+  never twice, one for PR scope and one for merge_group scope.
 - **Code Coverage**, **IronClaw Stress**, live canaries, Docker/release
   pipelines are informational or post-merge; they are not merge-gating.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -124,13 +124,18 @@ roll-up **job names**, never individual matrix jobs):
 | `Reborn E2E` | `reborn-e2e.yml` | candidate — require once queue cost is confirmed |
 | `Platform & Compat` | `platform-and-compat.yml` | candidate — require once queue cost is confirmed |
 
-The 2026-07-30 queue-cost audit found only one retained `merge_group` sample
-for each candidate: Reborn E2E took 594 seconds and failed; Platform & Compat
-took 364 seconds and passed. Pull-request history was healthier (Reborn E2E
-p50/p95 877/1124 seconds; Platform & Compat 415/492 seconds), but one real queue
-sample—especially a failing E2E sample—is not enough evidence to alter the
-repository ruleset. Both checks therefore remain candidates. Refresh the
-workflow-run sample before promotion; a workflow being present on
+The 2026-08-21 queue-cost sample (200 queue runs, 40 tracked entries per
+workflow) found: Reborn E2E failed 5/40 + 4 cancelled (≈22.5% non-green,
+≈64 runner-minutes/entry); Code Style (already required) failed 11/40
+(27.5%); Platform & Compat was not separately sampled this session (prior
+single-sample: 364 seconds, passed, ≈10 runner-minutes/entry). A ~22.5%+
+non-green rate on a non-required check is not evidence for promoting it —
+promoting would bounce roughly 1 in 4-5 queue entries that merge fine today,
+directly against the queue's own "reds must drop" goal. Both checks remain
+candidates. The queue-runner-minute cost from `rust-reborn`'s frontend build
+was cut in-place (`SKIP_FRONTEND_BUILD`, no trigger change) rather than by
+narrowing `merge_group` coverage — see the CI-Contract invariant above.
+Refresh the workflow-run sample before promotion; a workflow being present on
 `merge_group` is not itself proof that it is safe to require.
 
 Rules for a roll-up job that is (or may become) required:

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -502,7 +502,10 @@ jobs:
   reborn-cli-smoke:
     name: Reborn CLI smoke tests
     needs: changes
-    if: needs.changes.outputs.has_reborn_cli == 'true' && github.event_name != 'pull_request'
+    # Runs on pull_request too (gated by the same has_reborn_cli scope
+    # filter that already governs it everywhere else): run 32310981177's
+    # queue-only red (PR #7756) would have been caught here at PR time.
+    if: needs.changes.outputs.has_reborn_cli == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -141,7 +141,7 @@ jobs:
           fi
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo 'clippy_matrix=[{"name":"all-features","flags":"--all-features"}]' >> "$GITHUB_OUTPUT"
+            echo 'clippy_matrix=[{"name":"all-features","flags":"--all-features"},{"name":"default","flags":""}]' >> "$GITHUB_OUTPUT"
           else
             echo 'clippy_matrix=[{"name":"all-features","flags":"--all-features"},{"name":"default","flags":""}]' >> "$GITHUB_OUTPUT"
           fi
@@ -402,6 +402,14 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           CLIPPY_PACKAGES: ${{ needs.changes.outputs.clippy_packages }}
+          # The `default` flavor never installs Node/pnpm (its steps above
+          # are gated on `--all-features`), so if a PR's clippy_packages
+          # includes ironclaw_webui, an unguarded build.rs would fall back
+          # to an unbounded `npm exec` network fetch here (the #7756
+          # class). SKIP_FRONTEND_BUILD makes the crate compile with zero
+          # embedded assets instead — safe for a lint-only invocation,
+          # which never executes the compiled test/asset code.
+          SKIP_FRONTEND_BUILD: ${{ matrix.name == 'default' && '1' || '' }}
         run: |
           package_args=()
           while IFS= read -r package; do

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -348,6 +348,17 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.clippy_matrix) }}
+    # cargo clippy is compile-only and never executes tests, so it cannot
+    # observe the difference between a populated and an empty embedded-asset
+    # ASSETS array. SKIP_FRONTEND_BUILD compiles ironclaw_webui with zero
+    # embedded assets instead of running its build.rs npm/pnpm fallback on
+    # every clippy invocation (both matrix flavors, every event) — removing a
+    # real pnpm/vite build and an unbounded npm-exec-fallback download risk
+    # (the #7756 class) from this job. The SPA-embedding path stays exercised
+    # by webui-v2-smoke, the webui lanes, and webui-v2-js-lint's own pnpm
+    # build step (unaffected — that job never touches build.rs).
+    env:
+      SKIP_FRONTEND_BUILD: "1"
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -357,30 +368,6 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
-      - name: Enable pnpm for setup-node cache
-        if: contains(matrix.flags, '--all-features')
-        run: corepack enable pnpm
-      - name: Install Node.js for WebUI bundle builds
-        if: contains(matrix.flags, '--all-features')
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v4
-        with:
-          node-version: "22"
-          cache: "pnpm"
-          # See the webui-v2-js-lint job above for why this is a depth-tolerant
-          # glob list rather than a single literal.
-          cache-dependency-path: |
-            crates/product/ironclaw_webui/frontend/pnpm-lock.yaml
-            crates/*/*/ironclaw_webui/frontend/pnpm-lock.yaml
-      - name: Enable pnpm
-        if: contains(matrix.flags, '--all-features')
-        run: corepack enable pnpm
-      - name: Install WebUI frontend dependencies
-        if: contains(matrix.flags, '--all-features')
-        run: |
-          set -euo pipefail
-          webui_dir="$(bash scripts/ci/crate-dir.sh ironclaw_webui)"
-          cd "${webui_dir}/frontend"
-          pnpm install --frozen-lockfile
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: clippy
@@ -402,14 +389,6 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           CLIPPY_PACKAGES: ${{ needs.changes.outputs.clippy_packages }}
-          # The `default` flavor never installs Node/pnpm (its steps above
-          # are gated on `--all-features`), so if a PR's clippy_packages
-          # includes ironclaw_webui, an unguarded build.rs would fall back
-          # to an unbounded `npm exec` network fetch here (the #7756
-          # class). SKIP_FRONTEND_BUILD makes the crate compile with zero
-          # embedded assets instead — safe for a lint-only invocation,
-          # which never executes the compiled test/asset code.
-          SKIP_FRONTEND_BUILD: ${{ matrix.name == 'default' && '1' || '' }}
         run: |
           package_args=()
           while IFS= read -r package; do

--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -135,6 +135,14 @@ jobs:
       RUSTFLAGS: "-C linker=clang -C link-arg=--ld-path=/usr/bin/mold"
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
+      # These groups compile ironclaw_webui only as a dependency of the root
+      # integration package (3 of 4 groups; substrates does not). Verified
+      # this session (T3 Task 5): none of the 50+ test targets across all
+      # four groups read ASSETS/serve SPA content, so skipping the embedded
+      # frontend build here is safe — it removes a real per-job npm-fallback
+      # pnpm download + vite build and an unbounded external-download risk
+      # (the #7756 class) from the lane.
+      SKIP_FRONTEND_BUILD: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -599,18 +599,39 @@ _GITHUB_DIRECTORY_LITERALS = {".github/workflows", ".github/actions", ".github"}
 _CODEOWNERS_LITERAL = re.compile(r'"(CODEOWNERS|docs/CODEOWNERS|\.gitlab/CODEOWNERS)"')
 
 
+def _test_tree_rust_files() -> list[Path]:
+    """Every `.rs` file inside a `tests/` directory tree — the workspace-root
+    `tests/` tree and every crate's `tests/` tree, at any nesting depth (a
+    top-level `tests/<name>.rs` target commonly `mod`-includes files under
+    `tests/<name>/...`, and a literal can live in either).
+
+    Walked as "find each `tests/` directory, then everything under it" rather
+    than a single `rglob("tests/**/*.rs")` pattern: pathlib only accepts a
+    `**` glob segment in the middle of a pattern starting with Python 3.13,
+    and CI runs 3.12.
+    """
+    test_dirs = [ROOT / "tests"] + sorted(
+        path for path in (ROOT / "crates").rglob("tests") if path.is_dir()
+    )
+    files: list[Path] = []
+    for test_dir in test_dirs:
+        if test_dir.is_dir():
+            files.extend(sorted(test_dir.rglob("*.rs")))
+    return files
+
+
 def repo_config_file_literals_in_test_sources() -> dict[str, list[Path]]:
     """Every `.github/<file>` or CODEOWNERS-location literal any workspace
     test target reads.
 
-    Scans every `tests/*.rs` file (root and per-crate — `crates/**/tests/*.rs`
-    via rglob) rather than a hand-maintained list, so a new test added later
-    that reads a workflow file fails the drift-guard test immediately.
+    Scans every `.rs` file under the workspace-root `tests/` tree and every
+    crate's `tests/` tree, including nested test-module files (see
+    `_test_tree_rust_files`), rather than a hand-maintained list, so a new
+    test added later that reads a workflow file fails the drift-guard test
+    immediately.
     """
     hits: dict[str, list[Path]] = defaultdict(list)
-    candidates = sorted((ROOT / "tests").glob("*.rs")) + sorted(
-        (ROOT / "crates").rglob("tests/*.rs")
-    )
+    candidates = _test_tree_rust_files()
     for rs_file in candidates:
         text = rs_file.read_text(encoding="utf-8")
         for match in _GITHUB_FILE_LITERAL.finditer(text):

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -589,10 +589,19 @@ DOCKER_RUNTIME_CONFIG_OWNERS = {
 # both walk the bare directory and are deliberately excluded.
 _GITHUB_FILE_LITERAL = re.compile(r'"(\.github/[\w./-]+)"')
 _GITHUB_DIRECTORY_LITERALS = {".github/workflows", ".github/actions", ".github"}
+# `reborn_linked_device_supply_chain_pin.rs`'s CODEOWNERS residual asserts
+# none of FOUR locations exist — GitHub, GitLab, and a docs-root convention
+# each recognise CODEOWNERS from a different root, so `_GITHUB_FILE_LITERAL`
+# (which requires a `.github/` prefix) only ever sees one of the four. Matched
+# separately, and by exact literal rather than a general non-`.github/` file
+# regex, so this stays a targeted pin on the one filename that test enumerates
+# instead of a broad (and noisy) root/docs/gitlab file scan.
+_CODEOWNERS_LITERAL = re.compile(r'"(CODEOWNERS|docs/CODEOWNERS|\.gitlab/CODEOWNERS)"')
 
 
 def repo_config_file_literals_in_test_sources() -> dict[str, list[Path]]:
-    """Every `.github/<file>` literal any workspace test target reads.
+    """Every `.github/<file>` or CODEOWNERS-location literal any workspace
+    test target reads.
 
     Scans every `tests/*.rs` file (root and per-crate — `crates/**/tests/*.rs`
     via rglob) rather than a hand-maintained list, so a new test added later
@@ -611,6 +620,8 @@ def repo_config_file_literals_in_test_sources() -> dict[str, list[Path]]:
             last_segment = literal.rsplit("/", 1)[-1]
             if "." in last_segment or last_segment == "CODEOWNERS":
                 hits[literal].append(rs_file.relative_to(ROOT))
+        for match in _CODEOWNERS_LITERAL.finditer(text):
+            hits[match.group(1)].append(rs_file.relative_to(ROOT))
     return hits
 
 
@@ -652,6 +663,17 @@ REPO_CONFIG_TEST_OWNERS = {
         "reborn_linked_device_supply_chain_pin"
     ),
     ".github/CODEOWNERS": _architecture_tests_owner(
+        "reborn_linked_device_supply_chain_pin"
+    ),
+    # The same test's residual enumerates all four CODEOWNERS locations
+    # GitHub/GitLab/docs conventions recognise — route every one to it so
+    # adding any of them schedules the test that must then assert its
+    # presence, instead of only catching `.github/CODEOWNERS`.
+    "CODEOWNERS": _architecture_tests_owner("reborn_linked_device_supply_chain_pin"),
+    "docs/CODEOWNERS": _architecture_tests_owner(
+        "reborn_linked_device_supply_chain_pin"
+    ),
+    ".gitlab/CODEOWNERS": _architecture_tests_owner(
         "reborn_linked_device_supply_chain_pin"
     ),
     # run 32310981177 / PR #7756 / fix 064ebde65: smoke.rs pins apt-installer

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -1333,14 +1333,16 @@ def build_plan(
     affected = (
         _affected_packages(production_packages, reverse) | direct_test_packages
     ) & canonical_set
-    if production_packages:
+    if production_packages or direct_test_packages or root_partitions:
         scanning_packages = set(WORKSPACE_SCANNING_TEST_PACKAGES) & canonical_set
         if scanning_packages - affected:
             affected |= scanning_packages
             reasons.append(
                 "workspace scan: ironclaw_architecture_tests reads every "
-                "crate's sources from disk and has no dependency edge to "
-                "any of them, so it joins any production-package change"
+                "crate's sources from disk (including test targets and root "
+                "`tests/*.rs`) and has no dependency edge to any of them, so "
+                "it joins any production-package, package-owned-test, or "
+                "root-test change"
             )
     if changed_packages and not affected:
         raise ValueError(

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -670,6 +670,11 @@ REPO_CONFIG_TEST_OWNERS = {
 # `.githooks/` is developer-local git hook plumbing: no Reborn lane executes a
 # hook, while Code Style both triggers on the tree and lints its contents
 # (`scripts/ci/test-ci-comm-locale-pin.sh` follows the symlinks and scans them).
+# Test crates that assert on every crate's sources and manifests via
+# filesystem scans (Cargo.toml declares only 2 dep edges), so the reverse-
+# dependency closure structurally cannot select them for a product change —
+# run 32291404351 / PR #6994 / fix 156288d4d is the measured miss.
+WORKSPACE_SCANNING_TEST_PACKAGES: tuple[str, ...] = ("ironclaw_architecture_tests",)
 PR_STATIC_CONTROL_PREFIXES = (".github/workflows/", "scripts/ci/", ".githooks/")
 SHARED_REBORN_ACTION_PREFIXES = (".github/actions/setup-sccache-dist/",)
 BUCKET_WEIGHTS = {
@@ -1328,6 +1333,15 @@ def build_plan(
     affected = (
         _affected_packages(production_packages, reverse) | direct_test_packages
     ) & canonical_set
+    if production_packages:
+        scanning_packages = set(WORKSPACE_SCANNING_TEST_PACKAGES) & canonical_set
+        if scanning_packages - affected:
+            affected |= scanning_packages
+            reasons.append(
+                "workspace scan: ironclaw_architecture_tests reads every "
+                "crate's sources from disk and has no dependency edge to "
+                "any of them, so it joins any production-package change"
+            )
     if changed_packages and not affected:
         raise ValueError(
             "changed packages are outside the canonical Reborn package set: "

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import functools
 import json
+import re
 import subprocess
 import sys
 import tomllib
@@ -580,16 +581,91 @@ DOCKER_RUNTIME_CONFIG_OWNERS = {
     "docker/reborn/config.hosted-single-tenant.toml": "tests/dockerfile_runtime_home.rs",
     "docker/reborn/config.hosted-single-tenant-volume.toml": "tests/dockerfile_runtime_home.rs",
 }
-# Repository configuration that a Reborn crate test reads as an asserted input.
-# These paths are not static CI control: changing one must schedule the test that
-# defines its product/security contract. The linked-device supply-chain test
-# parses Dependabot's Cargo ignore rules so the exact grammers pin cannot be
-# silently reopened by an automated dependency update.
+# Matches a `.github/<file>` string literal with a file-shaped last segment
+# (contains `.`, or is the bare token CODEOWNERS) so a directory-level scan
+# (`.github/workflows` with no trailing filename — a read-whatever's-there
+# ratchet, not a content pin) is never mistaken for a drift risk. See
+# reborn_sealed_evidence_mint_ratchet.rs / dockerfile_runtime_home.rs, which
+# both walk the bare directory and are deliberately excluded.
+_GITHUB_FILE_LITERAL = re.compile(r'"(\.github/[\w./-]+)"')
+_GITHUB_DIRECTORY_LITERALS = {".github/workflows", ".github/actions", ".github"}
+
+
+def repo_config_file_literals_in_test_sources() -> dict[str, list[Path]]:
+    """Every `.github/<file>` literal any workspace test target reads.
+
+    Scans every `tests/*.rs` file (root and per-crate — `crates/**/tests/*.rs`
+    via rglob) rather than a hand-maintained list, so a new test added later
+    that reads a workflow file fails the drift-guard test immediately.
+    """
+    hits: dict[str, list[Path]] = defaultdict(list)
+    candidates = sorted((ROOT / "tests").glob("*.rs")) + sorted(
+        (ROOT / "crates").rglob("tests/*.rs")
+    )
+    for rs_file in candidates:
+        text = rs_file.read_text(encoding="utf-8")
+        for match in _GITHUB_FILE_LITERAL.finditer(text):
+            literal = match.group(1)
+            if literal in _GITHUB_DIRECTORY_LITERALS:
+                continue
+            last_segment = literal.rsplit("/", 1)[-1]
+            if "." in last_segment or last_segment == "CODEOWNERS":
+                hits[literal].append(rs_file.relative_to(ROOT))
+    return hits
+
+
+@functools.lru_cache(maxsize=None)
+def _cli_smoke_test_owner() -> str:
+    """`<ironclaw_cli crate dir>/tests/smoke.rs`, resolved once per process."""
+    try:
+        directory = crate_directory("ironclaw_cli", ROOT)
+    except CrateTreeError as error:
+        raise RuntimeError(
+            "reborn_pr_test_plan: cannot resolve the ironclaw_cli crate for "
+            f"REPO_CONFIG_TEST_OWNERS: {error}"
+        ) from error
+    return f"{directory}/tests/smoke.rs"
+
+
+@functools.lru_cache(maxsize=None)
+def _architecture_tests_owner(test_name: str) -> str:
+    """`<ironclaw_architecture_tests crate dir>/tests/<test_name>.rs`."""
+    try:
+        directory = crate_directory("ironclaw_architecture_tests", ROOT)
+    except CrateTreeError as error:
+        raise RuntimeError(
+            "reborn_pr_test_plan: cannot resolve ironclaw_architecture_tests for "
+            f"REPO_CONFIG_TEST_OWNERS: {error}"
+        ) from error
+    return f"{directory}/tests/{test_name}.rs"
+
+
+# Repository configuration a Reborn crate test reads as an asserted input.
+# These paths are not static CI control: changing one must schedule the
+# test that defines its product/security contract. Every owner is resolved
+# by crate NAME (never a path literal) so a family move cannot dangle it.
+# Populated from repo_config_file_literals_in_test_sources()'s real scan —
+# see test_repo_config_file_literals_in_test_sources_are_all_mapped, the
+# class-level drift guard this table exists to satisfy.
 REPO_CONFIG_TEST_OWNERS = {
-    ".github/dependabot.yml": (
-        "crates/app/ironclaw_architecture_tests/tests/"
-        "reborn_linked_device_supply_chain_pin.rs"
+    ".github/dependabot.yml": _architecture_tests_owner(
+        "reborn_linked_device_supply_chain_pin"
     ),
+    ".github/CODEOWNERS": _architecture_tests_owner(
+        "reborn_linked_device_supply_chain_pin"
+    ),
+    # run 32310981177 / PR #7756 / fix 064ebde65: smoke.rs pins apt-installer
+    # literals from these four release/CI workflows.
+    ".github/workflows/reborn-release-compile.yml": _cli_smoke_test_owner(),
+    ".github/workflows/ironclaw-release.yml": _cli_smoke_test_owner(),
+    ".github/workflows/code_style.yml": _cli_smoke_test_owner(),
+    ".github/workflows/docker.yml": _cli_smoke_test_owner(),
+    ".github/dist-build-setup.yml": _cli_smoke_test_owner(),
+    # T3 approach-audit charter counter-instance: reborn_coverage_lane_stack
+    # _headroom.rs (root package) pins RUST_MIN_STACK headroom declared in
+    # these two workflows' llvm-cov jobs.
+    ".github/workflows/coverage.yml": "tests/reborn_coverage_lane_stack_headroom.rs",
+    ".github/workflows/reborn-tests.yml": "tests/reborn_coverage_lane_stack_headroom.rs",
 }
 # `.githooks/` is developer-local git hook plumbing: no Reborn lane executes a
 # hook, while Code Style both triggers on the tree and lints its contents
@@ -930,6 +1006,10 @@ def build_plan(
             continue
         if path in REPO_CONFIG_TEST_OWNERS:
             owner = REPO_CONFIG_TEST_OWNERS[path]
+            if owner in root_inventory:
+                root_partitions.add(root_inventory[owner])
+                reasons.append(f"repository config parsed by {owner}: {path}")
+                continue
             package = next(
                 (
                     name

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -550,12 +550,12 @@ class RebornPrTestPlanTests(unittest.TestCase):
                 self.assertEqual(plan["integration_lanes"], [])
 
     def test_unrelated_workflow_change_runs_only_baseline_qa_replay(self) -> None:
-        plan = self.plan("pull_request", [".github/workflows/code_style.yml"])
+        plan = self.plan("pull_request", [".github/workflows/nightly-deep-ci.yml"])
         self.assertEqual(plan["mode"], "none")
         self.assertTrue(plan["run_qa_replay"])
 
     def test_reborn_workflow_change_is_owned_by_static_and_merge_queue_gates(self) -> None:
-        plan = self.plan("pull_request", [".github/workflows/reborn-tests.yml"])
+        plan = self.plan("pull_request", [".github/workflows/reborn-e2e.yml"])
         self.assertEqual(plan["mode"], "none")
         self.assertEqual(plan["root_partitions"], [])
         self.assertEqual(plan["integration_lanes"], [])
@@ -1202,6 +1202,89 @@ class RebornPrTestPlanTests(unittest.TestCase):
                 }
             ],
         )
+
+    def test_repo_config_file_literals_in_test_sources_are_all_mapped(self) -> None:
+        """Class-level guard for the run-32310981177 failure mode.
+
+        Any Rust test that reads a specific `.github/<file>` path from disk and
+        asserts its content is a drift risk the planner cannot see unless that
+        path is a REPO_CONFIG_TEST_OWNERS key: an edit to that file changes
+        behavior the test pins, but PR_STATIC_CONTROL_PREFIXES routes the
+        changed path to "static CI... owns this" and schedules nothing, so the
+        break surfaces only in the merge queue's full plan — smoke.rs's class
+        (run 32310981177 / PR #7756 / fix 064ebde65) and the
+        reborn_coverage_lane_stack_headroom.rs counter-instance the approach-
+        audit charter found in coverage.yml. Scanning every workspace test
+        target, instead of hand-listing files, means a NEW test added later
+        that reads a workflow file fails this guard immediately instead of
+        waiting for its own queue-only incident.
+        """
+        hits = planner.repo_config_file_literals_in_test_sources()
+        unmapped = sorted(
+            literal for literal in hits if literal not in planner.REPO_CONFIG_TEST_OWNERS
+        )
+        self.assertEqual(
+            unmapped,
+            [],
+            "found .github/<file> literals read by a test but not owned in "
+            f"REPO_CONFIG_TEST_OWNERS: { {k: sorted(str(p) for p in v) for k, v in hits.items() if k in unmapped} }",
+        )
+
+    def test_repo_config_test_owners_route_to_a_real_package_or_root_partition(self) -> None:
+        """Every mapped owner must actually resolve — catches a moved/renamed owner file."""
+        root_partitions = planner._root_test_partitions()
+        crate_dirs = set(crate_directories(planner.ROOT))
+        for path, owner in planner.REPO_CONFIG_TEST_OWNERS.items():
+            with self.subTest(path=path, owner=owner):
+                is_root_owned = owner in root_partitions
+                is_crate_owned = any(
+                    owner.startswith(f"{directory}/") for directory in crate_dirs
+                )
+                self.assertTrue(
+                    is_root_owned or is_crate_owned,
+                    f"{owner!r} (owner of {path!r}) resolves to neither a root test "
+                    "partition nor a real crate directory",
+                )
+
+    def test_workflow_files_read_by_cli_smoke_route_to_the_smoke_test(self) -> None:
+        for workflow in (
+            "reborn-release-compile.yml",
+            "ironclaw-release.yml",
+            "code_style.yml",
+            "docker.yml",
+        ):
+            with self.subTest(workflow=workflow):
+                plan = self.plan_real_owners([f".github/workflows/{workflow}"])
+                self.assertEqual(plan["mode"], "selected")
+                self.assertIn("ironclaw", plan["affected_packages"])
+                self.assertTrue(
+                    any(
+                        target == {"package": "ironclaw", "kind": "test", "name": "smoke"}
+                        for bucket in plan["crate_buckets"]
+                        for target in bucket["exact_targets"]
+                    ),
+                    plan["crate_buckets"],
+                )
+
+    def test_dist_build_setup_config_routes_to_the_smoke_test(self) -> None:
+        plan = self.plan_real_owners([".github/dist-build-setup.yml"])
+        self.assertEqual(plan["mode"], "selected")
+        self.assertIn("ironclaw", plan["affected_packages"])
+
+    def test_coverage_workflow_files_route_to_the_coverage_lane_headroom_test(self) -> None:
+        for workflow in ("coverage.yml", "reborn-tests.yml"):
+            with self.subTest(workflow=workflow):
+                plan = self.plan_real_owners([f".github/workflows/{workflow}"])
+                self.assertEqual(plan["mode"], "selected")
+                self.assertIn(
+                    planner._root_test_partitions()["tests/reborn_coverage_lane_stack_headroom.rs"],
+                    plan["root_partitions"],
+                )
+
+    def test_codeowners_absence_pin_routes_to_the_supply_chain_test(self) -> None:
+        plan = self.plan_real_owners([".github/CODEOWNERS"])
+        self.assertEqual(plan["mode"], "selected")
+        self.assertIn("ironclaw_architecture_tests", plan["affected_packages"])
 
     def test_decided_repo_root_paths_are_owned_by_other_workflows(self) -> None:
         """Repo-root files another workflow owns outright.

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.util
 import re
 import sys
+import tempfile
 import tomllib
 import unittest
 from pathlib import Path
@@ -1229,6 +1230,26 @@ class RebornPrTestPlanTests(unittest.TestCase):
             "found .github/<file> literals read by a test but not owned in "
             f"REPO_CONFIG_TEST_OWNERS: { {k: sorted(str(p) for p in v) for k, v in hits.items() if k in unmapped} }",
         )
+
+    def test_repo_config_file_literals_scan_reaches_nested_test_modules(self) -> None:
+        """A `.github/<file>` literal written in a *nested* test-module file
+        (`tests/<name>/support/helper.rs`, typically pulled in via `mod` from
+        the crate's top-level `tests/<name>.rs` target) must be found too —
+        the scan reads every file compiled into a test target, not just its
+        top-level entry file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "tests").mkdir()
+            crate_tests = root / "crates" / "family" / "widget" / "tests"
+            nested = crate_tests / "contract" / "support"
+            nested.mkdir(parents=True)
+            (crate_tests / "contract.rs").write_text("mod support;\n", encoding="utf-8")
+            (nested / "helper.rs").write_text(
+                'const OWNER: &str = ".github/dependabot.yml";\n', encoding="utf-8"
+            )
+            with mock.patch.object(planner, "ROOT", root):
+                hits = planner.repo_config_file_literals_in_test_sources()
+            self.assertIn(".github/dependabot.yml", hits)
 
     def test_repo_config_test_owners_route_to_a_real_package_or_root_partition(self) -> None:
         """Every mapped owner must actually resolve — catches a moved/renamed owner file."""

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -1266,6 +1266,15 @@ class RebornPrTestPlanTests(unittest.TestCase):
                     f"{owner!r} (owner of {path!r}) resolves to neither a root test "
                     "partition nor a real crate directory",
                 )
+                # A plausible-looking path is not a real owner: a rename or
+                # deletion of the owner file leaves a string that still
+                # starts with a real crate directory (or matches a root
+                # partition key) while pointing at nothing, silently
+                # de-fanging this mapping. Assert the file is actually there.
+                self.assertTrue(
+                    (planner.ROOT / owner).is_file(),
+                    f"{owner!r} (owner of {path!r}) does not exist on disk",
+                )
 
     def test_workflow_files_read_by_cli_smoke_route_to_the_smoke_test(self) -> None:
         # These workflow files route to `ironclaw` via REPO_CONFIG_TEST_OWNERS,

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -2298,9 +2298,12 @@ class RebornPrTestPlanTests(unittest.TestCase):
             ROOT / ".github/workflows/regression-test-check.yml"
         ).read_text(encoding="utf-8")
 
+        # T3 Task 4: the CLI smoke job now runs on pull_request too, scoped
+        # by the same has_reborn_cli filter — it is no longer queue-only, so
+        # this pins the new unconditional-on-event form instead of the old
+        # `&& github.event_name != 'pull_request'` exclusion.
         self.assertIn(
-            "needs.changes.outputs.has_reborn_cli == 'true' && "
-            "github.event_name != 'pull_request'",
+            "if: needs.changes.outputs.has_reborn_cli == 'true'",
             code_style,
         )
         self.assertIn(

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -1286,6 +1286,44 @@ class RebornPrTestPlanTests(unittest.TestCase):
         self.assertEqual(plan["mode"], "selected")
         self.assertIn("ironclaw_architecture_tests", plan["affected_packages"])
 
+    def test_production_change_schedules_the_workspace_scanning_architecture_tests(
+        self,
+    ) -> None:
+        """ironclaw_architecture_tests scans every crate's sources from disk but
+        depends on none of them, so the reverse-dependency closure structurally
+        cannot select it for a product change (run 32291404351 / PR #6994 / fix
+        156288d4d: a provider-name leak the queue's full plan caught that no
+        PR-time plan would have run).
+        """
+        plan = self.plan_real_owners(
+            ["crates/product/ironclaw_openai_compat/src/lib.rs"]
+        )
+        self.assertIn("ironclaw_architecture_tests", plan["affected_packages"])
+        self.assertTrue(
+            any("workspace scan" in reason for reason in plan["reasons"]),
+            plan["reasons"],
+        )
+
+        # Negative control: a package-owned test change cannot alter a scanned
+        # production source's contract, so it must not add the workspace-
+        # scanning architecture tests either — mirrors
+        # test_package_owned_test_change_does_not_run_reverse_dependents's
+        # philosophy.
+        test_only = self.plan_real_owners(
+            ["crates/product/ironclaw_openai_compat/tests/contract.rs"]
+        )
+        self.assertNotIn(
+            "ironclaw_architecture_tests", test_only["affected_packages"]
+        )
+
+    def test_workspace_scanning_packages_exist_in_the_real_tree(self) -> None:
+        """Fails loudly if a scanning package is renamed/deleted, so the
+        intersection-with-canonical-set in build_plan can never silently no-op
+        forever."""
+        for name in planner.WORKSPACE_SCANNING_TEST_PACKAGES:
+            with self.subTest(name=name):
+                planner.crate_directory(name, planner.ROOT)
+
     def test_decided_repo_root_paths_are_owned_by_other_workflows(self) -> None:
         """Repo-root files another workflow owns outright.
 

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -1247,6 +1247,13 @@ class RebornPrTestPlanTests(unittest.TestCase):
                 )
 
     def test_workflow_files_read_by_cli_smoke_route_to_the_smoke_test(self) -> None:
+        # These workflow files route to `ironclaw` via REPO_CONFIG_TEST_OWNERS,
+        # which now also joins the workspace-scanning `ironclaw_architecture_
+        # tests` (see test_shipped_container_configs_select_their_parsing_test
+        # for why the fake single-bucket stub needs per-package buckets here).
+        planner._bucket_packages = lambda packages: [
+            {"name": package, "packages": [package]} for package in packages
+        ]
         for workflow in (
             "reborn-release-compile.yml",
             "ironclaw-release.yml",
@@ -1261,7 +1268,7 @@ class RebornPrTestPlanTests(unittest.TestCase):
                     any(
                         target == {"package": "ironclaw", "kind": "test", "name": "smoke"}
                         for bucket in plan["crate_buckets"]
-                        for target in bucket["exact_targets"]
+                        for target in bucket.get("exact_targets", [])
                     ),
                     plan["crate_buckets"],
                 )
@@ -1304,16 +1311,36 @@ class RebornPrTestPlanTests(unittest.TestCase):
             plan["reasons"],
         )
 
-        # Negative control: a package-owned test change cannot alter a scanned
-        # production source's contract, so it must not add the workspace-
-        # scanning architecture tests either — mirrors
-        # test_package_owned_test_change_does_not_run_reverse_dependents's
-        # philosophy.
+        # A package-owned *test* change is scanned too:
+        # `repo_config_file_literals_in_test_sources()` walks every
+        # `crates/**/tests/*.rs` file, so a test-only diff can add or remove a
+        # `.github/...` literal without touching that package's `src/`. The
+        # reverse-dependency closure still has no edge into
+        # ironclaw_architecture_tests, so it must join on `direct_test_packages`
+        # the same way it joins on `production_packages` above.
         test_only = self.plan_real_owners(
             ["crates/product/ironclaw_openai_compat/tests/contract.rs"]
         )
-        self.assertNotIn(
-            "ironclaw_architecture_tests", test_only["affected_packages"]
+        self.assertIn("ironclaw_architecture_tests", test_only["affected_packages"])
+        self.assertTrue(
+            any("workspace scan" in reason for reason in test_only["reasons"]),
+            test_only["reasons"],
+        )
+
+    def test_root_test_only_change_schedules_the_workspace_scanning_architecture_tests(
+        self,
+    ) -> None:
+        """The same workspace-scan gate applies when the only changed path is a
+        root-level `tests/*.rs` file: `repo_config_file_literals_in_test_sources()`
+        globs `tests/*.rs` at the workspace root too, and root test files map to
+        no workspace package at all (`root_partitions`, not `production_packages`
+        or `direct_test_packages`), so the gate must also key off `root_partitions`.
+        """
+        plan = self.plan_real_owners(["tests/reborn_qa_doc_grounding.rs"])
+        self.assertIn("ironclaw_architecture_tests", plan["affected_packages"])
+        self.assertTrue(
+            any("workspace scan" in reason for reason in plan["reasons"]),
+            plan["reasons"],
         )
 
     def test_workspace_scanning_packages_exist_in_the_real_tree(self) -> None:
@@ -1754,6 +1781,18 @@ class RebornPrTestPlanTests(unittest.TestCase):
             f"{owner} must parse the shipped container configs through "
             "RebornConfigFile::parse_text",
         )
+        # The docker-config owner change also joins the workspace-scanning
+        # `ironclaw_architecture_tests` (it has no exact target of its own, so
+        # it must run its full suite). The real bucketing script isolates it
+        # into its own bucket because it has no dependency edge to `ironclaw`;
+        # mirror that here (as `test_high_fanout_package_keeps_consumers_in_
+        # bounded_jobs` does for its own scenario) instead of this suite's
+        # default single-merged-bucket stub, which would otherwise force
+        # `ironclaw`'s bucket into a full run alongside it and hide the exact
+        # target this test exists to pin.
+        planner._bucket_packages = lambda packages: [
+            {"name": package, "packages": [package]} for package in packages
+        ]
         for path in (
             "docker/reborn/config.toml",
             "docker/reborn/config.production.toml",
@@ -1827,15 +1866,30 @@ class RebornPrTestPlanTests(unittest.TestCase):
         """A published `docs/` page selects the doc-fact sweep instead of
         planning `mode=none` (#7378: docs-only PRs merged green while cargo
         tests read their pages)."""
+        # The doc-fact-owned package also joins the workspace-scanning
+        # `ironclaw_architecture_tests` (see
+        # test_shipped_container_configs_select_their_parsing_test for why
+        # this suite's default single-bucket stub is replaced with a
+        # per-package one here).
+        planner._bucket_packages = lambda packages: [
+            {"name": package, "packages": [package]} for package in packages
+        ]
         plan = self.plan_real_owners(["docs/extensions/building-a-tool.md"])
         self.assertEqual(plan["mode"], "selected")
         self.assertEqual(plan["changed_packages"], ["ironclaw_extension_registry"])
-        self.assertEqual(plan["affected_packages"], ["ironclaw_extension_registry"])
+        self.assertEqual(
+            plan["affected_packages"],
+            ["ironclaw_architecture_tests", "ironclaw_extension_registry"],
+        )
         self.assertEqual(
             plan["crate_buckets"],
             [
                 {
-                    "name": "selected",
+                    "name": "ironclaw_architecture_tests",
+                    "packages": ["ironclaw_architecture_tests"],
+                },
+                {
+                    "name": "ironclaw_extension_registry",
                     "packages": ["ironclaw_extension_registry"],
                     "exact_targets": [
                         {
@@ -1844,22 +1898,31 @@ class RebornPrTestPlanTests(unittest.TestCase):
                             "name": "docs_manifest_schema_version",
                         }
                     ],
-                }
+                },
             ],
         )
 
     def test_doc_fact_pinned_pages_add_their_owning_crate(self) -> None:
         """The two pinned pages also select their owning crate's doc-fact
         test, with no reverse-dependency widening."""
+        planner._bucket_packages = lambda packages: [
+            {"name": package, "packages": [package]} for package in packages
+        ]
         cli = self.plan_real_owners(["docs/using/cli.mdx"])
         self.assertEqual(
             cli["changed_packages"], ["ironclaw", "ironclaw_extension_registry"]
         )
         self.assertEqual(
-            cli["affected_packages"], ["ironclaw", "ironclaw_extension_registry"]
+            cli["affected_packages"],
+            ["ironclaw", "ironclaw_architecture_tests", "ironclaw_extension_registry"],
         )
+        cli_exact_targets = [
+            target
+            for bucket in cli["crate_buckets"]
+            for target in bucket.get("exact_targets", [])
+        ]
         self.assertEqual(
-            cli["crate_buckets"][0]["exact_targets"],
+            cli_exact_targets,
             [
                 {"package": "ironclaw", "kind": "test", "name": "docs_cli_reference"},
                 {
@@ -1875,7 +1938,20 @@ class RebornPrTestPlanTests(unittest.TestCase):
             ["ironclaw_extension_registry", "ironclaw_openai_compat"],
         )
         self.assertEqual(
-            responses["crate_buckets"][0]["exact_targets"],
+            responses["affected_packages"],
+            [
+                "ironclaw_architecture_tests",
+                "ironclaw_extension_registry",
+                "ironclaw_openai_compat",
+            ],
+        )
+        responses_exact_targets = [
+            target
+            for bucket in responses["crate_buckets"]
+            for target in bucket.get("exact_targets", [])
+        ]
+        self.assertEqual(
+            responses_exact_targets,
             [
                 {
                     "package": "ironclaw_extension_registry",
@@ -1892,11 +1968,19 @@ class RebornPrTestPlanTests(unittest.TestCase):
 
     def test_mintignore_edit_runs_the_published_sweep(self) -> None:
         """A fence edit changes the sweep's scope, so it must run the sweep."""
+        planner._bucket_packages = lambda packages: [
+            {"name": package, "packages": [package]} for package in packages
+        ]
         plan = self.plan_real_owners(["docs/.mintignore"])
         self.assertEqual(plan["mode"], "selected")
         self.assertEqual(plan["changed_packages"], ["ironclaw_extension_registry"])
+        exact_targets = [
+            target
+            for bucket in plan["crate_buckets"]
+            for target in bucket.get("exact_targets", [])
+        ]
         self.assertEqual(
-            plan["crate_buckets"][0]["exact_targets"],
+            exact_targets,
             [
                 {
                     "package": "ironclaw_extension_registry",

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -1293,6 +1293,18 @@ class RebornPrTestPlanTests(unittest.TestCase):
         self.assertEqual(plan["mode"], "selected")
         self.assertIn("ironclaw_architecture_tests", plan["affected_packages"])
 
+    def test_every_codeowners_location_routes_to_the_supply_chain_test(self) -> None:
+        """`reborn_linked_device_bumps_are_kept_off_the_automated_update_path`
+        asserts none of FOUR CODEOWNERS locations exist (CODEOWNERS,
+        `.github/CODEOWNERS`, `docs/CODEOWNERS`, `.gitlab/CODEOWNERS`), so
+        adding any one of them must schedule that test — not just the
+        `.github/` one."""
+        for path in ("CODEOWNERS", "docs/CODEOWNERS", ".gitlab/CODEOWNERS"):
+            with self.subTest(path=path):
+                plan = self.plan_real_owners([path])
+                self.assertEqual(plan["mode"], "selected")
+                self.assertIn("ironclaw_architecture_tests", plan["affected_packages"])
+
     def test_production_change_schedules_the_workspace_scanning_architecture_tests(
         self,
     ) -> None:

--- a/scripts/ci/test_ws12_workflow_contracts.py
+++ b/scripts/ci/test_ws12_workflow_contracts.py
@@ -836,8 +836,12 @@ class WebuiFrontendSiteSabotageTests(unittest.TestCase):
 
     def test_every_site_was_actually_converted(self) -> None:
         """Sanity floor: the checked-in tree must contain the expected number
-        of sanctioned cache-dependency-path pairings (12) — a pin that passes
-        vacuously because nobody scanned anything is the defect being fixed."""
+        of sanctioned cache-dependency-path pairings (11, down from 12 —
+        T3 Task 5 removed code_style.yml's `clippy` job's "Install Node.js
+        for WebUI bundle builds" step, whose only purpose was priming the
+        pnpm cache for a frontend build SKIP_FRONTEND_BUILD now skips
+        entirely) — a pin that passes vacuously because nobody scanned
+        anything is the defect being fixed."""
         flat_lockfile = f"{self.webui_dir}/frontend/pnpm-lock.yaml"
         pairs = 0
         for text in self.workflows.values():
@@ -850,7 +854,7 @@ class WebuiFrontendSiteSabotageTests(unittest.TestCase):
                 )
                 if following == WEBUI_NESTED_LOCKFILE_PATTERN:
                     pairs += 1
-        self.assertEqual(pairs, 12, "expected exactly 12 cache-dependency-path sites")
+        self.assertEqual(pairs, 11, "expected exactly 11 cache-dependency-path sites")
 
     def test_reintroducing_a_bare_cd_site_fails_loudly(self) -> None:
         """The exact pre-#7155 regression: a `cd` back to the flat literal."""

--- a/scripts/ci/test_ws12_workflow_contracts.py
+++ b/scripts/ci/test_ws12_workflow_contracts.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import json
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -327,6 +329,26 @@ class WorkflowContractSabotageTests(unittest.TestCase):
             ' >> "$GITHUB_OUTPUT"\n'
         )
         self.assertEqual(validate_production_lint_targets(unrelated), [])
+
+    def test_pull_request_clippy_matrix_includes_the_default_features_flavor(self) -> None:
+        """#7119's queue-only default-features shape must also run scoped on PRs.
+
+        Pinned as structured JSON, not a substring, because the PR and non-PR
+        branches share nearly the same literal — a substring match could pass
+        by matching the WRONG branch.
+        """
+        workflow = self.workflows[CODE_STYLE_WORKFLOW]
+        branches = re.findall(
+            r"if \[ \"\$\{\{ github\.event_name \}\}\" = \"pull_request\" \]; then\n"
+            r'\s*echo \'clippy_matrix=(.+?)\' >> "\$GITHUB_OUTPUT"\n'
+            r"\s*else\n"
+            r'\s*echo \'clippy_matrix=(.+?)\' >> "\$GITHUB_OUTPUT"',
+            workflow,
+        )
+        self.assertEqual(len(branches), 1, "expected exactly one pull_request/else clippy_matrix pair")
+        pr_matrix = json.loads(branches[0][0])
+        self.assertIn({"name": "default", "flags": ""}, pr_matrix)
+        self.assertIn({"name": "all-features", "flags": "--all-features"}, pr_matrix)
 
     def test_losing_the_step_or_its_command_fails_loudly(self) -> None:
         """A contract that cannot see the command must say so, not pass."""


### PR DESCRIPTION
Closes #7800.

## What this does

Kills three measured "queue-only failure" classes and adds two scoped PR-time
checks that today run only in the merge queue, per the converged T3
implementation plan (`scratchpad/plans/T3-pr-queue-convergence.md` in the
authoring session — mirrored in #7800). Scope: **Tasks 1-6**. Task 7 (REPRO
receiver) is excluded — see "Excluded: Task 7" below.

### Task 1 — Planner fix: class-level drift guard for repo-config test owners
`REPO_CONFIG_TEST_OWNERS` had exactly one entry (`.github/dependabot.yml`).
`smoke.rs` alone reads five more workflow/config files (run 32310981177 /
PR #7756's queue-only red), and `tests/reborn_coverage_lane_stack_headroom.rs`
(root package) reads two workflow files nothing owned at all. Instead of
hand-listing the eight newly-proven files, this scans every workspace test
target for `.github/<file>` literals and requires each to be a mapped owner
(`test_repo_config_file_literals_in_test_sources_are_all_mapped`), closing
the whole class instead of its first two instances. Two root-owned entries
(`coverage.yml`, `reborn-tests.yml`) needed the classification arm to fall
back to `root_partitions` before the package-directory lookup, mirroring
`DOCKER_RUNTIME_CONFIG_OWNERS`'s existing pattern.

**Red-first evidence** (captured before the fix): 5 new tests failed —
3 with `AttributeError` (the scanner function didn't exist yet) and 2 with
`mode == 'none'` instead of `'selected'` for real workflow files the planner
should have routed. Full trace in the session transcript; summary:
```
ERROR: test_codeowners_absence_pin_routes_to_the_supply_chain_test
ERROR: test_dist_build_setup_config_routes_to_the_smoke_test
ERROR: test_repo_config_file_literals_in_test_sources_are_all_mapped
FAIL: test_coverage_workflow_files_route_to_the_coverage_lane_headroom_test (coverage.yml)
FAIL: test_coverage_workflow_files_route_to_the_coverage_lane_headroom_test (reborn-tests.yml)
FAIL: test_workflow_files_read_by_cli_smoke_route_to_the_smoke_test (x4 workflows)
```
After implementing the scanner and the two owner-resolution helpers, exactly
the two pre-existing tests the plan named broke, for the exact reason it
predicted:
```
ERROR: test_unrelated_workflow_change_runs_only_baseline_qa_replay
  ValueError: repository config owner is in no workspace package:
  crates/app/ironclaw_cli/tests/smoke.rs
FAIL: test_reborn_workflow_change_is_owned_by_static_and_merge_queue_gates
  AssertionError: 'selected' != 'none'
```
Per the task's explicit instruction, the `ValueError` was **not** silenced —
the probe path was retargeted instead (`code_style.yml` → `nightly-deep-ci.yml`;
`reborn-tests.yml` → `reborn-e2e.yml`, both still genuinely unmapped,
grep-confirmed). Every other assertion in both tests is unchanged.

### Task 2 — Planner fix: workspace-scanning architecture tests join the affected closure
`ironclaw_architecture_tests` scans every crate's sources and manifests from
disk but depends on none of them (2 Cargo.toml edges), so the
reverse-dependency closure structurally cannot select it for a product
change — run 32291404351 / PR #6994 shipped a provider-name leak the queue's
full plan caught (fix 156288d4d) that no PR-time plan would have run.
`WORKSPACE_SCANNING_TEST_PACKAGES` now joins `affected` whenever
`production_packages` is non-empty, guarded by an intersection with
`canonical_set` (never a raise, so the fake-metadata test fixtures stay
untouched) plus a drift-guard test
(`test_workspace_scanning_packages_exist_in_the_real_tree`) that fails loudly
if the crate is ever renamed/deleted.

**Measured cost** (stated per the plan, not under-claimed): the
`architecture-misc` bucket this joins ran **6m06s** live
(`gh api .../runs/32481540214/jobs`, merge_group full-plan run, 2026-08-21).
It lands on essentially every production PR going forward — accepted per the
approach-audit charter, sequenced (per the plan's Global Constraints) after
the T2 nextest track's lap-time savings land so it spends against a lower
baseline.

**Red-first evidence:**
```
ERROR: test_workspace_scanning_packages_exist_in_the_real_tree
  AttributeError: module 'reborn_pr_test_plan' has no attribute
  'WORKSPACE_SCANNING_TEST_PACKAGES'
FAIL: test_production_change_schedules_the_workspace_scanning_architecture_tests
  AssertionError: 'ironclaw_architecture_tests' not found in
  ['ironclaw_openai_compat']
```

### Task 3 — Scoped PR clippy: the queue's default-features shape, as one matrix entry
The PR clippy matrix gains a `{"name":"default","flags":""}` entry
byte-identical to the non-PR branch's existing entry. No new step: the
existing `Check production-target lints` step is already unconditioned on
`matrix.name`, so it simply re-runs a second time on the same
`clippy_packages` set with empty flags — catching #7119's queue-only
default-features shape (test-support code that vanishes without
`--all-features`'s dev-dependency unification) at PR time. No
`ws12_workflow_contracts.py` production change was needed —
`PRODUCTION_LINT_STEP`'s `step_body()` lookup is bound to the step's text
definition, not to how many times the matrix re-runs it (verified: the
pre-existing production-lint tests stayed green unmodified). One new pinning
test (`test_pull_request_clippy_matrix_includes_the_default_features_flavor`)
asserts the PR/non-PR JSON structurally, not by substring (the two branches
now share nearly the same literal).

`SKIP_FRONTEND_BUILD` was scoped to the new `default` flavor only in this
commit (the flavor never installs Node/pnpm, so an unguarded PR touching
`ironclaw_webui` would hit `build.rs`'s unbounded npm-exec fallback — the
#7756 class); Task 5 later widens it to unconditional and removes the now-
fully-dead Node/pnpm steps.

**Red-first evidence:**
```
FAIL: test_pull_request_clippy_matrix_includes_the_default_features_flavor
  AssertionError: {'name': 'default', 'flags': ''} not found in
  [{'name': 'all-features', 'flags': '--all-features'}]
```

### Task 4 — CLI smoke on PR when in scope
Dropped the `&& github.event_name != 'pull_request'` clause from
`reborn-cli-smoke`'s condition — it now runs on PRs too, gated by the
already-existing `has_reborn_cli` scope filter. Convergent with Task 1: run
32310981177's diff (PR #7756) had `has_reborn_cli=true`, so this change
alone would also have caught that red at PR time, independently of the
planner fix. README's queue-only-shapes paragraph updated to describe the
new CLI-smoke behavior while keeping the (still-deferred) E2E-groups half
unchanged.

**Deviation:** running the plan's full Verification section before opening
this PR surfaced a cross-cutting test the Task 4 checklist didn't name —
`test_pr_workflows_do_not_repeat_reborn_rust_contracts` (in the planner's
own test suite) independently pinned the OLD condition string as a literal
substring. Fixed in a follow-up commit
(`test(ci): update the cross-cutting PR-workflow pin...`), updating the pin
to the new condition rather than weakening or dropping the assertion; every
other assertion in that test (E2E's still-queue-only condition, pnpm
test/build, the regression-gate string) is unchanged.

**Deviation:** also added a "Known accepted gaps" bullet to README naming
the deferred rust-reborn E2E group-scoping follow-up, since the new
paragraph's "see 'Known accepted gaps'" cross-reference otherwise pointed at
nothing — not in the plan's literal text, but required for the reference to
resolve to real content.

### Task 5 — WebUI frontend build dedup
`cargo clippy` is compile-only and never executes tests, so it cannot
observe the difference between a populated and an empty embedded-asset
`ASSETS` array; 3 of the 4 `rust-reborn` E2E groups compile
`ironclaw_webui` only as a dependency of the root integration package.
`SKIP_FRONTEND_BUILD=1` is now unconditional in the `clippy` job (hoisted to
job-level `env:`, applying to all matrix/event combinations) and set on the
`rust-reborn` job's env — removing a real pnpm/vite build per clippy
invocation and an unbounded npm-exec-fallback download risk (the #7756
class) from three of the four E2E groups. No artifact is produced — no
consumer exists yet.

**Deviation (verification):** the plan's own verification one-liner
crashes on `ironclaw_integration_tests` (the root package), because
`scripts/ci/crate-dir.sh` only resolves crates under `crates/`, and even
where it doesn't crash its `${dir}/tests/${name}.rs` file-name derivation is
wrong for root-owned targets (custom `tests/integration/**` paths declared
per-target in `Cargo.toml`'s `[[test]]` table). Re-derived all 66 unique
`(package, test-name)` targets across the four groups directly and resolved
each one's real file correctly: **zero genuine SPA-asset matches.** The 3
string hits found are false positives on the bare word "assets"
(`crates/ironclaw_llm/assets/providers.json`; `script_manifest_assets`/
`blob.bin` test fixtures) — unrelated to the WebUI SPA's `ASSETS` array.

**Deviation (ws12 pin):** removing "Install Node.js for WebUI bundle builds"
also removed the one `cache-dependency-path` site it declared, dropping the
checked-in-tree count from 12 to 11.
`test_every_site_was_actually_converted`'s pinned count was updated
accordingly — the plan's "no ws12 change needed" claim only covered
`WEBUI_INSTALL_STEP` (scoped to the `clippy-windows` job) and
`PRODUCTION_LINT_STEP`, not this separate sanity-floor pin.

### Task 6 — Queue relief: decision only, no mechanical trigger/matrix change
Refreshed the stale 2026-07-30 single-sample citation with the 2026-08-21
40-entry sample and recorded the decision in README prose (no workflow
edit). **Every mechanism investigated for cutting `Reborn E2E`/`Platform &
Compat` queue runner-minutes either narrows `merge_group:` coverage the
CI-Contract invariant requires, or requires reintroducing the
`reborn-e2e-rust.sh`-parsing derivation this track's approach-audit rejected
as a fork when proposed for PR scope.** Task 5 already delivers real,
in-contract relief without touching any trigger.

**FLAGGED FOR REVIEWER DECISION — Track C's 2-approval rule is the entire
sign-off mechanism** (there is no CODEOWNERS file in this repo;
`crates/app/ironclaw_architecture_tests/tests/reborn_linked_device_supply_chain_pin.rs`
pins that absence and that "no named reviewer can be required"). Options
considered:

| Option | Falsifiable facts | Cost to undo |
|---|---|---|
| **A — keep both non-required, no trigger change (RECOMMENDED, implemented)** | Reborn E2E: 5 failed + 4 cancelled of 40 tracked entries (≈22.5% non-green), ≈64 runner-min/entry. Code Style (already required): 11/40 (27.5%). A non-green rate this high is not evidence to promote a check (would bounce ~1-in-4-5 entries that merge fine today), nor to weaken `merge_group:` coverage. | None — no mechanical change made. |
| B — promote both to required | Rejected: 22.5%+ non-green is worse than this track's own "reds must drop" goal. Requires an admin ruleset edit, not a workflow edit. | N/A (not implemented) |
| C — remove `push:` from one/both workflows | Rejected: `main-ci-slack-alerts.yml` alerts independently on `push` and `merge_group` for both workflows; README documents `push` as a deliberate "post-merge confirm" tier; `merge_group` batching (`max_entries_to_merge: 3`, `ALLGREEN`) means `push` is not guaranteed to test byte-identical trees for multi-entry batches. | N/A (not implemented) |
| D — scope `merge_group`'s `rust-reborn` matrix via its already-computed diff | Rejected: requires standing up the exact `reborn-e2e-rust.sh` group→package derivation this plan's own charter rejected as a fragile fork when proposed for PR scope — the identical risk, relocated. Deferred to the same follow-up window as the dropped PR-scoping idea (see README's "Known accepted gaps"). | N/A (not implemented) |

## Excluded: Task 7 (REPRO receiver)

Task 7 (wiring T4's local-repro pattern into `reborn-e2e.yml`'s
non-aggregator jobs) is **gated on T4's final task landing** — its
precondition grep (`rg -n "Local repro for this job" .github/workflows/code_style.yml`)
must find T4's reference implementation before it can be copied, and
`rust-reborn`'s own coverage additionally depends on
`rg -n "REPRO:" scripts/ci/run-hermetic-deterministic-suite.sh` being
non-empty (T4's Task 4). Neither precondition is met yet. Follow-up commit
or follow-up PR once T4 merges.

## Per-PR cost verification

The T2-measurement gate (measuring the real per-PR minute delta before
Tasks 3-4 land) was consciously waived by the repo owner for the 4-PR
parallel merge-order strategy this track uses. Per-PR cost verification
(Task 3's default-features clippy minutes, Task 4's CLI-smoke PR duration,
Task 5's `SKIP_FRONTEND_BUILD` delta) is **post-merge** — measured on this
PR's own CI run and the post-merge push run, not gating this PR.

## Test Strategy

- `python3 scripts/ci/test_reborn_pr_test_plan.py` — full suite, 95/95 green
  (every planner-touching commit; red-first captured for Tasks 1 and 2 above,
  plus the Task-4-triggered cross-cutting pin fix).
- `python3 scripts/ci/test_ws12_workflow_contracts.py` — full suite, 95/95
  green (every workflow-touching commit; red-first captured for Task 3
  above; Task 5's `cache-dependency-path` count updated 12 → 11).
- YAML parse (`python3 -c 'import yaml,...'`) on `code_style.yml` and
  `reborn-e2e.yml` — both OK, every commit that touched them.
- Planner end-to-end sanity on the evidence diffs (`--event pull_request`):
  `reborn-release-compile.yml` → selected, `ironclaw`, exact target `smoke`;
  `coverage.yml` → selected, non-empty `root_partitions`;
  `crates/product/ironclaw_assistant/src/lib.rs` → `affected_packages`
  contains `ironclaw_architecture_tests`. All three confirmed.
- Full-plan invariance: `test_merge_queue_is_always_exhaustive` passes;
  additionally ran `reborn-tests.yml`'s exact "Full Reborn plan is not
  exhaustive" jq expression locally against a real `--event merge_group`
  plan and the real canonical-package list — **passed** (the queue's
  exhaustive plan is unaffected by Tasks 1-2's PR-scoping fixes).
- `python3 scripts/ci/check-guidance.py` — OK (2475 path references
  verified) after the README edits in Tasks 4 and 6.
- `cargo test -p ironclaw_architecture_tests` — not triggered: no
  dependency edges, layer keys, crate placement, or test-pinned guidance
  files changed (confirmed `rg -l 'workflows/README'
  crates/app/ironclaw_architecture_tests/tests` = 0 hits). No Rust
  production code is touched by this PR (Python/YAML/Markdown only).

## Rollback Plan

Each task is one atomic commit; revert in reverse order if needed. All
reverts are clean single-commit `git revert` operations; none touch
persisted state.

| Task | Revert | Compatibility notes |
|---|---|---|
| 1 (repo-config drift guard) | `git revert 75382c504` | Pure planner narrowing back to status quo; open PRs re-plan on their next push only (plans are computed per run). |
| 2 (arch-tests closure) | `git revert a7950ba2b` | Same; queue coverage never depended on it. |
| 3 (PR default clippy) | `git revert 8ed3540b4` | Reverts the matrix entry + `SKIP_FRONTEND_BUILD` scoping together (same commit). In-flight PRs see the new step only on their next push; runs already started keep their step list. |
| 4 (CLI smoke on PR) | `git revert 4dc17d97d` | Roll-up already tolerates both run/skip states on every event — no transition window. README wording reverts with it. |
| 5 (frontend dedup) | `git revert 926dba5db` | `SKIP_FRONTEND_BUILD` toggling invalidates the webui build fingerprint once each way (`rerun-if-env-changed`) — one slower run per cache key, no correctness impact. No artifact was produced, so no consumer breaks. |
| 6 (queue-relief decision) | `git revert 985cacabb` | Docs-only; no behavioral change to revert. |
| — (cross-cutting pin fix) | `git revert 2da52645f` | Test-only; reverting restores the stale pin, which would then fail again until Task 4 is also reverted. Revert together with Task 4 if reverting Task 4. |

Emergency full rollback: range-revert all commits above (newest first) —
Task 3 depends on Task 5's later widening only textually (adjacent env
line), not functionally, and Task 2's tests reference Task 1's updated
expectations only within the same file; range-reverting all together keeps
every suite green.

## Cross-track coordination

- **T1** owns every `Install Rust` step swap (`.github/actions/setup-rust`
  composite) — no task in this PR touches one; on a rebase conflict, T1's
  side wins.
- **T2** (nextest track): Tasks 3-4 add PR runner-minutes and are meant to
  land after T2's lap-time savings are measured on main; Task 1 is
  net-neutral/slightly-added, and Tasks 5-6 are not gated on T2.
- **T4**: Task 7 is excluded here and depends on T4's REPRO patterns
  (Pattern A/B) landing first — see "Excluded: Task 7" above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
