### PR TITLE
feat(ci): add OpenSSF Scorecard workflow configuration

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,33 @@
+name: OpenSSF Scorecard
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,7 +1,15 @@
 name: OpenSSF Scorecard
 
 on:
-  workflow_call:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "00 06 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/README.ja.md
+++ b/README.ja.md
@@ -12,6 +12,9 @@
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache%202.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
   <a href="https://t.me/ironclawAI"><img src="https://img.shields.io/badge/Telegram-%40ironclawAI-26A5E4?style=flat&logo=telegram&logoColor=white" alt="Telegram: @ironclawAI" /></a>
   <a href="https://www.reddit.com/r/ironclawAI/"><img src="https://img.shields.io/badge/Reddit-r%2FironclawAI-FF4500?style=flat&logo=reddit&logoColor=white" alt="Reddit: r/ironclawAI" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/nearai/ironclaw">
+    <img src="https://api.scorecard.dev/projects/github.com/nearai/ironclaw/badge" alt="OpenSSF Scorecard" />
+  </a>
 </p>
 
 <p align="center">

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,6 +15,9 @@
   <a href="https://gitcgr.com/nearai/ironclaw">
     <img src="https://gitcgr.com/badge/nearai/ironclaw.svg" alt="gitcgr" />
   </a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/nearai/ironclaw">
+    <img src="https://api.scorecard.dev/projects/github.com/nearai/ironclaw/badge" alt="OpenSSF Scorecard" />
+  </a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
   <a href="https://gitcgr.com/nearai/ironclaw">
     <img src="https://gitcgr.com/badge/nearai/ironclaw.svg" alt="gitcgr" />
   </a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/nearai/ironclaw">
+    <img src="https://api.scorecard.dev/projects/github.com/nearai/ironclaw/badge" alt="OpenSSF Scorecard" />
+  </a>
 </p>
 
 <p align="center">

--- a/README.ru.md
+++ b/README.ru.md
@@ -12,6 +12,9 @@
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache%202.0-blue.svg" alt="Лицензия: MIT OR Apache-2.0" /></a>
   <a href="https://t.me/ironclawAI"><img src="https://img.shields.io/badge/Telegram-%40ironclawAI-26A5E4?style=flat&logo=telegram&logoColor=white" alt="Telegram: @ironclawAI" /></a>
   <a href="https://www.reddit.com/r/ironclawAI/"><img src="https://img.shields.io/badge/Reddit-r%2FironclawAI-FF4500?style=flat&logo=reddit&logoColor=white" alt="Reddit: r/ironclawAI" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/nearai/ironclaw">
+    <img src="https://api.scorecard.dev/projects/github.com/nearai/ironclaw/badge" alt="OpenSSF Scorecard" />
+  </a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,6 +12,9 @@
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache%202.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
   <a href="https://t.me/ironclawAI"><img src="https://img.shields.io/badge/Telegram-%40ironclawAI-26A5E4?style=flat&logo=telegram&logoColor=white" alt="Telegram: @ironclawAI" /></a>
   <a href="https://www.reddit.com/r/ironclawAI/"><img src="https://img.shields.io/badge/Reddit-r%2FironclawAI-FF4500?style=flat&logo=reddit&logoColor=white" alt="Reddit: r/ironclawAI" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/nearai/ironclaw">
+    <img src="https://api.scorecard.dev/projects/github.com/nearai/ironclaw/badge" alt="OpenSSF Scorecard" />
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

<!-- 2-5 bullet points: what changed and why -->

- Add OpenSSF Scorecard repository security rating

Scorecard is helpful as a pre-launch security checker for a new OSS project or to help to plan improvements to an existing one. If a project is well maintained, it’s more likely to be used by others instead of an alternative. It can also be used to check a new dependency being added to a project, so a maintainer can make an informed decision about the risk of doing so.

For consumers:

Scorecard helps to make informed decisions about security risks and vulnerabilities. Using the public data, it is also possible to evaluate the security posture of over 1 million of the most used OSS projects.

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

Closes https://github.com/nearai/ironclaw/issues/7885

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (the root `integration` feature is empty — the flag is per-crate)
- [x] Manual testing: <!-- describe what you tested --> Used in my own repos
- [ ] If a coding agent was used and supports it, `pr-shepherd` was run before requesting review

## Test Strategy

<!-- Complete every field. Use `Not applicable: <reason>` when a tier is not needed. See docs/internal/testing-playbook.md. -->

User behavior:

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract:
- Reborn integration:
- Recorded fixture:
- Browser E2E:
- Backend or runtime:
- Live canary:

What the tests prove:

Commands run:

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Reborn Trust-Boundary Checklist

<!-- Required for Reborn/security/runtime/DB changes. Write "N/A" with reason if not relevant. -->

- [ ] Public policy/evidence/trust-bearing types: who can construct them?
- [ ] Untrusted content enters prompts only through an envelope/escaping primitive.
- [ ] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check.
- [ ] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output:
- [ ] Security/durability `serde(default)` fields fail closed or have migration tests.
- [ ] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic.
- [ ] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent).
- [ ] Sandbox/native/host names accurately describe trust boundary.

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
