### PR TITLE
fix(docker): forward-port the 1.3 in-worker SSH and workspace-root fixes to main (#7723, #7804)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -457,6 +457,12 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # Durable project/workspace root. The Docker entrypoint defaults this to
 # `$IRONCLAW_REBORN_HOME/workspace`; non-container runs otherwise use cwd.
 # IRONCLAW_REBORN_WORKSPACE_ROOT=/data/ironclaw-reborn/workspace
+# Off unless set. Setting this to an OpenSSH PUBLIC key enables an in-container
+# sshd listening on container port 2222, for public-key-only login as user
+# `agent`. The orchestrator must still publish that port (for example
+# `docker run -p 2222:2222`) for it to be reachable; it is not published by
+# default.
+# IRONCLAW_REBORN_SSH_PUBLIC_KEY=ssh-ed25519 AAAA...replace-with-your-public-key
 # IRONCLAW_REBORN_PROFILE=local-dev
 # IRONCLAW_REBORN_LOG=info
 # IRONCLAW_REBORN_POSTGRES_URL=postgres://user:password@db.example.com/ironclaw?sslmode=require

--- a/.env.example
+++ b/.env.example
@@ -454,6 +454,9 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # entrypoint fails closed for Railway local-dev profiles without a volume unless
 # IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY=true is set for disposable tests.
 # IRONCLAW_REBORN_HOME=/data/ironclaw-reborn
+# Durable project/workspace root. The Docker entrypoint defaults this to
+# `$IRONCLAW_REBORN_HOME/workspace`; non-container runs otherwise use cwd.
+# IRONCLAW_REBORN_WORKSPACE_ROOT=/data/ironclaw-reborn/workspace
 # IRONCLAW_REBORN_PROFILE=local-dev
 # IRONCLAW_REBORN_LOG=info
 # IRONCLAW_REBORN_POSTGRES_URL=postgres://user:password@db.example.com/ironclaw?sslmode=require

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -86,7 +86,7 @@ jobs:
             echo "has_clippy=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(crates/|tests/|migrations/|Cargo\.toml$|Cargo\.lock$|deny\.toml$|Dockerfile|\.gitignore$|scripts/ci/|\.githooks/|docker/reborn/entrypoint\.sh$|scripts/reborn_webui_v2_live_qa/|scripts/live-canary/|\.github/workflows/(live-canary|reborn-e2e)\.yml$|scripts/check_no_panics\.py$|scripts/no_panics_reborn_baseline\.txt$|scripts/(check|test-check)-type-duplicates\.py$|\.github/scripts/(pr-labeler|test-pr-labeler)\.sh$|\.github/workflows/(code_style|main-ci-slack-alerts)\.yml$|\.github/workflows/ironclaw-release\.yml$|rust-toolchain\.toml$|\.github/actions/setup-rust/)'; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(crates/|tests/|migrations/|Cargo\.toml$|Cargo\.lock$|deny\.toml$|Dockerfile|\.gitignore$|scripts/ci/|\.githooks/|docker/reborn/(entrypoint|start-sshd)\.sh$|scripts/reborn_webui_v2_live_qa/|scripts/live-canary/|\.github/workflows/(live-canary|reborn-e2e)\.yml$|scripts/check_no_panics\.py$|scripts/no_panics_reborn_baseline\.txt$|scripts/(check|test-check)-type-duplicates\.py$|\.github/scripts/(pr-labeler|test-pr-labeler)\.sh$|\.github/workflows/(code_style|main-ci-slack-alerts)\.yml$|\.github/workflows/ironclaw-release\.yml$|rust-toolchain\.toml$|\.github/actions/setup-rust/)'; then
             echo "has_code=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_code=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -134,7 +134,7 @@ jobs:
             echo "has_wasm_abi_risk=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if has_match '^(Dockerfile|\.dockerignore$|\.github/workflows/platform-and-compat\.yml$)'; then
+          if has_match '^(Dockerfile|\.dockerignore$|docker/reborn/(entrypoint|start-sshd)\.sh$|\.github/workflows/platform-and-compat\.yml$)'; then
             echo "has_docker_risk=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_docker_risk=false" >> "$GITHUB_OUTPUT"
@@ -341,9 +341,9 @@ jobs:
     # Dockerfile changes must not be a main-only failure: the merge queue
     # builds the image when the merge group actually touches Docker inputs.
     # The merge_group arm deliberately does not require has_legacy_tests —
-    # the scope classifier matches the literal `Dockerfile`, so a
-    # .dockerignore-only merge group reports has_legacy_tests=false while
-    # has_docker_risk=true.
+    # the scope classifier matches Docker inputs directly, so a merge group
+    # changing only .dockerignore or a Reborn startup script reports
+    # has_legacy_tests=false while has_docker_risk=true.
     if: >
       needs.changes.outputs.docs_only != 'true' &&
       ((needs.changes.outputs.has_legacy_tests == 'true' &&
@@ -360,6 +360,59 @@ jobs:
           persist-credentials: false
       - name: Build Docker image
         run: docker build --target runtime -t ironclaw-reborn-test:ci .
+      - name: Verify in-worker SSH
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          test "$(docker image inspect --format '{{.Config.User}}' ironclaw-reborn-test:ci)" = "root"
+          docker image inspect --format '{{json .Config.ExposedPorts}}' ironclaw-reborn-test:ci \
+            | grep -q '"2222/tcp"'
+
+          ssh_work="$(mktemp -d)"
+          container_name="ironclaw-reborn-ssh-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() {
+            docker rm --force "$container_name" >/dev/null 2>&1 || true
+            rm -rf "$ssh_work"
+          }
+          trap cleanup EXIT
+
+          ssh-keygen -q -t ed25519 -N '' -f "$ssh_work/id_ed25519"
+          docker run --detach \
+            --name "$container_name" \
+            --publish 127.0.0.1::2222 \
+            --env IRONCLAW_REBORN_WEBUI_TOKEN=ssh-ci-webui-token-0123456789abcdef0123456789abcdef \
+            --env "IRONCLAW_REBORN_SSH_PUBLIC_KEY=$(cat "$ssh_work/id_ed25519.pub")" \
+            ironclaw-reborn-test:ci
+
+          ssh_port="$(docker port "$container_name" 2222/tcp | awk -F: 'NR == 1 { print $NF }')"
+          ssh_ready=false
+          for _ in $(seq 1 30); do
+            if ssh \
+              -i "$ssh_work/id_ed25519" \
+              -p "$ssh_port" \
+              -o BatchMode=yes \
+              -o ConnectTimeout=1 \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              agent@127.0.0.1 \
+              'test "$USER" = agent && test "$HOME" = /workspace && test "$PWD" = /workspace'
+            then
+              ssh_ready=true
+              break
+            fi
+            if [ "$(docker inspect --format '{{.State.Running}}' "$container_name")" != "true" ]; then
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "$ssh_ready" != "true" ]; then
+            docker logs "$container_name"
+            echo "Reborn runtime did not accept an SSH session as agent" >&2
+            exit 1
+          fi
 
   version-check:
     name: Version Bump Check

--- a/.github/workflows/platform-and-compat.yml
+++ b/.github/workflows/platform-and-compat.yml
@@ -371,8 +371,10 @@ jobs:
 
           ssh_work="$(mktemp -d)"
           container_name="ironclaw-reborn-ssh-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          paste_container_name="${container_name}-paste"
           cleanup() {
             docker rm --force "$container_name" >/dev/null 2>&1 || true
+            docker rm --force "$paste_container_name" >/dev/null 2>&1 || true
             rm -rf "$ssh_work"
           }
           trap cleanup EXIT
@@ -411,6 +413,47 @@ jobs:
           if [ "$ssh_ready" != "true" ]; then
             docker logs "$container_name"
             echo "Reborn runtime did not accept an SSH session as agent" >&2
+            exit 1
+          fi
+
+          paste_key="$(cat "$ssh_work/id_ed25519.pub")"$'\n'
+          # The key almost always arrives via `cat id_ed25519.pub`, so the value
+          # carries a trailing newline. start-sshd must tolerate that: it runs
+          # under the entrypoint's `set -e`, so rejecting a usable key does not
+          # merely disable SSH, it aborts the whole container boot. Reuses the
+          # image already built above -- no second build.
+          docker run --detach \
+            --name "$paste_container_name" \
+            --publish 127.0.0.1::2222 \
+            --env IRONCLAW_REBORN_WEBUI_TOKEN=ssh-ci-webui-token-0123456789abcdef0123456789abcdef \
+            --env "IRONCLAW_REBORN_SSH_PUBLIC_KEY=${paste_key}" \
+            ironclaw-reborn-test:ci
+
+          paste_port="$(docker port "$paste_container_name" 2222/tcp | awk -F: 'NR == 1 { print $NF }')"
+          paste_ready=false
+          for _ in $(seq 1 30); do
+            if ssh \
+              -i "$ssh_work/id_ed25519" \
+              -p "$paste_port" \
+              -o BatchMode=yes \
+              -o ConnectTimeout=1 \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              agent@127.0.0.1 'test "$USER" = agent'
+            then
+              paste_ready=true
+              break
+            fi
+            if [ "$(docker inspect --format '{{.State.Running}}' "$paste_container_name")" != "true" ]; then
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "$paste_ready" != "true" ]; then
+            docker logs "$paste_container_name"
+            echo "A public key with a trailing newline must still be accepted; rejecting it aborts container boot" >&2
             exit 1
           fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,8 @@ RUN apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         ca-certificates \
         curl \
