### PR TITLE
ci: reduce required scope checkout transfer

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -62,6 +62,9 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         with:
           fetch-depth: 0
+          # The scope calculation needs merge-base ancestry for its three-dot
+          # diff, but no historical file contents.
+          filter: blob:none
           persist-credentials: false
       - id: diff
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -98,7 +98,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           ref: ${{ inputs.ref || github.sha }}
-          fetch-depth: 0
+          # PR planning uses a three-dot diff and reads the base Cargo.lock,
+          # so it needs the commit graph. Other events always build the full
+          # plan and need only the execution commit.
+          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
+          # Keep PR ancestry while omitting historical blobs. Checkout still
+          # materializes the complete execution tree used by the planner.
+          filter: blob:none
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -2346,6 +2346,34 @@ class RebornPrTestPlanTests(unittest.TestCase):
             workflow,
         )
 
+    def test_scope_checkouts_minimize_transfer_without_losing_pr_ancestry(
+        self,
+    ) -> None:
+        """Scope jobs keep merge-base semantics without downloading history blobs."""
+        reborn_tests = (ROOT / ".github/workflows/reborn-tests.yml").read_text(
+            encoding="utf-8"
+        )
+        reborn_scope = reborn_tests.split("\n  changes:\n", 1)[1].split(
+            "\n  crate-tests:\n", 1
+        )[0]
+        self.assertIn(
+            "fetch-depth: "
+            "${{ github.event_name == 'pull_request' && '0' || '1' }}",
+            reborn_scope,
+        )
+        self.assertIn("filter: blob:none", reborn_scope)
+        self.assertIn('git diff --name-only "$BASE_SHA"..."$HEAD_SHA"', reborn_scope)
+
+        code_style = (ROOT / ".github/workflows/code_style.yml").read_text(
+            encoding="utf-8"
+        )
+        style_scope = code_style.split("\n  changes:\n", 1)[1].split(
+            "\n  fast-checks:\n", 1
+        )[0]
+        self.assertIn("fetch-depth: 0", style_scope)
+        self.assertIn("filter: blob:none", style_scope)
+        self.assertIn('git diff --name-only "$BASE_SHA"..."$HEAD_SHA"', style_scope)
+
     def test_pr_workflows_do_not_repeat_reborn_rust_contracts(self) -> None:
         code_style = (ROOT / ".github/workflows/code_style.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary

- Reduce transfer in the two required-check scope jobs without changing their path-selection policy.
- Keep full commit ancestry where three-dot diffs need a merge base, but omit historical blobs with checkout's partial-clone filter.
- Use a depth-1 checkout for `Tests (Reborn)` events that always build the exhaustive plan and never inspect a diff.
- Add a contract that pins both the transfer optimization and the existing three-dot diff semantics.

## Change Type

- [x] CI/Infrastructure

## Linked Issue

Related #7799. This is the smaller replacement experiment after closing the nextest/matrix approach in #7817.

## Validation

- [x] Relevant tests pass: planner and WS12 workflow contracts
- [ ] If a coding agent was used and supports it, `pr-shepherd` was run before requesting review

## Test Strategy

User behavior: PR and merge-queue lane selection is unchanged; scope checkout should become faster and less variable.

Risk areas:
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `test_scope_checkouts_minimize_transfer_without_losing_pr_ancestry`
- Reborn integration: Not applicable: no Rust/runtime behavior changes.
- Recorded fixture: Not applicable: no model-visible behavior changes.
- Browser E2E: Not applicable: no UI changes.
- Backend or runtime: Not applicable: workflow checkout inputs only.
- Live canary: Not applicable: no deployed behavior changes.

What the tests prove: both required scope jobs use blobless partial clone, the Tests planner uses depth 1 only outside pull requests, and both jobs retain their three-dot diff.

Commands run:

```text
python3 scripts/ci/test_reborn_pr_test_plan.py
python3 scripts/ci/ws12_workflow_contracts.py
python3 scripts/ci/test_ws12_workflow_contracts.py
python3 -m unittest scripts.ci.test_reborn_pr_test_plan.RebornPrTestPlanTests.test_scope_checkouts_minimize_transfer_without_losing_pr_ancestry
python3 yaml.safe_load for both changed workflows
git diff --check
```

## Security Impact

None. Repository permissions and `persist-credentials: false` are unchanged.

## Reborn Trust-Boundary Checklist

N/A: CI checkout transfer only; no product trust boundary changes.

## Database Impact

None.

## Blast Radius

The `changes` jobs in the two required workflows. A checkout implementation incompatibility would fail scope detection before any test or lint matrix runs; no check is silently skipped.

Compatibility: `actions/checkout` v6 supports the `filter` input. Pull requests and Code Style merge-group runs retain `fetch-depth: 0`, so merge-base ancestry and base-lockfile reads remain available. Non-PR Tests events already select the exhaustive plan and do not read diff history.

Measurement: compare checkout and total `changes` duration on this PR and its merge-group run against the recent observed 1.1–6.0 minute scope range. This slice is successful if selection stays identical and checkout variance materially contracts; it is not claimed by itself to deliver the complete sub-10-minute CI target.

## Rollback Plan

Revert this commit. That restores `fetch-depth: 0` without partial clone in both scope jobs. Because the change is confined to checkout inputs and fails before lane fan-out, rollback requires no data migration or compatibility window.

## Review Follow-Through

Please require two approvals for this Track C workflow change. After PR CI, record the scope-job checkout timings before considering the next runner-capacity slice.

---

**Review track**: C
