### PR TITLE
fix(webui): refresh conversations after starting suggestion

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useSuggestions.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useSuggestions.test.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { runVmModuleForTest } from "../../../test-support/vm-module-harness";
+
+test("starting a suggestion refreshes its thread in the conversations sidebar", () => {
+  const invalidations = [];
+  const mutations = [];
+  const context = {
+    fetchSuggestions: async () => ({}),
+    generateSuggestions: async () => ({}),
+    pollDelayMs: () => false,
+    startSuggestion: async () => ({}),
+    dismissSuggestion: async () => ({}),
+    useQuery: () => ({ data: null, isLoading: false, error: null }),
+    useQueryClient: () => ({
+      invalidateQueries: (request) => invalidations.push(request),
+      setQueryData: () => {},
+    }),
+    useMutation: (options) => {
+      mutations.push(options);
+      return {
+        mutate: () => {},
+        isPending: false,
+        variables: null,
+        error: null,
+      };
+    },
+  };
+
+  const { useSuggestions } = runVmModuleForTest(
+    "./useSuggestions.ts",
+    ["useSuggestions"],
+    context,
+    import.meta.url,
+  );
+  useSuggestions();
+  mutations[1].onSuccess();
+
+  assert.deepEqual(
+    invalidations
+      .map((request) => [...request.queryKey])
+      .sort(([left], [right]) => left.localeCompare(right)),
+    [["suggestions"], ["threads"]],
+  );
+});

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useSuggestions.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useSuggestions.ts
@@ -44,9 +44,12 @@ export function useSuggestions() {
   const start = useMutation({
     mutationFn: (suggestionId: string) => startSuggestion(suggestionId),
     // The started card gains a durable thread/run binding; refresh so it
-    // renders as started if the user comes back to the landing.
+    // renders as started if the user comes back to the landing. Starting also
+    // creates a thread server-side, outside useThreads, so refresh the
+    // non-polling sidebar query at the same boundary.
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: SUGGESTIONS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ["threads"] });
     },
   });
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useThreads.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useThreads.ts
@@ -15,10 +15,10 @@ import {
 
 export function useThreads() {
   // No polling: the sidebar is kept current by local cache writes after
-  // create/send and by invalidating after delete. The v2 deployment has no
-  // out-of-band thread producers (no external channel, no background routine)
-  // in this binary. The fork's 5s poll was inherited from a v1 multi-channel
-  // context that doesn't apply here.
+  // create/send and by invalidating after suggestion start/delete. The v2
+  // deployment has no unaccounted out-of-band thread producers (no external
+  // channel or background routine) in this binary. The fork's 5s poll was
+  // inherited from a v1 multi-channel context that doesn't apply here.
   const query = useQuery({
     queryKey: ["threads"],
     queryFn: ({ signal }) => listThreads({ signal }),


### PR DESCRIPTION
## Summary

- Refresh the non-polling conversations query after a suggested task successfully creates its server-side thread.
- Keep the existing suggestion-card refresh and document the suggestion-start producer in the sidebar cache contract.
- Add a red-first hook regression that pins both complete React Query invalidation keys.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #7845

## Validation

- [ ] `cargo fmt --all -- --check` (not applicable: no Rust changed)
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` (not applicable: no Rust changed)
- [ ] `cargo build` (not applicable: no build-path change)
- [x] Relevant tests pass: focused frontend regression, neighboring chat/thread suites, and existing Reborn suggestion integration
- [ ] `cargo test -p <owning-crate> --features integration` (not applicable: no database/runtime behavior changed)
- [ ] Manual testing (not applicable: deterministic cache callback is covered at the caller seam)
- [ ] If a coding agent was used and supports it, `pr-shepherd` was run before requesting review

## Test Strategy

User behavior: Approving a suggested task immediately makes its newly created thread available to the conversations sidebar without requiring a follow-up message.

Risk areas:
- [ ] Model behavior
- [x] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `useSuggestions.test.ts::starting a suggestion refreshes its thread in the conversations sidebar`
- Reborn integration: Existing `suggestions.rs::starting_a_replacement_suggestion_creates_one_thread` run unchanged
- Recorded fixture: Not applicable: no model behavior changed
- Browser E2E: Not applicable: the hook test pins the stale-cache boundary and the Reborn integration test already pins canonical list visibility
- Backend or runtime: Not applicable: no backend/runtime behavior changed
- Live canary: Not applicable: deterministic frontend state transition

What the tests prove: the regression was red when successful suggestion start invalidated only `["suggestions"]`; it is green only when the exact `["threads"]` key is also invalidated. The existing integration test proves the server-created thread is already visible through canonical `THREADS_VIEW` with its suggested prompt.

Commands run:
- `pnpm exec vitest run --project unit src/pages/chat/hooks/useSuggestions.test.ts -t "starting a suggestion refreshes its thread in the conversations sidebar"` (red before, green after)
- `pnpm exec vitest run --project unit src/pages/chat/hooks/useSuggestions.test.ts src/pages/chat/components/suggested-task-surface.test.ts src/pages/chat/hooks/useThreads.test.ts src/pages/chat/lib/chat.test.ts` (53 passed)
- `pnpm typecheck`
- frontend source-convention checker (transpiled locally because this environment's Node binary lacks native type stripping)
- `cargo test -p ironclaw_integration_tests --test reborn_integration_suggestions starting_a_replacement_suggestion_creates_one_thread -- --exact`
- `git diff --check`

## Security Impact

None.

## Reborn Trust-Boundary Checklist

N/A: this changes only browser React Query cache invalidation after an already-authorized successful product command.

## Database Impact

None.

## Blast Radius

WebChat v2 suggested-task activation and conversations-sidebar cache coherence. A successful activation now schedules one normal thread-list revalidation; failed activations do not.

## Rollback Plan

Revert commit `3c33edb69846226bca2c350b15824dad7c53451b` to restore the previous cache behavior.

## Review Follow-Through

Multi-lane code review found one low-severity test weakness (partial query-key comparison); it was fixed by comparing complete keys order-independently. Final thermo maintainability review approved with no blockers.

---

**Review track**: B