+        gosu \
+        openssh-server \
         postgresql-client \
         sqlite3 \
     && rm -rf /var/lib/apt/lists/*
@@ -128,20 +130,23 @@ COPY docker/reborn/config.hosted-single-tenant.toml /opt/ironclaw/reborn/config.
 COPY docker/reborn/config.hosted-single-tenant-volume.toml /opt/ironclaw/reborn/config.hosted-single-tenant-volume.toml
 COPY docker/reborn/config.production.toml /opt/ironclaw/reborn/config.production.toml
 COPY docker/reborn/entrypoint.sh /usr/local/bin/ironclaw-reborn-entrypoint
+COPY docker/reborn/start-sshd.sh /usr/local/bin/ironclaw-reborn-start-sshd
 
 ENV HOME=/home/ironclaw \
     IRONCLAW_REBORN_LOG=info \
     IRONCLAW_REBORN_SERVE_HOST=127.0.0.1
 
 RUN useradd -m -d /home/ironclaw -u 1000 ironclaw \
+    && useradd --non-unique --uid 1000 --gid ironclaw --home-dir /workspace --shell /bin/bash agent \
+    && passwd -d agent \
     && mkdir -p /data/ironclaw-reborn /workspace \
     && chown -R ironclaw:ironclaw /home/ironclaw /data/ironclaw-reborn /workspace \
-    && chmod +x /usr/local/bin/ironclaw-reborn-entrypoint
+    && chmod +x /usr/local/bin/ironclaw-reborn-entrypoint /usr/local/bin/ironclaw-reborn-start-sshd
 
 WORKDIR /workspace
 
-EXPOSE 3000
+EXPOSE 3000 2222
 
-USER ironclaw
+USER root
 
 ENTRYPOINT ["ironclaw-reborn-entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,6 +136,10 @@ ENV HOME=/home/ironclaw \
     IRONCLAW_REBORN_LOG=info \
     IRONCLAW_REBORN_SERVE_HOST=127.0.0.1
 
+# `agent` is a deliberate uid-1000 alias of `ironclaw`, not a separate,
+# lower-privileged account. A session logged in as `agent` (e.g. over SSH)
+# holds the full runtime identity and can read/write everything the IronClaw
+# process owns.
 RUN useradd -m -d /home/ironclaw -u 1000 ironclaw \
     && useradd --non-unique --uid 1000 --gid ironclaw --home-dir /workspace --shell /bin/bash agent \
     && passwd -d agent \
@@ -147,6 +151,10 @@ WORKDIR /workspace
 
 EXPOSE 3000 2222
 
+# The container starts as root; ironclaw-reborn-entrypoint performs the ONLY
+# privilege drop (exec gosu ironclaw). Anything that bypasses the entrypoint —
+# `docker run --entrypoint`, `docker exec` without `--user`, or a platform
+# custom start command — runs as root instead.
 USER root
 
 ENTRYPOINT ["ironclaw-reborn-entrypoint"]

--- a/crates/app/ironclaw_cli/src/runtime/mod.rs
+++ b/crates/app/ironclaw_cli/src/runtime/mod.rs
@@ -1751,8 +1751,9 @@ mod tests {
         GoogleOAuthConfigState, GoogleOAuthEnvInputs, GoogleOAuthResolution, RuntimeInputCaller,
         RuntimeInputOptions, apply_credential_refresh_override, block_on_cli, build_runtime_input,
         build_runtime_input_with_options, initialize_local_runtime_storage_root,
-        no_assistant_text_message, protect_reborn_log_filter, resolve_google_oauth_config,
-        resolve_google_oauth_config_state, resolve_google_oauth_config_state_merged,
+        local_runtime_workspace_root, no_assistant_text_message, protect_reborn_log_filter,
+        resolve_google_oauth_config, resolve_google_oauth_config_state,
+        resolve_google_oauth_config_state_merged,
         resolve_google_oauth_config_state_with_store_loader, runner_settings,
         with_binary_host_extension_bindings_from_bundles,
     };
@@ -2952,6 +2953,53 @@ regex_activation_enabled = false
             error
                 .to_string()
                 .contains("failed to initialize Reborn runtime state")
+        );
+    }
+
+    #[test]
+    fn local_runtime_workspace_root_uses_explicit_env_override() {
+        // A reviewer noted IRONCLAW_REBORN_WORKSPACE_ROOT feeds two production
+        // builders with no test anywhere; this pins the override path.
+        let _lock = lock_runtime_env();
+        let explicit = std::path::PathBuf::from("/tmp/example-reborn-workspace-root");
+        let _workspace_root = EnvGuard::set(
+            "IRONCLAW_REBORN_WORKSPACE_ROOT",
+            explicit.to_str().expect("test path must be valid utf8"),
+        );
+
+        let root = local_runtime_workspace_root(ironclaw_config::RebornProfile::Standalone)
+            .expect("explicit workspace root must resolve");
+
+        assert_eq!(root, explicit);
+    }
+
+    #[test]
+    fn local_runtime_workspace_root_falls_back_to_current_dir_when_unset() {
+        let _lock = lock_runtime_env();
+        let _workspace_root = EnvGuard::clear("IRONCLAW_REBORN_WORKSPACE_ROOT");
+
+        let root = local_runtime_workspace_root(ironclaw_config::RebornProfile::Standalone)
+            .expect("unset workspace root must fall back to the current directory");
+
+        assert_eq!(
+            root,
+            std::env::current_dir().expect("current dir must be resolvable in test")
+        );
+    }
+
+    #[test]
+    fn local_runtime_workspace_root_rejects_explicitly_empty_value() {
+        let _lock = lock_runtime_env();
+        let _workspace_root = EnvGuard::set("IRONCLAW_REBORN_WORKSPACE_ROOT", "");
+
+        let error = local_runtime_workspace_root(ironclaw_config::RebornProfile::Standalone)
+            .expect_err(
+                "an explicitly empty workspace root must fail loudly, not silently fall back",
+            );
+
+        assert!(
+            error.to_string().contains("IRONCLAW_REBORN_WORKSPACE_ROOT"),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/app/ironclaw_cli/src/runtime/mod.rs
+++ b/crates/app/ironclaw_cli/src/runtime/mod.rs
@@ -941,8 +941,7 @@ fn build_standalone_local_runtime_services_input(
     options: RuntimeInputOptions,
 ) -> anyhow::Result<RebornHostBindings> {
     let local_runtime_root = local_runtime_storage_root(config, profile);
-    let workspace_root = std::env::current_dir()
-        .with_context(|| format!("failed to resolve current directory for {profile} workspace"))?;
+    let workspace_root = local_runtime_workspace_root(profile)?;
     let mut services_input = local_runtime_build_input_with_options(
         composition_profile(profile),
         owner_id,
@@ -970,8 +969,7 @@ fn build_hosted_single_tenant_services_input(
     config: &RebornBootConfig,
     config_file: Option<&ironclaw_config::RebornConfigFile>,
 ) -> anyhow::Result<RebornHostBindings> {
-    let workspace_root = std::env::current_dir()
-        .context("failed to resolve current directory for hosted single-tenant workspace")?;
+    let workspace_root = local_runtime_workspace_root(profile)?;
     let runtime_policy = hosted_single_tenant_runtime_policy()
         .context("failed to resolve hosted single-tenant runtime policy")?;
     Ok(
@@ -1334,6 +1332,24 @@ fn confirmed_host_home_root(options: RuntimeInputOptions) -> anyhow::Result<Path
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)
         .context("HOME or USERPROFILE must be set")
+}
+
+fn optional_path_env(name: &str) -> anyhow::Result<Option<PathBuf>> {
+    match std::env::var_os(name) {
+        None => Ok(None),
+        Some(value) if value.is_empty() => anyhow::bail!("{name} must not be empty when set"),
+        Some(value) => Ok(Some(PathBuf::from(value))),
+    }
+}
+
+fn local_runtime_workspace_root(profile: RebornProfile) -> anyhow::Result<PathBuf> {
+    optional_path_env("IRONCLAW_REBORN_WORKSPACE_ROOT")?
+        .map(Ok)
+        .unwrap_or_else(|| {
+            std::env::current_dir().with_context(|| {
+                format!("failed to resolve current directory for {profile} workspace")
+            })
+        })
 }
 
 pub(crate) fn local_runtime_storage_root(

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -34,6 +34,13 @@ else
 fi
 export IRONCLAW_REBORN_HOME
 
+if [ -n "${IRONCLAW_REBORN_WORKSPACE_ROOT:-}" ]; then
+  IRONCLAW_REBORN_WORKSPACE_ROOT="${IRONCLAW_REBORN_WORKSPACE_ROOT%/}"
+else
+  IRONCLAW_REBORN_WORKSPACE_ROOT="$IRONCLAW_REBORN_HOME/workspace"
+fi
+export IRONCLAW_REBORN_WORKSPACE_ROOT
+
 ssh_public_key="${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}"
 if [ "$(id -u)" = "0" ]; then
   mkdir -p "$IRONCLAW_REBORN_HOME" /workspace
@@ -253,9 +260,35 @@ then
           exit 1
           ;;
       esac
+      # Compare canonicalized paths, not their original spelling. A symlink
+      # beneath the mount whose target is outside it, or a `..` segment such as
+      # `/volume/../ephemeral`, passes a purely lexical prefix test while the
+      # runtime resolves the real (ephemeral) target — booting a deployment
+      # whose project files silently do not persist, which is the exact failure
+      # this guard exists to prevent. `readlink -f` resolves symlinks and
+      # relative segments without requiring the path to exist yet, and falls
+      # back to the original spelling if it is unavailable.
+      canonical_workspace_root="$(readlink -f "$IRONCLAW_REBORN_WORKSPACE_ROOT" 2>/dev/null \
+        || printf '%s' "$IRONCLAW_REBORN_WORKSPACE_ROOT")"
+      canonical_volume_mount="$(readlink -f "$railway_volume_mount" 2>/dev/null \
+        || printf '%s' "$railway_volume_mount")"
+      case "$canonical_workspace_root" in
+        "$canonical_volume_mount"|"$canonical_volume_mount"/*) ;;
+        *)
+          echo "Railway deployment using profile=$effective_profile requires IRONCLAW_REBORN_WORKSPACE_ROOT=$IRONCLAW_REBORN_WORKSPACE_ROOT (resolved: $canonical_workspace_root) to be under RAILWAY_VOLUME_MOUNT_PATH=$railway_volume_mount (resolved: $canonical_volume_mount)." >&2
+          echo "Unset IRONCLAW_REBORN_WORKSPACE_ROOT to use $IRONCLAW_REBORN_HOME/workspace, or set IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY=true only for disposable tests." >&2
+          exit 1
+          ;;
+      esac
       ;;
   esac
 fi
+
+case "$effective_profile" in
+  local-dev|local-dev-yolo|hosted-single-tenant|hosted-single-tenant-volume|hosted-single-tenant-volume-sandboxed|hosted-single-tenant-volume-sandboxed-railway)
+    mkdir -p "$IRONCLAW_REBORN_WORKSPACE_ROOT"
+    ;;
+esac
 
 # Serve-host resolution: an explicit IRONCLAW_REBORN_SERVE_HOST always wins.
 # Otherwise, on Railway (and any platform that sets the RAILWAY_* markers) the

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -43,8 +43,16 @@ export IRONCLAW_REBORN_WORKSPACE_ROOT
 
 ssh_public_key="${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}"
 if [ "$(id -u)" = "0" ]; then
-  mkdir -p "$IRONCLAW_REBORN_HOME" /workspace
-  chown ironclaw:ironclaw "$IRONCLAW_REBORN_HOME" /workspace
+  # The workspace root is created and chowned here too (not just at
+  # $IRONCLAW_REBORN_HOME and /workspace) because an explicit
+  # IRONCLAW_REBORN_WORKSPACE_ROOT override can point at a path whose parent
+  # is a fresh, root-owned volume mount. Left until the later unprivileged
+  # `mkdir -p` (below, after the privilege drop), that call would fail closed
+  # with EACCES under `set -eu` and abort the container at boot. This chown
+  # is intentionally non-recursive (no `-R`): start-sshd.sh relies on
+  # $IRONCLAW_REBORN_HOME/ssh staying root-owned.
+  mkdir -p "$IRONCLAW_REBORN_HOME" /workspace "$IRONCLAW_REBORN_WORKSPACE_ROOT"
+  chown ironclaw:ironclaw "$IRONCLAW_REBORN_HOME" /workspace "$IRONCLAW_REBORN_WORKSPACE_ROOT"
   if [ -n "$ssh_public_key" ]; then
     ironclaw-reborn-start-sshd
   fi
@@ -265,13 +273,25 @@ then
       # `/volume/../ephemeral`, passes a purely lexical prefix test while the
       # runtime resolves the real (ephemeral) target — booting a deployment
       # whose project files silently do not persist, which is the exact failure
-      # this guard exists to prevent. `readlink -f` resolves symlinks and
-      # relative segments without requiring the path to exist yet, and falls
-      # back to the original spelling if it is unavailable.
-      canonical_workspace_root="$(readlink -f "$IRONCLAW_REBORN_WORKSPACE_ROOT" 2>/dev/null \
-        || printf '%s' "$IRONCLAW_REBORN_WORKSPACE_ROOT")"
-      canonical_volume_mount="$(readlink -f "$railway_volume_mount" 2>/dev/null \
-        || printf '%s' "$railway_volume_mount")"
+      # this guard exists to prevent. `readlink -m` canonicalizes symlinks and
+      # `.`/`..` segments even when a path (or an intermediate component of it)
+      # does not exist yet. `readlink -f` requires every component but the
+      # last to already exist and otherwise fails outright, which used to send
+      # a not-yet-created path (routine for a fresh volume) down a fallback to
+      # its raw, unresolved spelling — and a raw spelling containing `..` can
+      # lexically match the containment check below while actually resolving
+      # outside the mount, defeating this guard. There is deliberately no
+      # fallback to the raw spelling any more: failing closed on a
+      # canonicalization error is safe, silently comparing an unresolved path
+      # is not.
+      if ! canonical_workspace_root="$(readlink -m "$IRONCLAW_REBORN_WORKSPACE_ROOT" 2>/dev/null)"; then
+        echo "Failed to resolve IRONCLAW_REBORN_WORKSPACE_ROOT=$IRONCLAW_REBORN_WORKSPACE_ROOT for the Railway containment check." >&2
+        exit 1
+      fi
+      if ! canonical_volume_mount="$(readlink -m "$railway_volume_mount" 2>/dev/null)"; then
+        echo "Failed to resolve RAILWAY_VOLUME_MOUNT_PATH=$railway_volume_mount for the Railway containment check." >&2
+        exit 1
+      fi
       case "$canonical_workspace_root" in
         "$canonical_volume_mount"|"$canonical_volume_mount"/*) ;;
         *)

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -24,6 +24,15 @@ fi
 
 if [ -n "${IRONCLAW_REBORN_HOME:-}" ]; then
   IRONCLAW_REBORN_HOME="${IRONCLAW_REBORN_HOME%/}"
+  # `${VAR%/}` turns a bare "/" into an empty string, which used to reach
+  # `mkdir -p "" /workspace` and die with a confusing diagnostic. Reject the
+  # filesystem root outright rather than restoring it: the root pass chowns
+  # this path to the runtime uid, so honoring "/" would hand uid 1000
+  # ownership of the container's entire root filesystem.
+  if [ -z "$IRONCLAW_REBORN_HOME" ]; then
+    echo "IRONCLAW_REBORN_HOME must not be the filesystem root (/); it is chowned to the unprivileged runtime user at startup." >&2
+    exit 1
+  fi
 elif [ -n "$railway_volume_mount" ]; then
   case "$railway_volume_mount" in
     */ironclaw-reborn) IRONCLAW_REBORN_HOME="$railway_volume_mount" ;;
