### PR TITLE
fix(extension-registry): forward-port the 1.2 activation_state row fix to main (#7721)

### DIFF
--- a/crates/extensions/ironclaw_extension_registry/src/installations.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/installations.rs
@@ -1188,6 +1188,17 @@ struct V2InstallationRecord {
     schema_version: String,
     installation_id: ExtensionInstallationId,
     extension_id: ExtensionId,
+    /// Written by 1.2.x builds, which added the field under this same
+    /// `extension_state.v2` schema string. This release has no persisted
+    /// activation concept -- `ExtensionActivationState` is a compatibility
+    /// shim that always reports `Enabled` -- so the value is never read here.
+    /// It is nonetheless carried forward rather than discarded like the
+    /// diagnostic `health` field: `health` is regenerable, whereas this
+    /// records operator intent that a rollback to 1.2 would otherwise
+    /// silently reset to enabled. Absent on rows this release writes fresh,
+    /// which 1.2 reads as its own `enabled` default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    activation_state: Option<String>,
     manifest: WireManifestRecord,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     incarnation_id: Option<InstallationIncarnationId>,
@@ -2206,6 +2217,9 @@ impl ExtensionInstallationStore {
                         schema_version: EXTENSION_STATE_V2_SCHEMA.to_string(),
                         installation_id: installation.installation_id().clone(),
                         extension_id: installation.extension_id().clone(),
+                        activation_state: current
+                            .as_ref()
+                            .and_then(|record| record.activation_state.clone()),
                         manifest: wire,
                         incarnation_id: installation.incarnation_id().cloned(),
                         legacy_tenant_owner: installation.owner().is_tenant(),
@@ -3451,6 +3465,9 @@ impl ExtensionInstallationStorePort for ExtensionInstallationStore {
                         schema_version: EXTENSION_STATE_V2_SCHEMA.to_string(),
                         installation_id,
                         extension_id,
+                        activation_state: current
+                            .as_ref()
+                            .and_then(|record| record.activation_state.clone()),
                         manifest: wire,
                         incarnation_id: current
                             .as_ref()

--- a/crates/extensions/ironclaw_extension_registry/tests/installations_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/installations_contract.rs
@@ -2261,3 +2261,196 @@ impl RootFilesystem for QueryCountingBackend {
         self.inner.reserve_sequence(path).await
     }
 }
+
+/// A 1.2.x build persists an `activation_state` field into the
+/// `extension_state.v2` installation row without bumping the schema string, so
+/// the row still declares `extension_state.v2` and is routed to the current
+/// typed reader. `V2InstallationRecord` denies unknown fields, so a release
+/// that does not model the field aborts composition with `extension
+/// installation state could not be loaded` and the process crash-loops with
+/// every installed extension unreachable.
+///
+/// The field is accepted, and — unlike the diagnostic `health` field, which is
+/// regenerable and therefore discarded — it is preserved verbatim across
+/// writes, because it records operator intent that a rollback to 1.2 would
+/// otherwise silently reset to enabled.
+#[tokio::test]
+async fn v2_rows_carrying_activation_state_load_and_preserve_it() {
+    let filesystem: Arc<dyn RootFilesystem> = Arc::new(InMemoryBackend::new());
+    let root =
+        VirtualPath::new("/system/extensions/.installations/activation-state-compat").unwrap();
+    let store = ExtensionInstallationStore::load_at(
+        Arc::clone(&filesystem),
+        root.clone(),
+        HostPortCatalog::empty(),
+        contracts(),
+    )
+    .await
+    .unwrap();
+    let installed = normalized_installation("sha256:abc");
+    store
+        .upsert_manifest_and_installation(manifest("sha256:abc"), installed.clone())
+        .await
+        .unwrap();
+
+    // Rewrite the persisted row into the shape a 1.2.x build leaves behind.
+    // Mutating the stored entry in place keeps its real `kind` and `indexed`
+    // map, neither of which is constructible from this crate.
+    let installations = VirtualPath::new(format!("{}/v2/installations", root.as_str())).unwrap();
+    let rows = filesystem
+        .query(&installations, &Filter::All, Page::first(10))
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    let mut body: serde_json::Value = rows[0].entry.parse_json().unwrap();
+    body.as_object_mut()
+        .unwrap()
+        .insert("activation_state".to_string(), serde_json::json!("enabled"));
+    let mut entry = rows[0].entry.clone();
+    entry.body = serde_json::to_vec(&body).unwrap();
+    filesystem
+        .put(
+            &rows[0].path,
+            entry,
+            CasExpectation::Version(rows[0].version),
+        )
+        .await
+        .unwrap();
+
+    // Reopening the root is what `serve` does on every boot.
+    let reopened = ExtensionInstallationStore::load_at(
+        Arc::clone(&filesystem),
+        root.clone(),
+        HostPortCatalog::empty(),
+        contracts(),
+    )
+    .await
+    .expect("a 1.2-written installation row must not fail composition");
+    assert_eq!(
+        reopened
+            .get_installation(installed.installation_id())
+            .await
+            .unwrap(),
+        Some(installed.clone()),
+        "the installation must survive the upgrade, not just the boot"
+    );
+
+    // A later write must not silently drop the operator's setting.
+    reopened
+        .upsert_installation(installed.clone())
+        .await
+        .unwrap();
+    let rows = filesystem
+        .query(&installations, &Filter::All, Page::first(10))
+        .await
+        .unwrap();
+    let body: serde_json::Value = rows[0].entry.parse_json().unwrap();
+    assert_eq!(
+        body["activation_state"],
+        serde_json::json!("enabled"),
+        "a rewrite must carry the 1.2 activation state forward: {body}"
+    );
+}
+
+/// The removal path rebuilds the installation record from scratch rather than
+/// mutating it in place, so it is the one other place a 1.2-written
+/// `activation_state` can be dropped. Removing an extension must not quietly
+/// reset the operator's setting: the tombstone is retained for reactivation,
+/// so it has to retain the field too.
+///
+/// `persist_removal_tombstone` keys the row by extension id, so this fixture
+/// installs under an installation id equal to the extension id to make the
+/// removal path land on the seeded row.
+#[tokio::test]
+async fn removal_tombstone_carries_the_1_2_activation_state_forward() {
+    let filesystem: Arc<dyn RootFilesystem> = Arc::new(InMemoryBackend::new());
+    let root =
+        VirtualPath::new("/system/extensions/.installations/activation-state-tombstone").unwrap();
+    let store = ExtensionInstallationStore::load_at(
+        Arc::clone(&filesystem),
+        root.clone(),
+        HostPortCatalog::empty(),
+        contracts(),
+    )
+    .await
+    .unwrap();
+    let installed = ExtensionInstallation::new(
+        installation_id("acme-tools"),
+        extension_id("acme-tools"),
+        ExtensionManifestRef::new(
+            extension_id("acme-tools"),
+            Some(manifest_hash("sha256:abc")),
+        ),
+        vec![],
+        Utc::now(),
+        InstallationOwner::Tenant,
+    )
+    .unwrap();
+    store
+        .upsert_manifest_and_installation(manifest("sha256:abc"), installed.clone())
+        .await
+        .unwrap();
+
+    let installations = VirtualPath::new(format!("{}/v2/installations", root.as_str())).unwrap();
+    let rows = filesystem
+        .query(&installations, &Filter::All, Page::first(10))
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    let mut body: serde_json::Value = rows[0].entry.parse_json().unwrap();
+    body.as_object_mut().unwrap().insert(
+        "activation_state".to_string(),
+        serde_json::json!("disabled"),
+    );
+    let mut entry = rows[0].entry.clone();
+    entry.body = serde_json::to_vec(&body).unwrap();
+    filesystem
+        .put(
+            &rows[0].path,
+            entry,
+            CasExpectation::Version(rows[0].version),
+        )
+        .await
+        .unwrap();
+
+    // Soft removal mutates the record in place, so it preserves the field for
+    // free; assert it anyway, because it is the state the rebuild path below
+    // reads from.
+    store
+        .delete_installation(installed.installation_id())
+        .await
+        .unwrap();
+    let rows = filesystem
+        .query(&installations, &Filter::All, Page::first(10))
+        .await
+        .unwrap();
+    let body: serde_json::Value = rows[0].entry.parse_json().unwrap();
+    assert_eq!(
+        body["activation_state"],
+        serde_json::json!("disabled"),
+        "soft removal must not reset the 1.2 setting: {body}"
+    );
+
+    // `persist_removal_tombstone` rebuilds the record from scratch -- this is
+    // the site the boot-path test cannot reach.
+    store
+        .persist_removal_tombstone(manifest("sha256:abc"))
+        .await
+        .unwrap();
+
+    let rows = filesystem
+        .query(&installations, &Filter::All, Page::first(10))
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1, "removal retains the row as a tombstone");
+    let body: serde_json::Value = rows[0].entry.parse_json().unwrap();
+    assert!(
+        body["removed_at"].is_string(),
+        "the row must actually be tombstoned, or this proves nothing: {body}"
+    );
+    assert_eq!(
+        body["activation_state"],
+        serde_json::json!("disabled"),
+        "removal must not reset a 1.2 operator setting: {body}"
+    );
+}


### PR DESCRIPTION
## Summary

- Forward-ports #7721 (`505cf0a15c`, on `release/2026-08-17` and `release/1.3.1`) to `main`. It was never brought back, so **`main` still carries the 1.3.0-rc.1 crash-loop bug**.
- A 1.2.x build persists an `activation_state` key into the `extension_state.v2` installation row (commit `bdf8aef02`, released on the 1.2 line only) *without bumping the schema string*. `V2InstallationRecord` is `#[serde(deny_unknown_fields)]` — still is on `main` today — so every deployment upgraded from 1.2.x aborts composition with `extension installation state could not be loaded` and crash-loops with all installed extensions unreachable.
- Accepts the field and carries it forward across both write paths (`put_v2_installation_core` and the tombstone rebuild in `persist_removal_tombstone`). It is preserved rather than discarded like the diagnostic `health` field because it records operator intent that a rollback to 1.2 would otherwise silently reset to enabled.
- No migration, no schema bump: the field is optional in both directions.

**Release blocker.** Cutting 1.4.0 from `main` without this re-ships the boot crash to every box upgrading from 1.2.x. This is the second time this exact forward-port gap has bitten the 1.2/1.3 line — `bdf8aef02` itself only ever existed on a release branch, which is what created the incompatible row in the first place.

Cherry-picked clean onto `main` (`git merge-tree` simulation: zero conflicts); the commit is byte-identical to the released fix.

## Change Type

- [x] Bug fix

## Linked Issue

Related #7720. Forward-port of #7721.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_extension_registry --all-targets --all-features -- -D warnings`
- [x] Relevant tests pass: `cargo test -p ironclaw_extension_registry --test installations_contract` → 33 passed, 0 failed
- [x] Manual testing: red/green mutation — neutralized the `activation_state` field and both carry-forward sites, re-ran the suite, and confirmed exactly the two new tests fail and nothing else

## Test Strategy

User behavior: an operator upgrading a deployment from 1.2.x boots successfully with their installed extensions intact, instead of hitting a crash loop where every extension is unreachable.

Risk areas:
- [x] Persistence
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `crates/extensions/ironclaw_extension_registry/tests/installations_contract.rs` — `v2_rows_carrying_activation_state_load_and_preserve_it` (boot/read + `put_v2_installation_core` write path) and `removal_tombstone_carries_the_1_2_activation_state_forward` (the `persist_removal_tombstone` rebuild path, which the boot test cannot reach). Both run against libSQL as well via `normalized_v2_contract_runs_on_libsql`.
- Reborn integration: `Not applicable: the failure is a serde contract on a persisted row shape; the contract tier reaches the exact deserialize/serialize seam, and no production wiring above the store participates in the bug.`
- Recorded fixture: `Not applicable: no model interaction.`
- Browser E2E: `Not applicable: no UI surface.`
- Backend or runtime: covered — the libSQL leg of the contract suite exercises the real backend.
- Live canary: `Not applicable: reproducing this needs a row written by a 1.2.x binary, which the canary does not produce.`

What the tests prove: a stored row containing `activation_state` (as written by 1.2.x) deserializes instead of aborting composition, and the value survives both write paths rather than being silently reset on the next write or on removal. Proven discriminating, not merely passing — see the mutation run below.

Commands run:

```
cargo test -p ironclaw_extension_registry --test installations_contract
  -> test result: ok. 33 passed; 0 failed

# red/green: field + both carry-forward sites removed
cargo test -p ironclaw_extension_registry --test installations_contract
  -> test result: FAILED. 31 passed; 2 failed
  -> removal_tombstone_carries_the_1_2_activation_state_forward ... FAILED
  -> v2_rows_carrying_activation_state_load_and_preserve_it ... FAILED

cargo fmt --all -- --check                                                  -> clean
cargo clippy -p ironclaw_extension_registry --all-targets --all-features    -> clean
```

## Security Impact

None. No permissions, network calls, secrets, file access, tool execution, or sandbox policy are touched. The accepted field is stored and re-emitted opaquely as `Option<String>` and is never read or interpreted by this release.

## Reborn Trust-Boundary Checklist

- Public policy/evidence/trust-bearing types: none added. `V2InstallationRecord` is a private wire struct, unchanged in visibility.
- Untrusted content enters prompts only through an envelope/escaping primitive: N/A — the value never reaches a prompt.
- Hashes declare purpose: N/A — no hashing changed.
- New/changed status/exit/policy/runtime/error variants: none. The struct gains one optional field; no match sites change. Confirmed by `cargo clippy --all-targets` on the owning crate (non-exhaustive matches would fail to compile).
- Security/durability `serde(default)` fields fail closed or have migration tests: **this is the migration test.** The field is `#[serde(default, skip_serializing_if = "Option::is_none")]`; absent means absent, and the two new contract tests pin both directions (a 1.2-written row loads and round-trips; a row this release writes fresh omits the key, which 1.2 reads as its own `enabled` default).
- Queues/maps/buffers/counters bounds: N/A.
- Driver/operator-visible error class semantics: unchanged; this removes an error, adding none.
- Sandbox/native/host naming: N/A.

## Database Impact

No schema change and no migration. The `extension_state.v2` schema string is deliberately **not** bumped: the field is optional in both directions, so 1.2 and this release read each other's rows. Rollback to 1.2 is safe and, with this change, no longer silently resets the operator's activation setting.
