### PR TITLE
refactor(webui): replace legacy Extensions panels with shared Panel

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/extensions/components/channels-tab.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/extensions/components/channels-tab.test.ts
@@ -25,6 +25,7 @@ function sourceForTest() {
 function renderTab(overrides = {}) {
   const context = {
     ExtensionCard() {},
+    Panel() {},
     RegistryCard() {},
     globalThis: {},
     html: (strings, ...values) => ({ strings: Array.from(strings), values }),

--- a/crates/product/ironclaw_webui/frontend/src/pages/extensions/components/channels-tab.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/extensions/components/channels-tab.tsx
@@ -1,3 +1,4 @@
+import { Panel } from "../../../design-system/primitives";
 import { useT } from "../../../lib/i18n";
 import { ExtensionCard, RegistryCard } from "./extension-card";
 import type {
@@ -34,7 +35,7 @@ export function ChannelsTab({
     <div className="space-y-5">
       {installedChannels.length > 0 &&
       (
-        <div className="v2-panel rounded-[18px] p-5 sm:p-6">
+        <Panel className="p-5 sm:p-6">
           <h3
             className="mb-4 font-mono text-[11px] uppercase tracking-[0.14em] text-signal"
           >
@@ -53,11 +54,11 @@ export function ChannelsTab({
               )
             )}
           </div>
-        </div>
+        </Panel>
       )}
       {channelRegistry.length > 0 &&
       (
-        <div className="v2-panel rounded-[18px] p-5 sm:p-6">
+        <Panel className="p-5 sm:p-6">
           <h3
             className="mb-4 font-mono text-[11px] uppercase tracking-[0.14em] text-signal"
           >
@@ -75,7 +76,7 @@ export function ChannelsTab({
               )
             )}
           </div>
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/crates/product/ironclaw_webui/frontend/src/pages/extensions/components/registry-tab.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/extensions/components/registry-tab.test.ts
@@ -26,6 +26,7 @@ function renderRegistryTab(props, filter = "") {
   const filterUpdates = [];
   const context = {
     ExtensionCard() {},
+    Panel() {},
     RegistryCard() {},
     SearchField() {},
     React: {

--- a/crates/product/ironclaw_webui/frontend/src/pages/extensions/components/registry-tab.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/extensions/components/registry-tab.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Panel } from "../../../design-system/primitives";
 import { useT } from "../../../lib/i18n";
 import { Icon } from "../../../design-system/icons";
 import { SearchField } from "../../../design-system/search-field";
@@ -104,7 +105,7 @@ export function RegistryTab({
 
   if (catalogEntries.length === 0) {
     return (
-      <div className="v2-panel rounded-[18px] p-6 sm:p-8">
+      <Panel className="p-6 sm:p-8">
         <div className="flex items-start justify-between gap-4">
           <h3 className="text-lg font-semibold text-white">
             {t("ext.registry.emptyTitle")}
@@ -114,7 +115,7 @@ export function RegistryTab({
         <p className="mt-2 max-w-md text-sm leading-6 text-iron-300">
           {t("ext.registry.emptyDesc")}
         </p>
-      </div>
+      </Panel>
     );
   }
 
@@ -135,7 +136,7 @@ export function RegistryTab({
         </span>
       </div>
 
-      <div className="v2-panel rounded-[18px] p-5 sm:p-6">
+      <Panel className="p-5 sm:p-6">
         {installedCount > 0 &&
         (
           <>
@@ -206,7 +207,7 @@ export function RegistryTab({
         (<p className="py-4 text-sm text-iron-300">
           {t("ext.registry.noMatch")}
         </p>)}
-      </div>
+      </Panel>
     </div>
   );
 }

--- a/crates/product/ironclaw_webui/frontend/src/pages/extensions/components/tools-tab.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/extensions/components/tools-tab.tsx
@@ -1,3 +1,4 @@
+import { Panel } from "../../../design-system/primitives";
 import { useT } from "../../../lib/i18n";
 import { ExtensionCard, RegistryCard } from "./extension-card";
 import type {
@@ -32,12 +33,12 @@ export function ToolsTab({
   const t = useT();
   if (tools.length === 0 && toolRegistry.length === 0) {
     return (
-      <div className="v2-panel rounded-[18px] p-6 sm:p-8">
+      <Panel className="p-6 sm:p-8">
         <h3 className="text-lg font-semibold text-white">{t("extensions.emptyToolsTitle")}</h3>
         <p className="mt-2 max-w-md text-sm leading-6 text-iron-300">
           {t("extensions.emptyToolsDesc")}
         </p>
-      </div>
+      </Panel>
     );
   }
 
@@ -45,7 +46,7 @@ export function ToolsTab({
     <div className="space-y-5">
       {tools.length > 0 &&
       (
-        <div className="v2-panel rounded-[18px] p-5 sm:p-6">
+        <Panel className="p-5 sm:p-6">
           <h3
             className="mb-4 font-mono text-[11px] uppercase tracking-[0.14em] text-signal"
           >
@@ -64,11 +65,11 @@ export function ToolsTab({
               )
             )}
           </div>
-        </div>
+        </Panel>
       )}
       {toolRegistry.length > 0 &&
       (
-        <div className="v2-panel rounded-[18px] p-5 sm:p-6">
+        <Panel className="p-5 sm:p-6">
           <h3
             className="mb-4 font-mono text-[11px] uppercase tracking-[0.14em] text-signal"
           >
@@ -86,7 +87,7 @@ export function ToolsTab({
               )
             )}
           </div>
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/crates/product/ironclaw_webui/frontend/src/pages/extensions/extensions-page.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/extensions/extensions-page.test.ts
@@ -4,6 +4,39 @@ import { readFileSync } from "node:fs";
 import { test } from "vitest";
 import vm from "node:vm";
 
+const sharedPanelTabs = [
+  ["./components/registry-tab.tsx", 2],
+  ["./components/channels-tab.tsx", 2],
+  ["./components/tools-tab.tsx", 3],
+] as const;
+
+test("standard extension tab containers use the shared Panel component", () => {
+  for (const [relativePath, expectedPanelCount] of sharedPanelTabs) {
+    const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+    assert.doesNotMatch(
+      source,
+      /\bv2-panel\b/,
+      `${relativePath} must not use the legacy panel styling shim`,
+    );
+    assert.match(
+      source,
+      /import \{ Panel \} from "\.\.\/\.\.\/\.\.\/design-system\/primitives";/,
+      `${relativePath} must import the shared Panel component`,
+    );
+    assert.match(
+      source,
+      /<Panel(?:\s|>)/,
+      `${relativePath} must render the shared Panel component`,
+    );
+    assert.equal(
+      source.match(/<Panel(?:\s|>)/g)?.length,
+      expectedPanelCount,
+      `${relativePath} must use Panel for every standard container`,
+    );
+  }
+});
+
 function extensionsPageSourceForTest() {
   const source = readFileSync(new URL("./extensions-page.tsx", import.meta.url), "utf8");
   const lines = [];


### PR DESCRIPTION
## Summary

- Replaces the legacy `.v2-panel` wrappers in the Extensions Registry, Channels, and Tools tabs with the shared `Panel` component.
- Preserves the existing content, spacing, grids, conditional rendering, and interactions while centralizing panel theme and surface styling.
- Adds a regression contract that requires all seven standard Extensions containers to use `Panel` and prevents the legacy class from being reintroduced.

## Linked Issue

Closes #7878

## Validation

- [x] `corepack pnpm test`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm build`
- [x] `cargo test -p ironclaw_webui --all-features`
- [x] `cargo clippy -p ironclaw_webui --all-features --all-targets -- -D warnings`
- [x] `scripts/pre-commit-safety.sh`
- [x] `git diff --check`

## E2E Impact

No new E2E coverage is required. This is a presentation-component migration with no changes to routes, interactions, data flow, or cross-layer behavior. The frontend regression contract directly covers the affected containers.

## Security Impact

No security impact.

## Database Impact

No schema, migration, or persistence changes.

## Blast Radius

Limited to standard panel containers in the Extensions Registry, Channels, and Tools tabs.

## Rollback Plan

Revert commit `30edb534de` to restore the legacy `.v2-panel` wrappers.

## Risk

Low.