### PR TITLE
docs(changelog): backfill the v1.3.0 release entry onto main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,96 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-19
+
+Stable promotion of `1.3.0-rc.2`, including the upgrade and container fixes
+validated in RC2 and the complete RC1 scope below.
+
+### Fixed in 1.3.0-rc.2
+
+- Upgrades from 1.2 now accept and preserve the released extension
+  `activation_state` field instead of crash-looping during startup.
+- The canonical Reborn runtime image again supports opt-in, public-key-only
+  worker SSH on port 2222 while running IronClaw as an unprivileged user.
+
+### Added
+
+- **Per-user model preferences.** Each user picks their own model from WebUI
+  settings, the CLI, or chat commands, and the choice follows them through
+  channel turns and inbound replay. Admins bound what is selectable with a
+  tenant-scoped model selection policy.
+- **Structured automations.** A scheduled trigger now carries a validated
+  execution contract — prompt spec, execution policy, required skills — checked
+  by a fail-closed preflight at creation instead of a free-form prompt string,
+  and unattended runs get their own protocol. A deterministic no-result
+  sentinel lets a run that has nothing to report finish silently instead of
+  delivering filler.
+- **Document editing.** Structural edits to `.docx`, `.xlsx`, and `.pptx`
+  files, and PDF rendering from HTML.
+- **Telegram linked devices.** Pair a personal Telegram account with the bot
+  channel so the agent can read your conversations and act as you through the
+  standard messaging operations. Reads are live against Telegram's own servers
+  — there is no local mirror, retention policy, or search index of the account
+  — while message content a run actually reads is retained in that run's
+  transcript like any other tool result.
+- **The full Slack messaging vocabulary.** Eight more standard operations —
+  edit message, delete message, add reaction, remove reaction, open DM, get
+  message, resolve user, list members — complete the core surface.
+- **Ranked memory recall.** Retrieval ranks by relevance instead of requiring
+  every term of the question to appear in the saved fact, so a differently
+  worded question still finds it, and broken memory is visibly different from
+  empty memory. Memory-save guidance ships with an always-on `MEMORY.md` prompt
+  lane.
+- **Opt-in parallel tool batches** in the agent loop.
+- Explicit Anthropic `cache_control` prompt-cache breakpoints on both
+  transports.
+- A shared WebUI search field, and per-field help text on admin extension
+  configuration forms alongside a rewritten channel setup guide.
+
+### Changed
+
+- **Substantially fewer database writes per turn.** Capability invocation state
+  persists at gate and terminal edges only; runtime milestone events, thread
+  index touches, message lookup indexes, trigger and outbound state, and
+  process heartbeats all coalesce or fold into existing rows.
+- Turn execution runs on prepared-context ("unbound") turns behind one accept
+  door, replacing the kernel binding-ref path.
+- Channel ingress is normalized once, with reply split from delivery.
+- The public documentation site deploys from a `docs-live` branch that stable
+  releases move, so published docs describe the released binary rather than
+  unreleased `main`.
+
+### Fixed
+
+- Context-window eviction compacts instead of discarding: the accepted task and
+  any steering survive the eviction.
+- Lease expiry recovers safe runs instead of failing them, and the journal
+  heartbeat pool is isolated.
+- An unavailable capability call is repaired instead of aborting the run, and
+  repeated-call detection is advisory rather than fatal.
+- Model-bound secrets are redacted without rejecting the turn.
+- Telegram sticker and voice attachments no longer brick the channel, and the
+  2FA gate on migrated data centers is recognized and says where the login code
+  arrives.
+- Extension cards and install results report what actually happened; bundled
+  MCP state refreshes after auth; hosted MCP OAuth supports origin-scoped
+  servers.
+- WebUI: SSE reconnect storms are bounded, long conversation titles reveal on
+  hover, exposed-route copy is localized, and a failed tool call reads as a
+  subtle badge instead of a loud summary.
+- The resource governor keeps retrying through a full libSQL writer attempt
+  instead of surfacing the contention as a failure, and libSQL write-lane
+  starvation no longer cascades through it: the delta journal gets its own
+  bounded write lane, congestion is distinguished from storage damage so a
+  contended write replays instead of invalidating the authority, and stale
+  reservations are swept rather than leaking as permanent `Active` holds.
+
+### Removed
+
+- Retired WebUI surfaces: the standalone missions page, the routines surface,
+  admin analytics placeholders, and project mission placeholders.
+- Retired IronLoop network settings.
+
 ## [1.2.0] - 2026-08-13
 
 Stable promotion of `1.2.0-rc.3`, including the fixes validated in RC2 and

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -11,6 +11,49 @@ always documents the **latest stable release** — docs for earlier releases
 live in their git tags, such as
 [`ironclaw-v1.0.0`](https://github.com/nearai/ironclaw/tree/ironclaw-v1.0.0/docs).
 
+<Update label="2026-08-19" description="v1.3.0">
+
+**Your model, your automations, fewer writes.**
+
+- **Per-user model preferences** — pick your model in Settings, the CLI, or a
+  chat command, and it follows you across chat and channels. Admins bound the
+  selectable set with a tenant-scoped model policy.
+- **Automations you can trust to stay quiet** — scheduled runs carry a
+  validated execution contract instead of a free-form prompt, and a run with
+  nothing to report finishes silently rather than delivering filler.
+- **Document editing** — structural edits to `.docx`, `.xlsx`, and `.pptx`,
+  plus PDF rendering from HTML.
+- **Telegram linked devices** — pair your personal Telegram account with the
+  bot so the agent can read your conversations and act as you. Reads are live
+  and IronClaw keeps no mirror of your Telegram history; what the agent reads
+  in a run is retained in that conversation's transcript, like any other tool
+  result.
+- **The complete Slack messaging vocabulary** — edit and delete messages,
+  add and remove reactions, open DMs, read a message, resolve a user, list
+  members.
+- **Memory that actually recalls** — retrieval ranks by relevance instead of
+  demanding every word of your question appear in the saved fact, and broken
+  memory no longer looks like empty memory.
+- **Faster, quieter runs** — opt-in parallel tool batches, Anthropic prompt
+  cache breakpoints, and a large reduction in per-turn database writes.
+- Context-window eviction now compacts instead of dropping your task, an
+  unavailable tool call is repaired instead of ending the run, and secrets
+  bound for the model are redacted without rejecting the turn.
+- Under sustained write load on libSQL, database contention no longer surfaces
+  as unrelated tool calls failing with a resource error.
+
+**Upgrading from 1.2.0:** no migration steps — installation state written by
+1.2.x is accepted and preserved (1.3.0-rc.1 crash-looped on it; fixed in
+rc.2). **Slack re-consent:** the new Slack operations need
+`reactions:read`, `reactions:write`, and `im:write`. There is no scope-upgrade
+flow, so an account connected before this release answers those three tools
+with a permission denial until you disconnect and reconnect Slack; the other
+13 operations are unaffected. **Removed:** the standalone missions, routines,
+and admin analytics placeholder pages in the WebUI, and the retired IronLoop
+network settings.
+
+</Update>
+
 <Update label="2026-08-13" description="v1.2.0">
 
 **Shared channels that just work.**


### PR DESCRIPTION
## Summary

- The `v1.3.0` changelog entry was authored on the release branch (`70795c16e`, "promote 1.3.0-rc.2 to 1.3.0") and never cherry-picked back to `main`, even though that commit's own body states it would be.
- Release branches freeze and are never merged back, so `main`'s public changelog currently jumps **1.2.0 → 1.4.0**. The moment the next stable tag repoints `docs-live`, the live docs site silently drops the entire 1.3.0 release.
- Backfills both records verbatim from `release/1.3.1`: the `<Update label="2026-08-19" description="v1.3.0">` block in `docs/changelog.mdx`, and the `## [1.3.0] - 2026-08-19` section in `CHANGELOG.md`.
- Unblocks the 1.4.0 cut — `scripts/ci/cut_ironclaw_release.py` gates the stable tag on a matching `<Update>` entry, and the v1.4.0 entry has to sit above a v1.3.0 one.

**No 1.3.1 section.** 1.3.1 was cut as `rc.1` and never promoted to a stable tag; its two Telegram fixes (#7766, #7803) are already on `main` and belong in the next release's notes, not a backdated section.

Content is copied unchanged from the released branch rather than rewritten, so the public record matches what actually shipped.

## Change Type

- [x] Documentation

## Linked Issue

Related: forward-port reconciliation ahead of the 1.4.0 cut. See `docs/internal/weekly-release-strategy.md`, "Candidate and artifact rules" step 3.

## Validation

- [x] Relevant tests pass: `docs_publication_boundary.py`, `check-guidance.py`, and a direct call into the release gate
- [x] Manual testing: asserted `ensure_stable_changelog_entry` refuses `v1.4.0` (expected — that entry is the pre-cut step) and now accepts `v1.3.0` (it refused before this change)

`cargo fmt` / `clippy` / `build` not applicable: no Rust files touched.

## Test Strategy

User behavior: a reader of the public changelog page sees an unbroken version history; without this, 1.3.0 vanishes from the site at the next stable tag.

Risk areas:
- none of the listed risk areas apply (documentation content only)

Tests added or updated:
- Unit or contract: `Not applicable: no new behavior — the existing repo gates (docs publication boundary, guidance, and the cut-script changelog gate) already cover this file, and all three were run.`
- Reborn integration: `Not applicable: no runtime behavior.`
- Recorded fixture: `Not applicable.`
- Browser E2E: `Not applicable: Mintlify renders this page; verification is the post-promotion site check in the release runbook.`
- Backend or runtime: `Not applicable.`
- Live canary: `Not applicable.`

What the tests prove: the inserted `<Update>` block is well-formed and correctly nested (verified by boundary line inspection: entry opens at line 14, closes at 55, and 1.2.0 follows at 57), the page stays inside the docs publication fence, and the release cut script's stable-tag gate now passes for `v1.3.0`.

Commands run:

```
python3 scripts/ci/docs_publication_boundary.py   # every page published or fenced
python3 scripts/ci/check-guidance.py              # OK, 386 guidance files
python3 -c "from cut_ironclaw_release import ensure_stable_changelog_entry; ..."
  -> v1.3.0 gate: OK
  -> v1.4.0 gate: REFUSED (expected; that entry is authored at cut time)
```

## Security Impact

None.

## Reborn Trust-Boundary Checklist

N/A — documentation content only; no types, prompts, hashes, status variants, serde fields, or trust boundaries touched.

## Database Impact

None.
