### PR TITLE
fix(threads): preserve incremental compaction summary context

### DIFF
--- a/crates/domains/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service.rs
@@ -66,7 +66,7 @@ use uuid::Uuid;
 
 use crate::identifiers::SummaryArtifactId;
 use crate::stored_message::serialize_stored_thread_message;
-use crate::summary_artifacts::{find_overlapping_summary, select_context_barrier};
+use crate::summary_artifacts::{find_overlapping_summary, sorted_context_summaries};
 use crate::title::derive_title_from_message;
 use crate::tool_result_records::{
     tool_result_record_chunk, validate_tool_result_record_content,
@@ -1099,21 +1099,11 @@ where
                             && summary.start_sequence < oldest_loaded_sequence
                     })
                 });
-            let validated_barrier_loaded = context
-                .iter()
-                .filter_map(|message| message.summary_id)
-                .find_map(|summary_id| {
-                    summaries
-                        .iter()
-                        .find(|summary| summary.summary_id == summary_id)
-                })
-                .is_some_and(|summary| summary.start_sequence >= oldest_loaded_sequence);
             // A replacement summary inside the retained suffix can move the
             // exact truncation watermark. Do not stop until its whole durable
             // range has been read, otherwise an older Draft/redaction can be
             // missed and a synthetic summary sequence reported as the boundary.
