### PR TITLE
feat(notifications): harden producer identity contract

### DIFF
--- a/crates/domains/ironclaw_notifications/README.md
+++ b/crates/domains/ironclaw_notifications/README.md
@@ -21,6 +21,23 @@ backend and provides tenant/user-rewritten mounts. Records contain metadata and
 typed references only; prompts, replies, tool payloads, secrets, and backend
 diagnostics are forbidden.
 
+## Producer safety contract
+
+Every producer must derive a stable id from the authoritative workflow event,
+use `NotificationKind::stable_key()` for the kind segment, and preserve the
+same recipient and source across retries. Kind keys are persistence vocabulary:
+changing one requires a migration because otherwise a replay would create a
+second record. Publication must remain best-effort with respect to the
+originating workflow, while failures stay observable through sanitized logs or
+the owning durable observer's retry mechanism.
+
+Actionable records use one id for one active lifecycle and resolve that record
+after verified recovery. Producers must not publish retry progress, transient
+polling states, subagent noise, prompts, tool payloads, credentials, backend
+diagnostics, or any other unbounded content. New notification kinds, source
+fields, actions, API shapes, and WebUI behavior are separate contract changes;
+producer onboarding alone must reuse the existing grammar.
+
 ## Validation
 
 ```bash

--- a/crates/domains/ironclaw_notifications/src/types.rs
+++ b/crates/domains/ironclaw_notifications/src/types.rs
@@ -129,6 +129,23 @@ pub enum NotificationKind {
     DeliveryFailed,
 }
 
+impl NotificationKind {
+    /// Stable producer identity segment used by durable notification ids.
+    ///
+    /// These values are persistence vocabulary, not display copy. Changing a
+    /// key would bypass idempotent replay and requires an explicit migration.
+    pub fn stable_key(self) -> &'static str {
+        match self {
+            Self::ApprovalRequired => "approval",
+            Self::AuthenticationRequired => "authentication",
+            Self::RunBlocked => "blocked",
+            Self::RunFailed => "failed",
+            Self::RunCompleted => "completed",
+            Self::DeliveryFailed => "delivery-failed",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NotificationSeverity {
@@ -342,5 +359,25 @@ mod tests {
         assert!(LifecycleRef::try_from(String::new()).is_err());
         assert!(serde_json::from_str::<LifecycleRef>("\"bad\\nref\"").is_err());
         assert!(LifecycleRef::new("x".repeat(LIFECYCLE_REF_MAX_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn notification_kind_stable_keys_are_unique_and_rollout_safe() {
+        let keys = [
+            (NotificationKind::ApprovalRequired, "approval"),
+            (NotificationKind::AuthenticationRequired, "authentication"),
+            (NotificationKind::RunBlocked, "blocked"),
+            (NotificationKind::RunFailed, "failed"),
+            (NotificationKind::RunCompleted, "completed"),
+            (NotificationKind::DeliveryFailed, "delivery-failed"),
+        ];
+        let unique = keys
+            .iter()
+            .map(|(kind, expected)| {
+                assert_eq!(kind.stable_key(), *expected);
+                kind.stable_key()
+            })
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(unique.len(), keys.len());
     }
 }

--- a/crates/product/ironclaw_assistant/src/run_delivery.rs
+++ b/crates/product/ironclaw_assistant/src/run_delivery.rs
@@ -709,14 +709,7 @@ pub(crate) fn run_notification_inbox_id(
     kind: NotificationKind,
     lifecycle_ref: Option<&str>,
 ) -> Result<NotificationId, NotificationInboxError> {
-    let kind = match kind {
-        NotificationKind::ApprovalRequired => "approval",
-        NotificationKind::AuthenticationRequired => "authentication",
-        NotificationKind::RunBlocked => "blocked",
-        NotificationKind::RunFailed => "failed",
-        NotificationKind::RunCompleted => "completed",
-        NotificationKind::DeliveryFailed => "delivery-failed",
-    };
+    let kind = kind.stable_key();
     let lifecycle_key = lifecycle_ref
         .map(|value| uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, value.as_bytes()).to_string())
         .unwrap_or_else(|| "run".to_string());

--- a/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
@@ -293,14 +293,7 @@ fn outcome_notification_id(
     run_id: TurnRunId,
     kind: NotificationKind,
 ) -> Result<NotificationId, String> {
-    let kind = match kind {
-        NotificationKind::RunCompleted => "completed",
-        NotificationKind::RunFailed => "failed",
-        NotificationKind::DeliveryFailed => "delivery-failed",
-        NotificationKind::ApprovalRequired => "approval",
-        NotificationKind::AuthenticationRequired => "authentication",
-        NotificationKind::RunBlocked => "blocked",
-    };
+    let kind = kind.stable_key();
     NotificationId::new(format!("run:{run_id}:{kind}"))
         .map_err(|error| format!("build run outcome notification id failed: {error}"))
 }


### PR DESCRIPTION
## Summary

- define the durable notification kind identity segments once in the notification domain
- migrate run delivery and authoritative run outcome producers to the shared stable-key contract without changing existing IDs
- add regression coverage that pins every key and ensures the identity segments remain unique
- document producer requirements for stable IDs, recipient scope, lifecycle resolution, metadata-only records, best-effort publication, and rollout compatibility
- explicitly exclude transient polling state, subagent noise, credentials, prompts, tool payloads, and backend diagnostics

## Linked Issue

Closes #7876
Part of #7872

## Validation

- `cargo fmt --check`
- `cargo test -p ironclaw_notifications`
- `cargo test -p ironclaw_assistant run_outcome_observer`
- `cargo clippy -p ironclaw_notifications -p ironclaw_assistant --tests -- -D warnings`
- E2E not added: this is a compatibility-preserving domain and producer-contract hardening change

## Security Impact

The documented contract reinforces metadata-only persistence and prohibits credentials, prompts, tool payloads, and backend diagnostics from notification records.

## Database Impact

None. Existing durable notification IDs are unchanged byte-for-byte, and no schema migration is required.

## Blast Radius

Notification ID construction in the existing run delivery and run outcome producers. Wire representations, APIs, storage schema, and WebUI behavior are unchanged.

## Rollback Plan

Revert this commit to restore the duplicated local key mappings. Existing notification IDs and persisted records remain compatible.