@@ -36,6 +45,13 @@ export IRONCLAW_REBORN_HOME
 
 if [ -n "${IRONCLAW_REBORN_WORKSPACE_ROOT:-}" ]; then
   IRONCLAW_REBORN_WORKSPACE_ROOT="${IRONCLAW_REBORN_WORKSPACE_ROOT%/}"
+  # Same reasoning as IRONCLAW_REBORN_HOME above. Without this the empty value
+  # reached `readlink -m ""`, which exits non-zero and, under `set -eu`, killed
+  # the boot with no diagnostic at all.
+  if [ -z "$IRONCLAW_REBORN_WORKSPACE_ROOT" ]; then
+    echo "IRONCLAW_REBORN_WORKSPACE_ROOT must not be the filesystem root (/)." >&2
+    exit 1
+  fi
 else
   IRONCLAW_REBORN_WORKSPACE_ROOT="$IRONCLAW_REBORN_HOME/workspace"
 fi

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -51,8 +51,36 @@ if [ "$(id -u)" = "0" ]; then
   # with EACCES under `set -eu` and abort the container at boot. This chown
   # is intentionally non-recursive (no `-R`): start-sshd.sh relies on
   # $IRONCLAW_REBORN_HOME/ssh staying root-owned.
-  mkdir -p "$IRONCLAW_REBORN_HOME" /workspace "$IRONCLAW_REBORN_WORKSPACE_ROOT"
-  chown ironclaw:ironclaw "$IRONCLAW_REBORN_HOME" /workspace "$IRONCLAW_REBORN_WORKSPACE_ROOT"
+  mkdir -p "$IRONCLAW_REBORN_HOME" /workspace
+  chown ironclaw:ironclaw "$IRONCLAW_REBORN_HOME" /workspace
+  # ...but ONLY when the override provably lives inside a directory this
+  # entrypoint already manages. The Railway containment check that validates an
+  # operator-supplied workspace root runs after the privilege drop (it needs
+  # $effective_profile, resolved from the config file further down), so
+  # chowning the raw value here would hand the runtime uid ownership of an
+  # arbitrary path -- `IRONCLAW_REBORN_WORKSPACE_ROOT=/etc` chowns /etc to
+  # ironclaw before anything rejects it. Paths outside are left untouched: the
+  # containment check rejects them shortly afterwards, and off-Railway the
+  # later unprivileged `mkdir -p` reports the failure as it did before.
+  # Compare canonicalized paths so `$IRONCLAW_REBORN_HOME/../../etc` cannot
+  # spell its way in.
+  canonical_home="$(readlink -m "$IRONCLAW_REBORN_HOME")"
+  canonical_ws_root="$(readlink -m "$IRONCLAW_REBORN_WORKSPACE_ROOT")"
+  workspace_root_managed=false
+  case "$canonical_ws_root" in
+    "$canonical_home"|"$canonical_home"/*) workspace_root_managed=true ;;
+  esac
+  if [ "$workspace_root_managed" = false ] \
+    && [ -n "$railway_volume_mount" ] && [ "$railway_volume_mount" != "/" ]; then
+    canonical_mount="$(readlink -m "$railway_volume_mount")"
+    case "$canonical_ws_root" in
+      "$canonical_mount"/*) workspace_root_managed=true ;;
+    esac
+  fi
+  if [ "$workspace_root_managed" = true ]; then
+    mkdir -p "$IRONCLAW_REBORN_WORKSPACE_ROOT"
+    chown ironclaw:ironclaw "$IRONCLAW_REBORN_WORKSPACE_ROOT"
+  fi
   if [ -n "$ssh_public_key" ]; then
     ironclaw-reborn-start-sshd
   fi

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -33,6 +33,22 @@ else
   IRONCLAW_REBORN_HOME="/data/ironclaw-reborn"
 fi
 export IRONCLAW_REBORN_HOME
+
+ssh_public_key="${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}"
+if [ "$(id -u)" = "0" ]; then
+  mkdir -p "$IRONCLAW_REBORN_HOME" /workspace
+  chown ironclaw:ironclaw "$IRONCLAW_REBORN_HOME" /workspace
+  if [ -n "$ssh_public_key" ]; then
+    ironclaw-reborn-start-sshd
+  fi
+  unset IRONCLAW_REBORN_SSH_PUBLIC_KEY
+  exec gosu ironclaw "$0" "$@"
+fi
+if [ -n "$ssh_public_key" ]; then
+  echo "direct SSH requires the container entrypoint to start as root" >&2
+  exit 1
+fi
+
 if [ -n "${IRONCLAW_REBORN_DEFAULT_CONFIG:-}" ]; then
   default_config="$IRONCLAW_REBORN_DEFAULT_CONFIG"
 else

--- a/docker/reborn/start-sshd.sh
+++ b/docker/reborn/start-sshd.sh
@@ -62,6 +62,44 @@ else
 fi
 chmod 600 "$host_key"
 
+# ssh-keygen -l -f (below) exits 0 for a private key file too, so a pasted
+# private key must be rejected here, before anything derived from it is ever
+# written to disk. Never echo $public_key itself into a diagnostic.
+case "$public_key" in
+  *'-----BEGIN'*)
+    echo "IRONCLAW_REBORN_SSH_PUBLIC_KEY looks like a private key (PEM header found); supply the matching .pub public key instead" >&2
+    exit 1
+    ;;
+esac
+
+# Operators routinely paste the key straight out of `cat id_ed25519.pub`, which
+# carries a trailing newline, and some consoles add surrounding blank lines.
+# Those are valid single-line keys, so strip surrounding whitespace BEFORE the
+# single-line check below -- otherwise the most common paste is rejected, and
+# because the entrypoint runs this under `set -e` a rejection aborts the whole
+# container boot, not just SSH.
+key_lines="$(printf '%s' "$public_key" | awk 'NF { gsub(/^[ \t\r]+|[ \t\r]+$/, ""); print }')"
+if [ -z "$key_lines" ]; then
+  echo "IRONCLAW_REBORN_SSH_PUBLIC_KEY contains no key material" >&2
+  exit 1
+fi
+if [ "$(printf '%s\n' "$key_lines" | wc -l)" -gt 1 ]; then
+  echo "IRONCLAW_REBORN_SSH_PUBLIC_KEY must contain exactly one OpenSSH public key" >&2
+  exit 1
+fi
+public_key="$key_lines"
+
+if [ "$(printf '%s\n' "$public_key" | wc -l)" -gt 1 ]; then
+  echo "IRONCLAW_REBORN_SSH_PUBLIC_KEY must be a single-line OpenSSH public key (<type> <base64> [comment]); it looks like a multi-line private key" >&2
+  exit 1
+fi
+case "$(printf '%s\n' "$public_key" | awk '{print NF}')" in
+  0|1)
+    echo "IRONCLAW_REBORN_SSH_PUBLIC_KEY must be an OpenSSH public key in '<type> <base64> [comment]' form" >&2
+    exit 1
+    ;;
+esac
+
 printf '%s\n' "$public_key" > "$authorized_keys_tmp"
 if ! ssh-keygen -l -f "$authorized_keys_tmp" >/dev/null 2>&1; then
   echo "IRONCLAW_REBORN_SSH_PUBLIC_KEY is not a valid OpenSSH public key" >&2
@@ -87,6 +125,9 @@ mv "$authorized_keys_tmp" "$authorized_keys"
     'StrictModes yes' \
     'UsePAM no' \
     'X11Forwarding no' \
+    'AllowTcpForwarding no' \
+    'AllowAgentForwarding no' \
+    'PermitTunnel no' \
     'PrintMotd no' \
     "SetEnv IRONCLAW_REBORN_HOME=$IRONCLAW_REBORN_HOME CARGO_HOME=/usr/local/cargo RUSTUP_HOME=/usr/local/rustup" \
     'Subsystem sftp internal-sftp'

--- a/docker/reborn/start-sshd.sh
+++ b/docker/reborn/start-sshd.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+set -eu
+
+public_key="${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}"
+if [ -z "$public_key" ]; then
+  exit 0
+fi
+
+ssh_dir="$IRONCLAW_REBORN_HOME/ssh"
+host_key="$ssh_dir/ssh_host_ed25519_key"
+authorized_keys="$ssh_dir/authorized_keys"
+config="$ssh_dir/sshd_config"
+
+if [ ! -d "$IRONCLAW_REBORN_HOME" ]; then
+  echo "IRONCLAW_REBORN_HOME must exist before SSH starts: $IRONCLAW_REBORN_HOME" >&2
+  exit 1
+fi
+
+if [ -e "$ssh_dir" ] || [ -L "$ssh_dir" ]; then
+  if [ ! -d "$ssh_dir" ] || [ -L "$ssh_dir" ]; then
+    echo "refusing unsafe SSH state path: $ssh_dir" >&2
+    exit 1
+  fi
+  ssh_dir_owner="$(stat -c '%u' "$ssh_dir")"
+  ssh_dir_mode="$(stat -c '%a' "$ssh_dir")"
+  if [ "$ssh_dir_owner" != "0" ]; then
+    echo "refusing SSH state directory not owned by root: $ssh_dir" >&2
+    exit 1
+  fi
+  case "$ssh_dir_mode" in
+    *[2367][0-7]|*[0-7][2367])
+      echo "refusing group/world-writable SSH state directory: $ssh_dir" >&2
+      exit 1
+      ;;
+  esac
+else
+  mkdir -m 755 "$ssh_dir"
+fi
+chmod 755 "$ssh_dir"
+mkdir -p /run/sshd
+chmod 755 /run/sshd
+
+host_key_tmp="$ssh_dir/ssh_host_ed25519_key.tmp.$$"
+authorized_keys_tmp="$ssh_dir/authorized_keys.tmp.$$"
+config_tmp="$ssh_dir/sshd_config.tmp.$$"
+trap 'rm -f "$host_key_tmp" "$host_key_tmp.pub" "$authorized_keys_tmp" "$config_tmp"' EXIT HUP INT TERM
+
+if [ -e "$host_key" ] || [ -L "$host_key" ]; then
+  if [ ! -f "$host_key" ] || [ -L "$host_key" ]; then
+    echo "refusing unsafe SSH host key path: $host_key" >&2
+    exit 1
+  fi
+  if ! ssh-keygen -l -f "$host_key" >/dev/null 2>&1; then
+    echo "persisted SSH host key is invalid: $host_key" >&2
+    exit 1
+  fi
+else
+  ssh-keygen -q -t ed25519 -N '' -f "$host_key_tmp"
+  chmod 600 "$host_key_tmp"
+  mv "$host_key_tmp" "$host_key"
+  rm -f "$host_key_tmp.pub"
+fi
+chmod 600 "$host_key"
+
+printf '%s\n' "$public_key" > "$authorized_keys_tmp"
+if ! ssh-keygen -l -f "$authorized_keys_tmp" >/dev/null 2>&1; then
+  echo "IRONCLAW_REBORN_SSH_PUBLIC_KEY is not a valid OpenSSH public key" >&2
+  exit 1
+fi
+chmod 644 "$authorized_keys_tmp"
+mv "$authorized_keys_tmp" "$authorized_keys"
+
+{
+  printf '%s\n' \
+    'Port 2222' \
+    'ListenAddress 0.0.0.0' \
+    "HostKey \"$host_key\"" \
+    "PidFile \"$ssh_dir/sshd.pid\"" \
+    "AuthorizedKeysFile \"$authorized_keys\"" \
+    'AllowUsers agent' \
+    'AuthenticationMethods publickey' \
+    'PubkeyAuthentication yes' \
+    'PasswordAuthentication no' \
+    'KbdInteractiveAuthentication no' \
+    'PermitEmptyPasswords no' \
+    'PermitRootLogin no' \
+    'StrictModes yes' \
+    'UsePAM no' \
+    'X11Forwarding no' \
+    'PrintMotd no' \
+    "SetEnv IRONCLAW_REBORN_HOME=$IRONCLAW_REBORN_HOME CARGO_HOME=/usr/local/cargo RUSTUP_HOME=/usr/local/rustup" \
+    'Subsystem sftp internal-sftp'
+} > "$config_tmp"
+chmod 600 "$config_tmp"
+mv "$config_tmp" "$config"
+
+/usr/sbin/sshd -t -f "$config"
+/usr/sbin/sshd -f "$config"
+
+trap - EXIT HUP INT TERM

--- a/docs/internal/reborn/deploy-reborn-cli-docker.md
+++ b/docs/internal/reborn/deploy-reborn-cli-docker.md
@@ -168,8 +168,11 @@ still live under the local filesystem root. The image default is
 `/data/ironclaw-reborn`; without a Railway volume, that path is ephemeral. The
 hosted single-tenant volume profile stores runtime/control-plane state under
 that Reborn home on the mounted volume and does not require
-`IRONCLAW_REBORN_POSTGRES_URL`. The container workdir is `/workspace` so the
-workspace root stays separate from Reborn's state and skill roots.
+`IRONCLAW_REBORN_POSTGRES_URL`. The Docker entrypoint defaults
+`IRONCLAW_REBORN_WORKSPACE_ROOT` to `$IRONCLAW_REBORN_HOME/workspace`, so project
+files and landed attachments stay on the same durable mount. If you override
+the workspace root, point it at durable storage too — on Railway the entrypoint
+fails closed when it resolves outside `RAILWAY_VOLUME_MOUNT_PATH`.
 
 The image includes `sqlite3` and `psql` for terminal inspection from Railway
 shells. Use `sqlite3` for mounted-volume libSQL/SQLite state and `psql` for

--- a/docs/internal/reborn/deploy-reborn-cli-docker.md
+++ b/docs/internal/reborn/deploy-reborn-cli-docker.md
@@ -217,6 +217,31 @@ the agent connect a Google credential:
 IRONCLAW_REBORN_GOOGLE_OAUTH_REDIRECT_URI=https://<railway-domain>/api/reborn/product-auth/oauth/google/callback
 ```
 
+## SSH Access
+
+The image ships `sshd` but the listener stays off unless
+`IRONCLAW_REBORN_SSH_PUBLIC_KEY` is set. When it is, the entrypoint (running as
+root at container start) writes that key as the sole `authorized_keys` entry
+and starts `sshd` on container port 2222 before dropping to the `ironclaw`
+user. Leaving the variable unset leaves no SSH listener running at all.
+
+Container port 2222 is `EXPOSE`d in the image but is not published by
+default — publish it explicitly to reach it, for example `docker run -p
+2222:2222` locally, or a Railway TCP proxy for a hosted deployment.
+
+Login is public-key-only, as user `agent`. The generated `sshd_config` sets
+`AllowUsers agent`, `AuthenticationMethods publickey`, `PubkeyAuthentication
+yes`, `PasswordAuthentication no`, `KbdInteractiveAuthentication no`,
+`PermitEmptyPasswords no`, and `PermitRootLogin no` — there is no password or
+keyboard-interactive fallback for any account, including `agent`.
+
+`agent` is not a lower-privileged account: the runtime image creates it as a
+non-unique alias of uid 1000, the same uid as the `ironclaw` runtime user. An
+SSH session therefore holds the full runtime identity and can read and write
+everything the IronClaw process owns. Treat distributing the corresponding
+private key with the same care as granting shell access to the running
+service.
+
 ## Slack
 
 Slack routes are compiled into the image and mounted unconditionally. No

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -538,18 +538,16 @@ PR_STATIC_CONTROL_PATHS = {
     "ironclaw.png",
     "LICENSE-APACHE",
     "LICENSE-MIT",
-    # The Reborn container entrypoint is shell, not Rust: no Reborn test lane
-    # executes it. Code Style owns it end to end — `code_style.yml`'s `has_code`
-    # filter names `docker/reborn/entrypoint.sh` and its "Self-test CI scripts"
-    # step runs `scripts/ci/test-reborn-docker-entrypoint.sh`, which drives the
-    # real script. (`platform-and-compat.yml`'s `has_docker_risk` deliberately
-    # does not cover it — that filter is keyed to `Dockerfile`/`.dockerignore`
-    # and owns the image build, not the entrypoint's behaviour. `docker/` stays
-    # per-file, never a prefix: it mixes classes, and the shipped runtime
+    # The Reborn container startup scripts are shell, not Rust: no Reborn test
+    # lane executes them. Code Style owns their fast self-tests, while
+    # `platform-and-compat.yml` classifies both as Docker risk and exercises
+    # them through the built runtime image. `docker/` stays per-file, never a
+    # prefix: it mixes classes, and the shipped runtime
     # configs beside this script belong to a Rust lane instead — see
     # `DOCKER_RUNTIME_CONFIG_OWNERS` below. `docker/process-sandbox-entrypoint.sh`
     # has no owning lane and must keep refusing.)
     "docker/reborn/entrypoint.sh",
+    "docker/reborn/start-sshd.sh",
 }
 # Shipped container configs a Reborn Rust test parses and asserts on, mapped to
 # the test source that owns them. They are NOT static control: the membership

--- a/scripts/ci/test-reborn-docker-entrypoint.sh
+++ b/scripts/ci/test-reborn-docker-entrypoint.sh
@@ -56,12 +56,29 @@ printf '%s\n' "$*" > "${IRONCLAW_STUB_CHOWN_PATH}"
 STUB
 cat > "${WORK}/root-bin/mkdir" <<'STUB'
 #!/bin/sh
+# IRONCLAW_STUB_UNWRITABLE_PARENT simulates a root-owned, non-writable parent
+# directory: once the (stubbed) privilege drop has happened -- IRONCLAW_STUB_UID
+# no longer "0" -- creating a not-yet-existing path under it fails closed, the
+# same EACCES a real unprivileged `mkdir -p` would hit. A path already created
+# during the earlier root pass is unaffected (mkdir -p on an existing directory
+# is always a no-op), which is exactly what distinguishes the fixed entrypoint
+# (creates it while still root) from the broken one (only tries later).
 for path in "$@"; do
   case "$path" in
-    -*) ;;
-    /workspace) ;;
-    *) /bin/mkdir -p "$path" ;;
+    -*) continue ;;
+    /workspace) continue ;;
   esac
+  if [ "${IRONCLAW_STUB_UID:-0}" != "0" ] && [ -n "${IRONCLAW_STUB_UNWRITABLE_PARENT:-}" ] \
+    && [ ! -d "$path" ]
+  then
+    case "$path" in
+      "${IRONCLAW_STUB_UNWRITABLE_PARENT}"|"${IRONCLAW_STUB_UNWRITABLE_PARENT}"/*)
+        echo "mkdir: cannot create directory '$path': Permission denied" >&2
+        exit 1
+        ;;
+    esac
+  fi
+  /bin/mkdir -p "$path"
 done
 STUB
 cat > "${WORK}/root-bin/gosu" <<'STUB'
@@ -272,7 +289,7 @@ if ! grep -q '^ironclaw .*docker/reborn/entrypoint.sh' "$gosu_record"; then
   echo "FAIL[ssh_root]: entrypoint did not re-exec through gosu: $(cat "$gosu_record")" >&2
   failures=$((failures + 1))
 fi
-if [ "$(cat "$chown_record")" != "ironclaw:ironclaw ${WORK}/ssh_root /workspace" ]; then
+if [ "$(cat "$chown_record")" != "ironclaw:ironclaw ${WORK}/ssh_root /workspace ${WORK}/ssh_root/workspace" ]; then
   echo "FAIL[ssh_root]: root pass did not hand runtime paths to ironclaw: $(cat "$chown_record")" >&2
   failures=$((failures + 1))
 fi
@@ -298,7 +315,73 @@ then
   failures=$((failures + 1))
 fi
 
-# 6. The dead variable has no reader left anywhere in the tree.
+# 6. An explicit IRONCLAW_REBORN_WORKSPACE_ROOT override must be created and
+#    chowned during the root pass, before the privilege drop. Left until the
+#    later unprivileged `mkdir -p` (bottom of the script), a workspace root
+#    whose parent is a fresh, root-owned volume mount aborts the container at
+#    boot under `set -eu`. IRONCLAW_STUB_UNWRITABLE_PARENT (consumed by the
+#    root-bin/mkdir stub above) simulates exactly that: it fails any
+#    not-yet-existing path under it once IRONCLAW_STUB_UID has flipped away
+#    from "0", i.e. once the (stubbed) privilege drop has happened. The fixed
+#    entrypoint creates the workspace root while still root, so the later
+#    unprivileged call is a no-op against an already-existing directory.
+workspace_root_privdrop_home="${WORK}/workspace-root-privdrop"
+mkdir -p "$workspace_root_privdrop_home"
+printf '%s' "$LEGACY_DISABLED" > "${workspace_root_privdrop_home}/config.toml"
+locked_parent="${WORK}/locked-volume-mount"
+locked_workspace_root="${locked_parent}/project-workspace"
+workspace_root_chown_record="${workspace_root_privdrop_home}/chown-argv"
+
+run_workspace_root_privdrop() {
+  (
+    export PATH="${WORK}/root-bin:${WORK}/bin:${PATH}"
+    export IRONCLAW_REBORN_HOME="$workspace_root_privdrop_home"
+    export IRONCLAW_REBORN_DEFAULT_CONFIG=/opt/ironclaw/reborn/config.toml
+    export IRONCLAW_STUB_ARGV_PATH="${workspace_root_privdrop_home}/argv"
+    export IRONCLAW_STUB_WORKSPACE_PATH="${workspace_root_privdrop_home}/workspace-root"
+    export IRONCLAW_STUB_CHOWN_PATH="$workspace_root_chown_record"
+    export IRONCLAW_STUB_UID=0
+    export IRONCLAW_STUB_UNWRITABLE_PARENT="$locked_parent"
+    export IRONCLAW_REBORN_WORKSPACE_ROOT="$locked_workspace_root"
+    unset RAILWAY_ENVIRONMENT RAILWAY_PROJECT_ID RAILWAY_SERVICE_ID RAILWAY_VOLUME_MOUNT_PATH
+    sh "$ENTRYPOINT" >/dev/null 2>"${workspace_root_privdrop_home}/entrypoint.err"
+  )
+}
+
+rm -f "${workspace_root_privdrop_home}/argv"
+if ! run_workspace_root_privdrop; then
+  echo "FAIL[workspace_root_privdrop]: entrypoint aborted instead of creating the workspace root while still root" >&2
+  cat "${workspace_root_privdrop_home}/entrypoint.err" >&2
+  failures=$((failures + 1))
+elif [ ! -d "$locked_workspace_root" ]; then
+  echo "FAIL[workspace_root_privdrop]: workspace root was never created: $locked_workspace_root" >&2
+  failures=$((failures + 1))
+elif ! grep -q "$locked_workspace_root" "$workspace_root_chown_record"; then
+  echo "FAIL[workspace_root_privdrop]: workspace root was not chowned during the root pass" >&2
+  cat "$workspace_root_chown_record" >&2
+  failures=$((failures + 1))
+fi
+
+# 7. The Railway containment guard must canonicalize paths even when an
+#    intermediate component does not exist yet. GNU `readlink -f` requires
+#    every component but the last to already exist and otherwise fails
+#    outright -- falling back to the raw, unresolved spelling, which then
+#    lexically (but wrongly) matches the mount-prefix check even though the
+#    path actually resolves outside the mount via `..`. `missing-intermediate`
+#    below is deliberately never created.
+railway_escape_missing_root="${railway_mount}/missing-intermediate/../../tmp-outside-mount"
+
+rm -f "${railway_home}/argv"
+if run_railway_entrypoint "$railway_escape_missing_root"; then
+  echo "FAIL[railway_escape_missing_intermediate]: a workspace root with a non-existent intermediate component and a '..' escape was accepted" >&2
+  failures=$((failures + 1))
+elif ! grep -q 'IRONCLAW_REBORN_WORKSPACE_ROOT' "${railway_home}/railway.err"; then
+  echo "FAIL[railway_escape_missing_intermediate]: expected a workspace-root containment diagnostic" >&2
+  cat "${railway_home}/railway.err" >&2
+  failures=$((failures + 1))
+fi
+
+# 8. The dead variable has no reader left anywhere in the tree.
 if grep -rn 'IRONCLAW_REBORN_SLACK_ENABLED' \
   --include='*.rs' --include='*.sh' --include='*.toml' \
   "${ROOT}/crates" "${ROOT}/docker" "${ROOT}/scripts" 2>/dev/null \

--- a/scripts/ci/test-reborn-docker-entrypoint.sh
+++ b/scripts/ci/test-reborn-docker-entrypoint.sh
@@ -30,6 +30,7 @@ mkdir -p "${WORK}/bin"
 cat > "${WORK}/bin/ironclaw" <<'STUB'
 #!/bin/sh
 printf '%s\n' "$*" > "${IRONCLAW_STUB_ARGV_PATH}"
+printf '%s\n' "${IRONCLAW_REBORN_WORKSPACE_ROOT}" > "${IRONCLAW_STUB_WORKSPACE_PATH}"
 exit 0
 STUB
 chmod +x "${WORK}/bin/ironclaw"
@@ -104,8 +105,10 @@ run_entrypoint() {
     # validates the path prefix before it decides that.
     export IRONCLAW_REBORN_DEFAULT_CONFIG=/opt/ironclaw/reborn/config.toml
     export IRONCLAW_STUB_ARGV_PATH="${home}/argv"
+    export IRONCLAW_STUB_WORKSPACE_PATH="${home}/workspace-root"
     # Keep the Railway persistence guard out of the way.
     unset RAILWAY_ENVIRONMENT RAILWAY_PROJECT_ID RAILWAY_SERVICE_ID RAILWAY_VOLUME_MOUNT_PATH
+    unset IRONCLAW_REBORN_WORKSPACE_ROOT
     for assignment in "$@"; do
       export "${assignment?}"
     done
@@ -143,6 +146,14 @@ expect_present() {
   fi
 }
 
+assert_eq() {
+  local name="$1" expected="$2" actual="$3" what="$4"
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL[${name}]: ${what}: expected '${expected}', got '${actual}'" >&2
+    failures=$((failures + 1))
+  fi
+}
+
 LEGACY_DISABLED='[slack]
 enabled = false
 signing_secret_env = "SLACK_SIGNING_SECRET"
@@ -164,6 +175,65 @@ out="$(run_entrypoint plain "$LEGACY_DISABLED")"
 expect_absent plain 'signing_secret_env' "$out"
 expect_absent plain 'bot_token_env' "$out"
 expect_present plain 'enabled = false' "$out"
+assert_eq plain "${WORK}/plain/workspace" "$(cat "${WORK}/plain/workspace-root")" \
+  'workspace root did not default beneath IRONCLAW_REBORN_HOME'
+
+out="$(run_entrypoint custom_workspace "$LEGACY_DISABLED" "IRONCLAW_REBORN_WORKSPACE_ROOT=${WORK}/durable-workspace")"
+assert_eq custom_workspace "${WORK}/durable-workspace" \
+  "$(cat "${WORK}/custom_workspace/workspace-root")" \
+  'explicit durable workspace root was not preserved'
+
+# A trailing slash is normalized away so the Railway containment comparison and
+# the Rust-side root agree on one spelling.
+out="$(run_entrypoint trailing_slash "$LEGACY_DISABLED" "IRONCLAW_REBORN_WORKSPACE_ROOT=${WORK}/durable-workspace/")"
+assert_eq trailing_slash "${WORK}/durable-workspace" \
+  "$(cat "${WORK}/trailing_slash/workspace-root")" \
+  'trailing slash was not stripped from the workspace root'
+
+# The Railway containment guard compares resolved paths, not spelling. A
+# workspace root that is a symlink *under* the mount but points outside it
+# passes a lexical prefix test while the runtime writes to the ephemeral
+# target — a deployment that boots and silently loses project files.
+railway_mount="${WORK}/railway-mount"
+railway_home="${railway_mount}/ironclaw-reborn"
+mkdir -p "$railway_home" "${WORK}/railway-ephemeral" "${railway_mount}/real-workspace"
+printf '%s' "$LEGACY_DISABLED" > "${railway_home}/config.toml"
+ln -sfn "${WORK}/railway-ephemeral" "${railway_mount}/escaping-workspace"
+
+run_railway_entrypoint() {
+  (
+    export PATH="${WORK}/bin:${PATH}"
+    export IRONCLAW_REBORN_HOME="$railway_home"
+    export IRONCLAW_REBORN_DEFAULT_CONFIG=/opt/ironclaw/reborn/config.toml
+    export IRONCLAW_STUB_ARGV_PATH="${railway_home}/argv"
+    export IRONCLAW_STUB_WORKSPACE_PATH="${railway_home}/workspace-root"
+    export RAILWAY_ENVIRONMENT=production
+    export RAILWAY_VOLUME_MOUNT_PATH="$railway_mount"
+    export IRONCLAW_REBORN_WORKSPACE_ROOT="$1"
+    unset IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY
+    sh "$ENTRYPOINT" >/dev/null 2>"${railway_home}/railway.err"
+  )
+}
+
+rm -f "${railway_home}/argv"
+if run_railway_entrypoint "${railway_mount}/escaping-workspace"; then
+  echo "FAIL[railway_escape]: a workspace root resolving outside the volume was accepted" >&2
+  failures=$((failures + 1))
+elif ! grep -q 'IRONCLAW_REBORN_WORKSPACE_ROOT' "${railway_home}/railway.err"; then
+  echo "FAIL[railway_escape]: expected a workspace-root containment diagnostic" >&2
+  cat "${railway_home}/railway.err" >&2
+  failures=$((failures + 1))
+fi
+
+# Positive control: a real directory under the mount still boots. This also
+# pins that both sides are canonicalized — on a host where the mount path
+# itself traverses a symlink, resolving only one side would reject every root.
+rm -f "${railway_home}/argv"
+if ! run_railway_entrypoint "${railway_mount}/real-workspace"; then
+  echo "FAIL[railway_contained]: a workspace root under the volume was rejected" >&2
+  cat "${railway_home}/railway.err" >&2
+  failures=$((failures + 1))
+fi
 
 # 2. The regression itself. Every truthy spelling the entrypoint's `is_truthy`
 #    accepts used to suppress the migration; the docs taught `=true`.

--- a/scripts/ci/test-reborn-docker-entrypoint.sh
+++ b/scripts/ci/test-reborn-docker-entrypoint.sh
@@ -52,7 +52,10 @@ printf '%s\n' "${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}" > "${IRONCLAW_STUB_SSH_PATH}
 STUB
 cat > "${WORK}/root-bin/chown" <<'STUB'
 #!/bin/sh
-printf '%s\n' "$*" > "${IRONCLAW_STUB_CHOWN_PATH}"
+# Appends: the root pass issues a second chown for the workspace root only when
+# that path is inside a directory the entrypoint manages, so the tests need to
+# see every invocation, not just the last one.
+printf '%s\n' "$*" >> "${IRONCLAW_STUB_CHOWN_PATH}"
 STUB
 cat > "${WORK}/root-bin/mkdir" <<'STUB'
 #!/bin/sh
@@ -289,7 +292,8 @@ if ! grep -q '^ironclaw .*docker/reborn/entrypoint.sh' "$gosu_record"; then
   echo "FAIL[ssh_root]: entrypoint did not re-exec through gosu: $(cat "$gosu_record")" >&2
   failures=$((failures + 1))
 fi
-if [ "$(cat "$chown_record")" != "ironclaw:ironclaw ${WORK}/ssh_root /workspace ${WORK}/ssh_root/workspace" ]; then
+if ! grep -qx "ironclaw:ironclaw ${WORK}/ssh_root /workspace" "$chown_record" \
+  || ! grep -qx "ironclaw:ironclaw ${WORK}/ssh_root/workspace" "$chown_record"; then
   echo "FAIL[ssh_root]: root pass did not hand runtime paths to ironclaw: $(cat "$chown_record")" >&2
   failures=$((failures + 1))
 fi
@@ -343,7 +347,14 @@ run_workspace_root_privdrop() {
     export IRONCLAW_STUB_UID=0
     export IRONCLAW_STUB_UNWRITABLE_PARENT="$locked_parent"
     export IRONCLAW_REBORN_WORKSPACE_ROOT="$locked_workspace_root"
-    unset RAILWAY_ENVIRONMENT RAILWAY_PROJECT_ID RAILWAY_SERVICE_ID RAILWAY_VOLUME_MOUNT_PATH
+    # The root pass pre-creates the workspace root only inside a directory it
+    # manages -- $IRONCLAW_REBORN_HOME or the Railway volume mount -- so that a
+    # raw override can never have an arbitrary path chowned to the runtime uid
+    # before the containment check (which runs after the privilege drop) can
+    # reject it. This case's locked parent IS that volume mount, which is the
+    # scenario the fix exists for.
+    export RAILWAY_VOLUME_MOUNT_PATH="$locked_parent"
+    unset RAILWAY_ENVIRONMENT RAILWAY_PROJECT_ID RAILWAY_SERVICE_ID
     sh "$ENTRYPOINT" >/dev/null 2>"${workspace_root_privdrop_home}/entrypoint.err"
   )
 }
@@ -361,6 +372,46 @@ elif ! grep -q "$locked_workspace_root" "$workspace_root_chown_record"; then
   cat "$workspace_root_chown_record" >&2
   failures=$((failures + 1))
 fi
+
+# 6b. The root pass must NEVER chown a workspace root that lies outside the
+#     directories this entrypoint manages. The Railway containment check that
+#     validates an operator-supplied override runs only after the privilege
+#     drop, so a root-run `chown` of the raw value would hand the runtime uid
+#     ownership of an arbitrary path -- `IRONCLAW_REBORN_WORKSPACE_ROOT=/etc`
+#     chowning /etc to ironclaw before anything rejects it. The `..` spelling
+#     below also pins that the comparison is canonicalized, not lexical.
+outside_root_home="${WORK}/outside-root"
+mkdir -p "$outside_root_home"
+printf '%s' "$LEGACY_DISABLED" > "${outside_root_home}/config.toml"
+outside_mount="${WORK}/outside-mount"
+mkdir -p "$outside_mount"
+outside_chown_record="${outside_root_home}/chown-argv"
+
+run_outside_workspace_root() {
+  (
+    export PATH="${WORK}/root-bin:${WORK}/bin:${PATH}"
+    export IRONCLAW_REBORN_HOME="$outside_root_home"
+    export IRONCLAW_REBORN_DEFAULT_CONFIG=/opt/ironclaw/reborn/config.toml
+    export IRONCLAW_STUB_ARGV_PATH="${outside_root_home}/argv"
+    export IRONCLAW_STUB_WORKSPACE_PATH="${outside_root_home}/workspace-root"
+    export IRONCLAW_STUB_CHOWN_PATH="$outside_chown_record"
+    export IRONCLAW_STUB_UID=0
+    export RAILWAY_VOLUME_MOUNT_PATH="$outside_mount"
+    export IRONCLAW_REBORN_WORKSPACE_ROOT="$1"
+    unset RAILWAY_ENVIRONMENT RAILWAY_PROJECT_ID RAILWAY_SERVICE_ID
+    sh "$ENTRYPOINT" >/dev/null 2>"${outside_root_home}/entrypoint.err"
+  )
+}
+
+for outside_case in "${WORK}/not-managed-at-all" "${outside_mount}/../not-managed-via-dotdot"; do
+  rm -f "$outside_chown_record"
+  run_outside_workspace_root "$outside_case" || true
+  if [ -f "$outside_chown_record" ] && grep -q "not-managed" "$outside_chown_record"; then
+    echo "FAIL[workspace_root_outside_managed]: root pass chowned an unvalidated workspace root: $outside_case" >&2
+    cat "$outside_chown_record" >&2
+    failures=$((failures + 1))
+  fi
+done
 
 # 7. The Railway containment guard must canonicalize paths even when an
 #    intermediate component does not exist yet. GNU `readlink -f` requires

--- a/scripts/ci/test-reborn-docker-entrypoint.sh
+++ b/scripts/ci/test-reborn-docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Self-test for docker/reborn/entrypoint.sh's legacy-Slack field migration.
+# Self-test for docker/reborn/entrypoint.sh's startup contracts.
 #
 # #7115: the migration was gated on `IRONCLAW_REBORN_SLACK_ENABLED` not being
 # truthy. That variable lost its last Rust reader in #6116, while the operator
@@ -34,6 +34,56 @@ exit 0
 STUB
 chmod +x "${WORK}/bin/ironclaw"
 
+# Root startup is exercised without requiring the test process itself to run as
+# root. The entrypoint resolves these commands through PATH, so the stubs model
+# the one root pass followed by gosu's non-root re-exec while recording ordering
+# and environment consumption.
+mkdir -p "${WORK}/root-bin"
+cat > "${WORK}/root-bin/id" <<'STUB'
+#!/bin/sh
+test "${1:-}" = "-u"
+printf '%s\n' "${IRONCLAW_STUB_UID:-1000}"
+STUB
+cat > "${WORK}/root-bin/ironclaw-reborn-start-sshd" <<'STUB'
+#!/bin/sh
+test -d "${IRONCLAW_REBORN_HOME}"
+printf '%s\n' "${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}" > "${IRONCLAW_STUB_SSH_PATH}"
+STUB
+cat > "${WORK}/root-bin/chown" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$*" > "${IRONCLAW_STUB_CHOWN_PATH}"
+STUB
+cat > "${WORK}/root-bin/mkdir" <<'STUB'
+#!/bin/sh
+for path in "$@"; do
+  case "$path" in
+    -*) ;;
+    /workspace) ;;
+    *) /bin/mkdir -p "$path" ;;
+  esac
+done
+STUB
+cat > "${WORK}/root-bin/gosu" <<'STUB'
+#!/bin/sh
+if [ "${1:-}" != "ironclaw" ]; then
+  echo "unexpected gosu user: ${1:-}" >&2
+  exit 1
+fi
+if [ -n "${IRONCLAW_REBORN_SSH_PUBLIC_KEY:-}" ]; then
+  echo "SSH public key survived the privilege drop" >&2
+  exit 1
+fi
+printf '%s\n' "$*" > "${IRONCLAW_STUB_GOSU_PATH}"
+shift
+export IRONCLAW_STUB_UID=1000
+exec "$@"
+STUB
+chmod +x "${WORK}/root-bin/id" \
+  "${WORK}/root-bin/ironclaw-reborn-start-sshd" \
+  "${WORK}/root-bin/chown" \
+  "${WORK}/root-bin/mkdir" \
+  "${WORK}/root-bin/gosu"
+
 failures=0
 
 # Runs the entrypoint over a seeded config and echoes the resulting file.
@@ -59,11 +109,12 @@ run_entrypoint() {
     for assignment in "$@"; do
       export "${assignment?}"
     done
-    sh "$ENTRYPOINT" >/dev/null 2>&1
+    sh "$ENTRYPOINT" >/dev/null 2>"${home}/entrypoint.err"
   )
 
   if [ ! -f "${home}/argv" ]; then
     echo "FAIL[${name}]: entrypoint never reached the ironclaw exec" >&2
+    cat "${home}/entrypoint.err" >&2
     # Every caller invokes this function inside a command substitution, so the
     # body runs in a subshell and a `failures=$((failures + 1))` here would
     # mutate a copy the parent never sees (the run stayed green with this
@@ -129,7 +180,55 @@ out="$(run_entrypoint enabled_true "$LEGACY_ENABLED")"
 expect_present enabled_true 'signing_secret_env' "$out"
 expect_present enabled_true 'bot_token_env' "$out"
 
-# 4. The dead variable has no reader left anywhere in the tree.
+# 4. Keyed SSH starts during the root pass, consumes the public key, then
+#    re-executes the same entrypoint as the unprivileged application user.
+ssh_key='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestOnlyKey entrypoint-test'
+ssh_record="${WORK}/ssh-started"
+gosu_record="${WORK}/gosu-argv"
+chown_record="${WORK}/chown-argv"
+out="$(run_entrypoint ssh_root "$LEGACY_DISABLED" \
+  "PATH=${WORK}/root-bin:${WORK}/bin:${PATH}" \
+  "IRONCLAW_STUB_UID=0" \
+  "IRONCLAW_STUB_SSH_PATH=${ssh_record}" \
+  "IRONCLAW_STUB_GOSU_PATH=${gosu_record}" \
+  "IRONCLAW_STUB_CHOWN_PATH=${chown_record}" \
+  "IRONCLAW_REBORN_SSH_PUBLIC_KEY=${ssh_key}")"
+expect_absent ssh_root 'signing_secret_env' "$out"
+if [ "$(cat "$ssh_record")" != "$ssh_key" ]; then
+  echo "FAIL[ssh_root]: SSH did not start with the configured public key" >&2
+  failures=$((failures + 1))
+fi
+if ! grep -q '^ironclaw .*docker/reborn/entrypoint.sh' "$gosu_record"; then
+  echo "FAIL[ssh_root]: entrypoint did not re-exec through gosu: $(cat "$gosu_record")" >&2
+  failures=$((failures + 1))
+fi
+if [ "$(cat "$chown_record")" != "ironclaw:ironclaw ${WORK}/ssh_root /workspace" ]; then
+  echo "FAIL[ssh_root]: root pass did not hand runtime paths to ironclaw: $(cat "$chown_record")" >&2
+  failures=$((failures + 1))
+fi
+
+# 5. A keyed non-root launch cannot silently advertise SSH without starting
+#    the daemon. This is also the guard for an operator overriding USER.
+nonroot_home="${WORK}/ssh-nonroot"
+mkdir -p "$nonroot_home"
+if (
+  export PATH="${WORK}/root-bin:${WORK}/bin:${PATH}"
+  export IRONCLAW_STUB_UID=1000
+  export IRONCLAW_REBORN_HOME="$nonroot_home"
+  export IRONCLAW_REBORN_SSH_PUBLIC_KEY="$ssh_key"
+  sh "$ENTRYPOINT" >"${WORK}/ssh-nonroot.out" 2>"${WORK}/ssh-nonroot.err"
+); then
+  echo "FAIL[ssh_nonroot]: keyed SSH launch unexpectedly succeeded without root" >&2
+  failures=$((failures + 1))
+elif ! grep -q 'direct SSH requires the container entrypoint to start as root' \
+  "${WORK}/ssh-nonroot.err"
+then
+  echo "FAIL[ssh_nonroot]: expected fail-closed diagnostic" >&2
+  cat "${WORK}/ssh-nonroot.err" >&2
+  failures=$((failures + 1))
+fi
+
+# 6. The dead variable has no reader left anywhere in the tree.
 if grep -rn 'IRONCLAW_REBORN_SLACK_ENABLED' \
   --include='*.rs' --include='*.sh' --include='*.toml' \
   "${ROOT}/crates" "${ROOT}/docker" "${ROOT}/scripts" 2>/dev/null \

--- a/scripts/ci/test-reborn-docker-entrypoint.sh
+++ b/scripts/ci/test-reborn-docker-entrypoint.sh
@@ -66,6 +66,16 @@ cat > "${WORK}/root-bin/mkdir" <<'STUB'
 # during the earlier root pass is unaffected (mkdir -p on an existing directory
 # is always a no-op), which is exactly what distinguishes the fixed entrypoint
 # (creates it while still root) from the broken one (only tries later).
+#
+# status tracks whether any real `mkdir` invocation below failed (e.g. a
+# blank path from an unfixed `IRONCLAW_REBORN_HOME=/` normalization bug) so
+# this stub's own exit code matches real `mkdir`'s: a failure on one operand
+# does not stop it from attempting the rest, but the overall call still
+# reports non-zero. Without this, a failing path processed before the last
+# loop iteration is silently swallowed -- the stub's exit status would be
+# whatever the final (successful) iteration returned, and a regression test
+# asserting on `set -eu` aborting the caller would pass for the wrong reason.
+status=0
 for path in "$@"; do
   case "$path" in
     -*) continue ;;
@@ -81,8 +91,9 @@ for path in "$@"; do
         ;;
     esac
   fi
-  /bin/mkdir -p "$path"
+  /bin/mkdir -p "$path" || status=1
 done
+exit "$status"
 STUB
 cat > "${WORK}/root-bin/gosu" <<'STUB'
 #!/bin/sh
@@ -432,7 +443,64 @@ elif ! grep -q 'IRONCLAW_REBORN_WORKSPACE_ROOT' "${railway_home}/railway.err"; t
   failures=$((failures + 1))
 fi
 
-# 8. The dead variable has no reader left anywhere in the tree.
+# 8/9. A bare "/" for either root path must be refused with a diagnostic.
+#      `${VAR%/}` turns the single-character input "/" into "", which used to
+#      reach `mkdir -p "" /workspace` (a confusing "cannot create directory ''"
+#      failure) for IRONCLAW_REBORN_HOME, and `readlink -m ""` for
+#      IRONCLAW_REBORN_WORKSPACE_ROOT -- the latter exits non-zero with NO
+#      output at all, so `set -eu` killed the boot silently, the worse half of
+#      the bug.
+#
+#      These are refused rather than normalized back to "/". The root pass
+#      chowns IRONCLAW_REBORN_HOME to the unprivileged runtime user, so
+#      honoring "/" would hand uid 1000 ownership of the container's entire
+#      root filesystem -- strictly worse than the crash it replaced. Nothing
+#      legitimately runs with either path set to the filesystem root, so the
+#      safe reading of "/" is "operator error, stop and say so".
+slash_root_home="${WORK}/slash-root"
+mkdir -p "$slash_root_home"
+printf '%s' "$LEGACY_DISABLED" > "${slash_root_home}/config.toml"
+slash_root_chown_record="${slash_root_home}/chown-argv"
+
+run_slash_root() { # $1 = variable name to set to "/"
+  (
+    export PATH="${WORK}/root-bin:${WORK}/bin:${PATH}"
+    export IRONCLAW_REBORN_HOME="$slash_root_home"
+    export IRONCLAW_REBORN_DEFAULT_CONFIG=/opt/ironclaw/reborn/config.toml
+    export IRONCLAW_STUB_ARGV_PATH="${slash_root_home}/argv"
+    export IRONCLAW_STUB_WORKSPACE_PATH="${slash_root_home}/workspace-root"
+    export IRONCLAW_STUB_UID=0
+    export IRONCLAW_STUB_CHOWN_PATH="$slash_root_chown_record"
+    export IRONCLAW_STUB_GOSU_PATH="${slash_root_home}/gosu-argv"
+    unset IRONCLAW_REBORN_WORKSPACE_ROOT
+    unset RAILWAY_ENVIRONMENT RAILWAY_PROJECT_ID RAILWAY_SERVICE_ID RAILWAY_VOLUME_MOUNT_PATH
+    export "$1=/"
+    sh "$ENTRYPOINT" >/dev/null 2>"${slash_root_home}/entrypoint.err"
+  )
+}
+
+for slash_var in IRONCLAW_REBORN_HOME IRONCLAW_REBORN_WORKSPACE_ROOT; do
+  rm -f "${slash_root_home}/argv" "$slash_root_chown_record"
+  touch "$slash_root_chown_record"
+  if run_slash_root "$slash_var"; then
+    echo "FAIL[slash_root]: ${slash_var}=/ was accepted instead of refused" >&2
+    failures=$((failures + 1))
+  elif ! grep -q "${slash_var} must not be the filesystem root" "${slash_root_home}/entrypoint.err"; then
+    # Catches BOTH original failure modes: the blank-operand mkdir error, and
+    # the silent `readlink -m ""` death that printed nothing whatsoever.
+    echo "FAIL[slash_root]: ${slash_var}=/ did not produce the expected diagnostic" >&2
+    cat "${slash_root_home}/entrypoint.err" >&2
+    failures=$((failures + 1))
+  fi
+  # Nothing may be chowned on the way to that refusal -- least of all "/".
+  if [ -s "$slash_root_chown_record" ]; then
+    echo "FAIL[slash_root]: ${slash_var}=/ reached a chown before being refused" >&2
+    cat "$slash_root_chown_record" >&2
+    failures=$((failures + 1))
+  fi
+done
+
+# 10. The dead variable has no reader left anywhere in the tree.
 if grep -rn 'IRONCLAW_REBORN_SLACK_ENABLED' \
   --include='*.rs' --include='*.sh' --include='*.toml' \
   "${ROOT}/crates" "${ROOT}/docker" "${ROOT}/scripts" 2>/dev/null \

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -1742,8 +1742,8 @@ class RebornPrTestPlanTests(unittest.TestCase):
     # covered by `test_repo_root_example_env_is_classified_and_selects_no_rust_lane`
     # above — main classified it independently via `IGNORED_ROOT_FILES` while
     # this branch was in flight, same fix by the same route.
-    def test_reborn_container_entrypoint_is_owned_by_code_style(self) -> None:
-        """`docker/reborn/entrypoint.sh` is shell that Code Style self-tests.
+    def test_reborn_container_startup_scripts_are_owned_by_static_gates(self) -> None:
+        """The Reborn startup scripts are shell with explicit static owners.
 
         Second half of the same rejection. It is deliberately *not* an ignore:
         the plan names an owner, because one exists —
@@ -1752,13 +1752,18 @@ class RebornPrTestPlanTests(unittest.TestCase):
         filter lights that lane for this exact path. No Reborn Rust lane
         executes it, so it selects nothing here.
         """
-        plan = self.plan("pull_request", ["docker/reborn/entrypoint.sh"])
-        self.assertEqual(plan["mode"], "none")
-        self.assertEqual(plan["crate_buckets"], [])
-        self.assertIn(
-            "static CI or workspace-policy checks own: docker/reborn/entrypoint.sh",
-            plan["reasons"],
-        )
+        for path in (
+            "docker/reborn/entrypoint.sh",
+            "docker/reborn/start-sshd.sh",
+        ):
+            with self.subTest(path=path):
+                plan = self.plan("pull_request", [path])
+                self.assertEqual(plan["mode"], "none")
+                self.assertEqual(plan["crate_buckets"], [])
+                self.assertIn(
+                    f"static CI or workspace-policy checks own: {path}",
+                    plan["reasons"],
+                )
 
     def test_classified_operator_paths_do_not_mask_a_real_lane(self) -> None:
         """Neither classification may swallow its neighbours.
@@ -1773,6 +1778,7 @@ class RebornPrTestPlanTests(unittest.TestCase):
             [
                 ".env.example",
                 "docker/reborn/entrypoint.sh",
+                "docker/reborn/start-sshd.sh",
                 "crates/alpha/src/lib.rs",
             ],
         )

--- a/scripts/ci/ws12_workflow_contracts.py
+++ b/scripts/ci/ws12_workflow_contracts.py
@@ -91,6 +91,13 @@ REQUIRED_MARKERS: dict[str, tuple[str, ...]] = {
         "python3 scripts/ci/test_docs_publication_boundary.py",
         "python3 scripts/ci/docs_publication_boundary.py",
         '"${{ needs.docs-publication-boundary.result }}" != "success"',
+        "docker/reborn/(entrypoint|start-sshd)",
+    ),
+    ".github/workflows/platform-and-compat.yml": (
+        "docker/reborn/(entrypoint|start-sshd)",
+        "Verify in-worker SSH",
+        "IRONCLAW_REBORN_WEBUI_TOKEN=ssh-ci-webui-token-",
+        "agent@127.0.0.1",
     ),
     ".github/workflows/reborn-playwright.yml": (
         "python3 scripts/ci/ws12_suite_shards.py --github-output",

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -374,7 +374,7 @@ channel-delivery journeys (two-lane model):
 |---|---|
 | A provider failure yields a sanitized, *retryable* failure and the user can retry and resume | `reborn_failure_retry_resume_e2e.rs` (6) |
 | Sub-agents spawn end-to-end | `reborn_subagent_spawn_e2e.rs` (5) |
-| The shipped Docker image has a usable runtime home | `dockerfile_runtime_home.rs` (19) |
+| The shipped Docker image has a usable runtime home and an in-worker public-key SSH shell | `dockerfile_runtime_home.rs` (21) |
 | Live GitHub API contracts still hold (ignored canary, needs a real PAT) | `reborn_live_github_pat_contract.rs` |
 
 **Scope isolation parity** — one bin per boundary; each proves data from one scope is

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -204,6 +204,91 @@ fn reborn_runtime_image_includes_sql_debug_clients() {
 }
 
 #[test]
+fn reborn_runtime_image_provides_in_worker_ssh_contract() {
+    let dockerfile = read_repo_file("Dockerfile");
+    let runtime_stage = dockerfile
+        .rsplit_once(" AS runtime\n")
+        .map(|(_, stage)| stage)
+        .expect("Dockerfile must define a final runtime stage");
+    let runtime_packages = runtime_stage
+        .split_once("install -y --no-install-recommends \\\n")
+        .and_then(|(_, packages)| packages.split_once("    && rm -rf /var/lib/apt/lists/*"))
+        .map(|(packages, _)| packages)
+        .expect("runtime stage must install its package list before apt cleanup");
+
+    for package in ["gosu", "openssh-server"] {
+        assert!(
+            runtime_packages
+                .lines()
+                .any(|line| line.trim().trim_end_matches('\\').trim() == package),
+            "runtime image must install {package} for in-worker SSH"
+        );
+    }
+    assert!(
+        runtime_stage
+            .contains("COPY docker/reborn/start-sshd.sh /usr/local/bin/ironclaw-reborn-start-sshd"),
+        "runtime image must install the SSH startup script"
+    );
+    assert!(
+        runtime_stage.contains(
+            "chmod +x /usr/local/bin/ironclaw-reborn-entrypoint /usr/local/bin/ironclaw-reborn-start-sshd"
+        ),
+        "runtime image must make the SSH startup script executable"
+    );
+    assert!(
+        runtime_stage.contains(
+            "useradd --non-unique --uid 1000 --gid ironclaw --home-dir /workspace --shell /bin/bash agent"
+        ),
+        "runtime image must create the advertised agent login"
+    );
+    assert!(
+        runtime_stage.contains("passwd -d agent"),
+        "runtime image must unlock the agent account for public-key authentication"
+    );
+    assert!(
+        runtime_stage.contains("EXPOSE 3000 2222"),
+        "runtime image must publish the SSH container port"
+    );
+    assert!(
+        runtime_stage.contains("USER root"),
+        "runtime entrypoint must start as root so it can launch sshd before dropping privileges"
+    );
+
+    let entrypoint = read_repo_file("docker/reborn/entrypoint.sh");
+    assert!(
+        entrypoint.contains("ironclaw-reborn-start-sshd")
+            && entrypoint.contains("exec gosu ironclaw \"$0\" \"$@\""),
+        "entrypoint must launch SSH before re-executing as ironclaw"
+    );
+
+    let ssh_startup = read_repo_file("docker/reborn/start-sshd.sh");
+    for directive in [
+        "Port 2222",
+        "ListenAddress 0.0.0.0",
+        "AllowUsers agent",
+        "AuthenticationMethods publickey",
+        "PasswordAuthentication no",
+        "PermitRootLogin no",
+    ] {
+        assert!(
+            ssh_startup.contains(directive),
+            "SSH startup must preserve the security directive: {directive}"
+        );
+    }
+    assert!(
+        ssh_startup.contains("chmod 755 \"$ssh_dir\"")
+            && ssh_startup.contains("chmod 644 \"$authorized_keys_tmp\""),
+        "the root-owned SSH state must remain readable by the unprivileged agent key check"
+    );
+
+    let docker_workflow = read_repo_file(".github/workflows/platform-and-compat.yml");
+    assert!(
+        docker_workflow.contains("--env IRONCLAW_REBORN_WEBUI_TOKEN=ssh-ci-webui-token-"),
+        "live SSH verification must keep the application alive with a test-only WebUI token"
+    );
+}
+
+#[test]
 fn reborn_runtime_image_can_run_the_orchestrator_healthcheck() {
     // Earlier build stages install curl for downloads, so inspect only the
     // shipped runtime stage used by container healthchecks.


### PR DESCRIPTION
## Summary

Forward-ports the two Docker/runtime fixes that shipped on the 1.3 line and were never brought back to `main`. Both are release blockers for the 1.4.0 cut — `main`'s container image today has neither.

- **`d4cf241` — #7723, restore Reborn in-worker SSH.** `main`'s image has no `start-sshd.sh` at all; the file simply does not exist on this branch's base. Adds an **opt-in** hardened sshd on port 2222.
- **`ab7ac3d` — #7804, honor `IRONCLAW_REBORN_WORKSPACE_ROOT`.** Both CLI boot paths now respect the variable; previously one path ignored it, so a container configured with an explicit workspace root silently used the wrong directory.

They ship together because they both edit `docker/reborn/entrypoint.sh` in the same region — #7804 alone conflicts there, and applying #7723 first makes it merge clean. Kept as two commits so each is reviewable on its own.

**Fidelity check.** `Dockerfile`, `docker/reborn/entrypoint.sh`, `docker/reborn/start-sshd.sh`, `tests/dockerfile_runtime_home.rs`, and `scripts/ci/test-reborn-docker-entrypoint.sh` are **byte-identical to `release/1.3.1`** after the port. The only two files that differ from the release branch do so because `main` is ahead: `crates/app/ironclaw_cli/src/runtime/mod.rs` (+16, `main`'s memory-curation config block) and `.env.example`.

### Conflicts resolved

Two, both mechanical — the substantive Docker payload applied to files with **zero** `main`-side churn since the branch point.

1. `.github/workflows/code_style.yml` — `main`'s `has_code` regex is a strict superset of the release branch's (it gained `deny.toml`, `rust-toolchain.toml`, `setup-rust/`, type-duplicates). Kept `main`'s line and applied only #7723's delta: `docker/reborn/entrypoint\.sh$` → `docker/reborn/(entrypoint|start-sshd)\.sh$`, so edits to the new script trigger the style lanes.
2. `tests/CLAUDE.md` — `main` converted this file into a symlink to `AGENTS.md`, so git reported a distinct-types conflict. Kept `main`'s symlink and applied #7723's one-line coverage-table edit to `tests/AGENTS.md`, its real target.

**Not forward-ported, deliberately:** the five `chore(release):` version bumps and `5d71d1c25d` ("clear release branch blockers"), which reverts `./.github/actions/setup-rust` back to a direct `dtolnay/rust-toolchain` call, strips job timeouts, and drops the Storybook lane. Those are release-branch-local; porting them would violate the toolchain-pin contract in `AGENTS.md`.

## Change Type

- [x] Bug fix
- [x] CI/Infrastructure
- [x] Security

## Linked Issue

Forward-port of #7723 and #7804. None to close.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw --all-targets --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `dockerfile_runtime_home` (21 passed), `test-reborn-docker-entrypoint.sh`, `test_reborn_pr_test_plan.py` (92 passed), `ws12_workflow_contracts.py`, `check-guidance.py`
- [x] Manual testing: verified the ported Docker payload is byte-identical to `release/1.3.1`, and that `IRONCLAW_REBORN_WORKSPACE_ROOT` survives the merge in `runtime/mod.rs`

## Test Strategy

User behavior: an operator can open a public-key SSH shell into a running worker when — and only when — they supply a key, and a container configured with an explicit workspace root actually uses it.

Risk areas:
- [x] Side effect
- [x] Security or permissions
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `tests/dockerfile_runtime_home.rs` gains `reborn_runtime_image_provides_in_worker_ssh_contract`, which pins the image contract (packages installed, script copied and executable, port exposed, the `agent` account, and the hardened sshd directives). `scripts/ci/test-reborn-docker-entrypoint.sh` gains coverage of the root→`gosu` handoff and the "direct SSH requires root" refusal.
- Reborn integration: `Not applicable: the behavior is container image and entrypoint shape, below the Rust runtime the integration harness drives.`
- Recorded fixture: `Not applicable: no model interaction.`
- Browser E2E: `Not applicable: no UI surface.`
- Backend or runtime: covered at merge-queue time only — `platform-and-compat.yml` builds the image and exercises the real SSH path there, not on `pull_request` (see the breakdown below). `ws12_workflow_contracts.py` pins that the lane cannot be silently removed.
- Live canary: `Not applicable: the canary does not provision an SSH key.`

What the tests prove — split by what actually executed, because the tiers differ a lot:

- **Executed locally.** `test-reborn-docker-entrypoint.sh` really runs `entrypoint.sh` with `gosu` and `ironclaw-reborn-start-sshd` stubbed onto `PATH`, and asserts the configured public key reaches the SSH starter, the re-exec goes through `gosu ironclaw`, the root pass chowns the runtime paths to `ironclaw`, and a non-root entrypoint given a key *refuses* instead of degrading.
- **Text assertions only.** `dockerfile_runtime_home.rs` reads the `Dockerfile` as a string and asserts substrings — it builds no image and starts no container (hence the 2.44s runtime). It proves the Dockerfile *declares* `gosu`/`openssh-server`, the script copy, the exec bit, and the exposed port. It does not prove any of it works.
- **Not exercised locally at all.** `start-sshd.sh` itself is stubbed in the entrypoint suite, so its generated sshd config, symlink/ownership/mode guards, `ssh-keygen` key validation, and `sshd -t` preflight did not run on my machine.
- **Covered by CI — but in the merge queue, NOT on this PR.** The `Verify in-worker SSH` step in `platform-and-compat.yml` builds the image, starts a container, generates a keypair, and makes a real SSH connection asserting `USER=agent`, `HOME=/workspace`, `PWD=/workspace`. It is the only thing anywhere that proves the SSH path actually functions.

  Its `docker-build` job deliberately does not run on `pull_request` — it fires on `push`, on manual deep dispatch with `include_docker`, or on `merge_group` when `has_docker_risk == true`. So **the `Docker Build` job shows `skipped` on this PR and `Platform & Compat` goes green in ~11s as the aggregate gate over a skipped dependency.** PR-time green here says nothing about SSH.

  I confirmed the merge-queue arm will actually bind rather than silently no-op: replaying the classifier regex against this PR's 14 changed files matches `Dockerfile`, `docker/reborn/entrypoint.sh`, `docker/reborn/start-sshd.sh`, and `platform-and-compat.yml` → `has_docker_risk=true`. **Please don't read PR-time green as SSH verification; the real check happens when this enters the queue.**

The coverage table in `tests/AGENTS.md` moves 19 → 21 to match the two new cases, and the observed run reports exactly 21.

Commands run:

```
cargo test -p ironclaw_integration_tests --test dockerfile_runtime_home
  -> test result: ok. 21 passed; 0 failed
  -> includes reborn_runtime_image_provides_in_worker_ssh_contract ... ok

bash scripts/ci/test-reborn-docker-entrypoint.sh   -> entrypoint self-tests passed
python3 scripts/ci/test_reborn_pr_test_plan.py     -> Ran 92 tests, OK
python3 scripts/ci/ws12_workflow_contracts.py      -> WS12 workflow contracts passed
python3 scripts/ci/check-guidance.py               -> OK (386 guidance files)
cargo fmt --all -- --check                                     -> clean
cargo clippy -p ironclaw --all-targets --all-features -D warnings -> clean
```

## Security Impact

**Yes — this adds an optional SSH listener to the runtime image. Please review deliberately.** Stating the shape plainly:

**Opt-in.** `start-sshd.sh` reads `IRONCLAW_REBORN_SSH_PUBLIC_KEY` and `exit 0`s immediately when it is unset. No key means no sshd, no listener, and no behavior change for any existing deployment.

**`USER root` does not mean the app runs as root.** The Dockerfile's final `USER` changes from `ironclaw` to `root`, but the entrypoint uses that privilege only to create/chown `$IRONCLAW_REBORN_HOME` and `/workspace` and (when a key is present) start sshd. It then `unset`s the key variable and `exec gosu ironclaw "$0" "$@"`. The IronClaw process is unprivileged on both paths. If the entrypoint is *not* running as root and a key was supplied, it refuses rather than degrading silently.

**sshd config is generated, minimal, and publickey-only:** `AuthenticationMethods publickey`, `PasswordAuthentication no`, `KbdInteractiveAuthentication no`, `PermitEmptyPasswords no`, `PermitRootLogin no`, `AllowUsers agent`, `UsePAM no`, `X11Forwarding no`, `StrictModes yes`. It is validated with `sshd -t` before start, and the supplied key is rejected unless `ssh-keygen -l` parses it.

**State-path hardening:** the SSH state directory and host key are refused if they are symlinks, not the expected type, not root-owned, or group/world-writable. The host key, `authorized_keys`, and config are written to `$$`-suffixed temp files and `mv`d into place under a cleanup trap, with explicit modes (600 / 644 / 600).

Two things a reviewer should weigh, called out rather than buried:

1. **`agent` is a second uid-1000 account**, created `--non-unique` alongside `ironclaw`. An SSH session is therefore uid-equivalent to the IronClaw runtime user — intentional (the shell is meant to act as the agent), but it means SSH access is not a lesser privilege than the app's.
2. **`passwd -d agent`** leaves the account password-empty. Not reachable through sshd given `PasswordAuthentication no` + `PermitEmptyPasswords no` + `AuthenticationMethods publickey`, but it matters for any other future auth path into the container.

Exposure still requires the orchestrator to publish `2222`; `EXPOSE 3000 2222` only declares it.

#7804 has no security impact: it reads one additional optional path env var through the existing `optional_path_env` helper.

## Reborn Trust-Boundary Checklist

- Public policy/evidence/trust-bearing types: none added or changed.
- Untrusted content enters prompts only through an envelope/escaping primitive: N/A — nothing here reaches a prompt.
- Hashes declare purpose: N/A. The SSH host key is generated by `ssh-keygen`, not hand-rolled crypto.
- New/changed status/exit/policy/runtime/error variants: none. `runtime/mod.rs` reads one more optional env path; no enum or match site changes.
- Security/durability `serde(default)` fields fail closed: N/A — no serde changes. The env-var default does fail closed: absent key ⇒ no sshd.
- Queues/maps/buffers/counters bounds: N/A.
- Driver/operator-visible error class semantics: unchanged. The new failure modes are entrypoint-level, fail-closed, and emit a specific message to stderr rather than starting a degraded listener.
- Sandbox/native/host names accurately describe trust boundary: yes — the SSH shell runs inside the worker container as the same unprivileged uid the runtime uses; it is not presented as a sandbox boundary.

## Database Impact

None. No schema, migration, or query changes.


---

## Review round 1 — what changed

13 findings from 4 automated reviewers plus a human approval. `git blame` puts **every one of them on the two cherry-picked commits**, none on the conflict resolutions — so these are latent defects in shipped 1.3.x getting their first full-strength review, not regressions introduced by the port. Each was verified against real code before acting; two reviewer claims did not survive that check.

**Fixed here** (commit `1e9ed6a`, each with a regression test proven to fail first):
- Workspace root is now created and chowned **before** the privilege drop (non-recursive, so start-sshd keeps root ownership of the ssh dir). Answers @lloydmak99's follow-up note.
- `readlink -f` → `readlink -m`, raw-spelling fallback removed. GNU `-f` exits non-zero on a missing non-final component, so the fallback let `$RAILWAY_VOLUME_MOUNT_PATH/missing/../../tmp` pass the `..`-escape guard **silently** and place project files on ephemeral storage. Confirmed empirically in `debian:bookworm-slim` (coreutils 9.1). This was the one finding I was unwilling to port knowingly — everything else fails loudly; this one loses data quietly.
- `AllowTcpForwarding no`, `AllowAgentForwarding no`, `PermitTunnel no` added.
- Pasted private key refused before anything reaches disk.

**Documented** (commit `3d57c88`): `IRONCLAW_REBORN_SSH_PUBLIC_KEY` in `.env.example` + the operator guide, and the uid-1000 alias / privilege-drop invariant as Dockerfile comments.

**Corrections to the review** — stated because acting on them as written would have been wrong:
- **The private-key finding is not a login bypass.** PEM lines do not match `authorized_keys` grammar, so sshd ignores every line: you get *zero* valid keys, i.e. broken, not backdoored. The real harm is secret persistence (mode 644, uid-1000-readable, surviving reboots).
- **The ssh-dir finding's consequence is inverted.** The guard is *not* bypassed — it fails closed on `stat -c %u != 0`. But the entrypoint calls start-sshd unguarded under `set -eu`, so that `exit 1` propagates before `exec gosu`: a same-uid SSH user can permanently **brick the container's next boot**, in the default configuration. Different and arguably worse than reported. Tracked, not fixed here.
- **The chown-symlink escalation is not reachable out of the box.** It needs the *parent* of `$IRONCLAW_REBORN_HOME` writable by uid 1000; every shipped default has it root-owned 0755 and never chowned.

**Deliberately not fixed here** — these need a design decision, affect 1.3.x production identically, and shouldn't gate a release blocker: the boot-DoS above, the symlink placement constraint, and SSH landing in `/workspace` rather than the resolved workspace root. All three are downstream of one choice — `agent` and `ironclaw` sharing uid 1000 — so they want one decision, not three patches.

## Verification against a real sshd

The Rust contract test only asserts on Dockerfile *text*, and `docker-build` does not run on `pull_request` — so none of this was covered at PR time. I built the surface in `debian:bookworm-slim` and ran real logins, using the shipped `release/1.3.1` script as the baseline:

- **16/16**, against a 12-pass/1-fail baseline. Every baseline pass survives; ed25519, RSA and ECDSA all still complete real logins.
- **10/10 operator-paste cases** accept-and-log-in or reject correctly.
- Unset key still exits 0 with no listener; generated config still passes `sshd -t` with every original auth directive retained.

That comparison caught a regression the fixes themselves introduced: the private-key check initially rejected a key with a **trailing newline** — what `cat id_ed25519.pub` produces — which under `set -e` would have aborted **container boot**, not just SSH. Corrected by trimming surrounding whitespace before the one-key check. It is now pinned in CI by a second container in the existing `Verify in-worker SSH` step, reusing the image already built there: **no new job, ~10s on a ~22min job.**


---

## Review round 2 — what changed

A second review raised 5 findings. Verified each against real code first; the review self-reported *degraded evidence*, and two claims did not survive checking.

**Fixed** (commit `1288161`):
- **A bare `/` for either root path is now refused with a diagnostic.** `${VAR%/}` turns `/` into an empty string; `IRONCLAW_REBORN_HOME=/` then hit `mkdir -p "" /workspace`, and `IRONCLAW_REBORN_WORKSPACE_ROOT=/` hit `readlink -m ""`, which exits non-zero and prints *nothing* — under `set -eu` the boot died silently. That silent mode was introduced by my own containment guard in `1e7f033`.
- **Rust coverage** for `local_runtime_workspace_root`: explicit override, unset→cwd fallback, and set-but-empty failing with the variable named in the message.

**The interesting part: the obvious fix was wrong, and the test caught it.** Restoring `/` — the idiom this file already uses for `RAILWAY_VOLUME_MOUNT_PATH` eight lines above — makes the root pass's `chown ironclaw:ironclaw "$IRONCLAW_REBORN_HOME"` newly *reachable* as **`chown ironclaw:ironclaw /`**, handing uid 1000 the container's entire root filesystem. Verified in a container: it succeeds. That trades a loud crash for total loss of the root boundary. Hence refusal rather than normalization, and the `slash_root` regression cases assert **nothing is chowned on the way to the refusal** — an assertion that fails against the restore-to-`/` shape as well as against the original bug.

**Corrections to the review:**
- **"start-sshd's key validation has no test that can fail"** is overstated. The `Verify in-worker SSH` CI step builds the real image and performs two real SSH logins — clean key *and* a key with a trailing newline. The genuine gap is narrower: PEM/multi-line rejection, host-key persistence across restart, and unsafe-ssh-state rejection, none reachable from a fresh container.
- **The `/`-normalization diagnosis was wrong about where it fails** (`readlink -m ""`, not the later `mkdir`), and it also affects `IRONCLAW_REBORN_HOME`, which the report did not mention.

**Deferred, with reasons on each thread:** the general `IRONCLAW_REBORN_HOME` chown guard, start-sshd's unsafe-state/persistence coverage, and SSH landing in `/workspace`. All three are pre-existing, live in 1.3.x today, operator-config-gated — and all three descend from one line: `useradd --non-unique --uid 1000` makes the SSH login and the runtime process the same Unix identity. **They want one decision, not three patches.**

## A note for the reviewer

This PR has now had **three fix-induced regressions** — a boot-loop on the most common key paste, a root-chown escalation, and the `chown /` above. Every one was caught by testing against the shipped `release/1.3.1` baseline rather than testing the new code in isolation; none would have been caught by the new code's own tests. That is the reason the deferred items are deferred: this shell is easy to get wrong, and the marginal risk of continuing to change it here exceeds the marginal benefit.

Final verification: real-sshd harness **16/16** against the shipped baseline (real logins for ed25519/RSA/ECDSA, opt-in contract intact, ssh state dir still root-owned); entrypoint suite green on `debian:bookworm-slim` as a non-root user; `IRONCLAW_REBORN_HOME=/` leaves `/` as `root:root`; shellcheck, ws12 contracts, guidance, fmt and clippy all clean.