-            if validated_barrier_loaded
-                || (context.len() > max_messages && !tail_has_unvalidated_summary)
+            if (context.len() > max_messages && !tail_has_unvalidated_summary)
                 || entry_count < limit as usize
             {
                 return Ok(context);
@@ -4499,28 +4489,24 @@ fn context_messages_with_summary_replacements(
     messages: &[ThreadMessageRecord],
     summaries: &[SummaryArtifact],
 ) -> Vec<ContextMessage> {
-    // A compaction summary is a projection barrier, not another transcript
-    // entry. Select the newest eligible summary itself, not merely its range:
-    // this stays deterministic even if legacy or concurrently written data
-    // contains overlapping summaries. Durable rows remain available through
-    // thread history.
-    let barrier_summary = select_context_barrier(summaries, |summary| {
+    let replacement_summaries = sorted_context_summaries(summaries, |summary| {
         summary.model_context_policy == Some(SummaryModelContextPolicy::ReplaceRangeWhenSelected)
             && !summary_covers_hidden_content(messages, summary)
     });
-    let barrier_start_sequence = barrier_summary
-        .map(|summary| summary.start_sequence)
-        .unwrap_or(0);
     let mut skip_through = 0u64;
+    let mut emitted_summaries: std::collections::HashSet<_> = std::collections::HashSet::new();
     let mut context = Vec::new();
-    for message in messages.iter().filter(|message| {
-        is_model_context_visible(message) && message.sequence >= barrier_start_sequence
-    }) {
+    for message in messages
+        .iter()
+        .filter(|message| is_model_context_visible(message))
+    {
         if message.sequence <= skip_through {
             continue;
         }
-        if let Some(summary) = barrier_summary.filter(|summary| {
-            summary.start_sequence <= message.sequence && message.sequence <= summary.end_sequence
+        if let Some(summary) = replacement_summaries.iter().find(|summary| {
+            summary.start_sequence <= message.sequence
+                && message.sequence <= summary.end_sequence
+                && !emitted_summaries.contains(&summary.summary_id)
         }) {
             context.push(ContextMessage {
                 message_id: None,
@@ -4531,6 +4517,7 @@ fn context_messages_with_summary_replacements(
                 content: summary.content.clone(),
                 image_attachments: Vec::new(),
             });
+            emitted_summaries.insert(summary.summary_id);
             skip_through = summary.end_sequence;
             continue;
         }

--- a/crates/domains/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service.rs
@@ -4489,28 +4489,32 @@ fn context_messages_with_summary_replacements(
     messages: &[ThreadMessageRecord],
     summaries: &[SummaryArtifact],
 ) -> Vec<ContextMessage> {
-    let replacement_summaries = summaries
+    // A compaction summary is a projection barrier, not another transcript
+    // entry. Select the newest eligible summary itself, not merely its range:
+    // this stays deterministic even if legacy or concurrently written data
+    // contains overlapping summaries. Durable rows remain available through
+    // thread history.
+    let barrier_summary = summaries
         .iter()
         .filter(|summary| {
             summary.model_context_policy
                 == Some(SummaryModelContextPolicy::ReplaceRangeWhenSelected)
                 && !summary_covers_hidden_content(messages, summary)
         })
-        .collect::<Vec<_>>();
+        .max_by_key(|summary| summary.end_sequence);
+    let barrier_start_sequence = barrier_summary
+        .map(|summary| summary.start_sequence)
+        .unwrap_or(0);
     let mut skip_through = 0u64;
-    let mut emitted_summaries: std::collections::HashSet<_> = std::collections::HashSet::new();
     let mut context = Vec::new();
-    for message in messages
-        .iter()
-        .filter(|message| is_model_context_visible(message))
-    {
+    for message in messages.iter().filter(|message| {
+        is_model_context_visible(message) && message.sequence >= barrier_start_sequence
+    }) {
         if message.sequence <= skip_through {
             continue;
         }
-        if let Some(summary) = replacement_summaries.iter().find(|summary| {
-            summary.start_sequence <= message.sequence
-                && message.sequence <= summary.end_sequence
-                && !emitted_summaries.contains(&summary.summary_id)
+        if let Some(summary) = barrier_summary.filter(|summary| {
+            summary.start_sequence <= message.sequence && message.sequence <= summary.end_sequence
         }) {
             context.push(ContextMessage {
                 message_id: None,
@@ -4521,7 +4525,6 @@ fn context_messages_with_summary_replacements(
                 content: summary.content.clone(),
                 image_attachments: Vec::new(),
             });
-            emitted_summaries.insert(summary.summary_id);
             skip_through = summary.end_sequence;
             continue;
         }

--- a/crates/domains/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/domains/ironclaw_threads/src/filesystem_service.rs
@@ -66,7 +66,7 @@ use uuid::Uuid;
 
 use crate::identifiers::SummaryArtifactId;
 use crate::stored_message::serialize_stored_thread_message;
-use crate::summary_artifacts::find_overlapping_summary;
+use crate::summary_artifacts::{find_overlapping_summary, select_context_barrier};
 use crate::title::derive_title_from_message;
 use crate::tool_result_records::{
     tool_result_record_chunk, validate_tool_result_record_content,
@@ -1099,11 +1099,21 @@ where
                             && summary.start_sequence < oldest_loaded_sequence
                     })
                 });
+            let validated_barrier_loaded = context
+                .iter()
+                .filter_map(|message| message.summary_id)
+                .find_map(|summary_id| {
+                    summaries
+                        .iter()
+                        .find(|summary| summary.summary_id == summary_id)
+                })
+                .is_some_and(|summary| summary.start_sequence >= oldest_loaded_sequence);
             // A replacement summary inside the retained suffix can move the
             // exact truncation watermark. Do not stop until its whole durable
             // range has been read, otherwise an older Draft/redaction can be
             // missed and a synthetic summary sequence reported as the boundary.
-            if (context.len() > max_messages && !tail_has_unvalidated_summary)
+            if validated_barrier_loaded
+                || (context.len() > max_messages && !tail_has_unvalidated_summary)
                 || entry_count < limit as usize
             {
                 return Ok(context);
@@ -4494,14 +4504,10 @@ fn context_messages_with_summary_replacements(
     // this stays deterministic even if legacy or concurrently written data
     // contains overlapping summaries. Durable rows remain available through
     // thread history.
-    let barrier_summary = summaries
-        .iter()
-        .filter(|summary| {
-            summary.model_context_policy
-                == Some(SummaryModelContextPolicy::ReplaceRangeWhenSelected)
-                && !summary_covers_hidden_content(messages, summary)
-        })
-        .max_by_key(|summary| summary.end_sequence);
+    let barrier_summary = select_context_barrier(summaries, |summary| {
+        summary.model_context_policy == Some(SummaryModelContextPolicy::ReplaceRangeWhenSelected)
+            && !summary_covers_hidden_content(messages, summary)
+    });
     let barrier_start_sequence = barrier_summary
         .map(|summary| summary.start_sequence)
         .unwrap_or(0);

--- a/crates/domains/ironclaw_threads/src/identifiers.rs
+++ b/crates/domains/ironclaw_threads/src/identifiers.rs
@@ -47,6 +47,10 @@ impl SummaryArtifactId {
     pub fn new() -> Self {
         Self(Uuid::new_v4())
     }
+
+    pub(crate) fn as_uuid(&self) -> Uuid {
+        self.0
+    }
 }
 
 impl Default for SummaryArtifactId {

--- a/crates/domains/ironclaw_threads/src/in_memory.rs
+++ b/crates/domains/ironclaw_threads/src/in_memory.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -9,7 +12,7 @@ use uuid::Uuid;
 
 use crate::identifiers::SummaryArtifactId;
 use crate::stored_message::serialize_stored_thread_message;
-use crate::summary_artifacts::{find_overlapping_summary, select_context_barrier};
+use crate::summary_artifacts::{find_overlapping_summary, sorted_context_summaries};
 use crate::title::derive_thread_title;
 use crate::tool_result_records::{
     tool_result_record_chunk, validate_tool_result_record_content,
@@ -1847,28 +1850,25 @@ fn ensure_user_accepted(
 }
 
 fn context_messages_with_summary_replacements(thread: &StoredThread) -> Vec<ContextMessage> {
-    // A compaction summary is a projection barrier, not another transcript
-    // entry. Select the newest eligible summary itself, not merely its range:
-    // this stays deterministic even if legacy or concurrently written data
-    // contains overlapping summaries. Durable rows remain available through
-    // thread history.
-    let barrier_summary = select_context_barrier(&thread.summary_artifacts, |summary| {
+    let replacement_summaries = sorted_context_summaries(&thread.summary_artifacts, |summary| {
         summary.model_context_policy == Some(SummaryModelContextPolicy::ReplaceRangeWhenSelected)
             && !summary_covers_hidden_content(thread, summary)
     });
-    let barrier_start_sequence = barrier_summary
-        .map(|summary| summary.start_sequence)
-        .unwrap_or(0);
     let mut skip_through = 0;
+    let mut emitted_summaries = HashSet::new();
     let mut context = Vec::new();
-    for message in thread.messages.iter().filter(|message| {
-        is_model_context_visible(message) && message.sequence >= barrier_start_sequence
-    }) {
+    for message in thread
+        .messages
+        .iter()
+        .filter(|message| is_model_context_visible(message))
+    {
         if message.sequence <= skip_through {
             continue;
         }
-        if let Some(summary) = barrier_summary.filter(|summary| {
-            summary.start_sequence <= message.sequence && message.sequence <= summary.end_sequence
+        if let Some(summary) = replacement_summaries.iter().find(|summary| {
+            summary.start_sequence <= message.sequence
+                && message.sequence <= summary.end_sequence
+                && !emitted_summaries.contains(&summary.summary_id)
         }) {
             context.push(ContextMessage {
                 message_id: None,
@@ -1879,6 +1879,7 @@ fn context_messages_with_summary_replacements(thread: &StoredThread) -> Vec<Cont
                 content: summary.content.clone(),
                 image_attachments: Vec::new(),
             });
+            emitted_summaries.insert(summary.summary_id);
             skip_through = summary.end_sequence;
             continue;
         }

--- a/crates/domains/ironclaw_threads/src/in_memory.rs
+++ b/crates/domains/ironclaw_threads/src/in_memory.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::identifiers::SummaryArtifactId;
 use crate::stored_message::serialize_stored_thread_message;
-use crate::summary_artifacts::find_overlapping_summary;
+use crate::summary_artifacts::{find_overlapping_summary, select_context_barrier};
 use crate::title::derive_thread_title;
 use crate::tool_result_records::{
     tool_result_record_chunk, validate_tool_result_record_content,
@@ -1852,15 +1852,10 @@ fn context_messages_with_summary_replacements(thread: &StoredThread) -> Vec<Cont
     // this stays deterministic even if legacy or concurrently written data
     // contains overlapping summaries. Durable rows remain available through
     // thread history.
-    let barrier_summary = thread
-        .summary_artifacts
-        .iter()
-        .filter(|summary| {
-            summary.model_context_policy
-                == Some(SummaryModelContextPolicy::ReplaceRangeWhenSelected)
-                && !summary_covers_hidden_content(thread, summary)
-        })
-        .max_by_key(|summary| summary.end_sequence);
+    let barrier_summary = select_context_barrier(&thread.summary_artifacts, |summary| {
+        summary.model_context_policy == Some(SummaryModelContextPolicy::ReplaceRangeWhenSelected)
+            && !summary_covers_hidden_content(thread, summary)
+    });
     let barrier_start_sequence = barrier_summary
         .map(|summary| summary.start_sequence)
         .unwrap_or(0);

--- a/crates/domains/ironclaw_threads/src/in_memory.rs
+++ b/crates/domains/ironclaw_threads/src/in_memory.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -1850,7 +1847,12 @@ fn ensure_user_accepted(
 }
 
 fn context_messages_with_summary_replacements(thread: &StoredThread) -> Vec<ContextMessage> {
-    let replacement_summaries = thread
+    // A compaction summary is a projection barrier, not another transcript
+    // entry. Select the newest eligible summary itself, not merely its range:
+    // this stays deterministic even if legacy or concurrently written data
+    // contains overlapping summaries. Durable rows remain available through
+    // thread history.
+    let barrier_summary = thread
         .summary_artifacts
         .iter()
         .filter(|summary| {
@@ -1858,22 +1860,20 @@ fn context_messages_with_summary_replacements(thread: &StoredThread) -> Vec<Cont
                 == Some(SummaryModelContextPolicy::ReplaceRangeWhenSelected)
                 && !summary_covers_hidden_content(thread, summary)
         })
-        .collect::<Vec<_>>();
+        .max_by_key(|summary| summary.end_sequence);
+    let barrier_start_sequence = barrier_summary
+        .map(|summary| summary.start_sequence)
+        .unwrap_or(0);
     let mut skip_through = 0;
-    let mut emitted_summaries = HashSet::new();
     let mut context = Vec::new();
-    for message in thread
-        .messages
-        .iter()
-        .filter(|message| is_model_context_visible(message))
-    {
+    for message in thread.messages.iter().filter(|message| {
+        is_model_context_visible(message) && message.sequence >= barrier_start_sequence
+    }) {
         if message.sequence <= skip_through {
             continue;
         }
-        if let Some(summary) = replacement_summaries.iter().find(|summary| {
-            summary.start_sequence <= message.sequence
-                && message.sequence <= summary.end_sequence
-                && !emitted_summaries.contains(&summary.summary_id)
+        if let Some(summary) = barrier_summary.filter(|summary| {
+            summary.start_sequence <= message.sequence && message.sequence <= summary.end_sequence
         }) {
             context.push(ContextMessage {
                 message_id: None,
@@ -1884,7 +1884,6 @@ fn context_messages_with_summary_replacements(thread: &StoredThread) -> Vec<Cont
                 content: summary.content.clone(),
                 image_attachments: Vec::new(),
             });
-            emitted_summaries.insert(summary.summary_id);
             skip_through = summary.end_sequence;
             continue;
         }

--- a/crates/domains/ironclaw_threads/src/summary_artifacts.rs
+++ b/crates/domains/ironclaw_threads/src/summary_artifacts.rs
@@ -1,8 +1,25 @@
+use std::cmp::Reverse;
+
 use crate::{
     CreateSummaryArtifactRequest, SessionThreadError, SummaryArtifact, SummaryKind,
     SummaryModelContextPolicy,
 };
 
+pub(crate) fn select_context_barrier(
+    summaries: &[SummaryArtifact],
+    mut eligible: impl FnMut(&SummaryArtifact) -> bool,
+) -> Option<&SummaryArtifact> {
+    summaries
+        .iter()
+        .filter(|summary| eligible(summary))
+        .max_by_key(|summary| {
+            (
+                summary.end_sequence,
+                Reverse(summary.start_sequence),
+                summary.content.as_str(),
+            )
+        })
+}
 pub(crate) fn is_exact_compaction_summary_replay(
     summary: &SummaryArtifact,
     request: &CreateSummaryArtifactRequest,
@@ -116,6 +133,23 @@ mod tests {
         }
     }
 
+    #[test]
+    fn context_barrier_selection_is_stable_for_equal_end_sequences() {
+        let left = summary_with(2, 10, "alpha");
+        let right = summary_with(2, 10, "zeta");
+        let forward = vec![left.clone(), right.clone()];
+        let reverse = vec![right, left];
+
+        let selected_forward = select_context_barrier(&forward, |_| true).unwrap();
+        let selected_reverse = select_context_barrier(&reverse, |_| true).unwrap();
+
+        assert_eq!(selected_forward.content, "zeta");
+        assert_eq!(selected_reverse.content, selected_forward.content);
+        assert_eq!(
+            selected_reverse.start_sequence,
+            selected_forward.start_sequence
+        );
+    }
     #[test]
     fn exact_compaction_summary_replay_matches_on_coordinates_and_content() {
         let request = request();

--- a/crates/domains/ironclaw_threads/src/summary_artifacts.rs
+++ b/crates/domains/ironclaw_threads/src/summary_artifacts.rs
@@ -1,25 +1,24 @@
-use std::cmp::Reverse;
-
 use crate::{
     CreateSummaryArtifactRequest, SessionThreadError, SummaryArtifact, SummaryKind,
     SummaryModelContextPolicy,
 };
 
-pub(crate) fn select_context_barrier(
+pub(crate) fn sorted_context_summaries(
     summaries: &[SummaryArtifact],
     mut eligible: impl FnMut(&SummaryArtifact) -> bool,
-) -> Option<&SummaryArtifact> {
-    summaries
+) -> Vec<&SummaryArtifact> {
+    let mut selected = summaries
         .iter()
         .filter(|summary| eligible(summary))
-        .max_by_key(|summary| {
-            (
-                summary.end_sequence,
-                Reverse(summary.start_sequence),
-                summary.content.as_str(),
-                summary.summary_id.as_uuid(),
-            )
-        })
+        .collect::<Vec<_>>();
+    selected.sort_unstable_by(|left, right| {
+        left.start_sequence
+            .cmp(&right.start_sequence)
+            .then_with(|| left.end_sequence.cmp(&right.end_sequence))
+            .then_with(|| left.content.cmp(&right.content))
+            .then_with(|| left.summary_id.as_uuid().cmp(&right.summary_id.as_uuid()))
+    });
+    selected
 }
 pub(crate) fn is_exact_compaction_summary_replay(
     summary: &SummaryArtifact,
@@ -135,16 +134,23 @@ mod tests {
     }
 
     #[test]
-    fn context_barrier_selection_is_stable_for_equal_end_sequences() {
-        let left = summary_with(2, 10, "same content");
-        let right = summary_with(2, 10, "same content");
-        let forward = vec![left.clone(), right.clone()];
-        let reverse = vec![right, left];
+    fn context_summaries_sort_stably_by_persisted_coordinates() {
+        let older = summary_with(1, 5, "older");
+        let left = summary_with(6, 10, "same content");
+        let right = summary_with(6, 10, "same content");
+        let forward = vec![older.clone(), left.clone(), right.clone()];
+        let reverse = vec![right, left, older];
 
-        let selected_forward = select_context_barrier(&forward, |_| true).unwrap();
-        let selected_reverse = select_context_barrier(&reverse, |_| true).unwrap();
+        let selected_forward = sorted_context_summaries(&forward, |_| true)
+            .into_iter()
+            .map(|summary| summary.summary_id)
+            .collect::<Vec<_>>();
+        let selected_reverse = sorted_context_summaries(&reverse, |_| true)
+            .into_iter()
+            .map(|summary| summary.summary_id)
+            .collect::<Vec<_>>();
 
-        assert_eq!(selected_reverse.summary_id, selected_forward.summary_id);
+        assert_eq!(selected_reverse, selected_forward);
     }
     #[test]
     fn exact_compaction_summary_replay_matches_on_coordinates_and_content() {

--- a/crates/domains/ironclaw_threads/src/summary_artifacts.rs
+++ b/crates/domains/ironclaw_threads/src/summary_artifacts.rs
@@ -17,6 +17,7 @@ pub(crate) fn select_context_barrier(
                 summary.end_sequence,
                 Reverse(summary.start_sequence),
                 summary.content.as_str(),
+                summary.summary_id.as_uuid(),
             )
         })
 }
@@ -135,20 +136,15 @@ mod tests {
 
     #[test]
     fn context_barrier_selection_is_stable_for_equal_end_sequences() {
-        let left = summary_with(2, 10, "alpha");
-        let right = summary_with(2, 10, "zeta");
+        let left = summary_with(2, 10, "same content");
+        let right = summary_with(2, 10, "same content");
         let forward = vec![left.clone(), right.clone()];
         let reverse = vec![right, left];
 
         let selected_forward = select_context_barrier(&forward, |_| true).unwrap();
         let selected_reverse = select_context_barrier(&reverse, |_| true).unwrap();
 
-        assert_eq!(selected_forward.content, "zeta");
-        assert_eq!(selected_reverse.content, selected_forward.content);
-        assert_eq!(
-            selected_reverse.start_sequence,
-            selected_forward.start_sequence
-        );
+        assert_eq!(selected_reverse.summary_id, selected_forward.summary_id);
     }
     #[test]
     fn exact_compaction_summary_replay_matches_on_coordinates_and_content() {

--- a/crates/domains/ironclaw_threads/tests/filesystem_message_range_contract.rs
+++ b/crates/domains/ironclaw_threads/tests/filesystem_message_range_contract.rs
@@ -19,10 +19,10 @@ use ironclaw_host_api::{
 use ironclaw_threads::{
     AcceptInboundMessageRequest, AppendFinalizedAssistantMessageRequest, BoundedThreadMessages,
     BoundedThreadMessagesRequest, CreateSummaryArtifactRequest, EnsureThreadRequest,
-    FilesystemSessionThreadService, InMemorySessionThreadService, MessageContent, MessageStatus,
-    RedactMessageRequest, SessionThreadError, SessionThreadService, SummaryKind,
-    SummaryModelContextPolicy, ThreadHistoryRequest, ThreadMessageId, ThreadMessageRangeRequest,
-    ThreadScope,
+    FilesystemSessionThreadService, InMemorySessionThreadService, LoadContextWindowRequest,
+    MessageContent, MessageKind, MessageStatus, RedactMessageRequest, SessionThreadError,
+    SessionThreadService, SummaryKind, SummaryModelContextPolicy, ThreadHistoryRequest,
+    ThreadMessageId, ThreadMessageRangeRequest, ThreadScope,
 };
 
 #[tokio::test]
@@ -70,6 +70,70 @@ async fn filesystem_store_bounded_read_uses_capped_query_page() {
         backend.ordered_query_limits(),
         vec![3],
         "bounded reads must request only max_messages + 1 ordered rows",
+    );
+}
+
+#[tokio::test]
+async fn filesystem_context_paging_stops_after_validated_barrier() {
+    let backend = Arc::new(QueryTrackingBackend::new());
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-context-barrier", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let scope = scope("context-barrier");
+    let thread_id = ThreadId::new("thread-context-barrier").unwrap();
+    service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(thread_id.clone()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+    for sequence in 1..=100 {
+        service
+            .accept_inbound_message(AcceptInboundMessageRequest {
+                scope: scope.clone(),
+                thread_id: thread_id.clone(),
+                actor_id: "actor-a".into(),
+                source_binding_id: None,
+                reply_target_binding_id: None,
+                external_event_id: Some(format!("barrier-{sequence}")),
+                content: MessageContent::text(format!("message {sequence}")),
+            })
+            .await
+            .unwrap();
+    }
+    service
+        .create_summary_artifact(CreateSummaryArtifactRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+            start_sequence: 91,
+            end_sequence: 95,
+            summary_kind: SummaryKind::Compaction,
+            content: MessageContent::text("validated barrier"),
+            model_context_policy: Some(SummaryModelContextPolicy::ReplaceRangeWhenSelected),
+        })
+        .await
+        .unwrap();
+    backend.reset_query_observations();
+
+    let context = service
+        .load_context_window(LoadContextWindowRequest {
+            scope,
+            thread_id,
+            max_messages: 8,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(context.messages.len(), 6);
+    assert_eq!(context.messages[0].kind, MessageKind::Summary);
+    assert_eq!(context.messages[0].content, "validated barrier");
+    assert_eq!(
+        backend.ordered_query_limits(),
+        vec![1024, 9, 9],
+        "paging must stop once the selected summary range is fully validated",
     );
 }
 

--- a/crates/domains/ironclaw_threads/tests/filesystem_message_range_contract.rs
+++ b/crates/domains/ironclaw_threads/tests/filesystem_message_range_contract.rs
@@ -19,10 +19,10 @@ use ironclaw_host_api::{
 use ironclaw_threads::{
     AcceptInboundMessageRequest, AppendFinalizedAssistantMessageRequest, BoundedThreadMessages,
     BoundedThreadMessagesRequest, CreateSummaryArtifactRequest, EnsureThreadRequest,
-    FilesystemSessionThreadService, InMemorySessionThreadService, LoadContextWindowRequest,
-    MessageContent, MessageKind, MessageStatus, RedactMessageRequest, SessionThreadError,
-    SessionThreadService, SummaryKind, SummaryModelContextPolicy, ThreadHistoryRequest,
-    ThreadMessageId, ThreadMessageRangeRequest, ThreadScope,
+    FilesystemSessionThreadService, InMemorySessionThreadService, MessageContent, MessageStatus,
+    RedactMessageRequest, SessionThreadError, SessionThreadService, SummaryKind,
+    SummaryModelContextPolicy, ThreadHistoryRequest, ThreadMessageId, ThreadMessageRangeRequest,
+    ThreadScope,
 };
 
 #[tokio::test]
@@ -70,70 +70,6 @@ async fn filesystem_store_bounded_read_uses_capped_query_page() {
         backend.ordered_query_limits(),
         vec![3],
         "bounded reads must request only max_messages + 1 ordered rows",
-    );
-}
-
-#[tokio::test]
-async fn filesystem_context_paging_stops_after_validated_barrier() {
-    let backend = Arc::new(QueryTrackingBackend::new());
-    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-context-barrier", "alice");
-    let service = FilesystemSessionThreadService::new(scoped);
-    let scope = scope("context-barrier");
-    let thread_id = ThreadId::new("thread-context-barrier").unwrap();
-    service
-        .ensure_thread(EnsureThreadRequest {
-            scope: scope.clone(),
-            thread_id: Some(thread_id.clone()),
-            created_by_actor_id: "actor-a".into(),
-            title: None,
-            metadata_json: None,
-        })
-        .await
-        .unwrap();
-    for sequence in 1..=100 {
-        service
-            .accept_inbound_message(AcceptInboundMessageRequest {
-                scope: scope.clone(),
-                thread_id: thread_id.clone(),
-                actor_id: "actor-a".into(),
-                source_binding_id: None,
-                reply_target_binding_id: None,
-                external_event_id: Some(format!("barrier-{sequence}")),
-                content: MessageContent::text(format!("message {sequence}")),
-            })
-            .await
-            .unwrap();
-    }
-    service
-        .create_summary_artifact(CreateSummaryArtifactRequest {
-            scope: scope.clone(),
-            thread_id: thread_id.clone(),
-            start_sequence: 91,
-            end_sequence: 95,
-            summary_kind: SummaryKind::Compaction,
-            content: MessageContent::text("validated barrier"),
-            model_context_policy: Some(SummaryModelContextPolicy::ReplaceRangeWhenSelected),
-        })
-        .await
-        .unwrap();
-    backend.reset_query_observations();
-
-    let context = service
-        .load_context_window(LoadContextWindowRequest {
-            scope,
-            thread_id,
-            max_messages: 8,
-        })
-        .await
-        .unwrap();
-
-    assert_eq!(context.messages.len(), 6);
-    assert_eq!(context.messages[0].kind, MessageKind::Summary);
-    assert_eq!(context.messages[0].content, "validated barrier");
-    assert_eq!(
-        backend.ordered_query_limits(),
-        vec![1024, 9, 9],
-        "paging must stop once the selected summary range is fully validated",
     );
 }
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -232,7 +232,7 @@ One thread, whole real turn. Grouped by what the user experiences.
 | Stopping a running turn actually stops it (Cancelled, not Completed) | `cancel.rs` |
 | Typing again while the assistant is working queues the message and it gets picked up mid-run | `steering.rs` |
 | A flaky model provider is retried and recovered from, with typed errors | `model_recovery.rs` |
-| The newest durable compaction summary acts as a prompt-context barrier while older history remains stored | `model_recovery.rs::newest_compaction_summary_is_a_context_barrier` |
+| Incremental compaction summaries preserve every disjoint compacted range while raw covered history remains stored | `model_recovery.rs::compaction_summary_chain_preserves_earlier_compacted_history` |
 | A turn receives the expected tool results after each model iteration | `golden_payload.rs` |
 | A turn that reads two file ranges in parallel receives both results in the requested order | `golden_payload.rs` |
 | Approaching the run limit surfaces a recoverable warning, while repeated capability calls receive one advisory warning and may continue | `terminal_warning.rs` |

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -232,6 +232,7 @@ One thread, whole real turn. Grouped by what the user experiences.
 | Stopping a running turn actually stops it (Cancelled, not Completed) | `cancel.rs` |
 | Typing again while the assistant is working queues the message and it gets picked up mid-run | `steering.rs` |
 | A flaky model provider is retried and recovered from, with typed errors | `model_recovery.rs` |
+| The newest durable compaction summary acts as a prompt-context barrier while older history remains stored | `model_recovery.rs::newest_compaction_summary_is_a_context_barrier` |
 | A turn receives the expected tool results after each model iteration | `golden_payload.rs` |
 | A turn that reads two file ranges in parallel receives both results in the requested order | `golden_payload.rs` |
 | Approaching the run limit surfaces a recoverable warning, while repeated capability calls receive one advisory warning and may continue | `terminal_warning.rs` |

--- a/tests/integration/model_recovery.rs
+++ b/tests/integration/model_recovery.rs
@@ -184,12 +184,12 @@ async fn long_tool_run_keeps_the_original_task_after_raw_history_exceeds_window_
 }
 
 #[tokio::test]
-async fn newest_compaction_summary_is_a_context_barrier() {
-    const OLDEST_TURN: &str = "oldest transcript marker before the context barrier";
+async fn compaction_summary_chain_preserves_earlier_compacted_history() {
+    const OLDEST_TURN: &str = "oldest transcript marker before compaction";
     const MIDDLE_TURN: &str = "middle transcript marker before the newest summary";
     const RETAINED_TAIL: &str = "retained transcript tail after the newest summary";
-    const OLDER_SUMMARY: &str = "older summary that must stay behind the barrier";
-    const NEWEST_SUMMARY: &str = "newest summary that establishes the context barrier";
+    const OLDER_SUMMARY: &str = "older summary preserving earlier compacted history";
+    const NEWEST_SUMMARY: &str = "newest incremental compaction summary";
 
     let harness = RebornIntegrationHarness::test_default()
         .script([
@@ -248,17 +248,17 @@ async fn newest_compaction_summary_is_a_context_barrier() {
         .await
         .expect("tail after the barrier remains visible");
     harness
-        .assert_last_model_message_content_not_contains(OLDER_SUMMARY)
+        .assert_last_model_message_content_contains(OLDER_SUMMARY)
         .await
-        .expect("older summary stays behind the barrier");
+        .expect("earlier compacted history remains represented");
     harness
         .assert_last_model_message_content_not_contains(OLDEST_TURN)
         .await
-        .expect("original history stays behind the barrier");
+        .expect("raw history covered by a summary stays out of the prompt");
     harness
         .assert_conversation_history_contains(OLDEST_TURN)
         .await
-        .expect("the barrier does not delete durable history");
+        .expect("summary projection does not delete durable history");
 }
 
 #[tokio::test]

--- a/tests/integration/model_recovery.rs
+++ b/tests/integration/model_recovery.rs
@@ -184,6 +184,84 @@ async fn long_tool_run_keeps_the_original_task_after_raw_history_exceeds_window_
 }
 
 #[tokio::test]
+async fn newest_compaction_summary_is_a_context_barrier() {
+    const OLDEST_TURN: &str = "oldest transcript marker before the context barrier";
+    const MIDDLE_TURN: &str = "middle transcript marker before the newest summary";
+    const RETAINED_TAIL: &str = "retained transcript tail after the newest summary";
+    const OLDER_SUMMARY: &str = "older summary that must stay behind the barrier";
+    const NEWEST_SUMMARY: &str = "newest summary that establishes the context barrier";
+
+    let harness = RebornIntegrationHarness::test_default()
+        .script([
+            RebornScriptedReply::text("oldest reply"),
+            RebornScriptedReply::text("middle reply"),
+            RebornScriptedReply::text("tail reply"),
+            RebornScriptedReply::text("barrier verified"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+
+    harness.submit_turn(OLDEST_TURN).await.expect("oldest turn");
+    harness.submit_turn(MIDDLE_TURN).await.expect("middle turn");
+    harness.submit_turn(RETAINED_TAIL).await.expect("tail turn");
+
+    let oldest = harness
+        .user_message_record(OLDEST_TURN)
+        .await
+        .expect("oldest message");
+    let middle = harness
+        .user_message_record(MIDDLE_TURN)
+        .await
+        .expect("middle message");
+    let retained = harness
+        .user_message_record(RETAINED_TAIL)
+        .await
+        .expect("retained message");
+    harness
+        .create_compaction_summary_for_test(
+            oldest.sequence,
+            middle.sequence.checked_sub(1).expect("ordered messages"),
+            OLDER_SUMMARY,
+        )
+        .await
+        .expect("older summary persists");
+    harness
+        .create_compaction_summary_for_test(
+            middle.sequence,
+            retained.sequence.checked_sub(1).expect("ordered messages"),
+            NEWEST_SUMMARY,
+        )
+        .await
+        .expect("newest summary persists");
+
+    harness
+        .submit_turn("build the prompt after the newest summary")
+        .await
+        .expect("post-summary turn");
+    harness
+        .assert_last_model_message_content_contains(NEWEST_SUMMARY)
+        .await
+        .expect("newest summary reaches the prompt");
+    harness
+        .assert_last_model_message_content_contains(RETAINED_TAIL)
+        .await
+        .expect("tail after the barrier remains visible");
+    harness
+        .assert_last_model_message_content_not_contains(OLDER_SUMMARY)
+        .await
+        .expect("older summary stays behind the barrier");
+    harness
+        .assert_last_model_message_content_not_contains(OLDEST_TURN)
+        .await
+        .expect("original history stays behind the barrier");
+    harness
+        .assert_conversation_history_contains(OLDEST_TURN)
+        .await
+        .expect("the barrier does not delete durable history");
+}
+
+#[tokio::test]
 async fn context_overflow_recovers_with_model_visible_observation() {
     // Seed one oversized user message so forced compaction exercises the real
     // compactor instead of taking its safe "nothing eligible" skip path.

--- a/tests/integration/support/assertions.rs
+++ b/tests/integration/support/assertions.rs
@@ -745,6 +745,22 @@ impl RebornIntegrationHarness {
         .into())
     }
 
+    /// Assert that the final interactive model request omits `needle`.
+    ///
+    /// Earlier requests may contain the value legitimately, so this checks only
+    /// the caller-visible prompt produced after the state transition under test.
+    pub async fn assert_last_model_message_content_not_contains(
+        &self,
+        needle: &str,
+    ) -> HarnessResult<()> {
+        let requests = self.scripted_llm.captured_requests();
+        let last = requests.last().ok_or("no model requests were captured")?;
+        if last.iter().any(|message| message.content.contains(needle)) {
+            return Err(format!("final model request unexpectedly contained {needle:?}").into());
+        }
+        Ok(())
+    }
+
     /// Assert that one model-visible message contains every `needle` in the
     /// supplied order. Other content may appear between needles.
     pub async fn assert_model_message_content_in_order(

--- a/tests/integration/support/builder.rs
+++ b/tests/integration/support/builder.rs
@@ -1173,6 +1173,33 @@ impl RebornIntegrationHarness {
         Ok(Arc::new(self.thread_harness.service_instance()?))
     }
 
+    /// Persist a compaction summary over this harness thread.
+    ///
+    /// Tests use this to exercise prompt projection independently from the
+    /// threshold and model-inference paths that create summaries in production.
+    pub(crate) async fn create_compaction_summary_for_test(
+        &self,
+        start_sequence: u64,
+        end_sequence: u64,
+        content: &str,
+    ) -> HarnessResult<ironclaw_threads::SummaryArtifact> {
+        let scope = thread_scope_from_binding(&self.binding)?;
+        Ok(self
+            .thread_service_for_test()?
+            .create_summary_artifact(ironclaw_threads::CreateSummaryArtifactRequest {
+                scope,
+                thread_id: self.binding.thread_id.clone(),
+                start_sequence,
+                end_sequence,
+                summary_kind: ironclaw_threads::SummaryKind::Compaction,
+                content: ironclaw_threads::MessageContent::text(content),
+                model_context_policy: Some(
+                    ironclaw_threads::SummaryModelContextPolicy::ReplaceRangeWhenSelected,
+                ),
+            })
+            .await?)
+    }
+
     /// The group-shared turn coordinator every thread's runs execute on.
     pub(crate) fn turn_coordinator_for_test(&self) -> Arc<dyn TurnCoordinator> {
         Arc::clone(&self.coordinator)


### PR DESCRIPTION
## Summary

- Preserve every eligible, disjoint incremental compaction summary in model context.
- Order summaries deterministically by persisted range, content, and artifact identity across both thread backends.
- Keep raw transcript rows covered by summaries out of prompts while retaining all durable history.
- Add whole-turn coverage proving a second compaction does not erase the first compacted range.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #7824

This is the safety bridge required before a true newest-summary barrier can land. Current compaction writes disjoint summaries; cumulative summary folding remains a separate #7824 roadmap item.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] Full workspace Clippy (scoped Clippy passed)
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_threads`; `cargo test -p ironclaw_integration_tests --test reborn_integration_model_recovery`
- [ ] Backend feature suite: not applicable; no feature-gated storage implementation changed
- [ ] Manual testing: not applicable; provider-request behavior is covered in-process
- [x] `pr-shepherd` / review-comment audit performed

## Test Strategy

User behavior: Repeated compactions retain every compacted range as an ordered summary chain. Covered raw rows stay out of model requests and remain durably readable.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: deterministic persisted ordering for summary artifacts; full `ironclaw_threads` suite.
- Reborn integration: `compaction_summary_chain_preserves_earlier_compacted_history` drives repeated summary replacement through the real prompt seam.
- Recorded fixture: Not applicable.
- Browser E2E: Not applicable.
- Backend or runtime: both in-memory and filesystem thread-service contract suites run under `ironclaw_threads`.
- Live canary: Not applicable.

What the tests prove: The final model request contains both disjoint summaries and the retained tail, excludes covered raw history, and durable history still contains the original rows.

Commands run:
- `cargo fmt --all`
- `cargo test -p ironclaw_threads` — 322 passed
- `cargo test -p ironclaw_integration_tests --test reborn_integration_model_recovery` — 30 passed
- `cargo clippy -p ironclaw_threads --all-targets --all-features -- -D warnings`

## Security Impact

None. No permission, network, credential, filesystem-access, tool-execution, or sandbox policy changes.

## Reborn Trust-Boundary Checklist

- [x] No public trust-bearing types changed.
- [x] Prompt content continues through existing summary sanitization and model-message framing.
- [x] No hashes or authenticity checks changed.
- [x] No status, exit, runtime, policy, or error variants changed.
- [x] No serialization defaults or migrations changed.
- [x] Context remains bounded by the existing prompt budget; this PR changes summary selection only.
- [x] No error-class or runtime-lane changes.

## Database Impact

None. No schema or migration changes. Both in-memory and filesystem projections use the same deterministic summary ordering. Durable message and summary rows are unchanged.

## Blast Radius

`SessionThreadService::load_context_window` for threads with multiple compaction summaries. Single-summary and no-summary threads retain existing behavior.

## Rollback Plan

Revert this PR. Stored data requires no rollback because the change only affects read-time context projection.

## Review Follow-Through

Addressed the deterministic-order and paging review threads, then adopted Pierre's blocking correction: incremental summaries are complementary and must all remain projected until cumulative summary folding exists.

---

**Review track**: B (bug fix)