### PR TITLE
fix(webui): remove Gateway v2 login eyebrow

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/i18n/ar.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/ar.ts
@@ -89,7 +89,6 @@ registerPack("ar", {
   "status.checking": "جارٍ التحقق",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "تحكم بالوكيل المحلي دون فقدان أثر المُشغِّل.",
   "login.heroSub": "يُبقي الوصول عبر الرمز (Token) وحدة تحكم المتصفح مرتبطة بنفس تشغيل البوابة والموافقات والأدوات وحالة الخيط.",
   "login.bearerAuth": "مصادقة Bearer",

--- a/crates/product/ironclaw_webui/frontend/src/i18n/de.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/de.ts
@@ -89,7 +89,6 @@ registerPack("de", {
   "status.checking": "prüfen",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "Lokale Agentensteuerung ohne den Operator‑Trail zu verlieren.",
   "login.heroSub": "Tokenzugriff bindet die Browser‑Konsole an dieselbe Gateway‑Runtime, Freigaben, Tools und Thread‑Zustand.",
   "login.bearerAuth": "Bearer‑Auth",

--- a/crates/product/ironclaw_webui/frontend/src/i18n/en.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/en.ts
@@ -89,7 +89,6 @@ registerPack("en", {
   "status.checking": "checking",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "Local agent control without losing the operator trail.",
   "login.heroSub":
     "Token access keeps the browser console tied to the same gateway runtime, approvals, tools, and thread state.",

--- a/crates/product/ironclaw_webui/frontend/src/i18n/es.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/es.ts
@@ -89,7 +89,6 @@ registerPack("es", {
   "status.checking": "comprobando",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "Control del agente local sin perder el rastro del operador.",
   "login.heroSub": "El acceso por token mantiene la consola del navegador vinculada al mismo runtime del gateway, aprobaciones, herramientas y estado del hilo.",
   "login.bearerAuth": "Auth Bearer",

--- a/crates/product/ironclaw_webui/frontend/src/i18n/fr.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/fr.ts
@@ -89,7 +89,6 @@ registerPack("fr", {
   "status.checking": "vérification",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "Contrôle de l’agent local sans perdre la trace opérateur.",
   "login.heroSub": "L’accès par token lie la console du navigateur au même runtime du gateway, aux validations, aux outils et à l’état des threads.",
   "login.bearerAuth": "Auth Bearer",

--- a/crates/product/ironclaw_webui/frontend/src/i18n/hi.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/hi.ts
@@ -89,7 +89,6 @@ registerPack("hi", {
   "status.checking": "जांच हो रही है",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "ऑपरेटर ट्रेल खोए बिना लोकल एजेंट कंट्रोल।",
   "login.heroSub": "टोकन एक्सेस ब्राउज़र कंसोल को उसी गेटवे runtime, approvals, tools और thread state से जोड़ता है।",
   "login.bearerAuth": "बियरर ऑथ",

--- a/crates/product/ironclaw_webui/frontend/src/i18n/ja.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/ja.ts
@@ -89,7 +89,6 @@ registerPack("ja", {
   "status.checking": "確認中",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "オペレーターの痕跡を失わずにローカルエージェントを制御。",
   "login.heroSub": "トークンアクセスにより、ブラウザコンソールは同じゲートウェイランタイム、承認、ツール、スレッド状態に紐づきます。",
   "login.bearerAuth": "Bearer 認証",

--- a/crates/product/ironclaw_webui/frontend/src/i18n/ko.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/ko.ts
@@ -89,7 +89,6 @@ registerPack("ko", {
   "status.checking": "확인 중",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "운영 추적을 유지하며 로컬 에이전트를 제어합니다.",
   "login.heroSub": "토큰 접근은 브라우저 콘솔을 동일한 게이트웨이 런타임, 승인, 도구 및 스레드 상태에 연결합니다.",
   "login.bearerAuth": "Bearer 인증",

--- a/crates/product/ironclaw_webui/frontend/src/i18n/pt-BR.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/pt-BR.ts
@@ -89,7 +89,6 @@ registerPack("pt-BR", {
   "status.checking": "verificando",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "Controle do agente local sem perder o rastro do operador.",
   "login.heroSub": "O acesso por token mantém o console do navegador ligado ao mesmo runtime do gateway, aprovações, ferramentas e estado do thread.",
   "login.bearerAuth": "Autenticação do portador",

--- a/crates/product/ironclaw_webui/frontend/src/i18n/uk.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/uk.ts
@@ -89,7 +89,6 @@ registerPack("uk", {
   "status.checking": "перевірка",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "Керування локальним агентом без втрати операторського сліду.",
   "login.heroSub": "Доступ за токеном прив’язує консоль браузера до того ж runtime шлюзу, затверджень, інструментів і стану тредів.",
   "login.bearerAuth": "Bearer-автентифікація",

--- a/crates/product/ironclaw_webui/frontend/src/i18n/zh-CN.ts
+++ b/crates/product/ironclaw_webui/frontend/src/i18n/zh-CN.ts
@@ -89,7 +89,6 @@ registerPack("zh-CN", {
   "status.checking": "检查中",
 
   // Login page
-  "login.tagline": "Gateway v2",
   "login.hero": "本地代理控制，不丢失操作轨迹。",
   "login.heroSub": "令牌访问将浏览器控制台绑定到同一网关运行时、审批、工具和线程状态。",
   "login.bearerAuth": "Bearer 认证",

--- a/crates/product/ironclaw_webui/frontend/src/lib/i18n.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/lib/i18n.test.ts
@@ -538,11 +538,12 @@ test("locale packs include extension setup and OAuth failure copy", () => {
   }
 });
 
-test("pairing connect copy drops the removed paste-a-code flow and stays consistent across locales", () => {
-  // Keys retired with the paste-a-code pairing panel / renamed fallbacks — must
-  // be gone from EVERY locale (there is no full key-set parity test, so a
-  // straggler in one locale would otherwise linger silently).
+test("locale packs drop retired UI keys and stay consistent across locales", () => {
+  // Keys retired with removed UI flows — must be gone from EVERY locale (there
+  // is no full key-set parity test, so a straggler in one locale would
+  // otherwise linger silently).
   const retiredKeys = [
+    "login.tagline",
     "pairing.title",
     "pairing.instructions",
     "pairing.placeholder",

--- a/crates/product/ironclaw_webui/frontend/src/pages/login/login-page.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/login/login-page.test.ts
@@ -21,7 +21,7 @@ function renderLoginPage({ providers = [], isLocalDev = true } = {}) {
     FormField: component("FormField"),
     Icon: component("Icon"),
     useInterfaceTheme: () => ({ theme: "dark", toggleTheme: () => {} }),
-    useT: () => (key) => key,
+    useT: () => (key) => (key === "login.tagline" ? "Gateway v2" : key),
     cn: (...classes) => classes.flat().filter(Boolean).join(" "),
     // A string component type remains visible in the serialized element tree,
     // allowing the layout assertion to verify the OAuth section itself.
@@ -44,6 +44,12 @@ function renderLoginPage({ providers = [], isLocalDev = true } = {}) {
   );
   return LoginPage({ onSubmit: () => {} });
 }
+
+test("login page does not render the retired Gateway v2 eyebrow", () => {
+  const serialized = JSON.stringify(renderLoginPage({ isLocalDev: false }));
+
+  assert.doesNotMatch(serialized, /Gateway v2/);
+});
 
 test("login page shows the local-dev status hint when no OAuth providers are configured on a local origin", () => {
   const rendered = renderLoginPage({ providers: [], isLocalDev: true });

--- a/crates/product/ironclaw_webui/frontend/src/pages/login/login-page.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/login/login-page.tsx
@@ -46,9 +46,6 @@ export function LoginPage({ initialToken, error, oauthRedirectAfter = "/", onSub
         className="w-full max-w-md p-6 shadow-none sm:p-8"
       >
         <div className="mb-8">
-          <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-[var(--v2-accent-text)]">
-            {t("login.tagline")}
-          </p>
           <h1
             className="text-5xl font-semibold leading-none tracking-[-0.04em] text-[var(--v2-text-strong)]"
           >


### PR DESCRIPTION
## Summary

- Remove the `Gateway v2` eyebrow from the WebUI login card.
- Remove the unused `login.tagline` key from all 11 locale packs.
- Add caller-level regression coverage for the rendered login page and a retired-locale-key guard.

## Verified bug

On local `origin/main` at `6f4739532`, `LoginPage` rendered `t("login.tagline")` as the visible login-card eyebrow. The regression test failed before the fix (1 failed, 6 passed) with `login.tagline` present in the serialized `LoginPage` tree.

## Verification

- `corepack pnpm exec vitest run --project unit src/pages/login/login-page.test.ts` — red before the fix; green after it.
- `corepack pnpm exec vitest run --project unit` — 167 files, 1,469 tests passed.
- `corepack pnpm exec vitest run --project unit src/lib/i18n.test.ts src/pages/login/login-page.test.ts` — 35 tests passed on the pushed tree.
- `corepack pnpm exec tsc --noEmit` — passed.
- Frontend source-convention and bundle-budget checks — passed after compiling the repository check scripts because this environment\047s Node build cannot execute `--experimental-strip-types`.
- `cargo fmt --all -- --check` — passed.
- `cargo test -p ironclaw_webui --test i18n_consistency --test webui_v2_descriptors_contract --test webui_v2_handlers_contract` — 161 tests passed.
- Multi-agent code review and final thermo-nuclear maintainability review — no findings.

## Scope and rollback

This is presentation/i18n-only; authentication, backend routes, persistence, and wire contracts are unchanged. Reverting commit `61a192203` fully rolls back the change.

The frontend caller-level test is sufficient for this UI-only path; no browser E2E or backend integration test was added.