### PR TITLE
fix: bound model-visible tool result previews

### DIFF
--- a/crates/app/ironclaw_architecture_tests/tests/reborn_origin_gate_matrix_ratchet.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_origin_gate_matrix_ratchet.rs
@@ -84,6 +84,7 @@ use ironclaw_host_api::{
     capability::{OriginGateMatrix, OriginGatePolicy, UNGATED_LOOP_RUN_CAPABILITIES},
     ids::CapabilityId,
 };
+use serde_json::Value;
 
 use ratchet_support::{crate_dir, workspace_root};
 
@@ -184,6 +185,194 @@ fn collect_capability_tables<'a>(value: &'a toml::Value, out: &mut Vec<&'a toml:
     }
 }
 
+/// Validate the model-view declaration for one explicitly networked tool.
+///
+/// This is deliberately a helper for the existing package-manifest ratchet,
+/// not a second package scanner. Dynamic MCP declarations and tools without
+/// an explicit output schema are outside this migration and return `Ok(())`.
+fn validate_network_output_schema_policy(
+    manifest_path: &Path,
+    capability: &toml::Table,
+) -> Result<(), String> {
+    let is_networked = match capability.get("effects") {
+        None => false,
+        Some(toml::Value::Array(effects)) => effects
+            .iter()
+            .any(|effect| effect.as_str().is_some_and(|effect| effect == "network")),
+        Some(other) => {
+            return Err(format!(
+                "effects must be an array when checking output schema, got {other:?}"
+            ));
+        }
+    };
+    if !is_networked {
+        return Ok(());
+    }
+
+    let Some(output_schema_ref) = capability.get("output_schema_ref") else {
+        return Ok(());
+    };
+    let Some(output_schema_ref) = output_schema_ref.as_str() else {
+        return Err("output_schema_ref must be a string".to_string());
+    };
+    let model_view = match capability.get("model_view") {
+        None => None,
+        Some(toml::Value::String(policy)) => match policy.as_str() {
+            "structural" | "producer" => Some(policy.as_str()),
+            _ => {
+                return Err(format!(
+                    "model_view must be `structural` or `producer`, got `{policy}`"
+                ));
+            }
+        },
+        Some(other) => return Err(format!("model_view must be a string, got {other:?}")),
+    };
+
+    let schema_path = resolve_manifest_asset(manifest_path, output_schema_ref)?;
+    let schema_source = fs::read_to_string(&schema_path).map_err(|error| {
+        format!(
+            "failed to read output schema `{output_schema_ref}` at {}: {error}",
+            schema_path.display()
+        )
+    })?;
+    let schema: Value = serde_json::from_str(&schema_source).map_err(|error| {
+        format!(
+            "failed to parse output schema `{output_schema_ref}` at {}: {error}",
+            schema_path.display()
+        )
+    })?;
+    let has_open_object = schema_contains_open_object(&schema);
+    if has_open_object && model_view.is_none() {
+        return Err(format!(
+            "open-object output schema `{output_schema_ref}` requires model_view = \
+             `structural` or `producer`"
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_manifest_asset(manifest_path: &Path, asset_ref: &str) -> Result<PathBuf, String> {
+    let asset = Path::new(asset_ref);
+    if asset_ref.trim().is_empty() || asset.is_absolute() {
+        return Err(format!(
+            "output schema path `{asset_ref}` must be a relative asset path"
+        ));
+    }
+    if asset
+        .components()
+        .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(format!(
+            "output schema path `{asset_ref}` contains a non-normal path component"
+        ));
+    }
+    let package_root = manifest_path.parent().ok_or_else(|| {
+        format!(
+            "manifest path {} has no package root",
+            manifest_path.display()
+        )
+    })?;
+    let resolved = package_root.join(asset);
+    if !resolved.starts_with(package_root) {
+        return Err(format!(
+            "output schema path `{asset_ref}` escapes package root {}",
+            package_root.display()
+        ));
+    }
+    if !resolved.is_file() {
+        return Err(format!(
+            "output schema asset `{asset_ref}` does not exist under {}",
+            package_root.display()
+        ));
+    }
+    Ok(resolved)
+}
+
+/// Return whether a JSON Schema contains the open-object shape this ratchet
+/// covers. Boolean `true` schemas and any nested object with an explicit
+/// `additionalProperties = true` are open; all other shape analysis belongs
+/// to a later schema contract.
+fn schema_contains_open_object(schema: &Value) -> bool {
+    match schema {
+        Value::Bool(value) => *value,
+        Value::Array(items) => items.iter().any(schema_contains_open_object),
+        Value::Object(object) => {
+            matches!(object.get("additionalProperties"), Some(Value::Bool(true)))
+                || object.values().any(schema_contains_open_object)
+        }
+        Value::Null | Value::Number(_) | Value::String(_) => false,
+    }
+}
+
+fn validate_manifest_capabilities(manifests: &[PathBuf]) -> (Vec<String>, usize) {
+    let allowlist: BTreeSet<&str> = UNGATED_LOOP_RUN_CAPABILITIES.iter().copied().collect();
+    let mut violations = Vec::new();
+    let mut checked_capabilities = 0usize;
+
+    for path in manifests {
+        let raw = fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+        let value: toml::Value = toml::from_str(&raw)
+            .unwrap_or_else(|err| panic!("failed to parse {}: {err}", path.display()));
+        let mut capabilities = Vec::new();
+        collect_capability_tables(&value, &mut capabilities);
+
+        for capability in capabilities {
+            checked_capabilities += 1;
+            let id = capability
+                .get("id")
+                .and_then(toml::Value::as_str)
+                .unwrap_or("<capability with no id>");
+
+            if let Err(error) = validate_network_output_schema_policy(path, capability) {
+                violations.push(format!("{} :: {id}: {error}", path.display()));
+            }
+
+            let Some(matrix_value) = capability.get("origin_gate_matrix") else {
+                violations.push(format!(
+                    "{} :: {id}: capability declares no origin_gate_matrix (§5.2.1 invariant 1)",
+                    path.display()
+                ));
+                continue;
+            };
+
+            let matrix: OriginGateMatrix = match matrix_value.clone().try_into() {
+                Ok(matrix) => matrix,
+                Err(err) => {
+                    violations.push(format!(
+                        "{} :: {id}: invalid origin_gate_matrix structure or policy: {err}",
+                        path.display()
+                    ));
+                    continue;
+                }
+            };
+
+            if matrix.loop_run == OriginGatePolicy::ConsentSufficient {
+                violations.push(format!(
+                    "{id}: consent_sufficient is Product-only (§5.2.1) — not valid on the \
+                     loop_run column"
+                ));
+            }
+            if matrix.automation == OriginGatePolicy::ConsentSufficient {
+                violations.push(format!(
+                    "{id}: consent_sufficient is Product-only (§5.2.1) — not valid on the \
+                     automation column"
+                ));
+            }
+
+            if matrix.loop_run == OriginGatePolicy::Ungated && !allowlist.contains(id) {
+                violations.push(format!(
+                    "{id}: loop_run = \"ungated\" but id is NOT in the reviewed \
+                     UNGATED_LOOP_RUN_CAPABILITIES allowlist — a hand-authored typo would \
+                     silently remove this capability's approval gate for the model"
+                ));
+            }
+        }
+    }
+
+    (violations, checked_capabilities)
+}
+
 /// Invariant 1 (of the S5 ratchet): the Ungated allowlist is pinned to the
 /// reviewed 17-id seed, deduplicated, and every id well-formed. See the header.
 #[test]
@@ -255,66 +444,7 @@ fn extension_toml_capabilities_declare_wellformed_origin_gate_matrix() {
         );
     }
 
-    let allowlist: BTreeSet<&str> = UNGATED_LOOP_RUN_CAPABILITIES.iter().copied().collect();
-    let mut violations: Vec<String> = Vec::new();
-    let mut checked_capabilities = 0usize;
-
-    for path in &manifests {
-        let raw = fs::read_to_string(path)
-            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
-        let value: toml::Value = toml::from_str(&raw)
-            .unwrap_or_else(|err| panic!("failed to parse {}: {err}", path.display()));
-        let mut capabilities = Vec::new();
-        collect_capability_tables(&value, &mut capabilities);
-
-        for capability in capabilities {
-            checked_capabilities += 1;
-            let id = capability
-                .get("id")
-                .and_then(toml::Value::as_str)
-                .unwrap_or("<capability with no id>");
-
-            let Some(matrix_value) = capability.get("origin_gate_matrix") else {
-                violations.push(format!(
-                    "{} :: {id}: capability declares no origin_gate_matrix (§5.2.1 invariant 1)",
-                    path.display()
-                ));
-                continue;
-            };
-
-            let matrix: OriginGateMatrix = match matrix_value.clone().try_into() {
-                Ok(matrix) => matrix,
-                Err(err) => {
-                    violations.push(format!(
-                        "{} :: {id}: invalid origin_gate_matrix structure or policy: {err}",
-                        path.display()
-                    ));
-                    continue;
-                }
-            };
-
-            if matrix.loop_run == OriginGatePolicy::ConsentSufficient {
-                violations.push(format!(
-                    "{id}: consent_sufficient is Product-only (§5.2.1) — not valid on the \
-                     loop_run column"
-                ));
-            }
-            if matrix.automation == OriginGatePolicy::ConsentSufficient {
-                violations.push(format!(
-                    "{id}: consent_sufficient is Product-only (§5.2.1) — not valid on the \
-                     automation column"
-                ));
-            }
-
-            if matrix.loop_run == OriginGatePolicy::Ungated && !allowlist.contains(id) {
-                violations.push(format!(
-                    "{id}: loop_run = \"ungated\" but id is NOT in the reviewed \
-                     UNGATED_LOOP_RUN_CAPABILITIES allowlist — a hand-authored typo would \
-                     silently remove this capability's approval gate for the model"
-                ));
-            }
-        }
-    }
+    let (violations, checked_capabilities) = validate_manifest_capabilities(&manifests);
 
     assert!(
         checked_capabilities > 0,
@@ -324,6 +454,41 @@ fn extension_toml_capabilities_declare_wellformed_origin_gate_matrix() {
         violations.is_empty(),
         "hand-authored extension-manifest origin_gate_matrix violations (§5.2.1):\n{}",
         violations.join("\n")
+    );
+}
+
+#[test]
+fn package_manifest_scan_reaches_network_output_policy() {
+    let temp = tempfile::tempdir().expect("temporary package root");
+    let schema_path = temp.path().join("schemas/open.json");
+    fs::create_dir_all(schema_path.parent().expect("schema parent")).expect("schema directory");
+    fs::write(&schema_path, r#"{"additionalProperties":true}"#).expect("open-object schema");
+    let manifest_path = temp.path().join("manifest.toml");
+    fs::write(
+        &manifest_path,
+        r#"
+schema_version = "reborn.extension_manifest.v3"
+id = "sample"
+
+[[tools]]
+id = "sample.network"
+effects = ["network"]
+output_schema_ref = "schemas/open.json"
+origin_gate_matrix = { loop_run = "gated", product = "gated", automation = "gated" }
+"#,
+    )
+    .expect("manifest fixture");
+
+    let (violations, checked_capabilities) =
+        validate_manifest_capabilities(std::slice::from_ref(&manifest_path));
+
+    assert_eq!(checked_capabilities, 1);
+    assert!(
+        violations
+            .iter()
+            .any(|violation| violation.contains("requires model_view")),
+        "the package scanner must route network output schemas through the model-view gate: \
+         {violations:?}"
     );
 }
 
@@ -384,4 +549,98 @@ origin_gate_matrix = { loop_run = "gated_unless_granted", product = "forbidden",
         Some("ungated"),
         "the walker must surface the raw loop_run policy for the allowlist check"
     );
+}
+
+#[test]
+fn network_output_schema_gate_rejects_open_object_without_model_view() {
+    let temp = tempfile::tempdir().expect("temporary package root");
+    let manifest_path = temp.path().join("manifest.toml");
+    let schema_path = temp.path().join("schemas/output.json");
+    fs::create_dir_all(schema_path.parent().expect("schema parent")).expect("schema directory");
+    fs::write(
+        &schema_path,
+        r#"{"type":"object","additionalProperties":true}"#,
+    )
+    .expect("open-object schema");
+    fs::write(&manifest_path, "").expect("manifest placeholder");
+
+    let value: toml::Value = toml::from_str(
+        r#"
+effects = ["network"]
+output_schema_ref = "schemas/output.json"
+"#,
+    )
+    .expect("capability fixture parses");
+    let capability = value.as_table().expect("capability table");
+    let error = validate_network_output_schema_policy(&manifest_path, capability)
+        .expect_err("an open-object network output must declare a model-view policy");
+    assert!(error.contains("requires model_view"), "{error}");
+}
+
+#[test]
+fn network_output_schema_gate_accepts_policies_and_closed_object_schema() {
+    let temp = tempfile::tempdir().expect("temporary package root");
+    let manifest_path = temp.path().join("manifest.toml");
+    let schema_path = temp.path().join("schemas/output.json");
+    fs::create_dir_all(schema_path.parent().expect("schema parent")).expect("schema directory");
+    fs::write(
+        &schema_path,
+        r#"{"type":"object","additionalProperties":true}"#,
+    )
+    .expect("open-object schema");
+    fs::write(&manifest_path, "").expect("manifest placeholder");
+
+    for policy in ["structural", "producer"] {
+        let value: toml::Value = toml::from_str(&format!(
+            "effects = [\"network\"]\noutput_schema_ref = \"schemas/output.json\"\nmodel_view = \"{policy}\"\n"
+        ))
+        .expect("capability fixture parses");
+        let capability = value.as_table().expect("capability table");
+        validate_network_output_schema_policy(&manifest_path, capability)
+            .unwrap_or_else(|error| panic!("{policy} policy should pass: {error}"));
+    }
+
+    fs::write(
+        &schema_path,
+        r#"{"type":"object","additionalProperties":false,"properties":{"message":{"type":"string","maxLength":128}}}"#,
+    )
+    .expect("closed-object schema");
+    let value: toml::Value =
+        toml::from_str("effects = [\"network\"]\noutput_schema_ref = \"schemas/output.json\"\n")
+            .expect("capability fixture parses");
+    let capability = value.as_table().expect("capability table");
+    validate_network_output_schema_policy(&manifest_path, capability)
+        .expect("a closed-object output need not declare a policy");
+}
+
+#[test]
+fn network_output_schema_gate_fails_closed_for_missing_or_malformed_assets() {
+    let temp = tempfile::tempdir().expect("temporary package root");
+    let manifest_path = temp.path().join("manifest.toml");
+    fs::write(&manifest_path, "").expect("manifest placeholder");
+
+    let missing: toml::Value = toml::from_str(
+        "effects = [\"network\"]\noutput_schema_ref = \"schemas/missing.json\"\nmodel_view = \"structural\"\n",
+    )
+    .expect("capability fixture parses");
+    let error = validate_network_output_schema_policy(
+        &manifest_path,
+        missing.as_table().expect("capability table"),
+    )
+    .expect_err("missing schema assets must fail closed");
+    assert!(error.contains("does not exist"), "{error}");
+
+    let schema_path = temp.path().join("schemas/malformed.json");
+    fs::create_dir_all(schema_path.parent().expect("schema parent")).expect("schema directory");
+    fs::write(&schema_path, "{not-json").expect("malformed schema");
+    let malformed: toml::Value = toml::from_str(
+        "effects = [\"network\"]\noutput_schema_ref = \"schemas/malformed.json\"\nmodel_view = \"producer\"\n",
+    )
+    .expect("capability fixture parses");
+    let error = validate_network_output_schema_policy(
+        &manifest_path,
+        malformed.as_table().expect("capability table"),
+    )
+    .expect_err("malformed schema assets must fail closed");
+    assert!(error.contains("failed to parse output schema"), "{error}");
 }

--- a/crates/app/ironclaw_cli/src/first_party/gsuite.rs
+++ b/crates/app/ironclaw_cli/src/first_party/gsuite.rs
@@ -99,7 +99,8 @@ impl FirstPartyCapabilityHandler for GsuiteFirstPartyHandler {
             })
             .await
             .map_err(|error| gsuite_error(error, &request.capability_id))?;
-        Ok(FirstPartyCapabilityResult::new(result.output, result.usage))
+        Ok(FirstPartyCapabilityResult::new(result.output, result.usage)
+            .with_model_preview(result.model_preview))
     }
 }
 

--- a/crates/app/ironclaw_composition/src/root/product_live_adapters.rs
+++ b/crates/app/ironclaw_composition/src/root/product_live_adapters.rs
@@ -257,6 +257,7 @@ impl LoopCapabilityResultWriter for ProductLiveCapabilityIo {
             invocation_id,
             capability_id,
             output,
+            model_preview: _,
             display_preview,
             // `ProductLiveCapabilityIo` is an ephemeral in-memory test fixture
             // (see crate CONTRACT.md / #5902) that never durably persists a
@@ -964,6 +965,7 @@ mod tests {
             invocation_id,
             capability_id: &capability_id,
             output: serde_json::json!({"content": "fn main() {}"}),
+            model_preview: None,
             display_preview: None,
             durable_persistence: DurablePersistence::Persist,
         })
@@ -1037,6 +1039,7 @@ mod tests {
             invocation_id,
             capability_id: &capability_id,
             output: serde_json::json!({"results": []}),
+            model_preview: None,
             display_preview: None,
             durable_persistence: DurablePersistence::Persist,
         })
@@ -1080,6 +1083,7 @@ mod tests {
             invocation_id,
             capability_id: &capability_id,
             output: serde_json::json!({"success": true}),
+            model_preview: None,
             display_preview: Some(CapabilityDisplayOutputPreview {
                 output_summary: Some("Edited 1 file: +1/-1".to_string()),
                 output_preview:
@@ -1127,6 +1131,7 @@ mod tests {
             invocation_id,
             capability_id: &capability_id,
             output: serde_json::json!({"reply": "ok"}),
+            model_preview: None,
             display_preview: None,
             durable_persistence: DurablePersistence::Persist,
         })

--- a/crates/app/ironclaw_composition/src/runtime/capability_host.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host.rs
@@ -29,7 +29,7 @@ use ironclaw_loop_host::{
     CapabilityResultWrite, CapabilityTrajectoryObserver, CapabilityWriteResult, DurablePersistence,
     HostManagedModelGateway, HostManagedPromptDiagnosticSink, HostManagedToolDiagnosticEmitter,
     LoopCapabilityInputResolver, LoopCapabilityPortFactory, LoopCapabilityResultWriter,
-    ThreadScopeResolver, loop_driver_execution_extension_id,
+    ThreadScopeResolver, loop_driver_execution_extension_id, result_reference_observation,
 };
 use ironclaw_product_contracts::{
     inspector::TOOL_RESULT_DIAGNOSTIC_CAPTURE_MAX_BYTES, project_service::ProjectService,
@@ -37,15 +37,12 @@ use ironclaw_product_contracts::{
 
 use ironclaw_loop_contracts::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityFailureDetail, CapabilityInputRef,
-    LoopCapabilityPort, LoopHostMilestoneSink, LoopRunContext,
-    MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION, ModelVisibleArtifact,
-    ModelVisibleToolObservation, ObservationTrust, ProviderToolCall, ToolObservationDetail,
-    ToolObservationStatus, resolution,
+    LoopCapabilityPort, LoopHostMilestoneSink, LoopRunContext, ProviderToolCall, resolution,
 };
 use ironclaw_threads::{
     AppendCapabilityDisplayPreviewRequest, CapabilityDisplayPreviewEnvelope,
     CapabilityDisplayPreviewEnvelopeInput, CapabilityDisplayPreviewStatus, SessionThreadService,
-    TOOL_RESULT_RECORD_READ_MAX_BYTES, ThreadMessageId, ThreadScope,
+    ThreadMessageId, ThreadScope,
 };
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 use ironclaw_turns::{ExternalToolCatalog, LoopResultRef};
@@ -381,12 +378,6 @@ impl LoopCapabilityPortFactory for RefreshingLoopCapabilityPortFactory {
 const CAPABILITY_IO_MAX_STAGED_REFS: usize = 1024;
 const CAPABILITY_IO_MAX_STAGED_BYTES: usize = 4 * 1024 * 1024;
 const DURABLE_TOOL_RESULT_MAX_BYTES: usize = 4 * 1024 * 1024;
-/// First-look preview bound on the initial result-reference observation.
-/// Matches `result_read`'s max chunk size so the preview is exactly the
-/// first chunk `result_read` would itself return at `offset: 0` — a model
-/// that pages past `next_offset` sees no gap or overlap.
-const RESULT_PREVIEW_MAX_BYTES: usize = TOOL_RESULT_RECORD_READ_MAX_BYTES;
-
 struct StagedCapabilityIo {
     inputs: StdMutex<StagedValueStore>,
     results: StdMutex<StagedValueStore>,
@@ -891,6 +882,7 @@ impl LoopCapabilityResultWriter for StagedCapabilityIo {
             invocation_id,
             capability_id,
             output,
+            model_preview,
             display_preview,
             durable_persistence,
         } = write;
@@ -903,13 +895,15 @@ impl LoopCapabilityResultWriter for StagedCapabilityIo {
                     )
                 })?;
         let output_content = serialized_result_output(&output)?;
-        let item_count = output.as_array().map(|items| items.len() as u64);
         let serialized_bytes = output_content.len();
         let output_bytes = serialized_bytes.try_into().unwrap_or(u64::MAX);
-        // Snapshot the first-look preview from the same bytes the durable
-        // record stores, before `output_content` is moved into persistence,
-        // so its offsets line up exactly with what `result_read` returns.
-        let preview = first_look_result_preview(&output_content);
+        let model_observation = result_reference_observation(
+            &result_ref,
+            output_bytes,
+            &output,
+            &output_content,
+            model_preview,
+        );
         let diagnostic_result = self
             .tool_diagnostics
             .prepare_result(&output_content, TOOL_RESULT_DIAGNOSTIC_CAPTURE_MAX_BYTES);
@@ -966,12 +960,7 @@ impl LoopCapabilityResultWriter for StagedCapabilityIo {
         );
         let mut write_result =
             CapabilityWriteResult::from_output(result_ref, output_bytes, &output);
-        write_result.model_observation = Some(result_reference_observation(
-            &write_result.result_ref,
-            write_result.byte_len,
-            preview,
-            item_count,
-        ));
+        write_result.model_observation = Some(model_observation);
         Ok(write_result)
     }
 
@@ -1065,116 +1054,6 @@ fn serialized_result_output(output: &serde_json::Value) -> Result<Vec<u8>, Agent
         ));
     }
     Ok(content)
