### PR TITLE
fix(webui): adopt shared controls in Admin Users

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/admin/components/user-actions.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/admin/components/user-actions.test.ts
@@ -133,20 +133,27 @@ function baseAdminState(overrides = {}) {
 }
 
 function loadUsersView(harness) {
+  function Button() {}
   function ConfirmDialog() {}
+  function FormField() {}
+  function Input() {}
+  function SearchField() {}
   const module = runVmModuleForTest(
     "./users-tab.tsx",
-    ["AdminUsersTabView", "UserRow"],
+    ["AdminUsersTabView", "CreateUserForm", "UserRow"],
     {
       React: harness.React,
       useT: () => translate,
       Panel: function Panel() {},
       StatusPill: function StatusPill() {},
       EmptyPanel: function EmptyPanel() {},
-      Button: function Button() {},
+      Button,
       ConfirmDialog,
+      FormField,
       Icon: function Icon() {},
+      Input,
       InlineNotice: function InlineNotice() {},
+      SearchField,
       SelectMenu: function SelectMenu() {},
       Skeleton: function Skeleton() {},
       useAdminUsers: () => baseAdminState(),
@@ -167,7 +174,7 @@ function loadUsersView(harness) {
     },
     import.meta.url,
   );
-  return { ...module, ConfirmDialog };
+  return { ...module, Button, ConfirmDialog, FormField, Input, SearchField };
 }
 
 function loadDetailModule(harness) {
@@ -239,6 +246,102 @@ test("user detail exposes thread scraping only when the deployment gate is enabl
 
   assert.equal(findByType(harness.render(View, props), ThreadScrapingPanel), null);
   assert.ok(findByType(harness.render(View, { ...props, threadScrapingEnabled: true }), ThreadScrapingPanel));
+});
+
+test("admin users compose shared form and search controls without changing their behavior", async () => {
+  const formHarness = createReactHarness();
+  const {
+    Button,
+    CreateUserForm,
+    FormField,
+    Input,
+  } = loadUsersView(formHarness);
+  const createCalls = [];
+  const formProps = {
+    error: null,
+    isCreating: false,
+    onCreate: async (payload) => { createCalls.push(payload); },
+    resetError: () => {},
+  };
+
+  let form = formHarness.render(CreateUserForm, formProps);
+  findByType(form, Button).props.onClick();
+  form = formHarness.render(CreateUserForm, formProps);
+
+  const fields = new Set();
+  const inputs = new Set();
+  visit(form, (node) => {
+    if (node?.type === FormField) fields.add(node.props);
+    if (node?.type === Input) inputs.add(node.props);
+  });
+  assert.deepEqual([...fields].map(({ htmlFor, label, required }) => ({ htmlFor, label, required })), [
+    {
+      htmlFor: "admin-user-display-name",
+      label: "admin.users.displayName",
+      required: true,
+    },
+    {
+      htmlFor: "admin-user-email",
+      label: "admin.users.email",
+      required: undefined,
+    },
+  ]);
+  const inputProps = [...inputs];
+  assert.deepEqual(inputProps.map(({ id, required, size, type, value }) => ({ id, required, size, type, value })), [
+    {
+      id: "admin-user-display-name",
+      required: true,
+      size: "sm",
+      type: "text",
+      value: "",
+    },
+    {
+      id: "admin-user-email",
+      required: undefined,
+      size: "sm",
+      type: "email",
+      value: "",
+    },
+  ]);
+  inputProps[0].onChange({ currentTarget: { value: "  Owner  " } });
+  inputProps[1].onChange({ currentTarget: { value: " owner@example.com " } });
+  form = formHarness.render(CreateUserForm, formProps);
+  await findByType(form, "form").props.onSubmit({ preventDefault() {} });
+  assert.deepEqual(JSON.parse(JSON.stringify(createCalls)), [{
+    display_name: "Owner",
+    email: "owner@example.com",
+    role: "member",
+  }]);
+
+  const searchHarness = createReactHarness();
+  const {
+    AdminUsersTabView,
+    SearchField,
+  } = loadUsersView(searchHarness);
+  let rendered = searchHarness.render(AdminUsersTabView, {
+    onSelectUser: () => {},
+    adminState: baseAdminState(),
+  });
+  let search = findByType(rendered, SearchField);
+  assert.ok(search, "expected Admin Users to render the shared SearchField");
+  assert.equal(search.props.value, "");
+  assert.equal(search.props.placeholder, "admin.users.searchPlaceholder");
+  assert.equal(search.props["aria-label"], "admin.users.searchPlaceholder");
+  assert.equal(search.props.clearLabel, "settings.clearSearch");
+
+  search.props.onChange("owner");
+  rendered = searchHarness.render(AdminUsersTabView, {
+    onSelectUser: () => {},
+    adminState: baseAdminState(),
+  });
+  search = findByType(rendered, SearchField);
+  assert.equal(search.props.value, "owner");
+  search.props.onClear();
+  rendered = searchHarness.render(AdminUsersTabView, {
+    onSelectUser: () => {},
+    adminState: baseAdminState(),
+  });
+  assert.equal(findByType(rendered, SearchField).props.value, "");
 });
 
 test("users list shows activate and role failures and disables actions while pending", () => {

--- a/crates/product/ironclaw_webui/frontend/src/pages/admin/components/users-tab.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/admin/components/users-tab.tsx
@@ -5,7 +5,9 @@ import { Panel, StatusPill } from "../../../design-system/primitives";
 import { Button } from "../../../design-system/button";
 import { ConfirmDialog } from "../../../design-system/confirm-dialog";
 import { Icon } from "../../../design-system/icons";
+import { FormField, Input } from "../../../design-system/input";
 import { InlineNotice } from "../../../design-system/inline-notice";
+import { SearchField } from "../../../design-system/search-field";
 import { SelectMenu } from "../../../design-system/select-menu";
 import { Skeleton } from "../../../design-system/skeleton";
 import { useAdminUsers } from "../hooks/useAdminUsers";
@@ -100,27 +102,34 @@ function CreateUserForm({ onCreate, isCreating, error, resetError }) {
       <h3 className="mb-4 font-mono text-[11px] uppercase tracking-[0.14em] text-signal">{t("admin.users.createUser")}</h3>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div className="grid gap-4 sm:grid-cols-3">
-          <div>
-            <label className="mb-1 block text-xs text-iron-300">{t("admin.users.displayName")}</label>
-            <input
+          <FormField
+            htmlFor="admin-user-display-name"
+            label={t("admin.users.displayName")}
+            required
+          >
+            <Input
+              id="admin-user-display-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.currentTarget.value)}
               required
-              className="h-9 w-full rounded-md border border-iron-700 bg-iron-800/70 px-3 text-sm text-iron-100 outline-none placeholder:text-iron-400 focus:border-signal/45"
+              size="sm"
               placeholder={t("admin.users.displayNamePlaceholder")}
             />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs text-iron-300">{t("admin.users.email")}</label>
-            <input
+          </FormField>
+          <FormField
+            htmlFor="admin-user-email"
+            label={t("admin.users.email")}
+          >
+            <Input
+              id="admin-user-email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.currentTarget.value)}
-              className="h-9 w-full rounded-md border border-iron-700 bg-iron-800/70 px-3 text-sm text-iron-100 outline-none placeholder:text-iron-400 focus:border-signal/45"
+              size="sm"
               placeholder={t("admin.users.emailPlaceholder")}
             />
-          </div>
+          </FormField>
           <div>
             <label className="mb-1 block text-xs text-iron-300">{t("admin.users.role")}</label>
             <SelectMenu
@@ -338,12 +347,14 @@ export function AdminUsersTabView({ onSelectUser, adminState }) {
             {t("admin.users.title", { count: filtered.length, total: users.length })}
           </h3>
           <div className="flex items-center gap-2">
-            <input
-              type="text"
+            <SearchField
               placeholder={t("admin.users.searchPlaceholder")}
+              aria-label={t("admin.users.searchPlaceholder")}
               value={search}
-              onChange={(e) => setSearch(e.currentTarget.value)}
-              className="h-8 w-48 rounded-md border border-iron-700 bg-iron-800/70 px-3 text-xs text-iron-100 outline-none placeholder:text-iron-400 focus:border-signal/45"
+              onChange={setSearch}
+              onClear={() => setSearch("")}
+              clearLabel={t("settings.clearSearch")}
+              className="w-48"
             />
             <div className="flex gap-1">
               {FILTERS.map(


### PR DESCRIPTION
## Summary

- Migrates the Admin Users display-name and email fields to the shared `FormField` and `Input` components while preserving required/email validation and the existing create-user payload.
- Replaces the locally styled user search input with `SearchField`, including accessible labeling and a clear action, while preserving search and role filtering.
- Adds regression coverage for the shared-control composition, controlled search behavior, and trimmed create-user submission.

## Linked Issue

Closes #7879

## Validation

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm build`
- [x] `cargo test -p ironclaw_webui --all-features`
- [x] `cargo clippy -p ironclaw_webui --all-features --all-targets -- -D warnings`
- [x] `scripts/pre-commit-safety.sh`
- [x] `git diff --check`

## Security Impact

No. This changes only Admin Users frontend control composition and does not alter authentication, authorization, or secret handling.

## Database Impact

No schema, migration, or persistence changes.

## Blast Radius

Limited to the Admin Users create form and user-list search control in the WebUI frontend.

## Rollback Plan

Revert this PR to restore the previous locally styled native controls.