-}
-
-/// A bounded, UTF-8-safe first-look slice of a serialized result payload,
-/// truncated at `RESULT_PREVIEW_MAX_BYTES`.
-struct FirstLookResultPreview {
-    text: String,
-    /// `None` when `text` already covers the entire payload.
-    next_offset: Option<u64>,
-}
-
-/// Builds the inline first-look preview from the same serialized bytes the
-/// durable record stores, so a truncated preview's `next_offset` matches
-/// exactly what `result_read` would return continuing from that offset.
-fn first_look_result_preview(serialized: &[u8]) -> Option<FirstLookResultPreview> {
-    let Ok(full_text) = std::str::from_utf8(serialized) else {
-        return None;
-    };
-    if full_text.len() <= RESULT_PREVIEW_MAX_BYTES {
-        return Some(FirstLookResultPreview {
-            text: full_text.to_string(),
-            next_offset: None,
-        });
-    }
-    let end = floor_char_boundary(full_text, RESULT_PREVIEW_MAX_BYTES);
-    Some(FirstLookResultPreview {
-        text: full_text[..end].to_string(),
-        next_offset: Some(end as u64),
-    })
-}
-
-fn floor_char_boundary(value: &str, index: usize) -> usize {
-    if index >= value.len() {
-        return value.len();
-    }
-    let mut index = index;
-    while index > 0 && !value.is_char_boundary(index) {
-        index -= 1;
-    }
-    index
-}
-
-/// Truncated-preview summary text; names the full array's element count when
-/// known so the model doesn't misread a truncated array preview as the whole
-/// result (issue: byte-slice lands mid-JSON-array).
-fn truncated_preview_summary(next_offset: u64, item_count: Option<u64>) -> String {
-    let base = format!(
-        "Tool completed; preview truncated, use result_read with the result \
-         reference and offset {next_offset} for more output."
-    );
-    match item_count {
-        Some(count) => format!("{base} Full result is a JSON array of {count} items."),
-        None => base,
-    }
-}
-
-fn result_reference_observation(
-    result_ref: &LoopResultRef,
-    byte_len: u64,
-    preview: Option<FirstLookResultPreview>,
-    item_count: Option<u64>,
-) -> ModelVisibleToolObservation {
-    let (summary, preview_text, total_bytes, next_offset, item_count) = match preview {
-        Some(FirstLookResultPreview {
-            text,
-            next_offset: Some(next_offset),
-        }) => (
-            truncated_preview_summary(next_offset, item_count),
-            Some(text),
-            Some(byte_len),
-            Some(next_offset),
-            item_count,
-        ),
-        Some(FirstLookResultPreview {
-            text,
-            next_offset: None,
-        }) => (
-            "Tool completed; preview contains the full result.".to_string(),
-            Some(text),
-            Some(byte_len),
-            None,
-            None,
-        ),
-        None => (
-            "Tool completed; use result_read with the result reference for more output."
-                .to_string(),
-            None,
-            None,
-            None,
-            None,
-        ),
-    };
-    ModelVisibleToolObservation {
-        schema_version: MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
-        status: ToolObservationStatus::Success,
-        summary,
-        detail: ToolObservationDetail::ResultReference {
-            result_ref: result_ref.as_str().to_string(),
-            byte_len,
-            preview: preview_text,
-            total_bytes,
-            next_offset,
-            item_count,
-        },
-        artifacts: vec![ModelVisibleArtifact {
-            artifact_ref: result_ref.as_str().to_string(),
-            summary: "Stored tool result".to_string(),
-        }],
-        recovery: None,
-        trust: ObservationTrust::UntrustedToolOutput,
-    }
 }
 
 fn durable_result_store_error(error: ironclaw_threads::SessionThreadError) -> AgentLoopHostError {

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/outbound_delivery.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/outbound_delivery.rs
@@ -183,6 +183,7 @@ pub(super) async fn write_completed_result(
             invocation_id: InvocationId::new(),
             capability_id: &invocation.request.capability_id,
             output,
+            model_preview: None,
             display_preview: None,
             durable_persistence: DurablePersistence::Persist,
         })

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/tests.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/tests.rs
@@ -1014,6 +1014,7 @@ mod tests {
                 invocation_id,
                 capability_id: &capability_id,
                 output: serde_json::json!({"content": "hello"}),
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -1110,6 +1111,7 @@ mod tests {
                 invocation_id,
                 capability_id: &capability_id,
                 output: serde_json::json!({"content": "hello"}),
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -1192,6 +1194,7 @@ mod tests {
                 invocation_id,
                 capability_id: &capability_id,
                 output: serde_json::json!({"content": "hello"}),
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -1253,6 +1256,7 @@ mod tests {
                 invocation_id,
                 capability_id: &capability_id,
                 output: serde_json::json!({"content": "hello"}),
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -1307,6 +1311,7 @@ mod tests {
                 invocation_id,
                 capability_id: &capability_id,
                 output: serde_json::Value::String("x".repeat(DURABLE_TOOL_RESULT_MAX_BYTES)),
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -1387,6 +1392,7 @@ mod tests {
                 invocation_id,
                 capability_id: &capability_id,
                 output: serde_json::json!({"content": "original"}),
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -1493,6 +1499,7 @@ mod tests {
                 invocation_id,
                 capability_id: &capability_id,
                 output: output.clone(),
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -1523,13 +1530,11 @@ mod tests {
         );
     }
 
-    /// Issue #5838: a result over the preview cap is truncated at a UTF-8 char
-    /// boundary (not mid-character), the reported `next_offset` matches the
-    /// preview's own byte length exactly, and reading a continuation chunk
-    /// from that offset through the production `result_read` capability
-    /// reproduces the full serialized result with no gap or overlap.
+    /// An oversized result gets a structurally valid automatic projection, and
+    /// the surfaced offset starts a byte-exact `result_read` from the complete
+    /// durable source rather than pretending the projection is a source prefix.
     #[tokio::test]
-    async fn standalone_result_read_continues_exactly_where_first_look_preview_truncated() {
+    async fn standalone_result_read_starts_at_zero_for_projected_preview() {
         let dir = tempfile::tempdir().expect("tempdir");
         let services = crate::factory::build_runtime_substrate(
             crate::deployment::local_filesystem_build_input(
@@ -1573,15 +1578,16 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
 
-        // A multi-byte character straddling the preview boundary: the
-        // serialized JSON string (leading `"` + (cap - 2) ASCII bytes) puts
-        // the 3-byte '日' character at bytes [cap - 1, cap + 2), so byte `cap`
-        // (the raw cap) falls inside it and must round down.
-        let cap = ironclaw_threads::TOOL_RESULT_RECORD_READ_MAX_BYTES;
-        let content = format!("{}{}{}", "a".repeat(cap - 2), '日', "a".repeat(100));
+        let preview_cap =
+            ironclaw_host_api::model_result_preview::AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES;
+        let page_cap = ironclaw_threads::TOOL_RESULT_RECORD_READ_MAX_BYTES;
+        let content = format!("{}{}", "a".repeat(preview_cap + 100), '日');
         let output = serde_json::Value::String(content);
         let full_text = serde_json::to_string(&output).expect("serialize reference output");
-        assert!(full_text.len() > cap, "fixture must exceed the preview cap");
+        assert!(
+            full_text.len() > preview_cap && full_text.len() < page_cap,
+            "fixture must exceed the automatic cap but fit one result_read page"
+        );
 
         let input_ref = capability_io
             .register_provider_tool_call_input(
@@ -1599,6 +1605,7 @@ mod tests {
                 invocation_id,
                 capability_id: &capability_id,
                 output,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -1623,18 +1630,12 @@ mod tests {
             "a non-array result must not claim an array item count: {}",
             observation.summary
         );
-        assert!(
-            preview.is_char_boundary(preview.len()),
-            "preview must end on a UTF-8 char boundary"
-        );
-        assert!(
-            next_offset < cap as u64,
-            "the multi-byte char must round the boundary down below the raw cap"
-        );
+        serde_json::from_str::<serde_json::Value>(&preview)
+            .expect("automatic projection remains structurally valid JSON");
+        assert!(preview.len() <= preview_cap);
         assert_eq!(
-            preview.len() as u64,
-            next_offset,
-            "next_offset must match the preview's own byte length exactly"
+            next_offset, 0,
+            "a projection starts paging at source byte zero"
         );
         assert!(observation.summary.contains("result_read"));
         assert!(observation.summary.contains(&next_offset.to_string()));
@@ -1704,7 +1705,7 @@ mod tests {
                     serde_json::json!({
                         "result_ref": write_result.result_ref.as_str(),
                         "offset": next_offset,
-                        "max_bytes": cap,
+                        "max_bytes": page_cap,
                     }),
                 ),
             ))
@@ -1736,18 +1737,14 @@ mod tests {
             "the continuation must reach the end of the payload"
         );
 
-        let mut reassembled = preview;
-        reassembled.push_str(continuation_content);
         assert_eq!(
-            reassembled, full_text,
-            "preview + continuation must reproduce the full serialized result with no gap or overlap"
+            continuation_content, full_text,
+            "offset-zero result_read must reproduce the complete durable result exactly"
         );
     }
 
-    /// Issue: a truncated preview that slices mid-JSON-array leaves the model
-    /// unable to tell how many items the full result contains. When the
-    /// capability output is a top-level JSON array, the truncated-branch
-    /// observation carries `item_count` and mentions it in the summary.
+    /// An oversized top-level array projection carries `item_count`, so the
+    /// model knows the full collection size even though values are elided.
     #[tokio::test]
     async fn write_capability_result_truncated_array_preview_reports_item_count() {
         let run_context = run_context("first-look-preview-array").await;
@@ -1800,6 +1797,7 @@ mod tests {
                 invocation_id,
                 capability_id: &capability_id,
                 output,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -1847,6 +1845,7 @@ mod tests {
                 invocation_id: InvocationId::new(),
                 capability_id: &capability_id,
                 output: singleton_output,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -1944,6 +1943,7 @@ mod tests {
                 invocation_id,
                 capability_id: &capability_id,
                 output,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -2199,6 +2199,7 @@ mod tests {
                 invocation_id,
                 capability_id: &CapabilityId::new("builtin.echo").expect("capability id"),
                 output,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::InlineOnly,
             })

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/tests/tests/display_preview.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/tests/tests/display_preview.rs
@@ -62,6 +62,7 @@ async fn capability_io_writes_display_preview_to_durable_history() {
             invocation_id,
             capability_id: &capability_id,
             output: serde_json::json!({"success": true}),
+            model_preview: None,
             display_preview: Some(CapabilityDisplayOutputPreview {
                 output_summary: Some("Edited 1 file: +1/-1".to_string()),
                 output_preview:

--- a/crates/app/ironclaw_composition/tests/gsuite.rs
+++ b/crates/app/ironclaw_composition/tests/gsuite.rs
@@ -95,7 +95,8 @@ impl FirstPartyCapabilityHandler for GsuiteFirstPartyHandler {
             })
             .await
             .map_err(|error| gsuite_error(error, &request.capability_id))?;
-        Ok(FirstPartyCapabilityResult::new(result.output, result.usage))
+        Ok(FirstPartyCapabilityResult::new(result.output, result.usage)
+            .with_model_preview(result.model_preview))
     }
 }
 

--- a/crates/app/ironclaw_composition/tests/product_live_adapters.rs
+++ b/crates/app/ironclaw_composition/tests/product_live_adapters.rs
@@ -104,6 +104,7 @@ async fn write_capability_result_for_test(
             invocation_id: InvocationId::new(),
             capability_id: &capability_id,
             output,
+            model_preview: None,
             display_preview: None,
             durable_persistence: DurablePersistence::Persist,
         })
@@ -189,6 +190,7 @@ async fn capability_io_write_capability_result_returns_serialized_payload_byte_l
             invocation_id: InvocationId::new(),
             capability_id: &capability_id,
             output: output.clone(),
+            model_preview: None,
             display_preview: None,
             durable_persistence: DurablePersistence::Persist,
         })

--- a/crates/app/ironclaw_composition/tests/refreshing_capability_port_test_support.rs
+++ b/crates/app/ironclaw_composition/tests/refreshing_capability_port_test_support.rs
@@ -115,6 +115,7 @@ impl HostRuntime for StubHostRuntime {
             ironclaw_host_runtime::RuntimeCapabilityCompleted {
                 capability_id: request.1,
                 output: serde_json::json!({"ok": true}),
+                model_preview: None,
                 display_preview: None,
                 usage: ironclaw_host_api::resource::ResourceUsage::default(),
             },

--- a/crates/contracts/ironclaw_extension_contracts/src/tool_adapter.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/tool_adapter.rs
@@ -25,6 +25,7 @@ use ironclaw_host_api::{
         ProviderDiagnostic, RuntimeDispatchErrorKind,
     },
     ids::{CapabilityId, SecretHandle},
+    model_result_preview::ModelResultPreview,
     mount::MountView,
     resource::{ResourceEstimate, ResourceReservation, ResourceScope},
 };
@@ -60,6 +61,7 @@ pub struct ToolCallResources {
 #[derive(Debug)]
 pub struct ToolResult {
     pub output: serde_json::Value,
+    pub model_preview: Option<ModelResultPreview>,
     pub display_preview: Option<CapabilityDisplayOutputPreview>,
     /// The adapter's own count of the output payload bytes (the host
     /// re-measures for enforcement; this is advisory).

--- a/crates/contracts/ironclaw_host_api/src/credential_redaction.rs
+++ b/crates/contracts/ironclaw_host_api/src/credential_redaction.rs
@@ -22,8 +22,10 @@
 /// Human-readable credential markers. Matched at a word boundary (see
 /// [`contains_credential_marker`]); the ones ending/starting in a non-alnum
 /// delimiter carry their own boundary.
-const CREDENTIAL_MARKERS: [&str; 9] = [
+const CREDENTIAL_MARKERS: [&str; 11] = [
     "access token",
+    "access-token",
+    "access_token",
     "api key",
     "api_key",
     "apikey",
@@ -117,8 +119,9 @@ pub(crate) fn redact_credential_text(value: &str) -> String {
                 let start = from + found;
                 let end = start + marker.len();
                 if marker_match_at(&lower, marker, start, end) {
+                    let redaction_end = credential_marker_redaction_end(rest, marker, end);
                     if best.is_none_or(|(best_start, _)| start < best_start) {
-                        best = Some((start, end));
+                        best = Some((start, redaction_end));
                     }
                     break;
                 }
@@ -138,6 +141,21 @@ pub(crate) fn redact_credential_text(value: &str) -> String {
         }
     }
     redact_secret_like_tokens(&redacted)
+}
+
+fn credential_marker_redaction_end(value: &str, marker: &str, marker_end: usize) -> usize {
+    if marker != "bearer " {
+        return marker_end;
+    }
+
+    value[marker_end..]
+        .char_indices()
+        .find_map(|(offset, character)| {
+            (character.is_whitespace()
+                || matches!(character, '"' | '\'' | ',' | ';' | ')' | ']' | '}'))
+            .then_some(marker_end + offset)
+        })
+        .unwrap_or(value.len())
 }
 
 /// Replace whole tokens with a credential-shaped prefix (`sk-`, `ghp_`, `AKIA…`).

--- a/crates/contracts/ironclaw_host_api/src/dispatch.rs
+++ b/crates/contracts/ironclaw_host_api/src/dispatch.rs
@@ -17,6 +17,7 @@ use crate::{
     host_remediation::HostRemediation,
     ids::{CapabilityId, ExtensionId, RunId, SecretHandle, UserId},
     invocation::InvocationOrigin,
+    model_result_preview::ModelResultPreview,
     mount::MountView,
     resource::{
         ResourceEstimate, ResourceReceipt, ResourceReservation, ResourceScope, ResourceUsage,
@@ -181,6 +182,7 @@ pub struct CapabilityDispatchResult {
     pub provider: ExtensionId,
     pub runtime: RuntimeKind,
     pub output: Value,
+    pub model_preview: Option<ModelResultPreview>,
     pub display_preview: Option<CapabilityDisplayOutputPreview>,
     pub usage: ResourceUsage,
     pub receipt: ResourceReceipt,

--- a/crates/contracts/ironclaw_host_api/src/model_result_preview.rs
+++ b/crates/contracts/ironclaw_host_api/src/model_result_preview.rs
@@ -8,8 +8,8 @@
 //! (the #6129 substring-`secret` bug), forcing the model into a re-read amnesia
 //! loop. `ModelResultPreview` is the content vehicle instead:
 //!
-//! - **24 KiB** bound — mirrors `ironclaw_threads::TOOL_RESULT_RECORD_READ_MAX_BYTES`
-//!   (the largest raw first-look chunk the model reads at once).
+//! - **bounded by use** — automatic completion previews are capped at 4 KiB;
+//!   explicit `result_read` pages remain capped at 24 KiB.
 //! - **tolerates delimiters and newlines** — it is the tool's own raw-ish output,
 //!   so `{ } [ ] / < >` and multi-line structure are legitimate content, not a
 //!   redaction signal. (Rejects only NUL and other disallowed control chars.)
@@ -26,11 +26,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::HostApiError;
 
-/// Maximum size of a model-visible result preview, in bytes. Mirrors
-/// `ironclaw_threads::contract::TOOL_RESULT_RECORD_READ_MAX_BYTES` (24 KiB) — the
-/// largest raw first-look chunk a `result_read` returns — so the inline preview
-/// and a follow-up read share one cap.
+/// Maximum size of any model-visible result preview, in bytes. This remains the
+/// page limit for explicit `result_read` calls.
 pub const MODEL_RESULT_PREVIEW_MAX_BYTES: usize = 24 * 1024;
+
+/// Maximum size of the automatic first-look preview attached to a completed
+/// capability result. Producers and the canonical result writer share this
+/// smaller budget so tool completion cannot spend an entire result-read page.
+pub const AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES: usize = 4 * 1024;
 
 /// A bounded, credential-redacted, model-visible preview of a tool result's
 /// content. Tolerates delimiters/newlines (it is the tool's own output); refuses
@@ -57,20 +60,14 @@ impl ModelResultPreview {
     /// alternative is showing nothing.
     pub fn redacted(value: impl Into<String>) -> Result<Self, HostApiError> {
         let mut value = value.into();
-        match validate_model_result_preview(&value) {
-            Ok(()) => Ok(Self(value)),
-            Err(_) => {
-                if let Ok(mut structured) = serde_json::from_str(&value)
-                    && redact_structured_credential_values(&mut structured, 0)
-                {
-                    value = serde_json::to_string(&structured)
-                        .unwrap_or_else(|_| "[redacted]".to_string());
-                }
-                let redacted = crate::credential_redaction::redact_credential_text(&value);
-                validate_model_result_preview(&redacted)?;
-                Ok(Self(redacted))
-            }
+        if let Ok(mut structured) = serde_json::from_str(&value)
+            && redact_structured_credential_values(&mut structured, 0)
+        {
+            value = serde_json::to_string(&structured).unwrap_or_else(|_| "[redacted]".to_string());
         }
+        let redacted = crate::credential_redaction::redact_credential_text(&value);
+        validate_model_result_preview(&redacted)?;
+        Ok(Self(redacted))
     }
 
     pub fn as_str(&self) -> &str {
@@ -273,6 +270,27 @@ mod tests {
             preview.as_str().contains("deploy finished"),
             "surrounding content survives"
         );
+    }
+
+    #[test]
+    fn redacted_masks_bearer_value_with_its_marker() {
+        let preview = ModelResultPreview::redacted("Bearer live-secret-value")
+            .expect("bearer credential can be redacted");
+
+        assert_eq!(preview.as_str(), "[redacted]");
+        assert!(!preview.as_str().contains("live-secret-value"));
+    }
+
+    #[test]
+    fn redacted_inspects_nested_structured_text_even_when_outer_text_validates() {
+        let preview = ModelResultPreview::redacted(
+            r#"{"body":"{\"access_token\":\"opaque-live-value\",\"message\":\"safe\"}"}"#,
+        )
+        .expect("nested structured credential can be redacted");
+
+        assert!(!preview.as_str().contains("opaque-live-value"));
+        assert!(preview.as_str().contains("[redacted]"));
+        assert!(preview.as_str().contains("safe"));
     }
 
     #[test]

--- a/crates/contracts/ironclaw_host_api/src/resolution.rs
+++ b/crates/contracts/ironclaw_host_api/src/resolution.rs
@@ -439,15 +439,17 @@ pub struct OutcomeRefs {
     /// inline preview (was the `ResultReference` observation's `detail.preview`).
     /// A [`ModelResultPreview`], NOT a [`SafeSummary`]: it carries the tool's own
     /// output (delimiters, JSON, newlines), credential-redacted at a word
-    /// boundary, up to 24 KiB — so the model sees the result inline without a
-    /// follow-up `result_read`. The full bytes stay host-owned behind `result`;
-    /// `None` when no preview is staged or the content failed the credential
-    /// redaction contract.
+    /// boundary. Automatic completion projections are capped at 4 KiB; explicit
+    /// `result_read` pages may carry up to 24 KiB. The full bytes stay host-owned
+    /// behind `result`; `None` when no preview is staged or the content failed
+    /// the credential redaction contract.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preview: Option<ModelResultPreview>,
-    /// Continuation metadata for a TRUNCATED first-look preview so the model can
+    /// Continuation metadata for a bounded first-look preview so the model can
     /// read the full result (`result_read`, large results): the referenced ref,
-    /// full byte size, next offset, and JSON-array element count. The metadata
+    /// full byte size, next offset, and JSON-array element count. Semantic or
+    /// structural projections use offset zero because they are not source-byte
+    /// prefixes. The metadata
     /// remains present when an unsafe preview is suppressed, so the durable
     /// source ref stays authoritative without exposing rejected content.
     #[serde(default, skip_serializing_if = "ResultPreviewMeta::is_empty")]
@@ -477,16 +479,17 @@ pub struct ResultPreviewMeta {
     /// (`OutcomeRefs::origin`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub referenced_result_ref: Option<LoopRef>,
-    /// Full byte size of the referenced result when the preview is a truncated
-    /// chunk; `None` for a complete inline preview.
+    /// Full byte size of the referenced result when the preview is incomplete;
+    /// `None` for a complete inline preview.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_bytes: Option<u64>,
-    /// Byte offset to continue reading from for a truncated preview; `None` when
-    /// the preview is the complete result.
+    /// Byte offset to continue reading from for a source prefix, or zero when the
+    /// preview is a semantic/structural projection; `None` when the preview is
+    /// the complete result.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_offset: Option<u64>,
-    /// Element count when the full result is a top-level JSON array (truncated
-    /// previews only), so the model does not misread a byte-sliced array.
+    /// Element count when the full result is a top-level JSON array (incomplete
+    /// previews only), so the model does not misread a projection as complete.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub item_count: Option<u64>,
     /// The observation's own model-visible summary caption — the host-authored

--- a/crates/contracts/ironclaw_loop_contracts/src/resolution.rs
+++ b/crates/contracts/ironclaw_loop_contracts/src/resolution.rs
@@ -560,10 +560,13 @@ fn result_progress_of(progress: CapabilityProgress) -> ResultProgress {
 /// (routing content through `SafeSummary` dropped every delimiter-bearing/JSON
 /// result and scrubbed `Secretary`, forcing a re-read amnesia loop). It is carried
 /// as a [`ModelResultPreview`]: delimiters/newlines retained, credential-redacted
-/// at a word boundary, up to 24 KiB. The paired [`ResultPreviewMeta`] carries the
-/// TRUNCATED-preview continuation info (`result_read` / large results): the
+/// at a word boundary, up to 24 KiB for explicit `result_read` pages. Automatic
+/// completion previews use a smaller producer/writer budget and may be semantic
+/// projections rather than source prefixes. The paired [`ResultPreviewMeta`] carries the
+/// continuation info (`result_read` / large results): the
 /// referenced result ref, full byte size, next offset, and JSON-array element
-/// count, so the model reads the full result. This metadata is preserved even
+/// count; a transformed preview uses offset zero so the model reads the complete
+/// durable source. This metadata is preserved even
 /// when the preview text is rejected: continuation authority belongs to the
 /// durable source result, not to the ephemeral invocation presenting it. Detail
 /// kinds other than `ResultReference` have no inline content.

--- a/crates/domains/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/domains/ironclaw_threads/src/tool_result_reference.rs
@@ -17,8 +17,9 @@ const MAX_TOOL_RESULT_REF_BYTES: usize = 256;
 const MAX_TOOL_RESULT_SUMMARY_BYTES: usize = 512;
 /// Whole-envelope cap for a `model_observation` JSON blob (preview text plus
 /// surrounding schema fields). Derived as 2x
-/// `crate::contract::TOOL_RESULT_RECORD_READ_MAX_BYTES` (the largest raw
-/// preview/chunk this crate will ever embed): a preview of ordinary tool
+/// `crate::contract::TOOL_RESULT_RECORD_READ_MAX_BYTES` (the largest explicit
+/// result-read chunk this crate will ever embed; automatic completion previews
+/// use a smaller bound): a preview of ordinary tool
 /// output (text/JSON) grows only slightly under JSON-string escaping, so 2x
 /// leaves ample room for the preview plus the fixed envelope fields (summary,
 /// result_ref, artifacts). A pathological all-`"`/all-control preview that

--- a/crates/extensions/ironclaw_extension_host/src/mcp.rs
+++ b/crates/extensions/ironclaw_extension_host/src/mcp.rs
@@ -559,6 +559,7 @@ mod tests {
                                 )
                                 .unwrap(),
                             ),
+                            model_view: None,
                             prompt_doc_ref: None,
                             required_host_ports: Vec::new(),
                             runtime_credentials: vec![

--- a/crates/extensions/ironclaw_extension_host/src/resolver.rs
+++ b/crates/extensions/ironclaw_extension_host/src/resolver.rs
@@ -116,6 +116,7 @@ impl BoundCapabilityAdapter for SnapshotBoundCapability {
         };
         Ok(RuntimeAdapterResult {
             output: result.output,
+            model_preview: result.model_preview,
             display_preview: result.display_preview,
             output_bytes,
             usage: usage.clone(),

--- a/crates/extensions/ironclaw_extension_host/src/test_support.rs
+++ b/crates/extensions/ironclaw_extension_host/src/test_support.rs
@@ -549,6 +549,7 @@ impl ToolAdapter for FakeToolAdapter {
     ) -> Result<ToolResult, ToolError> {
         Ok(ToolResult {
             output: serde_json::json!({"ok": true}),
+            model_preview: None,
             display_preview: None,
             output_bytes: 0,
         })

--- a/crates/extensions/ironclaw_extension_host/src/test_support/first_party_registrars.rs
+++ b/crates/extensions/ironclaw_extension_host/src/test_support/first_party_registrars.rs
@@ -119,7 +119,8 @@ impl FirstPartyCapabilityHandler for GsuiteFirstPartyHandler {
             })
             .await
             .map_err(|error| gsuite_error(error, &request.capability_id))?;
-        Ok(FirstPartyCapabilityResult::new(result.output, result.usage))
+        Ok(FirstPartyCapabilityResult::new(result.output, result.usage)
+            .with_model_preview(result.model_preview))
     }
 }
 

--- a/crates/extensions/ironclaw_extension_manager/src/admin_configuration_capability.rs
+++ b/crates/extensions/ironclaw_extension_manager/src/admin_configuration_capability.rs
@@ -82,6 +82,7 @@ fn manifest() -> Result<CapabilityManifest, ExtensionError> {
         output_schema_ref: Some(CapabilityProfileSchemaRef::new(
             "schemas/builtin/admin_configuration_replace.output.v1.json",
         )?),
+        model_view: None,
         prompt_doc_ref: None,
         required_host_ports: Vec::new(),
         runtime_credentials: Vec::new(),

--- a/crates/extensions/ironclaw_extension_manager/src/extension_lifecycle_capabilities.rs
+++ b/crates/extensions/ironclaw_extension_manager/src/extension_lifecycle_capabilities.rs
@@ -183,6 +183,7 @@ fn lifecycle_manifest_with_visibility(
         output_schema_ref: Some(CapabilityProfileSchemaRef::new(format!(
             "schemas/builtin/{schema_name}.output.v1.json"
         ))?),
+        model_view: None,
         prompt_doc_ref: None,
         required_host_ports: Vec::new(),
         runtime_credentials: Vec::new(),

--- a/crates/extensions/ironclaw_extension_manager/src/ironhub/capabilities.rs
+++ b/crates/extensions/ironclaw_extension_manager/src/ironhub/capabilities.rs
@@ -119,6 +119,7 @@ fn capability_manifest(
         output_schema_ref: Some(CapabilityProfileSchemaRef::new(format!(
             "schemas/builtin/{schema_name}.output.v1.json"
         ))?),
+        model_view: None,
         prompt_doc_ref: None,
         required_host_ports: vec![],
         runtime_credentials: Vec::new(),

--- a/crates/extensions/ironclaw_extension_manager/src/operator_config_capability.rs
+++ b/crates/extensions/ironclaw_extension_manager/src/operator_config_capability.rs
@@ -87,6 +87,7 @@ fn manifest() -> Result<CapabilityManifest, ExtensionError> {
         output_schema_ref: Some(CapabilityProfileSchemaRef::new(
             "schemas/builtin/operator_config_set_auto_approve.output.v1.json",
         )?),
+        model_view: None,
         prompt_doc_ref: None,
         required_host_ports: Vec::new(),
         runtime_credentials: Vec::new(),
@@ -116,6 +117,7 @@ fn tool_permission_manifest() -> Result<CapabilityManifest, ExtensionError> {
         output_schema_ref: Some(CapabilityProfileSchemaRef::new(
             "schemas/builtin/operator_config_set_tool_permission.output.v1.json",
         )?),
+        model_view: None,
         prompt_doc_ref: None,
         required_host_ports: Vec::new(),
         runtime_credentials: Vec::new(),

--- a/crates/extensions/ironclaw_extension_manager/src/skill_auto_activate_capability.rs
+++ b/crates/extensions/ironclaw_extension_manager/src/skill_auto_activate_capability.rs
@@ -71,6 +71,7 @@ fn manifest() -> Result<CapabilityManifest, ExtensionError> {
         output_schema_ref: Some(CapabilityProfileSchemaRef::new(
             "schemas/builtin/skill_auto_activate_learned_set.output.v1.json",
         )?),
+        model_view: None,
         prompt_doc_ref: None,
         required_host_ports: Vec::new(),
         runtime_credentials: Vec::new(),

--- a/crates/extensions/ironclaw_extension_registry/src/hosted_mcp_discovery.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/hosted_mcp_discovery.rs
@@ -212,6 +212,7 @@ fn discovered_capability_manifest(
         standard_op: None,
         input_schema_ref,
         output_schema_ref: Some(output_schema_ref),
+        model_view: None,
         prompt_doc_ref: None,
         required_host_ports: template.required_host_ports.clone(),
         runtime_credentials: template.runtime_credentials.clone(),

--- a/crates/extensions/ironclaw_extension_registry/src/v2.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/v2.rs
@@ -243,6 +243,20 @@ pub enum CapabilityVisibility {
     Api,
 }
 
+/// Declarative policy for the model-facing view of a capability result.
+///
+/// This is registry metadata only: it describes which result-view contract a
+/// capability declares, without naming a runtime lane or changing execution
+/// taxonomy. The host always retains the complete durable result; `structural`
+/// selects the generic structural fallback and `producer` permits a producer's
+/// semantic preview with that fallback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelViewPolicy {
+    Structural,
+    Producer,
+}
+
 /// Host API contract identifier declared by an extension manifest.
 ///
 /// This is the manifest-level contract discriminator, for example
@@ -562,6 +576,11 @@ pub struct CapabilityDeclV2 {
     /// v2 manifests may still carry one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_schema_ref: Option<CapabilityProfileSchemaRef>,
+    /// Optional model-facing result-view policy. Missing values are retained
+    /// as `None` for compatibility with resolved records written before this
+    /// declaration existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_view: Option<ModelViewPolicy>,
     pub prompt_doc_ref: Option<CapabilityProfileSchemaRef>,
     pub required_host_ports: Vec<HostPortId>,
     pub runtime_credentials: Vec<RuntimeCredentialRequirement>,
@@ -1410,6 +1429,7 @@ impl CapabilityDeclV2 {
             standard_op: raw.standard_op,
             input_schema_ref,
             output_schema_ref,
+            model_view: raw.model_view,
             prompt_doc_ref,
             required_host_ports,
             runtime_credentials,
@@ -1954,6 +1974,8 @@ pub(crate) struct RawCapabilityV2 {
     pub(crate) input_schema_ref: String,
     #[serde(default)]
     pub(crate) output_schema_ref: Option<String>,
+    #[serde(default)]
+    pub(crate) model_view: Option<ModelViewPolicy>,
     #[serde(default)]
     pub(crate) prompt_doc_ref: Option<String>,
     #[serde(default)]

--- a/crates/extensions/ironclaw_extension_registry/src/v3.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/v3.rs
@@ -47,7 +47,7 @@ use crate::resolved::{
 };
 use crate::v2::{
     CapabilityDeclV2, CapabilitySurfaceDeclV2, ExtensionManifestV2, ExtensionRuntimeV2,
-    MAX_MANIFEST_BYTES, ManifestSource, RawCapabilityV2, RawRuntimeCredentialV2,
+    MAX_MANIFEST_BYTES, ManifestSource, ModelViewPolicy, RawCapabilityV2, RawRuntimeCredentialV2,
     requested_trust_to_descriptor_trust,
 };
 
@@ -169,6 +169,10 @@ struct RawToolV3 {
     input_schema_ref: Option<String>,
     #[serde(default)]
     output_schema_ref: Option<String>,
+    /// Optional registry-owned model-facing result-view policy. This is
+    /// declaration metadata only; runtime lanes remain orthogonal.
+    #[serde(default)]
+    model_view: Option<ModelViewPolicy>,
     #[serde(default)]
     prompt_doc_ref: Option<String>,
     #[serde(default)]
@@ -472,6 +476,7 @@ pub(crate) fn parse_v3(
             standard_op: None,
             input_schema_ref: format!("schemas/{id}/dynamic/mcp_server.input.v1.json"),
             output_schema_ref: None,
+            model_view: None,
             prompt_doc_ref: None,
             required_host_ports: derived_host_ports(&mcp.effects, true),
             runtime_credentials: template_credentials.clone(),
@@ -617,6 +622,7 @@ pub(crate) fn parse_v3(
                     standard_op: None,
                     input_schema_ref,
                     output_schema_ref: None,
+                    model_view: tool.model_view,
                     prompt_doc_ref: tool.prompt_doc_ref,
                     required_host_ports: derived_host_ports(&mcp.effects, true),
                     runtime_credentials: template_credentials.clone(),
@@ -635,6 +641,7 @@ pub(crate) fn parse_v3(
                 standard_op: tool.standard_op,
                 input_schema_ref,
                 output_schema_ref,
+                model_view: tool.model_view,
                 prompt_doc_ref: tool.prompt_doc_ref,
                 required_host_ports: derived_host_ports(&tool.effects, sandboxed_runtime),
                 runtime_credentials: tool

--- a/crates/extensions/ironclaw_extension_registry/tests/manifest_v2_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/manifest_v2_contract.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use ironclaw_extension_contracts::surface::CapabilitySurfaceKind;
+use ironclaw_extension_registry::v2::ModelViewPolicy;
 use ironclaw_extension_registry::{
     CapabilityProviderHostApiContract, CapabilitySurfaceDeclV2, CapabilityVisibility,
     ExtensionManifestV2, ExtensionRuntimeV2, HostApiContractRegistry, HostApiId,
@@ -105,6 +106,25 @@ fn parses_minimum_valid_v2_manifest_for_installed_third_party_extension() {
     // A manifest that omits the §5.2.1 origin→gate key parses to `None`
     // (undeclared), preserving compatibility with existing manifests.
     assert!(cap.origin_gate_matrix.is_none());
+}
+
+#[test]
+fn parses_optional_model_view_policy_on_v2_capability() {
+    let toml = third_party_wasm_manifest("acme-tools", "acme-tools.echo").replace(
+        "output_schema_ref = \"schemas/example/echo.output.v1.json\"",
+        "output_schema_ref = \"schemas/example/echo.output.v1.json\"\nmodel_view = \"producer\"",
+    );
+    let manifest = ExtensionManifestV2::parse(
+        &toml,
+        ManifestSource::InstalledLocal,
+        &catalog(),
+        &contracts(),
+    )
+    .expect("model-view policy is a valid optional v2 declaration");
+    assert_eq!(
+        manifest.capabilities[0].model_view,
+        Some(ModelViewPolicy::Producer)
+    );
 }
 
 /// The `standard:` schema-ref namespace is reserved to host-synthesized

--- a/crates/extensions/ironclaw_extension_registry/tests/manifest_v3_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/manifest_v3_contract.rs
@@ -11,6 +11,7 @@ use ironclaw_extension_contracts::{
     channel::ConversationModel, memory::MemoryLifecycleHook, recipe::VendorAuthRecipe,
     surface::CapabilitySurfaceKind,
 };
+use ironclaw_extension_registry::v2::ModelViewPolicy;
 use ironclaw_extension_registry::{
     CapabilityProviderHostApiContract, CapabilitySurfaceDeclV2, CapabilityVisibility,
     ExtensionManifest, ExtensionManifestRecord, ExtensionPackage, ExtensionRuntimeV2,
@@ -62,6 +63,57 @@ fn parse_v3_with_source(
 
 fn acme_record() -> ExtensionManifestRecord {
     parse_v3(ACME_MANIFEST).expect("acme fixture manifest must parse")
+}
+
+#[test]
+fn parses_and_resolves_optional_model_view_policy_on_v3_tool() {
+    let toml = ACME_MANIFEST.replace(
+        "input_schema_ref = \"schemas/acme/send_note.input.v1.json\"",
+        "input_schema_ref = \"schemas/acme/send_note.input.v1.json\"\noutput_schema_ref = \"schemas/acme/send_note.output.v1.json\"\nmodel_view = \"producer\"",
+    );
+    let record = parse_v3(&toml).expect("model-view policy is a valid optional v3 declaration");
+    let tool = &record.manifest().capabilities[0];
+    assert_eq!(tool.model_view, Some(ModelViewPolicy::Producer));
+    assert_eq!(
+        record.resolved().tools[0].model_view,
+        Some(ModelViewPolicy::Producer)
+    );
+}
+
+#[test]
+fn rejects_unknown_model_view_policy_on_v3_tool() {
+    let toml = ACME_MANIFEST.replace(
+        "input_schema_ref = \"schemas/acme/send_note.input.v1.json\"",
+        "input_schema_ref = \"schemas/acme/send_note.input.v1.json\"\nmodel_view = \"semantic\"",
+    );
+    let error = parse_v3(&toml).expect_err("the model-view policy vocabulary is closed");
+    assert!(
+        error.contains("model_view") || error.contains("unknown variant"),
+        "{error}"
+    );
+}
+
+#[test]
+fn legacy_resolved_tools_without_model_view_rehydrate_to_none() {
+    let toml = ACME_MANIFEST.replace(
+        "input_schema_ref = \"schemas/acme/send_note.input.v1.json\"",
+        "input_schema_ref = \"schemas/acme/send_note.input.v1.json\"\noutput_schema_ref = \"schemas/acme/send_note.output.v1.json\"\nmodel_view = \"structural\"",
+    );
+    let record = parse_v3(&toml).expect("model-view policy fixture parses");
+    let mut resolved = serde_json::to_value(record.resolved()).expect("serialize resolved record");
+    for tool in resolved["tools"].as_array_mut().expect("tools array") {
+        tool.as_object_mut()
+            .expect("tool object")
+            .remove("model_view");
+    }
+    let rehydrated: ironclaw_extension_registry::ResolvedExtensionManifest =
+        serde_json::from_value(resolved).expect("legacy resolved record must remain readable");
+    assert!(
+        rehydrated
+            .tools
+            .iter()
+            .all(|tool| tool.model_view.is_none())
+    );
 }
 
 // arch-exempt: large_file, manifest-v3 cases remain one conformance suite pending fixture split, plan #7477

--- a/crates/extensions/ironclaw_extension_support/src/gsuite/handlers.rs
+++ b/crates/extensions/ironclaw_extension_support/src/gsuite/handlers.rs
@@ -25,6 +25,7 @@ use ironclaw_host_api::{
         RuntimeHttpEgressRequest,
     },
     ids::{CapabilityId, ExtensionId},
+    model_result_preview::ModelResultPreview,
     resource::{ResourceScope, ResourceUsage},
     runtime::RuntimeKind,
 };
@@ -45,6 +46,7 @@ use crate::latency::{
 };
 
 mod calendar_list_events;
+mod gmail_message_preview;
 
 pub const CALENDAR_LIST_CALENDARS_CAPABILITY_ID: &str = "google-calendar.list_calendars";
 pub const CALENDAR_LIST_EVENTS_CAPABILITY_ID: &str = "google-calendar.list_events";
@@ -505,6 +507,12 @@ impl GsuiteExecutor {
                 return Err(error);
             }
         };
+        let model_preview = match capability.operation {
+            GsuiteCapabilityOperation::GmailGetMessage => {
+                Some(gmail_message_preview::from_get_message_output(&output)?)
+            }
+            _ => None,
+        };
         let output_bytes = json_bytes(&output);
         trace_gsuite_latency_ok(
             "shape_output",
@@ -516,6 +524,7 @@ impl GsuiteExecutor {
         let wall_clock_ms = started.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
         Ok(GsuiteDispatchResult {
             output,
+            model_preview,
             usage: ResourceUsage::default()
                 .set_wall_clock_ms(wall_clock_ms)
                 .set_output_bytes(output_bytes)
@@ -550,6 +559,7 @@ pub struct GsuiteDispatchRequest<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GsuiteDispatchResult {
     pub output: Value,
+    pub model_preview: Option<ModelResultPreview>,
     pub usage: ResourceUsage,
 }
 

--- a/crates/extensions/ironclaw_extension_support/src/gsuite/handlers/gmail_message_preview.rs
+++ b/crates/extensions/ironclaw_extension_support/src/gsuite/handlers/gmail_message_preview.rs
@@ -1,0 +1,214 @@
+use base64::{
+    Engine as _,
+    engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
+};
+use ironclaw_host_api::{
+    dispatch::RuntimeDispatchErrorKind,
+    model_result_preview::{AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES, ModelResultPreview},
+};
+use serde_json::{Value, json};
+
+use super::GsuiteDispatchError;
+
+pub(super) fn from_get_message_output(
+    output: &Value,
+) -> Result<ModelResultPreview, GsuiteDispatchError> {
+    let message = output
+        .get("body")
+        .and_then(Value::as_object)
+        .ok_or_else(|| GsuiteDispatchError::new(RuntimeDispatchErrorKind::OutputDecode))?;
+    let payload = message
+        .get("payload")
+        .and_then(Value::as_object)
+        .ok_or_else(|| GsuiteDispatchError::new(RuntimeDispatchErrorKind::OutputDecode))?;
+    let mut headers = serde_json::Map::new();
+    if let Some(values) = payload.get("headers").and_then(Value::as_array) {
+        for header in values {
+            let Some(name) = header.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let key = match name.to_ascii_lowercase().as_str() {
+                "from" => "from",
+                "to" => "to",
+                "subject" => "subject",
+                "date" => "date",
+                _ => continue,
+            };
+            if let Some(value) = header.get("value").and_then(Value::as_str) {
+                headers.insert(
+                    key.to_string(),
+                    Value::String(truncate_owned_utf8(value, 512)),
+                );
+            }
+        }
+    }
+
+    let body = plain_text_body(payload)?;
+    bounded_preview(headers, &body)
+}
+
+fn plain_text_body(
+    payload: &serde_json::Map<String, Value>,
+) -> Result<String, GsuiteDispatchError> {
+    if payload.get("mimeType").and_then(Value::as_str) == Some("text/plain")
+        && let Some(data) = payload
+            .get("body")
+            .and_then(Value::as_object)
+            .and_then(|body| body.get("data"))
+            .and_then(Value::as_str)
+    {
+        let decoded = URL_SAFE_NO_PAD
+            .decode(data)
+            .or_else(|_| URL_SAFE.decode(data))
+            .map_err(output_decode_error)?;
+        return String::from_utf8(decoded).map_err(output_decode_error);
+    }
+    if let Some(parts) = payload.get("parts").and_then(Value::as_array) {
+        for part in parts {
+            let Some(part) = part.as_object() else {
+                continue;
+            };
+            let body = plain_text_body(part)?;
+            if !body.is_empty() {
+                return Ok(body);
+            }
+        }
+    }
+    Ok(String::new())
+}
+
+fn bounded_preview(
+    mut headers: serde_json::Map<String, Value>,
+    body: &str,
+) -> Result<ModelResultPreview, GsuiteDispatchError> {
+    shrink_headers_to_preview_budget(&mut headers, !body.is_empty())?;
+    let mut low = 0;
+    let mut high = body.len();
+    let mut best = None;
+    while low <= high {
+        let midpoint = low + (high - low) / 2;
+        let end = floor_utf8_boundary(body, midpoint);
+        let candidate = json!({
+            "headers": headers,
+            "body": &body[..end],
+            "body_truncated": end < body.len(),
+        });
+        let serialized = serde_json::to_string(&candidate).map_err(output_decode_error)?;
+        if serialized.len() > AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES {
+            if midpoint == 0 {
+                break;
+            }
+            high = midpoint - 1;
+            continue;
+        }
+        let preview = ModelResultPreview::redacted(serialized).map_err(output_decode_error)?;
+        if preview.as_str().len() <= AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES {
+            best = Some(preview);
+            low = midpoint.saturating_add(1);
+        } else if midpoint == 0 {
+            break;
+        } else {
+            high = midpoint - 1;
+        }
+    }
+    best.ok_or_else(|| GsuiteDispatchError::new(RuntimeDispatchErrorKind::OutputDecode))
+}
+
+fn shrink_headers_to_preview_budget(
+    headers: &mut serde_json::Map<String, Value>,
+    body_truncated: bool,
+) -> Result<(), GsuiteDispatchError> {
+    let header_budget = AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES / 2;
+    loop {
+        let envelope = json!({
+            "headers": &*headers,
+            "body": "",
+            "body_truncated": body_truncated,
+        });
+        if serde_json::to_vec(&envelope)
+            .map_err(output_decode_error)?
+            .len()
+            <= header_budget
+        {
+            return Ok(());
+        }
+
+        let Some((key, len)) = headers
+            .iter()
+            .filter_map(|(key, value)| value.as_str().map(|value| (key, value.len())))
+            .filter(|(_, len)| *len > 0)
+            .max_by_key(|(_, len)| *len)
+            .map(|(key, len)| (key.clone(), len))
+        else {
+            return Err(GsuiteDispatchError::new(
+                RuntimeDispatchErrorKind::OutputDecode,
+            ));
+        };
+        if let Some(Value::String(value)) = headers.get_mut(&key) {
+            *value = truncate_owned_utf8(value, len / 2);
+        }
+    }
+}
+
+fn output_decode_error(error: impl std::fmt::Display) -> GsuiteDispatchError {
+    tracing::warn!(error = %error, "failed to construct Gmail semantic preview");
+    GsuiteDispatchError::new(RuntimeDispatchErrorKind::OutputDecode)
+}
+
+fn truncate_owned_utf8(value: &str, max_bytes: usize) -> String {
+    value[..floor_utf8_boundary(value, max_bytes)].to_string()
+}
+
+fn floor_utf8_boundary(value: &str, index: usize) -> usize {
+    let mut index = index.min(value.len());
+    while index > 0 && !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_preview_terminates_at_multibyte_boundaries() {
+        let body = "😀".repeat(5_000);
+
+        let preview = bounded_preview(serde_json::Map::new(), &body)
+            .expect("multibyte body has a bounded preview");
+        let value: Value =
+            serde_json::from_str(preview.as_str()).expect("preview remains valid JSON");
+
+        assert!(preview.as_str().len() <= AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES);
+        assert_eq!(value["body_truncated"], true);
+        assert!(value["body"].as_str().is_some_and(|body| !body.is_empty()));
+    }
+
+    #[test]
+    fn bounded_preview_redacts_credentials_embedded_in_message_text() {
+        let body = r#"{"access_token":"opaque-live-value","message":"safe"}"#;
+
+        let preview = bounded_preview(serde_json::Map::new(), body)
+            .expect("credential-bearing body has a redacted preview");
+
+        assert!(!preview.as_str().contains("opaque-live-value"));
+        assert!(preview.as_str().contains("[redacted]"));
+        assert!(preview.as_str().contains("safe"));
+    }
+
+    #[test]
+    fn bounded_preview_keeps_valid_escaped_headers_within_budget() {
+        let escaped = "\\\"".repeat(256);
+        let headers = ["from", "to", "subject", "date"]
+            .into_iter()
+            .map(|name| (name.to_string(), Value::String(escaped.clone())))
+            .collect();
+
+        let preview = bounded_preview(headers, "readable body")
+            .expect("escaped headers still yield a semantic preview");
+
+        assert!(preview.as_str().len() <= AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES);
+        assert!(preview.as_str().contains("readable body"));
+    }
+}

--- a/crates/extensions/ironclaw_extension_support/tests/gsuite_recorded_shapes.rs
+++ b/crates/extensions/ironclaw_extension_support/tests/gsuite_recorded_shapes.rs
@@ -2,6 +2,7 @@ mod support;
 
 use std::sync::Arc;
 
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use ironclaw_auth::{
     GOOGLE_CALENDAR_EVENTS_SCOPE, GOOGLE_CALENDAR_READONLY_SCOPE, GOOGLE_GMAIL_MODIFY_SCOPE,
     GOOGLE_GMAIL_READONLY_SCOPE, GOOGLE_GMAIL_SEND_SCOPE,
@@ -18,6 +19,7 @@ use ironclaw_extension_support::{
 };
 use ironclaw_host_api::{
     action::NetworkMethod,
+    dispatch::RuntimeDispatchErrorKind,
     http::{RuntimeHttpEgressRequest, RuntimeHttpEgressResponse},
 };
 use serde_json::{Value, json};
@@ -365,4 +367,101 @@ async fn gmail_handlers_use_recorded_google_api_shapes() {
             .url
             .ends_with("/users/me/messages/msg-001/trash")
     );
+}
+
+#[tokio::test]
+async fn gmail_get_message_returns_bounded_readable_preview_and_complete_output() {
+    let readable_body =
+        "The release is approved. Please ship after the final checks. 日\n".repeat(1_000);
+    let encoded_body = URL_SAFE_NO_PAD.encode(readable_body.as_bytes());
+    let provider_message = json!({
+        "id": "msg-large-001",
+        "threadId": "thread-001",
+        "payload": {
+            "mimeType": "multipart/alternative",
+            "headers": [
+                { "name": "From", "value": "Ada <ada@example.com>" },
+                { "name": "To", "value": "Grace <grace@example.com>" },
+                { "name": "Subject", "value": "Release approval" },
+                { "name": "Date", "value": "Tue, 25 Aug 2026 10:30:00 +0000" },
+                { "name": "DKIM-Signature", "value": "transport-signature-chain" }
+            ],
+            "parts": [
+                {
+                    "mimeType": "text/html",
+                    "body": { "data": URL_SAFE_NO_PAD.encode(b"<p>HTML fallback</p>") }
+                },
+                {
+                    "mimeType": "multipart/mixed",
+                    "parts": [{
+                        "mimeType": "text/plain",
+                        "body": { "size": readable_body.len(), "data": encoded_body }
+                    }]
+                }
+            ]
+        }
+    });
+    let scope = scope();
+    let auth =
+        auth_with_google_account(&scope, vec![provider_scope(GOOGLE_GMAIL_READONLY_SCOPE)]).await;
+    let egress = Arc::new(RecordingEgress::with_responses(vec![
+        RecordingEgress::json_status(200, provider_message.clone()),
+    ]));
+
+    let result = dispatch_result(
+        auth,
+        scope,
+        GMAIL_GET_MESSAGE_CAPABILITY_ID,
+        json!({ "message_id": "msg-large-001" }),
+        egress,
+    )
+    .await;
+    let preview = result
+        .model_preview
+        .as_ref()
+        .expect("Gmail get_message returns a semantic model preview")
+        .as_str();
+
+    assert!(preview.len() <= 4 * 1024);
+    assert!(preview.contains("Ada <ada@example.com>"));
+    assert!(preview.contains("Grace <grace@example.com>"));
+    assert!(preview.contains("Release approval"));
+    assert!(preview.contains("The release is approved."));
+    assert!(preview.contains("日"));
+    assert!(preview.contains(r#""body_truncated":true"#));
+    assert!(!preview.contains("HTML fallback"));
+    assert!(!preview.contains("transport-signature-chain"));
+    assert!(!preview.contains(&URL_SAFE_NO_PAD.encode(readable_body.as_bytes())));
+    assert_eq!(result.output["body"], provider_message);
+}
+
+#[tokio::test]
+async fn gmail_get_message_rejects_malformed_plain_text_body() {
+    let scope = scope();
+    let auth =
+        auth_with_google_account(&scope, vec![provider_scope(GOOGLE_GMAIL_READONLY_SCOPE)]).await;
+    let egress = Arc::new(RecordingEgress::with_responses(vec![
+        RecordingEgress::json_status(
+            200,
+            json!({
+                "id": "msg-malformed",
+                "payload": {
+                    "mimeType": "text/plain",
+                    "headers": [],
+                    "body": { "data": "%%%not-base64url%%%" }
+                }
+            }),
+        ),
+    ]));
+
+    let error = dispatch_error(
+        auth,
+        scope,
+        GMAIL_GET_MESSAGE_CAPABILITY_ID,
+        json!({ "message_id": "msg-malformed" }),
+        egress,
+    )
+    .await;
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::OutputDecode);
 }

--- a/crates/extensions/ironclaw_extension_support/tests/support/mod.rs
+++ b/crates/extensions/ironclaw_extension_support/tests/support/mod.rs
@@ -12,7 +12,8 @@ use ironclaw_auth::{
 };
 use ironclaw_extension_support::{
     GsuiteCredentialStageError, GsuiteCredentialStageRequest, GsuiteCredentialStager,
-    GsuiteDispatchError, GsuiteDispatchRequest, GsuiteExecutor, google_provider_id,
+    GsuiteDispatchError, GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor,
+    google_provider_id,
 };
 use ironclaw_host_api::{
     http::{
@@ -147,7 +148,13 @@ impl RuntimeHttpEgress for RecordingEgress {
             .pop_front()
             .unwrap_or_else(|| {
                 if self.permissive_success {
-                    Ok(RecordingEgress::json(json!({"id":"sent-message"})))
+                    Ok(RecordingEgress::json(json!({
+                        "id": "sent-message",
+                        "payload": {
+                            "headers": [],
+                            "body": { "data": "" }
+                        }
+                    })))
                 } else {
                     panic!("recording egress response queue exhausted")
                 }
@@ -251,6 +258,18 @@ pub(crate) async fn dispatch_ok(
     input: serde_json::Value,
     egress: Arc<RecordingEgress>,
 ) -> serde_json::Value {
+    dispatch_result(auth, scope, capability, input, egress)
+        .await
+        .output
+}
+
+pub(crate) async fn dispatch_result(
+    auth: Arc<InMemoryAuthProductServices>,
+    scope: ResourceScope,
+    capability: &str,
+    input: serde_json::Value,
+    egress: Arc<RecordingEgress>,
+) -> GsuiteDispatchResult {
     let executor = GsuiteExecutor::new(auth.clone(), auth, noop_credential_stager());
     let capability_id = capability_id(capability);
     executor
@@ -262,7 +281,6 @@ pub(crate) async fn dispatch_ok(
         })
         .await
         .unwrap()
-        .output
 }
 
 pub(crate) async fn dispatch_error(

--- a/crates/extensions/packages/github/manifest.toml
+++ b/crates/extensions/packages/github/manifest.toml
@@ -711,6 +711,7 @@ default_permission = "allow"
 visibility = "model"
 input_schema_ref = "schemas/github/get_job_logs.input.v1.json"
 output_schema_ref = "schemas/github/raw_output.v1.json"
+model_view = "structural"
 prompt_doc_ref = "prompts/github/get_job_logs.md"
 # The logs endpoint 302-redirects to a short-lived, pre-signed Azure blob URL
 # (e.g. productionresultssaN.blob.core.windows.net). The host egress follows the

--- a/crates/extensions/packages/gmail/manifest.toml
+++ b/crates/extensions/packages/gmail/manifest.toml
@@ -51,6 +51,8 @@ effects = ["network", "use_secret"]
 default_permission = "allow"
 visibility = "model"
 input_schema_ref = "schemas/gmail/get_message.input.v1.json"
+output_schema_ref = "schemas/gmail/get_message.output.v1.json"
+model_view = "producer"
 prompt_doc_ref = "prompts/gmail/get_message.md"
 
 network_targets = [

--- a/crates/extensions/packages/telegram/src/linked/tools.rs
+++ b/crates/extensions/packages/telegram/src/linked/tools.rs
@@ -182,6 +182,7 @@ pub(crate) fn tool_result(output: Value) -> ToolResult {
         .unwrap_or_default();
     ToolResult {
         output,
+        model_preview: None,
         display_preview: None,
         output_bytes,
     }

--- a/crates/kernel/ironclaw_capabilities/src/dispatch.rs
+++ b/crates/kernel/ironclaw_capabilities/src/dispatch.rs
@@ -24,6 +24,7 @@ use ironclaw_host_api::{
     ids::{CapabilityId, ExtensionId, InvocationId},
     invocation::{Actor, InvocationOrigin},
     lane::RuntimeLane,
+    model_result_preview::ModelResultPreview,
     resource::{ResourceReceipt, ResourceReservation, ResourceScope, ResourceUsage},
     runtime::RuntimeKind,
 };
@@ -97,6 +98,7 @@ pub trait BoundCapabilityAdapter: Send + Sync {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeAdapterResult {
     pub output: Value,
+    pub model_preview: Option<ModelResultPreview>,
     pub display_preview: Option<CapabilityDisplayOutputPreview>,
     pub usage: ResourceUsage,
     pub receipt: ResourceReceipt,
@@ -316,6 +318,7 @@ where
             provider,
             runtime,
             output: execution.output,
+            model_preview: execution.model_preview,
             display_preview: execution.display_preview,
             usage: execution.usage,
             receipt: execution.receipt,

--- a/crates/kernel/ironclaw_capabilities/src/host/tests.rs
+++ b/crates/kernel/ironclaw_capabilities/src/host/tests.rs
@@ -814,6 +814,7 @@ async fn resumed_pending_claim_dispatch_seals_witness_deadline_from_lease_expiry
                 provider: ExtensionId::new("echo").unwrap(),
                 runtime: RuntimeKind::Wasm,
                 output: serde_json::json!({"ok": true}),
+                model_preview: None,
                 display_preview: None,
                 usage: ironclaw_host_api::resource::ResourceUsage::default(),
                 receipt: ironclaw_host_api::resource::ResourceReceipt {

--- a/crates/kernel/ironclaw_capabilities/src/registry.rs
+++ b/crates/kernel/ironclaw_capabilities/src/registry.rs
@@ -151,6 +151,7 @@ impl BoundCapabilityAdapter for ToolAdapterCapabilityHandler {
         };
         Ok(RuntimeAdapterResult {
             output: result.output,
+            model_preview: result.model_preview,
             display_preview: result.display_preview,
             output_bytes,
             usage: usage.clone(),
@@ -262,6 +263,7 @@ mod tests {
         ) -> Result<ToolResult, ToolError> {
             Ok(ToolResult {
                 output: json!({"ok": true}),
+                model_preview: None,
                 display_preview: None,
                 output_bytes: 11,
             })

--- a/crates/kernel/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/capability_host_dispatcher_integration.rs
@@ -426,6 +426,7 @@ impl BoundCapabilityAdapter for RecordingRuntimeAdapter {
             })?;
         Ok(RuntimeAdapterResult {
             output,
+            model_preview: None,
             display_preview: None,
             usage,
             receipt,

--- a/crates/kernel/ironclaw_capabilities/tests/runtime_dispatch_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/runtime_dispatch_contract.rs
@@ -32,6 +32,7 @@ use ironclaw_host_api::{
     },
     invocation::{Actor, Invocation, InvocationOrigin},
     lane::RuntimeLane,
+    model_result_preview::ModelResultPreview,
     mount::MountView,
     resource::{
         ReservationStatus, ResourceEstimate, ResourceReservation, ResourceScope, ResourceUsage,
@@ -97,6 +98,31 @@ async fn dispatcher_routes_capability_through_resolved_binding() {
     assert_eq!(requests[0].scope, scope);
     assert_eq!(requests[0].mounts, None);
     assert_eq!(requests[0].input, json!({"message": "hello dispatcher"}));
+}
+
+#[tokio::test]
+async fn dispatcher_preserves_model_preview_from_resolved_binding() {
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let binding = RecordingBinding::new(json!({"message": "complete"}), Arc::clone(&governor))
+        .with_model_preview(ModelResultPreview::new("model-visible semantic preview").unwrap());
+    let resolver = ScriptedResolver::from_entries([(
+        "echo.preview",
+        resolved("echo", RuntimeKind::Wasm, binding),
+    )]);
+
+    let dispatcher = RuntimeDispatcher::new(&resolver, governor.as_ref());
+    let result = dispatcher
+        .dispatch_json(sample_request("echo.preview", json!({})))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result
+            .model_preview
+            .as_ref()
+            .map(ModelResultPreview::as_str),
+        Some("model-visible semantic preview")
+    );
 }
 
 #[tokio::test]
@@ -440,6 +466,7 @@ impl ToolResolver for ScriptedResolver {
 #[derive(Clone)]
 struct RecordingBinding {
     output: Value,
+    model_preview: Option<ModelResultPreview>,
     failure: Option<Arc<dyn Fn() -> DispatchError + Send + Sync>>,
     governor: Arc<InMemoryResourceGovernor>,
     requests: Arc<Mutex<Vec<RecordedBindingRequest>>>,
@@ -457,6 +484,7 @@ impl RecordingBinding {
     fn new(output: Value, governor: Arc<InMemoryResourceGovernor>) -> Self {
         Self {
             output,
+            model_preview: None,
             failure: None,
             governor,
             requests: Arc::new(Mutex::new(Vec::new())),
@@ -469,10 +497,16 @@ impl RecordingBinding {
     ) -> Self {
         Self {
             output: json!(null),
+            model_preview: None,
             failure: Some(Arc::new(error)),
             governor,
             requests: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    fn with_model_preview(mut self, model_preview: ModelResultPreview) -> Self {
+        self.model_preview = Some(model_preview);
+        self
     }
 
     fn requests(&self) -> Vec<RecordedBindingRequest> {
@@ -524,6 +558,7 @@ impl BoundCapabilityAdapter for RecordingBinding {
             })?;
         Ok(RuntimeAdapterResult {
             output: self.output.clone(),
+            model_preview: self.model_preview.clone(),
             display_preview: None,
             output_bytes,
             usage,

--- a/crates/kernel/ironclaw_capabilities/tests/runtime_dispatch_event_contract.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/runtime_dispatch_event_contract.rs
@@ -508,6 +508,7 @@ impl BoundCapabilityAdapter for EchoBinding {
             })?;
         Ok(RuntimeAdapterResult {
             output,
+            model_preview: None,
             display_preview: None,
             output_bytes,
             usage,

--- a/crates/kernel/ironclaw_capabilities/tests/support/mod.rs
+++ b/crates/kernel/ironclaw_capabilities/tests/support/mod.rs
@@ -334,6 +334,7 @@ impl CapabilityDispatcher for RecordingDispatcher {
             provider: extension_id(),
             runtime: RuntimeKind::Wasm,
             output: json!({"ok": true}),
+            model_preview: None,
             display_preview: None,
             usage: ResourceUsage::default(),
             receipt: ResourceReceipt {
@@ -371,6 +372,7 @@ pub fn dispatch_result_with_output(
         provider: extension_id(),
         runtime: RuntimeKind::Wasm,
         output,
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {

--- a/crates/kernel/ironclaw_host_runtime/src/capability_response_processor.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/capability_response_processor.rs
@@ -177,6 +177,7 @@ fn completed_or_output_violation_outcome(
     let completed = RuntimeCapabilityCompleted {
         capability_id: capability_id.clone(),
         output: dispatch.output,
+        model_preview: dispatch.model_preview,
         display_preview: dispatch.display_preview,
         usage: dispatch.usage,
     };

--- a/crates/kernel/ironclaw_host_runtime/src/document_output.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/document_output.rs
@@ -66,18 +66,18 @@ const DOCUMENT_OUTPUT_CAPABILITIES: &[&str] = &["google-drive.download_file"];
 /// removed — on a missing `mime_type`, a non-string payload, an oversize
 /// payload, or an extraction failure the field is dropped and a short marker is
 /// placed in `content` instead, so raw base64 can never reach the model.
-pub(crate) fn extract_documents_in_output(capability_id: &str, mut output: Value) -> Value {
+pub(crate) fn extract_documents_in_output(capability_id: &str, mut output: Value) -> (Value, bool) {
     // Opt-in per capability: a result from any non-listed capability passes
     // through unchanged, even if it contains a `content_base64` field.
     if !DOCUMENT_OUTPUT_CAPABILITIES.contains(&capability_id) {
-        return output;
+        return (output, false);
     }
     let Some(obj) = output.as_object_mut() else {
-        return output;
+        return (output, false);
     };
     // The only leak-free early exit: there is no base64 payload to handle.
     if !obj.contains_key("content_base64") {
-        return output;
+        return (output, false);
     }
 
     // From here we are committed to removing `content_base64` below, whatever
@@ -103,7 +103,7 @@ pub(crate) fn extract_documents_in_output(capability_id: &str, mut output: Value
 
     obj.remove("content_base64");
     obj.insert("content".to_string(), Value::String(content));
-    output
+    (output, true)
 }
 
 /// Decode base64 bytes and run the type-aware extractor, returning the text or
@@ -165,7 +165,8 @@ mod tests {
 
     #[test]
     fn non_object_passes_through() {
-        let out = extract_documents_in_output(GATED, json!("just a string"));
+        let (out, changed) = extract_documents_in_output(GATED, json!("just a string"));
+        assert!(!changed);
         assert_eq!(out, json!("just a string"));
     }
 
@@ -180,9 +181,10 @@ mod tests {
             "mime_type": "text/csv",
             "content_base64": b64(b"name,age\nAlice,30"),
         });
-        let out = extract_documents_in_output("builtin.echo", input.clone());
+        let (out, changed) = extract_documents_in_output("builtin.echo", input.clone());
+        assert!(!changed);
         assert_eq!(
-            out, input,
+            &out, &input,
             "a non-listed capability must leave `content_base64` untouched"
         );
         assert!(
@@ -202,14 +204,18 @@ mod tests {
             "mime_type": "text/plain",
             "content": "hello world",
         });
-        assert_eq!(extract_documents_in_output(GATED, input.clone()), input);
+        let (out, changed) = extract_documents_in_output(GATED, input.clone());
+        assert!(!changed);
+        assert_eq!(out, input);
     }
 
     #[test]
     fn missing_mime_strips_base64_and_marks() {
         // content_base64 present but no mime_type must NOT leak base64: it is
         // stripped and replaced with a marker.
-        let out = extract_documents_in_output(GATED, json!({ "content_base64": b64(b"abc") }));
+        let (out, changed) =
+            extract_documents_in_output(GATED, json!({ "content_base64": b64(b"abc") }));
+        assert!(changed);
         assert!(
             out.get("content_base64").is_none(),
             "base64 must be stripped even when mime_type is missing"
@@ -225,13 +231,14 @@ mod tests {
     fn non_string_content_base64_is_stripped() {
         // An unexpected non-string `content_base64` must still be removed, never
         // passed through.
-        let out = extract_documents_in_output(
+        let (out, changed) = extract_documents_in_output(
             GATED,
             json!({
                 "mime_type": "application/pdf",
                 "content_base64": { "nested": "object" },
             }),
         );
+        assert!(changed);
         assert!(out.get("content_base64").is_none());
         assert!(out["content"].as_str().unwrap_or("").starts_with('['));
     }
@@ -240,7 +247,7 @@ mod tests {
     fn extracts_csv_and_drops_base64() {
         // Exercises the decode -> extract_text -> replace path end-to-end
         // without a binary fixture; text/csv is handled by the extractor.
-        let out = extract_documents_in_output(
+        let (out, changed) = extract_documents_in_output(
             GATED,
             json!({
                 "file_id": "f1",
@@ -249,6 +256,7 @@ mod tests {
                 "content_base64": b64(b"name,age\nAlice,30"),
             }),
         );
+        assert!(changed);
         assert_eq!(out["content"], json!("name,age\nAlice,30"));
         assert!(
             out.get("content_base64").is_none(),
@@ -260,7 +268,7 @@ mod tests {
     fn extracts_pdf_binary() {
         // Real binary document: a minimal PDF whose text is "Hello World".
         let pdf = include_bytes!("../../../../tests/fixtures/hello.pdf");
-        let out = extract_documents_in_output(
+        let (out, changed) = extract_documents_in_output(
             GATED,
             json!({
                 "file_id": "f1",
@@ -269,6 +277,7 @@ mod tests {
                 "content_base64": b64(pdf),
             }),
         );
+        assert!(changed);
         let content = out["content"].as_str().unwrap_or("");
         assert!(
             content.contains("Hello"),
@@ -281,7 +290,7 @@ mod tests {
     fn unsupported_binary_yields_failure_marker_not_base64() {
         // An unsupported/opaque binary still must not leak base64; the model
         // gets a bracketed marker instead.
-        let out = extract_documents_in_output(
+        let (out, changed) = extract_documents_in_output(
             GATED,
             json!({
                 "file_id": "f1",
@@ -290,6 +299,7 @@ mod tests {
                 "content_base64": b64(&[0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]),
             }),
         );
+        assert!(changed);
         let content = out["content"].as_str().unwrap_or("");
         assert!(content.starts_with('['), "expected marker, got: {content}");
         assert!(out.get("content_base64").is_none());
@@ -297,13 +307,14 @@ mod tests {
 
     #[test]
     fn invalid_base64_yields_marker() {
-        let out = extract_documents_in_output(
+        let (out, changed) = extract_documents_in_output(
             GATED,
             json!({
                 "mime_type": "application/pdf",
                 "content_base64": "not valid base64 !!!",
             }),
         );
+        assert!(changed);
         let content = out["content"].as_str().unwrap_or("");
         assert!(content.contains("Could not decode"), "got: {content}");
         assert!(out.get("content_base64").is_none());

--- a/crates/kernel/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party.rs
@@ -18,6 +18,7 @@ use ironclaw_host_api::{
     host_remediation::HostRemediation,
     ids::{CapabilityId, RunId, SecretHandle, UserId},
     invocation::InvocationOrigin,
+    model_result_preview::ModelResultPreview,
     mount::MountView,
     resource::{ResourceEstimate, ResourceScope, ResourceUsage},
 };
@@ -123,6 +124,7 @@ impl FirstPartyCapabilityRequest {
 #[non_exhaustive]
 pub struct FirstPartyCapabilityResult {
     pub output: Value,
+    pub model_preview: Option<ModelResultPreview>,
     pub display_preview: Option<CapabilityDisplayOutputPreview>,
     pub usage: ResourceUsage,
 }
@@ -131,9 +133,15 @@ impl FirstPartyCapabilityResult {
     pub fn new(output: Value, usage: ResourceUsage) -> Self {
         Self {
             output,
+            model_preview: None,
             display_preview: None,
             usage,
         }
+    }
+
+    pub fn with_model_preview(mut self, model_preview: Option<ModelResultPreview>) -> Self {
+        self.model_preview = model_preview;
+        self
     }
 
     pub fn with_display_preview(

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -667,6 +667,7 @@ fn first_party_capability_manifest(
         output_schema_ref: Some(CapabilityProfileSchemaRef::new(format!(
             "schemas/builtin/{schema_name}.output.v1.json"
         ))?),
+        model_view: None,
         prompt_doc_ref: None,
         required_host_ports: Vec::new(),
         runtime_credentials: Vec::new(),

--- a/crates/kernel/ironclaw_host_runtime/src/lib.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/lib.rs
@@ -400,6 +400,7 @@ pub struct VisibleCapabilitySurface {
 pub struct RuntimeCapabilityCompleted {
     pub capability_id: CapabilityId,
     pub output: Value,
+    pub model_preview: Option<ironclaw_host_api::model_result_preview::ModelResultPreview>,
     pub display_preview: Option<CapabilityDisplayOutputPreview>,
     pub usage: ResourceUsage,
 }

--- a/crates/kernel/ironclaw_host_runtime/src/obligations/handler.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/obligations/handler.rs
@@ -556,16 +556,18 @@ impl CapabilityObligationHandler for BuiltinObligationHandler {
         // Turn any base64 document payload into extracted text before redaction
         // and the output-size obligations run, so the model gets bounded text
         // (leak-scanned, size-checked) and the large base64 never survives.
-        dispatch.output = crate::document_output::extract_documents_in_output(
-            dispatch.capability_id.as_str(),
-            dispatch.output,
-        );
+        let (document_output, mut output_changed) =
+            crate::document_output::extract_documents_in_output(
+                dispatch.capability_id.as_str(),
+                dispatch.output,
+            );
+        dispatch.output = document_output;
         if request
             .obligations
             .iter()
             .any(|obligation| matches!(obligation, Obligation::RedactOutput))
         {
-            dispatch.output = match redact_output(dispatch.output) {
+            let redacted_output = match redact_output(dispatch.output) {
                 Ok(value) => value,
                 Err(error) => {
                     // Leak-detector blocked: record the boundary decision
@@ -586,7 +588,12 @@ impl CapabilityObligationHandler for BuiltinObligationHandler {
                     return Err(error);
                 }
             };
+            dispatch.output = redacted_output.0;
+            output_changed |= redacted_output.1;
             dispatch.display_preview = None;
+        }
+        if output_changed {
+            dispatch.model_preview = None;
         }
 
         let output_bytes = dispatch_output_bytes(&dispatch.output)?;
@@ -1128,34 +1135,43 @@ pub const LEAK_REDACT_FAILED_CODE: &str = "leak_redact_failed";
 
 fn redact_output(
     output: serde_json::Value,
-) -> Result<serde_json::Value, CapabilityObligationError> {
+) -> Result<(serde_json::Value, bool), CapabilityObligationError> {
     match output {
         serde_json::Value::String(value) => {
-            redact_output_string(value).map(serde_json::Value::String)
+            let redacted = redact_output_string(&value)?;
+            let changed = redacted != value;
+            Ok((serde_json::Value::String(redacted), changed))
         }
-        serde_json::Value::Array(values) => values
-            .into_iter()
-            .map(redact_output)
-            .collect::<Result<Vec<_>, _>>()
-            .map(serde_json::Value::Array),
+        serde_json::Value::Array(values) => {
+            let mut changed = false;
+            let mut redacted = Vec::with_capacity(values.len());
+            for value in values {
+                let result = redact_output(value)?;
+                changed |= result.1;
+                redacted.push(result.0);
+            }
+            Ok((serde_json::Value::Array(redacted), changed))
+        }
         serde_json::Value::Object(entries) => {
             let mut redacted = serde_json::Map::with_capacity(entries.len());
+            let mut changed = false;
             for (key, value) in entries {
-                let key = redact_output_string(key)?;
-                let value = redact_output(value)?;
-                if redacted.insert(key, value).is_some() {
+                let redacted_key = redact_output_string(&key)?;
+                let redacted_value = redact_output(value)?;
+                changed |= redacted_key != key || redacted_value.1;
+                if redacted.insert(redacted_key, redacted_value.0).is_some() {
                     return Err(output_obligation_failed());
                 }
             }
-            Ok(serde_json::Value::Object(redacted))
+            Ok((serde_json::Value::Object(redacted), changed))
         }
-        value => Ok(value),
+        value => Ok((value, false)),
     }
 }
 
-fn redact_output_string(value: String) -> Result<String, CapabilityObligationError> {
+fn redact_output_string(value: &str) -> Result<String, CapabilityObligationError> {
     LeakDetector::new()
-        .scan_and_clean(&value)
+        .scan_and_clean(value)
         .map_err(|_| output_obligation_failed())
 }
 

--- a/crates/kernel/ironclaw_host_runtime/src/obligations/tests.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/obligations/tests.rs
@@ -22,6 +22,7 @@ use ironclaw_host_api::{
         AgentId, CapabilityId, CorrelationId, ExtensionId, InvocationId, ProjectId,
         ResourceReservationId, SecretHandle, TenantId, UserId,
     },
+    model_result_preview::ModelResultPreview,
     mount::MountView,
     resource::{ResourceEstimate, ResourceScope},
     runtime::{RuntimeKind, TrustClass},
@@ -286,7 +287,7 @@ async fn inject_secret_once_falls_back_to_tenant_shared_admin_key() {
 }
 
 #[tokio::test]
-async fn redact_output_clears_display_preview_side_channel() {
+async fn redact_output_clears_previews_when_output_changes() {
     use ironclaw_host_api::{
         resource::{ReservationStatus, ResourceReceipt, ResourceUsage},
         runtime::RuntimeKind,
@@ -308,10 +309,14 @@ async fn redact_output_clears_display_preview_side_channel() {
         capability_id: capability_id.clone(),
         provider: context.extension_id.clone(),
         runtime: RuntimeKind::Wasm,
-        output: serde_json::json!({"secret": "sk-secret", "safe": "ok"}),
+        output: serde_json::json!({
+            "secret": "Bearer abcdef1234567890123456",
+            "safe": "ok"
+        }),
+        model_preview: Some(ModelResultPreview::new(r#"{"message":"preview"}"#).unwrap()),
         display_preview: Some(CapabilityDisplayOutputPreview {
             output_summary: Some("contains secret".to_string()),
-            output_preview: "sk-secret".to_string(),
+            output_preview: "Bearer abcdef1234567890123456".to_string(),
             output_kind: "text".to_string(),
             subtitle: None,
             truncated: false,
@@ -339,7 +344,58 @@ async fn redact_output_clears_display_preview_side_channel() {
         .expect("redacted dispatch completes");
 
     assert!(completed.display_preview.is_none());
+    assert!(completed.model_preview.is_none());
     assert_eq!(completed.output["safe"], serde_json::json!("ok"));
+    assert_ne!(completed.output, dispatch.output);
+}
+
+#[tokio::test]
+async fn redact_output_preserves_model_preview_when_output_is_unchanged() {
+    use ironclaw_host_api::resource::{ReservationStatus, ResourceReceipt, ResourceUsage};
+
+    let services = BuiltinObligationServices::with_handoff_stores(
+        Arc::new(InMemoryAuditSink::new()),
+        Arc::new(NetworkObligationPolicyStore::new()),
+        Arc::new(SecretStore::ephemeral()),
+        Arc::new(RuntimeSecretInjectionStore::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+    );
+    let handler = services.obligation_handler();
+    let context = execution_context();
+    let capability_id = capability_id();
+    let estimate = ResourceEstimate::default();
+    let obligations = vec![Obligation::RedactOutput];
+    let preview = ModelResultPreview::new(r#"{"message":"preview"}"#).unwrap();
+    let dispatch = CapabilityDispatchResult {
+        capability_id: capability_id.clone(),
+        provider: context.extension_id.clone(),
+        runtime: RuntimeKind::Wasm,
+        output: serde_json::json!({"safe": "ok"}),
+        model_preview: Some(preview.clone()),
+        display_preview: None,
+        usage: ResourceUsage::default(),
+        receipt: ResourceReceipt {
+            id: ResourceReservationId::new(),
+            scope: context.resource_scope.clone(),
+            status: ReservationStatus::Released,
+            estimate: ResourceEstimate::default(),
+            actual: None,
+        },
+    };
+
+    let completed = handler
+        .complete_dispatch(CapabilityObligationCompletionRequest {
+            phase: CapabilityObligationPhase::Invoke,
+            context: &context,
+            capability_id: &capability_id,
+            estimate: &estimate,
+            obligations: &obligations,
+            dispatch: &dispatch,
+        })
+        .await
+        .expect("unchanged dispatch completes");
+
+    assert_eq!(completed.model_preview, Some(preview));
 }
 
 #[tokio::test]
@@ -379,6 +435,7 @@ async fn complete_dispatch_extracts_base64_document_into_text() {
             "mime_type": "text/csv",
             "content_base64": encoded,
         }),
+        model_preview: Some(ModelResultPreview::new(r#"{"message":"encoded"}"#).unwrap()),
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {
@@ -410,6 +467,7 @@ async fn complete_dispatch_extracts_base64_document_into_text() {
         completed.output.get("content_base64").is_none(),
         "base64 must be stripped before the result reaches the model"
     );
+    assert!(completed.model_preview.is_none());
 }
 
 #[tokio::test]
@@ -461,6 +519,7 @@ async fn leak_detector_block_records_security_audit_event_through_complete_dispa
         provider: context.extension_id.clone(),
         runtime: RuntimeKind::Wasm,
         output: leaky_payload,
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {
@@ -550,6 +609,7 @@ async fn leak_detector_block_without_security_sink_does_not_panic() {
         provider: context.extension_id.clone(),
         runtime: RuntimeKind::Wasm,
         output: serde_json::Value::String("leak AKIAIOSFODNN7EXAMPLE".to_string()),
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {

--- a/crates/kernel/ironclaw_host_runtime/src/services/extension_tool_binder.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/extension_tool_binder.rs
@@ -185,6 +185,7 @@ where
             .map_err(tool_error_from_dispatch)?;
         Ok(ToolResult {
             output: execution.output,
+            model_preview: execution.model_preview,
             display_preview: execution.display_preview,
             output_bytes: execution.output_bytes,
         })

--- a/crates/kernel/ironclaw_host_runtime/src/services/process_executor.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/process_executor.rs
@@ -327,6 +327,7 @@ mod tests {
             provider: ExtensionId::new("demo").unwrap(),
             runtime: RuntimeKind::Script,
             output: json!({"ok": true}),
+            model_preview: None,
             display_preview: None,
             usage: ResourceUsage::default(),
             receipt: ResourceReceipt {

--- a/crates/kernel/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -456,6 +456,7 @@ where
 
         Ok(RuntimeAdapterResult {
             output: execution.result.output,
+            model_preview: None,
             display_preview: None,
             usage: execution.result.usage,
             receipt: execution.receipt,
@@ -535,6 +536,7 @@ where
 
         Ok(RuntimeAdapterResult {
             output: execution.result.output,
+            model_preview: None,
             display_preview: None,
             usage: execution.result.usage,
             receipt: execution.receipt,
@@ -1021,6 +1023,7 @@ where
 
         Ok(RuntimeAdapterResult {
             output: result.output,
+            model_preview: result.model_preview,
             display_preview: result.display_preview,
             usage,
             receipt,

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests.rs
@@ -896,6 +896,7 @@ async fn host_runtime_services_with_security_audit_sink_records_leak_block() {
         provider: context.extension_id.clone(),
         runtime: RuntimeKind::Wasm,
         output: Value::String("hello AKIAABCDEFGHIJKLMNOP goodbye".to_string()),
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {
@@ -1564,6 +1565,7 @@ impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for RecordingRunti
             })?;
         Ok(RuntimeAdapterResult {
             output: Value::Null,
+            model_preview: None,
             display_preview: None,
             usage,
             receipt,

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/extension_tool_binder.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/extension_tool_binder.rs
@@ -47,6 +47,7 @@ fn first_party_test_package(service: &str, capability_id: &str) -> ExtensionPack
                     )
                     .unwrap(),
                 output_schema_ref: None,
+                model_view: None,
                 prompt_doc_ref: None,
                 required_host_ports: Vec::new(),
                 runtime_credentials: Vec::new(),

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
@@ -1204,6 +1204,7 @@ impl crate::FirstPartyCapabilityHandler for SucceedingFirstPartyHandler {
     ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
         Ok(crate::FirstPartyCapabilityResult {
             output: serde_json::json!({"ok": true}),
+            model_preview: None,
             display_preview: None,
             usage: ironclaw_host_api::resource::ResourceUsage::default(),
         })

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/registry_lane_tool_resolver.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/registry_lane_tool_resolver.rs
@@ -96,6 +96,7 @@ impl RuntimeAdapter<DiskFilesystem, InMemoryResourceGovernor> for EchoLane {
             })?;
         Ok(RuntimeAdapterResult {
             output,
+            model_preview: None,
             display_preview: None,
             output_bytes: usage.output_bytes,
             usage,

--- a/crates/kernel/ironclaw_host_runtime/src/services/wasm_execution.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/wasm_execution.rs
@@ -277,6 +277,7 @@ where
     let receipt = guard.reconcile(execution.usage.clone(), wasm_resource_error)?;
     Ok(RuntimeAdapterResult {
         output,
+        model_preview: None,
         display_preview: None,
         output_bytes: execution.usage.output_bytes,
         usage: execution.usage,

--- a/crates/kernel/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
@@ -1143,6 +1143,7 @@ fn dispatch_result() -> CapabilityDispatchResult {
         provider: ExtensionId::new("echo").unwrap(),
         runtime: RuntimeKind::Wasm,
         output: json!({"ok": true}),
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {
@@ -1165,6 +1166,7 @@ fn sample_dispatch(
         provider: ExtensionId::new("echo").unwrap(),
         runtime: RuntimeKind::Wasm,
         output,
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {

--- a/crates/kernel/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -644,6 +644,7 @@ impl BoundCapabilityAdapter for RecordingAdapter {
 
         Ok(RuntimeAdapterResult {
             output: self.output.clone(),
+            model_preview: None,
             display_preview: None,
             usage,
             receipt,

--- a/crates/kernel/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -697,6 +697,7 @@ fn first_party_registry_with_effects(effects: Vec<EffectKind>) -> ExtensionRegis
                 output_schema_ref: Some(
                     CapabilityProfileSchemaRef::new("schemas/host/status.output.v1.json").unwrap(),
                 ),
+                model_view: None,
                 prompt_doc_ref: Some(
                     CapabilityProfileSchemaRef::new("prompts/host/status.md").unwrap(),
                 ),

--- a/crates/kernel/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -2652,6 +2652,7 @@ fn dispatch_result() -> CapabilityDispatchResult {
         provider: extension_id(),
         runtime: RuntimeKind::Wasm,
         output: json!({"ok": true}),
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {
@@ -2677,6 +2678,7 @@ fn dispatch_result_with_output(
         provider,
         runtime: RuntimeKind::Wasm,
         output,
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {

--- a/crates/kernel/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/host_runtime_persistent_approvals_contract.rs
@@ -815,6 +815,7 @@ fn dispatch_result() -> CapabilityDispatchResult {
         provider: extension_id(),
         runtime: RuntimeKind::Wasm,
         output: json!({"ok": true}),
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {

--- a/crates/kernel/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
@@ -315,6 +315,7 @@ impl CapabilityDispatcher for ObligationAwareDispatcher {
             provider: extension_id(),
             runtime: RuntimeKind::Wasm,
             output: json!({"ok": true}),
+            model_preview: None,
             display_preview: None,
             usage: ResourceUsage::default(),
             receipt,

--- a/crates/kernel/ironclaw_host_runtime/tests/production_trust_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/production_trust_contract.rs
@@ -165,6 +165,7 @@ fn dispatch_result() -> CapabilityDispatchResult {
         provider: extension_id(),
         runtime: RuntimeKind::Wasm,
         output: json!({"ok": true}),
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {

--- a/crates/kernel/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
@@ -255,6 +255,7 @@ impl BoundCapabilityAdapter for RecordingRuntimeAdapter {
             })?;
         Ok(RuntimeAdapterResult {
             output,
+            model_preview: None,
             display_preview: None,
             usage,
             receipt,

--- a/crates/kernel/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -2382,6 +2382,7 @@ fn dispatch_result() -> CapabilityDispatchResult {
         provider: ExtensionId::new("echo").unwrap(),
         runtime: RuntimeKind::Wasm,
         output: json!({"ok": true}),
+        model_preview: None,
         display_preview: None,
         usage: ResourceUsage::default(),
         receipt: ResourceReceipt {

--- a/crates/lanes/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/lanes/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -907,6 +907,7 @@ fn execute_prepared_wasm(
     };
     Ok(RuntimeAdapterResult {
         output,
+        model_preview: None,
         display_preview: None,
         output_bytes: execution.usage.output_bytes,
         usage: execution.usage,

--- a/crates/loop/ironclaw_loop_host/src/capability_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/capability_port.rs
@@ -20,6 +20,7 @@ use ironclaw_host_api::{
         ProviderToolName,
     },
     invocation::InvocationOrigin,
+    model_result_preview::ModelResultPreview,
     mount::MountView,
     resolution::{Resolution, ResolutionBatch},
     resource::{ResourceEstimate, ResourceScope},
@@ -501,6 +502,7 @@ pub struct CapabilityResultWrite<'a> {
     pub invocation_id: InvocationId,
     pub capability_id: &'a CapabilityId,
     pub output: serde_json::Value,
+    pub model_preview: Option<ModelResultPreview>,
     pub display_preview: Option<CapabilityDisplayOutputPreview>,
     pub durable_persistence: DurablePersistence,
 }
@@ -1692,6 +1694,7 @@ impl HostRuntimeLoopCapabilityPort {
                 invocation_id: InvocationId::from_uuid(request.activity_id.as_uuid()),
                 capability_id: &request.capability_id,
                 output,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })
@@ -3628,6 +3631,7 @@ async fn runtime_outcome_to_loop(
                     invocation_id: conversion.invocation_id,
                     capability_id: &completed.capability_id,
                     output: completed.output.clone(),
+                    model_preview: completed.model_preview.clone(),
                     display_preview: completed.display_preview.clone(),
                     durable_persistence: DurablePersistence::Persist,
                 })
@@ -5088,6 +5092,7 @@ mod tests {
                 RuntimeCapabilityCompleted {
                     capability_id: request.1,
                     output: serde_json::json!({"ok": true}),
+                    model_preview: None,
                     display_preview: None,
                     usage: ResourceUsage::default().set_output_bytes(RECORDING_OUTPUT_BYTES),
                 },
@@ -5240,6 +5245,7 @@ mod tests {
                 RuntimeCapabilityCompleted {
                     capability_id: request.2,
                     output: serde_json::json!({"resumed": true}),
+                    model_preview: None,
                     display_preview: None,
                     usage: ResourceUsage::default().set_output_bytes(RECORDING_OUTPUT_BYTES),
                 },
@@ -5508,6 +5514,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingResultWriter {
         records: Mutex<Vec<(CapabilityId, serde_json::Value)>>,
+        model_previews: Mutex<Vec<Option<ModelResultPreview>>>,
         display_previews: Mutex<Vec<Option<CapabilityDisplayOutputPreview>>>,
         failure_previews: Mutex<Vec<(InvocationId, CapabilityId, String)>>,
     }
@@ -5521,6 +5528,13 @@ mod tests {
             self.display_previews
                 .lock()
                 .expect("display previews lock")
+                .clone()
+        }
+
+        fn model_previews(&self) -> Vec<Option<ModelResultPreview>> {
+            self.model_previews
+                .lock()
+                .expect("model previews lock")
                 .clone()
         }
 
@@ -5548,6 +5562,10 @@ mod tests {
                 .lock()
                 .expect("records lock")
                 .push((write.capability_id.clone(), write.output));
+            self.model_previews
+                .lock()
+                .expect("model previews lock")
+                .push(write.model_preview);
             self.display_previews
                 .lock()
                 .expect("display previews lock")

--- a/crates/loop/ironclaw_loop_host/src/capability_port/tests/runtime_lifecycle_tests.rs
+++ b/crates/loop/ironclaw_loop_host/src/capability_port/tests/runtime_lifecycle_tests.rs
@@ -130,7 +130,7 @@ async fn runtime_capability_emits_completion_after_result_write_retry_succeeds()
 }
 
 #[tokio::test]
-async fn runtime_completed_display_preview_is_forwarded_to_result_writer() {
+async fn runtime_completed_previews_are_forwarded_to_result_writer() {
     let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
     let provider_id = ExtensionId::new("demo").expect("valid provider id");
     let result_writer = Arc::new(RecordingResultWriter::default());
@@ -148,6 +148,10 @@ async fn runtime_completed_display_preview_is_forwarded_to_result_writer() {
                 RuntimeCapabilityCompleted {
                     capability_id: capability_id.clone(),
                     output: serde_json::json!({"ok": true}),
+                    model_preview: Some(
+                        ModelResultPreview::new(r#"{"message":"semantic"}"#)
+                            .expect("model preview"),
+                    ),
                     display_preview: Some(CapabilityDisplayOutputPreview {
                         output_summary: Some("Edited 1 file: +1/-1".to_string()),
                         output_preview: "--- a/file\n+++ b/file\n-old\n+new\n".to_string(),
@@ -178,6 +182,16 @@ async fn runtime_completed_display_preview_is_forwarded_to_result_writer() {
         .expect("display preview forwarded");
     assert_eq!(preview.output_kind, "unified_diff");
     assert!(preview.output_preview.contains("+new"));
+    assert_eq!(
+        result_writer
+            .model_previews()
+            .into_iter()
+            .next()
+            .flatten()
+            .expect("model preview forwarded")
+            .as_str(),
+        r#"{"message":"semantic"}"#
+    );
 }
 
 #[tokio::test]
@@ -313,6 +327,7 @@ async fn runtime_capability_batch_continues_after_runtime_failure_outcome() {
                     RuntimeCapabilityCompleted {
                         capability_id: capability_id.clone(),
                         output: serde_json::json!({"ok": true}),
+                        model_preview: None,
                         display_preview: None,
                         usage: ResourceUsage::default(),
                     },
@@ -470,6 +485,7 @@ async fn runtime_capability_mismatched_outcome_does_not_emit_terminal_milestone(
                 RuntimeCapabilityCompleted {
                     capability_id: other_capability_id,
                     output: serde_json::json!({"ok": true}),
+                    model_preview: None,
                     display_preview: None,
                     usage: ResourceUsage::default(),
                 },
@@ -640,6 +656,7 @@ async fn auth_resume_uses_replay_input_without_resolving_stale_input_ref() {
             Box::new(RuntimeCapabilityCompleted {
                 capability_id: capability_id.clone(),
                 output: serde_json::json!({"auth_resumed": true}),
+                model_preview: None,
                 display_preview: None,
                 usage: ResourceUsage::default(),
             }),
@@ -1596,6 +1613,7 @@ impl HostRuntime for ApprovalResumeRecordingRuntime {
             RuntimeCapabilityCompleted {
                 capability_id: request.2,
                 output: serde_json::json!({"resumed": true}),
+                model_preview: None,
                 display_preview: None,
                 usage: ResourceUsage::default(),
             },
@@ -1614,6 +1632,7 @@ impl HostRuntime for ApprovalResumeRecordingRuntime {
             RuntimeCapabilityCompleted {
                 capability_id: request.1,
                 output: serde_json::json!({"auth_resumed": true}),
+                model_preview: None,
                 display_preview: None,
                 usage: ResourceUsage::default(),
             },

--- a/crates/loop/ironclaw_loop_host/src/external_tool_capability.rs
+++ b/crates/loop/ironclaw_loop_host/src/external_tool_capability.rs
@@ -224,6 +224,7 @@ impl ExternalToolCapabilityPort {
                     invocation_id: InvocationId::new(),
                     capability_id: &request.capability_id,
                     output,
+                    model_preview: None,
                     display_preview: None,
                     durable_persistence: DurablePersistence::Persist,
                 })

--- a/crates/loop/ironclaw_loop_host/src/lib.rs
+++ b/crates/loop/ironclaw_loop_host/src/lib.rs
@@ -43,6 +43,7 @@ mod model_gateway_error_mapping;
 mod model_routes;
 mod model_visible_scrub;
 mod prompt_context_budget;
+mod result_preview;
 mod result_read;
 mod skill_activation;
 mod skill_bundle_context_source;
@@ -127,6 +128,7 @@ pub use model_routes::{
     ResolvedModelRouteSnapshot, StaticModelRouteResolver,
 };
 pub use model_visible_scrub::scrub_model_visible_detail;
+pub use result_preview::result_reference_observation;
 pub use result_read::{RESULT_READ_CAPABILITY_ID, result_read_capability};
 #[cfg(feature = "test-support")]
 pub use result_read::{RESULT_READ_CAPABILITY_ID_FOR_TEST, wrap_result_read_capability_for_test};

--- a/crates/loop/ironclaw_loop_host/src/model_gateway.rs
+++ b/crates/loop/ironclaw_loop_host/src/model_gateway.rs
@@ -2555,6 +2555,11 @@ fn tool_result_replay_message(
             Some(HostManagedToolResultContent::Reference { envelope }) => {
                 let safe_summary = envelope.safe_summary.as_str().to_string();
                 let model_content = envelope.model_visible_content_or_safe_summary();
+                let model_content = if model_content != safe_summary {
+                    ironclaw_safety::wrap_external_content("tool output", &model_content)
+                } else {
+                    model_content
+                };
                 (safe_summary, model_content, true)
             }
             Some(HostManagedToolResultContent::Resolved { safe_summary }) => (
@@ -3288,9 +3293,10 @@ mod tests {
         let replay = tool_result_replay_message(&message).expect("replay message");
 
         assert_eq!(replay.safe_summary, "tool failed");
+        let serialized = serde_json::to_string(&observation).expect("observation serializes");
         assert_eq!(
-            serde_json::from_str::<serde_json::Value>(&replay.model_content).unwrap(),
-            observation
+            replay.model_content,
+            ironclaw_safety::wrap_external_content("tool output", &serialized)
         );
     }
 

--- a/crates/loop/ironclaw_loop_host/src/result_preview.rs
+++ b/crates/loop/ironclaw_loop_host/src/result_preview.rs
@@ -1,0 +1,292 @@
+use ironclaw_host_api::{
+    model_result_preview::{AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES, ModelResultPreview},
+    turn::LoopResultRef,
+};
+use ironclaw_loop_contracts::{
+    MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION, ModelVisibleArtifact,
+    ModelVisibleToolObservation, ObservationTrust, ToolObservationDetail, ToolObservationStatus,
+};
+
+/// Build the model-visible observation for a completed capability result.
+///
+/// `serialized` is the exact durable representation, while `output` is used
+/// only to derive a bounded structural preview and array cardinality. The
+/// complete result remains behind `result_ref`; this function only constructs
+/// the small model-facing first look.
+pub fn result_reference_observation(
+    result_ref: &LoopResultRef,
+    byte_len: u64,
+    output: &serde_json::Value,
+    serialized: &[u8],
+    producer_preview: Option<ModelResultPreview>,
+) -> ModelVisibleToolObservation {
+    let item_count = output.as_array().map(|items| items.len() as u64);
+    let preview = first_look_result_preview(output, serialized, producer_preview);
+    result_reference_observation_from_preview(result_ref, byte_len, preview, item_count)
+}
+
+struct FirstLookResultPreview {
+    text: String,
+    /// `None` when `text` already covers the entire payload.
+    next_offset: Option<u64>,
+}
+
+fn first_look_result_preview(
+    output: &serde_json::Value,
+    serialized: &[u8],
+    producer_preview: Option<ModelResultPreview>,
+) -> Option<FirstLookResultPreview> {
+    let full_text = std::str::from_utf8(serialized).ok()?;
+    if let Some(preview) = producer_preview
+        && let Some(text) = bounded_redacted_preview(preview.into_inner())
+    {
+        let next_offset = (text.as_bytes() != serialized).then_some(0);
+        return Some(FirstLookResultPreview { text, next_offset });
+    }
+    if serialized.len() <= AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES
+        && let Some(text) = bounded_redacted_preview(full_text.to_string())
+    {
+        let next_offset = (text.as_bytes() != serialized).then_some(0);
+        return Some(FirstLookResultPreview { text, next_offset });
+    }
+
+    let summary = oversized_json_summary(output, serialized.len());
+    let text = bounded_redacted_preview(summary)
+        .unwrap_or_else(|| r#"{"kind":"oversized_json","values_elided":true}"#.to_string());
+    Some(FirstLookResultPreview {
+        text,
+        next_offset: Some(0),
+    })
+}
+
+fn bounded_redacted_preview(value: String) -> Option<String> {
+    let preview = ModelResultPreview::redacted(value).ok()?;
+    (preview.as_str().len() <= AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES)
+        .then(|| preview.into_inner())
+}
+
+fn oversized_json_summary(output: &serde_json::Value, total_bytes: usize) -> String {
+    let summary = match output {
+        serde_json::Value::Object(fields) => {
+            let omitted_key_count = fields.len().saturating_sub(16);
+            let keys = fields
+                .keys()
+                .take(16)
+                .map(|key| truncate_utf8(key, 128))
+                .collect::<Vec<_>>();
+            serde_json::json!({
+                "kind": "object",
+                "total_bytes": total_bytes,
+                "keys": keys,
+                "omitted_key_count": omitted_key_count,
+                "values_elided": true,
+            })
+        }
+        serde_json::Value::Array(items) => serde_json::json!({
+            "kind": "array",
+            "total_bytes": total_bytes,
+            "item_count": items.len(),
+            "values_elided": true,
+        }),
+        serde_json::Value::Null => scalar_summary("null", total_bytes),
+        serde_json::Value::Bool(_) => scalar_summary("boolean", total_bytes),
+        serde_json::Value::Number(_) => scalar_summary("number", total_bytes),
+        serde_json::Value::String(_) => scalar_summary("string", total_bytes),
+    };
+    serde_json::to_string(&summary)
+        .unwrap_or_else(|_| r#"{"kind":"oversized_json","values_elided":true}"#.to_string())
+}
+
+fn scalar_summary(kind: &str, total_bytes: usize) -> serde_json::Value {
+    serde_json::json!({
+        "kind": kind,
+        "total_bytes": total_bytes,
+        "values_elided": true,
+    })
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> &str {
+    &value[..floor_char_boundary(value, max_bytes)]
+}
+
+fn floor_char_boundary(value: &str, index: usize) -> usize {
+    if index >= value.len() {
+        return value.len();
+    }
+    let mut index = index;
+    while index > 0 && !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn result_reference_observation_from_preview(
+    result_ref: &LoopResultRef,
+    byte_len: u64,
+    preview: Option<FirstLookResultPreview>,
+    item_count: Option<u64>,
+) -> ModelVisibleToolObservation {
+    let (summary, preview_text, total_bytes, next_offset, item_count) = match preview {
+        Some(FirstLookResultPreview {
+            text,
+            next_offset: Some(next_offset),
+        }) => (
+            preview_continuation_summary(next_offset, item_count),
+            Some(text),
+            Some(byte_len),
+            Some(next_offset),
+            item_count,
+        ),
+        Some(FirstLookResultPreview {
+            text,
+            next_offset: None,
+        }) => (
+            "Tool completed; preview contains the full result.".to_string(),
+            Some(text),
+            Some(byte_len),
+            None,
+            None,
+        ),
+        None => (
+            "Tool completed; use result_read with the result reference for more output."
+                .to_string(),
+            None,
+            None,
+            None,
+            None,
+        ),
+    };
+    ModelVisibleToolObservation {
+        schema_version: MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION,
+        status: ToolObservationStatus::Success,
+        summary,
+        detail: ToolObservationDetail::ResultReference {
+            result_ref: result_ref.as_str().to_string(),
+            byte_len,
+            preview: preview_text,
+            total_bytes,
+            next_offset,
+            item_count,
+        },
+        artifacts: vec![ModelVisibleArtifact {
+            artifact_ref: result_ref.as_str().to_string(),
+            summary: "Stored tool result".to_string(),
+        }],
+        recovery: None,
+        trust: ObservationTrust::UntrustedToolOutput,
+    }
+}
+
+fn preview_continuation_summary(next_offset: u64, item_count: Option<u64>) -> String {
+    let base = if next_offset == 0 {
+        "Tool completed; preview is a projection of the full result. Use result_read with the result reference and offset 0 for more output."
+            .to_string()
+    } else {
+        format!(
+            "Tool completed; preview truncated, use result_read with the result reference and offset {next_offset} for more output."
+        )
+    };
+    match item_count {
+        Some(count) => format!("{base} Full result is a JSON array of {count} items."),
+        None => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oversized_outputs_use_bounded_structural_projections_for_every_json_shape() {
+        let cases = [
+            (
+                serde_json::json!({"records": "x".repeat(8 * 1024), "status": "ok"}),
+                "object",
+            ),
+            (serde_json::json!(["x".repeat(8 * 1024)]), "array"),
+            (serde_json::json!("x".repeat(8 * 1024)), "string"),
+        ];
+
+        for (output, expected_kind) in cases {
+            let serialized = serde_json::to_vec(&output).expect("fixture serializes");
+            let preview = first_look_result_preview(&output, &serialized, None)
+                .expect("JSON output always has a preview");
+            let projected: serde_json::Value =
+                serde_json::from_str(&preview.text).expect("projection is valid JSON");
+
+            assert_eq!(projected["kind"], expected_kind);
+            assert!(preview.text.len() <= AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES);
+            assert_eq!(preview.next_offset, Some(0));
+            assert!(!preview.text.contains(&"x".repeat(1_024)));
+        }
+    }
+
+    #[test]
+    fn producer_preview_uses_the_same_budget_and_offset_contract() {
+        let output = serde_json::json!({"transport": "x".repeat(8 * 1024)});
+        let serialized = serde_json::to_vec(&output).expect("fixture serializes");
+        let semantic = ModelResultPreview::new(r#"{"message":"readable"}"#)
+            .expect("semantic preview is valid");
+
+        let preview = first_look_result_preview(&output, &serialized, Some(semantic))
+            .expect("producer preview is retained");
+
+        assert_eq!(preview.text, r#"{"message":"readable"}"#);
+        assert_eq!(preview.next_offset, Some(0));
+    }
+
+    #[test]
+    fn oversized_producer_preview_falls_back_to_generic_projection() {
+        let output = serde_json::json!({"records": "x".repeat(8 * 1024)});
+        let serialized = serde_json::to_vec(&output).expect("fixture serializes");
+        let oversized =
+            ModelResultPreview::new("p".repeat(AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES + 1))
+                .expect("producer preview remains below the explicit page cap");
+
+        let preview = first_look_result_preview(&output, &serialized, Some(oversized))
+            .expect("generic projection is available");
+        let projected: serde_json::Value =
+            serde_json::from_str(&preview.text).expect("projection is valid JSON");
+
+        assert_eq!(projected["kind"], "object");
+        assert!(preview.text.len() <= AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES);
+        assert_eq!(preview.next_offset, Some(0));
+    }
+
+    #[test]
+    fn offset_zero_summary_names_the_projection_and_read_origin() {
+        let result_ref = LoopResultRef::new("result:test-run.id").expect("result ref");
+        let output = serde_json::json!(["one", "two"]);
+        let serialized = serde_json::to_vec(&output).expect("fixture serializes");
+        let observation = result_reference_observation(
+            &result_ref,
+            serialized.len() as u64,
+            &output,
+            &serialized,
+            Some(ModelResultPreview::new(r#"{"items":["one"]}"#).expect("preview")),
+        );
+
+        assert!(observation.summary.contains("preview is a projection"));
+        assert!(observation.summary.contains("result_read"));
+        assert!(observation.summary.contains("offset 0"));
+        assert!(observation.summary.contains("2 items"));
+    }
+
+    #[test]
+    fn positive_offset_summary_keeps_truncated_wording() {
+        let result_ref = LoopResultRef::new("result:test-run.id").expect("result ref");
+        let observation = result_reference_observation_from_preview(
+            &result_ref,
+            128,
+            Some(FirstLookResultPreview {
+                text: "prefix".to_string(),
+                next_offset: Some(64),
+            }),
+            None,
+        );
+
+        assert!(observation.summary.contains("preview truncated"));
+        assert!(observation.summary.contains("offset 64"));
+        assert!(!observation.summary.contains("preview is a projection"));
+    }
+}

--- a/crates/loop/ironclaw_loop_host/src/result_read.rs
+++ b/crates/loop/ironclaw_loop_host/src/result_read.rs
@@ -269,6 +269,7 @@ impl SyntheticCapabilityHandler for ResultReadHandler {
                 invocation_id: InvocationId::new(),
                 capability_id: &invocation.request.capability_id,
                 output,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::InlineOnly,
             })

--- a/crates/loop/ironclaw_loop_host/src/skill_activation/skill_activation_capability.rs
+++ b/crates/loop/ironclaw_loop_host/src/skill_activation/skill_activation_capability.rs
@@ -106,6 +106,7 @@ where
                 invocation_id: InvocationId::new(),
                 capability_id: &invocation.request.capability_id,
                 output,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })

--- a/crates/loop/ironclaw_loop_host/src/structured_result.rs
+++ b/crates/loop/ironclaw_loop_host/src/structured_result.rs
@@ -128,6 +128,7 @@ impl SyntheticCapabilityHandler for StructuredResultHandler {
                 invocation_id: InvocationId::new(),
                 capability_id: &invocation.request.capability_id,
                 output: invocation.input.clone(),
+                model_preview: None,
                 display_preview: None,
                 // The validated value IS the run's terminal output: durable,
                 // read back by the product tier after the run completes.

--- a/crates/loop/ironclaw_loop_host/src/subagent_spawn_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/subagent_spawn_port.rs
@@ -949,6 +949,7 @@ impl SubagentSpawnCapabilityPort {
                 invocation_id: InvocationId::new(),
                 capability_id: &self.spawn_id,
                 output: payload,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -1381,6 +1381,7 @@ impl ToolDisclosureCapabilityPort {
                 invocation_id: InvocationId::new(),
                 capability_id: &request.capability_id,
                 output,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })

--- a/crates/loop/ironclaw_loop_host/tests/host_capability_port_composition.rs
+++ b/crates/loop/ironclaw_loop_host/tests/host_capability_port_composition.rs
@@ -350,6 +350,7 @@ impl HostRuntime for SingleToolHostRuntime {
             RuntimeCapabilityCompleted {
                 capability_id: request.1,
                 output: serde_json::json!({"ok": true}),
+                model_preview: None,
                 display_preview: None,
                 usage: ResourceUsage::default(),
             },

--- a/crates/loop/ironclaw_loop_host/tests/llm_gateway.rs
+++ b/crates/loop/ironclaw_loop_host/tests/llm_gateway.rs
@@ -2219,9 +2219,10 @@ async fn gateway_replays_model_observation_from_tool_result_reference_before_saf
     let tool_result = &requests[0].messages[1];
     assert_eq!(tool_result.role, Role::Tool);
     assert_eq!(tool_result.tool_call_id.as_deref(), Some("call_1"));
+    let serialized = serde_json::to_string(&observation).expect("observation serializes");
     assert_eq!(
-        serde_json::from_str::<serde_json::Value>(&tool_result.content).unwrap(),
-        observation
+        tool_result.content,
+        ironclaw_safety::wrap_external_content("tool output", &serialized)
     );
     assert!(!tool_result.content.contains("tool failed"));
 }
@@ -2394,13 +2395,16 @@ async fn gateway_replays_model_observation_for_orphan_tool_reference() {
     assert_eq!(requests[0].messages.len(), 1);
     let message = &requests[0].messages[0];
     assert_eq!(message.role, Role::User);
-    let json = message
+    let wrapped = message
         .content
         .strip_prefix("[Tool result summary]: ")
         .expect("tool summary prefix");
     assert_eq!(
-        serde_json::from_str::<serde_json::Value>(json).unwrap(),
-        observation
+        wrapped,
+        ironclaw_safety::wrap_external_content(
+            "tool output",
+            &serde_json::to_string(&observation).expect("observation serializes")
+        )
     );
     assert!(!message.content.contains("tool failed"));
 }

--- a/crates/product/ironclaw_assistant/src/project_create_capability.rs
+++ b/crates/product/ironclaw_assistant/src/project_create_capability.rs
@@ -110,6 +110,7 @@ impl SyntheticCapabilityHandler for ProjectCreateHandler {
                 invocation_id: InvocationId::new(),
                 capability_id: &invocation.request.capability_id,
                 output,
+                model_preview: None,
                 display_preview: None,
                 durable_persistence: DurablePersistence::Persist,
             })

--- a/docs/internal/reborn/contracts/dispatcher.md
+++ b/docs/internal/reborn/contracts/dispatcher.md
@@ -108,8 +108,8 @@ Implementation evidence:
   `CapabilityDispatcher::dispatch_json(Authorized)` port and internal
   `CapabilityDispatchRequest`.
 - `crates/kernel/ironclaw_capabilities/tests/runtime_dispatch_contract.rs` covers sealed-lane
-  mismatch rejection, `None` mount preservation, resolver misses, and prepared
-  reservation validation.
+  mismatch rejection, `None` mount preservation, resolver misses, prepared
+  reservation validation, and preservation of a non-`None` model preview.
 
 ---
 
@@ -194,6 +194,7 @@ pub struct CapabilityDispatchResult {
     pub provider: ExtensionId,
     pub runtime: RuntimeKind,
     pub output: serde_json::Value,
+    pub model_preview: Option<ModelResultPreview>,
     pub display_preview: Option<CapabilityDisplayOutputPreview>,
     pub usage: ResourceUsage,
     pub receipt: ResourceReceipt,
@@ -201,7 +202,8 @@ pub struct CapabilityDispatchResult {
 ```
 
 The shape intentionally exposes common host-level facts and avoids leaking WASM-specific internals as the generic contract.
-`display_preview` is an optional, model-hidden presentation side channel for already-sanitizable UI material such as unified diffs; callers must keep the canonical capability output in `output`.
+`model_preview` is an optional bounded, credential-redacted model-facing content projection. A producer may use a semantic projection (for example, parsed readable Gmail headers and decoded plain-text content), so it need not be a prefix of `output`. The dispatcher copies it unchanged from the resolved binding; the canonical capability output remains in `output` and is persisted behind the result reference for `result_read` paging.
+`display_preview` is an optional, model-hidden presentation side channel for already-sanitizable UI material such as unified diffs; callers must keep both preview channels separate from the canonical capability output and from authorization decisions.
 
 ---
 

--- a/docs/internal/reborn/contracts/extensions.md
+++ b/docs/internal/reborn/contracts/extensions.md
@@ -554,8 +554,23 @@ Rules:
   and optional `required` flag. The field is only
   valid when the capability declares `use_secret`; duplicate handles within one
   capability are invalid. The manifest never contains raw secret material.
-- every capability must provide `input_schema_ref` and `output_schema_ref`;
-  `prompt_doc_ref` is optional lazy help metadata.
+- every capability must provide `input_schema_ref`; v2 capabilities provide
+  `output_schema_ref`, while v3 tools may omit it for runtime-owned or
+  dynamically discovered output shapes. `prompt_doc_ref` is optional lazy help
+  metadata.
+- `model_view` is optional registry adoption metadata for the model-facing
+  result view. Its only values are `structural` (the producer relies on the
+  universal host fallback) and `producer` (the producer supplies an optional
+  typed semantic preview, with the same structural fallback). This declaration
+  is checked against package schemas at registration/architecture-test time; it
+  is not runtime authorization and is not threaded into execution. Runtime
+  safety comes from the typed, bounded preview contract and the canonical
+  writer. `model_view` does not name a runtime or alter execution taxonomy.
+  When a network tool explicitly declares `output_schema_ref`, registry-owned
+  architecture checks load that package-local JSON Schema fail-closed; an
+  open-object schema (boolean `true` or nested `additionalProperties = true`)
+  must declare one of these policies. Dynamic MCP tools and tools without an
+  explicit output schema are outside this gate.
 - during this cutover, `CapabilityDescriptor.parameters_schema` is a projection
   placeholder of the form `{ "$ref": input_schema_ref }`. Catalog publication is
   responsible for resolving schema/doc refs into hot per-turn tool descriptors.

--- a/docs/internal/reborn/contracts/host-api.md
+++ b/docs/internal/reborn/contracts/host-api.md
@@ -751,7 +751,12 @@ pub struct SandboxQuota {
 pub struct Authorized {
     /* private: sealed invocation + RuntimeLane + mounts + reservation + deadline */
 }
-pub struct CapabilityDispatchResult;
+pub struct ModelResultPreview;
+pub struct CapabilityDispatchResult {
+    pub output: serde_json::Value,
+    pub model_preview: Option<ModelResultPreview>,
+    /* capability identity, runtime, usage, and receipt */
+}
 pub struct CapabilityDisplayOutputPreview;
 pub trait CapabilityDispatcher {
     async fn dispatch_json(
@@ -777,7 +782,8 @@ Rules:
 - `Actor::Sealed(user_id)` on the authorized invocation is forwarded unchanged as the authenticated actor. The dispatcher and runtime adapters must not replace it with `scope.user_id` because the actor and subject may intentionally differ.
 - Process re-dispatch uses a durable `ProcessAuthorizedContinuation` and a kernel-only, process-record-backed remint port to re-mint an `Authorized` witness at execution; missing continuations fail closed as `MissingProcessAuthorization`. The continuation is process-lifetime authority, not a second policy check, and reminting must validate the persisted process record before sealing.
 - A re-minted witness carries the original process reservation when one exists. If that reservation has been released/revoked before or during execution, runtime settlement fails closed with a resource dispatch error; adapters must not silently reserve replacement capacity.
-- `CapabilityDispatchResult` exposes normalized host facts: capability ID, provider, runtime, output, optional display-preview metadata, usage, and resource receipt.
+- `CapabilityDispatchResult` exposes normalized host facts: capability ID, provider, runtime, canonical output, optional bounded `model_preview`, optional display-preview metadata, usage, and resource receipt.
+- `model_preview` is a bounded, credential-redacted model-facing content projection. It may be semantic (for example, parsed readable Gmail headers and plain-text body) rather than a prefix of `output`; the canonical output remains durable behind the result reference and is the authority for `result_read` paging.
 - `CapabilityDisplayOutputPreview` is a display-only side channel for renderer-ready output such as unified diffs. It must not change model-visible capability output, grant authority, or carry backend-private paths/secrets.
 - `DispatchError` uses stable control-plane variants for registry/routing failures and `RuntimeDispatchErrorKind` for WASM/Script/MCP failures.
 - `RuntimeDispatchErrorKind::OperationFailed` is for model-visible capability-domain failures after a valid invocation reaches the capability implementation; runtime-lane execution failures such as guest traps remain runtime failures, not operation failures.

--- a/docs/internal/reborn/contracts/lightweight-agent-loop.md
+++ b/docs/internal/reborn/contracts/lightweight-agent-loop.md
@@ -124,7 +124,13 @@ model-facing recovery information, it may attach a bounded
 `ModelVisibleToolObservation` side channel to the tool-result reference. That
 observation is model-visible untrusted tool output, not a replacement for
 `LoopSafeSummary`, and must be validated/redacted before it can be replayed to
-the model.
+the model. A completed runtime result may carry a bounded `model_preview` in
+that observation: it can be a semantic projection (such as parsed headers and
+decoded plain-text content) rather than the serialized output prefix. The
+complete canonical output remains durable behind the result reference, and
+`result_read` pages that durable byte stream; the loop must preserve the
+reference and continuation metadata even when the inline preview is truncated
+or transformed.
 
 Equivalent pseudocode:
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -133,7 +133,7 @@ the canonical "a user does X in one conversation and sees the effect in another"
 |---|---|
 | Install an integration in one chat and see it active in another | `scenario_install_then_visible_cross_thread.rs`, `scenario_install_then_active_cross_thread.rs` |
 | Remove an integration and have it gone everywhere | `scenario_remove_then_absent_cross_thread.rs` |
-| Not call an integration's tools until it is actually installed | `scenario_uninstalled_tool_call_denied_until_active.rs` |
+| Not call an integration's tools until it is actually installed; after activation, exercise Gmail's production multipart/base64url semantic preview (bounded parsed headers/body) while proving the complete result survives durable record-store paging byte-for-byte | `scenario_uninstalled_tool_call_denied_until_active.rs` |
 | Ask for an integration that doesn't exist and get a clear error rather than a crash | `scenario_install_unknown_extension_id_fails_safely.rs` |
 | Get field-level repair guidance when the agent sends malformed install arguments | `scenario_malformed_lifecycle_arguments_are_structured.rs` |
 | Be sent to a normal per-account sign-in when installing GitHub (no false "operator must configure this" wall) | `scenario_extension_install_github_normal_gate.rs` |

--- a/tests/integration/group_extensions/main.rs
+++ b/tests/integration/group_extensions/main.rs
@@ -54,6 +54,20 @@ async fn malformed_lifecycle_arguments_are_structured_inner() {
 }
 
 #[test]
+fn gmail_semantic_preview_production_chain() {
+    run_async_test_with_stack(
+        "gmail_semantic_preview_production_chain",
+        gmail_semantic_preview_production_chain_inner,
+    );
+}
+
+async fn gmail_semantic_preview_production_chain_inner() {
+    scenario_uninstalled_tool_call_denied_until_active::run()
+        .await
+        .expect("installed Gmail preserves its semantic preview through the production chain");
+}
+
+#[test]
 fn extensions_group_e2e() {
     run_async_test_with_stack("extensions_group_e2e", extensions_group_e2e_inner);
 }
@@ -130,11 +144,6 @@ async fn extensions_group_e2e_inner() {
     // publishes it. Uses "gmail" on its own isolated, Google-OAuth-configured
     // group (see that scenario's module doc) — `g` itself is passed but
     // unused, kept for call-site symmetry with every other scenario.
-    report.record(
-        "uninstalled_tool_call_denied_until_active",
-        scenario_uninstalled_tool_call_denied_until_active::run(&g).await,
-    );
-
     // Scenario 6 (issue #6105): the Slack channel lifecycle state machine —
     // install → connect → use → remove (real personal-connection
     // cleanup) → reconnect → reinstall → use again, asserting connection

--- a/tests/integration/group_extensions/scenario_uninstalled_tool_call_denied_until_active.rs
+++ b/tests/integration/group_extensions/scenario_uninstalled_tool_call_denied_until_active.rs
@@ -39,12 +39,13 @@
 
 use super::reborn_support::group::{HarnessResult, RebornIntegrationGroup};
 use super::reborn_support::reply::RebornScriptedReply;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use ironclaw_auth::{
     GOOGLE_GMAIL_MODIFY_SCOPE, GOOGLE_GMAIL_READONLY_SCOPE, GOOGLE_GMAIL_SEND_SCOPE,
 };
 use serde_json::json;
 
-pub async fn run(_g: &RebornIntegrationGroup) -> HarnessResult<()> {
+pub async fn run() -> HarnessResult<()> {
     let g = RebornIntegrationGroup::extension_lifecycle_google_oauth_configured().await?;
     let g = &g;
     // One conversation, two turns. Turn 1's rejected tool call consumes script
@@ -57,6 +58,11 @@ pub async fn run(_g: &RebornIntegrationGroup) -> HarnessResult<()> {
             RebornScriptedReply::text("gmail unavailable"),
             RebornScriptedReply::tool_call("gmail.list_messages", json!({})),
             RebornScriptedReply::text("gmail dispatched"),
+            RebornScriptedReply::tool_call(
+                "gmail.get_message",
+                json!({"message_id": "msg-semantic-preview"}),
+            ),
+            RebornScriptedReply::text("gmail message read"),
         ])
         .build()
         .await?;
@@ -136,5 +142,161 @@ pub async fn run(_g: &RebornIntegrationGroup) -> HarnessResult<()> {
             "Bearer itest-google-token",
         )
         .await?;
+
+    // Drive the semantic producer through the same installed extension,
+    // first-party runtime adapter, obligations, loop capability port, and
+    // durable staged-I/O writer used in production. The model sees selected
+    // readable content while the canonical stored result retains the complete
+    // provider response.
+    let readable_body = format!(
+        "Production chain semantic preview. 😀\n{}",
+        "plain-body-line ".repeat(900)
+    );
+    let encoded_plain_body = URL_SAFE_NO_PAD.encode(readable_body.as_bytes());
+    let html_marker = "HTML-ONLY-CONTENT";
+    let encoded_html_body =
+        URL_SAFE_NO_PAD.encode(format!("<html><body>{html_marker}</body></html>").as_bytes());
+    let encoded_attachment = URL_SAFE_NO_PAD.encode(b"attachment-transport-bytes");
+    let provider_message = json!({
+        "id": "msg-semantic-preview",
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "headers": [
+                {"name": "From", "value": "Ada <ada@example.com>"},
+                {"name": "To", "value": "Grace <grace@example.com>"},
+                {"name": "Subject", "value": "Production preview"},
+                {"name": "Date", "value": "Tue, 25 Aug 2026 12:34:56 +0000"},
+                {"name": "X-Transport-Debug", "value": "transport-only-metadata"}
+            ],
+            "parts": [
+                {
+                    "mimeType": "text/html",
+                    "body": {"data": encoded_html_body}
+                },
+                {
+                    "mimeType": "multipart/alternative",
+                    "parts": [
+                        {
+                            "mimeType": "text/plain",
+                            "body": {"data": encoded_plain_body}
+                        },
+                        {
+                            "mimeType": "text/calendar",
+                            "body": {"data": URL_SAFE_NO_PAD.encode(b"calendar-transport-part")}
+                        }
+                    ]
+                },
+                {
+                    "mimeType": "application/octet-stream",
+                    "filename": "transport.bin",
+                    "body": {"data": encoded_attachment}
+                }
+            ]
+        }
+    });
+    g.install_network_response_script(200, serde_json::to_vec(&provider_message)?)?;
+
+    caller.submit_turn("read the message").await?;
+    caller.assert_tool_invoked("gmail.get_message").await?;
+    let envelopes = caller.persisted_tool_result_envelopes().await?;
+    let observation = envelopes
+        .last()
+        .and_then(|envelope| envelope.model_observation.as_ref())
+        .ok_or("Gmail result did not persist a model observation")?;
+    let preview = observation["detail"]["preview"]
+        .as_str()
+        .ok_or_else(|| format!("Gmail result persisted no preview: {observation}"))?;
+    if preview.len() > 4 * 1024 {
+        return Err(format!(
+            "Gmail semantic preview exceeded the automatic 4KiB budget: {} bytes",
+            preview.len()
+        )
+        .into());
+    }
+    let preview: serde_json::Value = serde_json::from_str(preview)?;
+    let preview_headers = preview
+        .get("headers")
+        .and_then(serde_json::Value::as_object)
+        .ok_or("Gmail semantic preview omitted parsed headers")?;
+    for (name, expected) in [
+        ("from", "Ada <ada@example.com>"),
+        ("to", "Grace <grace@example.com>"),
+        ("subject", "Production preview"),
+        ("date", "Tue, 25 Aug 2026 12:34:56 +0000"),
+    ] {
+        if preview_headers
+            .get(name)
+            .and_then(serde_json::Value::as_str)
+            != Some(expected)
+        {
+            return Err(format!(
+                "Gmail semantic preview header {name:?} was not preserved: {preview}"
+            )
+            .into());
+        }
+    }
+    let preview_body = preview
+        .get("body")
+        .and_then(serde_json::Value::as_str)
+        .ok_or("Gmail semantic preview omitted the decoded plain-text body")?;
+    if !preview_body.starts_with("Production chain semantic preview. 😀\nplain-body-line ")
+        || preview_body.len() >= readable_body.len()
+        || preview["body_truncated"] != json!(true)
+    {
+        return Err(format!(
+            "Gmail semantic preview did not carry a decoded, truncated body: {preview}"
+        )
+        .into());
+    }
+    let preview_text = preview.to_string();
+    for forbidden in [
+        html_marker,
+        "transport-only-metadata",
+        "calendar-transport-part",
+        "attachment-transport-bytes",
+        encoded_plain_body.as_str(),
+        encoded_html_body.as_str(),
+        encoded_attachment.as_str(),
+    ] {
+        if preview_text.contains(forbidden) {
+            return Err(format!(
+                "Gmail semantic preview leaked forbidden transport content {forbidden:?}"
+            )
+            .into());
+        }
+    }
+    caller
+        .assert_model_message_content_contains("Ada <ada@example.com>")
+        .await?;
+    if caller
+        .assert_model_message_content_contains("transport-only-metadata")
+        .await
+        .is_ok()
+    {
+        return Err("transport-only Gmail fields leaked into the semantic preview".into());
+    }
+    let envelope = envelopes
+        .last()
+        .ok_or("Gmail result did not persist a tool-result envelope")?;
+    let expected_output = caller.tool_result_output("gmail.get_message").await?;
+    if expected_output["body"] != provider_message {
+        return Err("normalized Gmail output did not retain the complete provider response".into());
+    }
+    let expected_bytes = serde_json::to_vec(&expected_output)?;
+    if expected_bytes.len() <= 512 {
+        return Err("Gmail fixture must exceed one durable record page".into());
+    }
+    let durable_bytes = caller
+        .read_durable_tool_result_record_pages(&envelope.result_ref, 512)
+        .await?;
+    if durable_bytes != expected_bytes {
+        return Err(format!(
+            "durable Gmail result bytes differed from the complete provider output: \
+             expected {} bytes, read {} bytes",
+            expected_bytes.len(),
+            durable_bytes.len()
+        )
+        .into());
+    }
     Ok(())
 }

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -24,7 +24,7 @@ use ironclaw_llm::Role;
 use ironclaw_loop_contracts::{BatchPolicyKind, LoopHostMilestoneKind, LoopRecoveryClass};
 use ironclaw_processes::ProcessKind;
 use ironclaw_resources::{ResourceAccount, ResourceGovernor, ResourceTally};
-use ironclaw_threads::SessionThreadService as _;
+use ironclaw_threads::{ReadToolResultRecordRequest, SessionThreadService as _};
 use ironclaw_turns::{TurnEventKind, TurnRunId, TurnRunState};
 use rust_decimal::Decimal;
 
@@ -1175,6 +1175,68 @@ impl RebornIntegrationHarness {
             .collect()
     }
 
+    /// Read one durable tool-result record through the production thread store,
+    /// walking the store's continuation offsets until the complete byte stream
+    /// is returned. This deliberately does not use the in-process capability
+    /// recorder: callers can prove durable persistence and paging equality.
+    pub async fn read_durable_tool_result_record_pages(
+        &self,
+        result_ref: &str,
+        max_bytes: usize,
+    ) -> HarnessResult<Vec<u8>> {
+        let service = self.thread_harness.service_instance()?;
+        let mut offset = 0_u64;
+        let mut total_bytes = None;
+        let mut content = Vec::new();
+        loop {
+            let chunk = service
+                .read_tool_result_record(ReadToolResultRecordRequest {
+                    scope: self.thread_harness.scope.clone(),
+                    thread_id: self.binding.thread_id.clone(),
+                    result_ref: result_ref.to_string(),
+                    offset,
+                    max_bytes,
+                })
+                .await?
+                .ok_or_else(|| format!("durable tool result record {result_ref:?} is missing"))?;
+            if let Some(expected) = total_bytes {
+                if expected != chunk.total_bytes {
+                    return Err(format!(
+                        "durable tool result record {result_ref:?} changed size while paging: \
+                         expected {expected}, saw {}",
+                        chunk.total_bytes
+                    )
+                    .into());
+                }
+            } else {
+                total_bytes = Some(chunk.total_bytes);
+            }
+            content.extend_from_slice(&chunk.content);
+            match chunk.next_offset {
+                Some(next_offset) if next_offset > offset => offset = next_offset,
+                Some(next_offset) => {
+                    return Err(format!(
+                        "durable tool result record {result_ref:?} did not advance paging offset \
+                         {offset} -> {next_offset}"
+                    )
+                    .into());
+                }
+                None => {
+                    let expected = total_bytes.unwrap_or_default();
+                    if content.len() as u64 != expected {
+                        return Err(format!(
+                            "durable tool result record {result_ref:?} ended at {} bytes, \
+                             expected {expected}",
+                            content.len()
+                        )
+                        .into());
+                    }
+                    return Ok(content);
+                }
+            }
+        }
+    }
+
     /// Collects the persisted `safe_summary` field of every `ToolResultReference`
     /// message on this thread's FULL history. Shared collector for
     /// [`assert_tool_error`], [`assert_no_tool_error`], and
@@ -2075,6 +2137,23 @@ impl RebornIntegrationHarness {
                  the whole payload)"
                     .into()
             })
+    }
+
+    /// The inline preview from the most recent persisted `ToolResultReference`
+    /// observation. Used by result paging scenarios that must distinguish the
+    /// explicit 24 KiB page contract from the smaller automatic-preview budget.
+    pub async fn latest_tool_result_preview(&self) -> HarnessResult<String> {
+        let message = self.latest_tool_result_reference_message().await?;
+        let content = message
+            .content
+            .ok_or("latest ToolResultReference message has no content")?;
+        let envelope: serde_json::Value = serde_json::from_str(&content).map_err(|error| {
+            format!("latest ToolResultReference content is not valid JSON: {error}")
+        })?;
+        envelope["model_observation"]["detail"]["preview"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| "latest ToolResultReference observation has no preview".into())
     }
 
     /// Slice `history[baseline..]`, failing loud on an out-of-range `baseline` —

--- a/tests/integration/support/group.rs
+++ b/tests/integration/support/group.rs
@@ -739,6 +739,19 @@ impl RebornIntegrationGroup {
         self.shared.planned_runtime_parts_shape
     }
 
+    /// Queue an exact provider response on this group's production network
+    /// egress lane. Extension scenarios use this after earlier calls have
+    /// completed so the next provider request receives the intended fixture.
+    pub(crate) fn install_network_response_script(
+        &self,
+        status: u16,
+        body: Vec<u8>,
+    ) -> HarnessResult<()> {
+        self.shared
+            .capability_recorder
+            .install_network_response_script(status, body)
+    }
+
     /// C-MULTIUSER: grant global always-allow (auto-approve) for a SPECIFIC run
     /// owner's `(tenant, user)` scope over the shared CAS-persisted
     /// `AutoApproveSettingStorePort`. In a `multiuser_approvals` group (built with

--- a/tests/integration/support/harness/profiles/device_link.rs
+++ b/tests/integration/support/harness/profiles/device_link.rs
@@ -510,6 +510,7 @@ impl ToolAdapter for LinkedAccountFixtureToolAdapter {
             .unwrap_or_default();
         Ok(ToolResult {
             output,
+            model_preview: None,
             display_preview: None,
             output_bytes,
         })

--- a/tests/integration/support/harness/profiles/extension.rs
+++ b/tests/integration/support/harness/profiles/extension.rs
@@ -1043,6 +1043,7 @@ impl ToolAdapter for AcmeFixtureToolAdapter {
                     .unwrap_or_default();
                 Ok(ironclaw_extension_contracts::tool_adapter::ToolResult {
                     output,
+                    model_preview: None,
                     display_preview: None,
                     output_bytes,
                 })
@@ -1407,6 +1408,7 @@ fn tool_result(output: serde_json::Value) -> ToolResult {
         .unwrap_or_default();
     ToolResult {
         output,
+        model_preview: None,
         display_preview: None,
         output_bytes,
     }

--- a/tests/integration/support/harness_mcp.rs
+++ b/tests/integration/support/harness_mcp.rs
@@ -149,6 +149,7 @@ pub(super) fn mock_mcp_extension_package(
             output_schema_ref: Some(CapabilityProfileSchemaRef::new(
                 "schemas/mock-mcp/mock.output.v1.json",
             )?),
+            model_view: None,
             prompt_doc_ref: None,
             required_host_ports: Vec::new(),
             runtime_credentials: Vec::new(),

--- a/tests/integration/tool_call.rs
+++ b/tests/integration/tool_call.rs
@@ -9,6 +9,7 @@ mod reborn_support;
 #[path = "../support/mod.rs"]
 mod support;
 
+use ironclaw_host_api::model_result_preview::AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES;
 use ironclaw_threads::MessageKind;
 use reborn_support::builder::RebornIntegrationHarness;
 use reborn_support::group::RebornIntegrationGroup;
@@ -887,8 +888,8 @@ fn large_durable_file_content() -> String {
 fn durable_file_content_with_suppressed_continuation_preview() -> String {
     (0..1500)
         .map(|i| {
-            if i == 800 {
-                "line-0800 secret filler filler filler".to_string()
+            if i == 100 {
+                "line-0100 secret filler filler filler".to_string()
             } else {
                 format!("line-{i:04} filler filler filler filler")
             }
@@ -941,13 +942,13 @@ async fn durable_large_read_file_result_reaches_model_as_truncated_preview() {
 
     // Model-visible seam: the persisted ToolResultReference message (what the
     // conversation history — and thus the next model request — actually
-    // carries) contains the host-authored truncation summary...
+    // carries) identifies the host-authored structural projection...
     h.assert_conversation_history_role_contains(
         MessageKind::ToolResultReference,
-        "preview truncated",
+        "preview is a projection",
     )
     .await
-    .expect("model-visible history carries the ResultReference truncation summary");
+    .expect("model-visible history identifies the ResultReference projection");
     // ...and never the raw payload's tail. Scoped to ToolResultReference-kind
     // messages (not ANY role): the model's OWN `write_file` tool-call
     // arguments legitimately echo the full content elsewhere in history —
@@ -958,6 +959,30 @@ async fn durable_large_read_file_result_reaches_model_as_truncated_preview() {
             .await
             .is_err(),
         "raw payload tail must not reach the model-visible tool-result transcript"
+    );
+
+    let envelopes = h
+        .persisted_tool_result_envelopes()
+        .await
+        .expect("tool-result envelopes persist");
+    let observation = envelopes
+        .last()
+        .and_then(|envelope| envelope.model_observation.as_ref())
+        .expect("read_file result carries a model observation");
+    let detail = &observation["detail"];
+    let preview = detail["preview"]
+        .as_str()
+        .expect("large structured output carries a projected preview");
+    serde_json::from_str::<serde_json::Value>(preview)
+        .expect("projected preview remains structurally valid JSON");
+    assert!(
+        preview.len() <= 4 * 1024,
+        "automatic model preview must stay within its independent 4 KiB budget"
+    );
+    assert_eq!(
+        detail["next_offset"].as_u64(),
+        Some(0),
+        "a projected preview is not a byte prefix, so result_read must start at the durable payload"
     );
 }
 
@@ -1070,6 +1095,10 @@ async fn result_read_continues_a_durable_result_byte_exactly() {
         .latest_tool_result_next_offset()
         .await
         .expect("read_file's observation reports a continuation offset");
+    assert_eq!(
+        next_offset, 0,
+        "a structural projection is not a source prefix, so paging starts at byte zero"
+    );
     assert!(
         (next_offset as usize) < serialized.len(),
         "test fixture must exceed the preview cutoff to exercise continuation"
@@ -1231,6 +1260,70 @@ async fn result_read_continues_a_durable_result_byte_exactly() {
         page_two_detail["next_offset"].as_u64(),
         page_two["next_offset"].as_u64(),
         "second-page replay metadata must match the second page output"
+    );
+}
+
+#[tokio::test]
+async fn result_read_continuation_keeps_24k_model_preview() {
+    let h = RebornIntegrationHarness::test_default()
+        .with_durable_capability_io_file_tools()
+        .script([
+            RebornScriptedReply::tool_call(
+                "builtin.read_file",
+                json!({"path": "/workspace/clean-large.txt"}),
+            ),
+            RebornScriptedReply::text("read it"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    let workspace_path = h
+        .capability_recorder
+        .workspace_file_path("clean-large.txt")
+        .expect("durable file-tools harness exposes its workspace");
+    std::fs::write(&workspace_path, "x".repeat(40 * 1024))
+        .expect("clean large fixture is seeded outside the model");
+
+    h.submit_turn("read the clean large file")
+        .await
+        .expect("first turn completes");
+    let result_ref = h
+        .latest_tool_result_ref()
+        .await
+        .expect("read_file result ref is persisted");
+    h.push_script([
+        RebornScriptedReply::tool_call(
+            "builtin.result_read",
+            json!({
+                "result_ref": result_ref,
+                "offset": 0,
+                "max_bytes": ironclaw_threads::TOOL_RESULT_RECORD_READ_MAX_BYTES,
+            }),
+        ),
+        RebornScriptedReply::text("continued"),
+    ]);
+
+    h.submit_turn("read the first full result page")
+        .await
+        .expect("second turn completes");
+
+    let chunk = h
+        .tool_result_output("builtin.result_read")
+        .await
+        .expect("result_read result recorded");
+    let chunk_content = chunk["content"].as_str().expect("chunk content is text");
+    let preview = h
+        .latest_tool_result_preview()
+        .await
+        .expect("result_read exposes its page inline");
+    assert_eq!(preview, chunk_content);
+    assert!(
+        preview.len() > AUTOMATIC_MODEL_RESULT_PREVIEW_MAX_BYTES,
+        "explicit result_read pages must not inherit the 4 KiB automatic cap"
+    );
+    assert!(
+        preview.len() <= ironclaw_threads::TOOL_RESULT_RECORD_READ_MAX_BYTES,
+        "explicit result_read previews remain bounded by the 24 KiB page contract"
     );
 }
 


### PR DESCRIPTION
## Summary

- Replace blind model-visible tool-result byte slicing with one bounded, structure-aware projection path for every capability result.
- Keep complete durable output byte-authoritative and pageable, while limiting automatic previews to 4 KiB independently of the existing 24 KiB explicit `result_read` page.
- Add an optional typed producer preview contract and use it for `gmail.get_message` to expose selected headers plus decoded `text/plain` body content instead of MIME transport noise.
- Add registry adoption metadata and an architecture gate for network tools with open output schemas, plus canonical untrusted-content framing before any persisted tool observation reaches a model.

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Fixes #7891

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: changed-crate all-target/all-feature clippy, full `ironclaw_loop_host`, full `ironclaw_extension_support`, full `ironclaw_host_api`, full `ironclaw_extension_registry`, architecture gate, and production-wired regressions listed below
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (not applicable: no database-backed owning-crate behavior changed)
- [ ] Manual testing: not applicable; production-wired integration and recorded-provider fixtures cover the behavior
- [x] If a coding agent was used and supports it, `pr-shepherd` was run before requesting review

The workspace-wide clippy spelling was not rerun; the changed crates were checked with `--all-targets --all-features -- -D warnings` and passed.

## Test Strategy

User behavior: Large and unstructured tool outputs now reach the model as bounded, valid projections; Gmail messages expose readable headers/body text, and the model can still page the exact canonical result.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: preview size/redaction/structure contracts, Gmail multipart decoding and header projection, typed propagation, obligation invalidation, manifest parsing and legacy rehydration.
- Reborn integration: automatic 4 KiB structural projection, explicit 24 KiB paging, exact durable replay, and installed Gmail production chain.
- Recorded fixture: Gmail `get_message` semantic preview from recorded Google response shapes.
- Browser E2E: Not applicable: no browser surface changed.
- Backend or runtime: capability dispatch, host-runtime obligation, loop gateway, and durable result-writer seams.
- Live canary: Not applicable: the regression uses deterministic recorded provider data and no external account mutation.

What the tests prove: automatic model context is bounded without truncating JSON mid-structure; Gmail previews contain readable semantic content and exclude transport/base64 noise; credentials are redacted recursively; every model-visible observation is framed as untrusted content; explicit reads retain their independent 24 KiB contract; durable output reconstructs byte-for-byte.

Commands run:

```text
cargo fmt --all -- --check
cargo test -p ironclaw_extension_support
cargo test -p ironclaw_host_api
cargo test -p ironclaw_extension_registry
cargo test -p ironclaw_loop_host
cargo test -p ironclaw_architecture_tests --test reborn_origin_gate_matrix_ratchet
SKIP_FRONTEND_BUILD=1 cargo clippy -p ironclaw_host_api -p ironclaw_extension_contracts -p ironclaw_extension_registry -p ironclaw_extension_support -p ironclaw_extension_host -p ironclaw_extension_manager -p ironclaw_capabilities -p ironclaw_host_runtime -p ironclaw_loop_host -p ironclaw_composition -p ironclaw_integration_tests --all-targets --all-features -- -D warnings
SKIP_FRONTEND_BUILD=1 RUST_MIN_STACK=16777216 cargo test -p ironclaw_integration_tests --test reborn_group_extensions gmail_semantic_preview_production_chain -- --exact --nocapture
SKIP_FRONTEND_BUILD=1 RUST_MIN_STACK=16777216 cargo test -p ironclaw_integration_tests --test reborn_integration_tool_call durable_large_read_file_result_reaches_model_as_truncated_preview -- --exact --nocapture
SKIP_FRONTEND_BUILD=1 RUST_MIN_STACK=16777216 cargo test -p ironclaw_integration_tests --test reborn_integration_tool_call result_read_continues_a_durable_result_byte_exactly -- --exact --nocapture
SKIP_FRONTEND_BUILD=1 RUST_MIN_STACK=16777216 cargo test -p ironclaw_integration_tests --test reborn_integration_tool_call result_read_continuation_keeps_24k_model_preview -- --exact --nocapture
```

## Security Impact

Model-visible tool output now passes through the canonical external-content safety envelope. The shared preview contract recursively redacts structured credential fields and bearer-token values before model exposure. Authorization, provider egress, credential injection, durable storage, and paging authority are unchanged.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: producers can construct only a bounded, wire-revalidated `ModelResultPreview`; the canonical host writer owns the final observation and fallback.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive.
- [x] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check. No hash behavior changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output: typed result-field propagation was enumerated by compiler and changed-crate all-feature clippy; no status/error variant was added.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. Optional manifest/result fields have legacy rehydration coverage; missing preview falls back structurally.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. Automatic preview is 4 KiB; explicit reads remain bounded by the existing 24 KiB contract; accounting uses existing saturating paths.
- [x] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent). No driver/operator error classification changed.
- [x] Sandbox/native/host names accurately describe trust boundary. No runtime-lane or sandbox taxonomy changed.

## Database Impact

None. Durable output schema and storage remain unchanged; the new preview is derived and optional.

## Blast Radius

Touches the capability-result contract and its existing adapters across extension, kernel, loop-host, and composition layers. A propagation omission would drop the optional producer preview but retain the universal structural fallback and complete durable result. Gmail parsing is isolated to the GSuite producer.

Dynamic MCP tools and tools without explicit output schemas are intentionally outside the current registry ratchet. They still receive the universal bounded structural fallback.

## Rollback Plan

Revert this PR. The previous blind preview behavior returns without a data migration because complete durable results and `result_read` records are unchanged. If only Gmail projection is problematic, remove its producer preview and manifest declaration; the generic structural fallback remains valid.

## Review Follow-Through

Five-lane code review, cleanup review, post-implementation approach audit, and thermo-nuclear maintainability review were run. Findings around credential redaction, escaped Gmail headers, error-cause observability, model prompt framing, production fixture coverage, typed operation selection, and contract wording were addressed and reverified. Final thermo-nuclear verdict: `APPROVE`.

Follow-up risk: the architecture ratchet intentionally excludes dynamically discovered MCP tools and tools without explicit output schemas. Cumulative replay-budget policy remains separate from per-result projection.

---

**Review track**: C
