### PR TITLE
fix(webui): allow tool-heavy trajectory downloads

### DIFF
--- a/crates/product/ironclaw_assistant/src/reborn_services/thread_artifact.rs
+++ b/crates/product/ironclaw_assistant/src/reborn_services/thread_artifact.rs
@@ -25,7 +25,11 @@ use super::{
 pub const THREAD_ARTIFACT_SCHEMA: &str = "ironclaw.thread_artifact.v1";
 pub use ironclaw_product_contracts::product_wire::RebornThreadArtifactRequest;
 
-pub const THREAD_ARTIFACT_MAX_MESSAGES: usize = 1_000;
+/// A tool-heavy run persists several small rows per invocation. Keep the
+/// independent row-count guard high enough for those trajectories while the
+/// 16 MiB stored-data and 20 MiB serialized-output caps remain the primary
+/// memory and response-size bounds.
+pub const THREAD_ARTIFACT_MAX_MESSAGES: usize = 10_000;
 const THREAD_ARTIFACT_MAX_STORED_BYTES: usize = 16 * 1024 * 1024;
 const THREAD_ARTIFACT_MAX_SERIALIZED_BYTES: usize = 20 * 1024 * 1024;
 pub const THREAD_ARTIFACT_VIEW: RebornViewDescriptor = RebornViewDescriptor {

--- a/crates/product/ironclaw_assistant/tests/reborn_services_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/reborn_services_contract.rs
@@ -2231,6 +2231,7 @@ enum ScriptedThreadBehavior {
         history: Box<ThreadHistory>,
         snapshot: Box<BoundedThreadMessageSnapshot>,
         bounded_error: bool,
+        bounded_limit_exceeded: bool,
     },
     ListPages,
     SubmittedReplay {
@@ -2299,6 +2300,7 @@ impl ScriptedThreadService {
                 history: Box::new(history),
                 snapshot: Box::new(snapshot),
                 bounded_error: false,
+                bounded_limit_exceeded: false,
             },
             history_requests: Mutex::new(Vec::new()),
             bounded_requests: Mutex::new(Vec::new()),
@@ -2317,6 +2319,26 @@ impl ScriptedThreadService {
                 history: Box::new(history),
                 snapshot: Box::new(snapshot),
                 bounded_error: true,
+                bounded_limit_exceeded: false,
+            },
+            history_requests: Mutex::new(Vec::new()),
+            bounded_requests: Mutex::new(Vec::new()),
+            list_requests: Mutex::new(Vec::new()),
+            list_responses: Mutex::new(Vec::new()),
+            replay_call_count: Mutex::new(0),
+        }
+    }
+
+    fn thread_artifact_limit_exceeded(
+        history: ThreadHistory,
+        snapshot: BoundedThreadMessageSnapshot,
+    ) -> Self {
+        Self {
+            behavior: ScriptedThreadBehavior::ThreadArtifact {
+                history: Box::new(history),
+                snapshot: Box::new(snapshot),
+                bounded_error: false,
+                bounded_limit_exceeded: true,
             },
             history_requests: Mutex::new(Vec::new()),
             bounded_requests: Mutex::new(Vec::new()),
@@ -2707,12 +2729,15 @@ impl SessionThreadService for ScriptedThreadService {
             ScriptedThreadBehavior::ThreadArtifact {
                 snapshot,
                 bounded_error,
+                bounded_limit_exceeded,
                 ..
             } => {
                 if *bounded_error {
                     Err(SessionThreadError::Backend(
                         "bounded query unsupported".to_string(),
                     ))
+                } else if *bounded_limit_exceeded {
+                    Ok(BoundedThreadMessages::LimitExceeded)
                 } else {
                     Ok(BoundedThreadMessages::Complete(Box::new(
                         snapshot.as_ref().clone(),
@@ -9342,10 +9367,10 @@ async fn thread_artifact_projects_messages_from_the_bounded_snapshot() {
 }
 
 #[tokio::test]
-async fn thread_artifact_rejects_oversized_thread_before_context_or_log_reads() {
+async fn thread_artifact_accepts_more_than_one_thousand_small_messages() {
     let owner = caller();
     let thread_scope = thread_scope_for(&owner);
-    let thread_id = ThreadId::new("thread-artifact-over-budget").expect("thread id");
+    let thread_id = ThreadId::new("thread-artifact-many-messages").expect("thread id");
     let run_id = TurnRunId::new();
     let thread_service = Arc::new(InMemorySessionThreadService::default());
     thread_service
@@ -9358,7 +9383,7 @@ async fn thread_artifact_rejects_oversized_thread_before_context_or_log_reads() 
         })
         .await
         .expect("thread");
-    for sequence in 0..(THREAD_ARTIFACT_MAX_MESSAGES + 1) {
+    for sequence in 0..=1_000 {
         seed_submitted_message(
             &thread_service,
             &thread_scope,
@@ -9368,11 +9393,10 @@ async fn thread_artifact_rejects_oversized_thread_before_context_or_log_reads() 
         )
         .await;
     }
-    let operator_logs = Arc::new(RecordingOperatorLogsService::default());
     let services = session_services(thread_service, Arc::new(FakeTurnCoordinator::default()))
-        .with_operator_logs_service(operator_logs.clone());
+        .with_operator_logs_service(Arc::new(RecordingOperatorLogsService::default()));
 
-    let error = services
+    let page = services
         .query(
             owner,
             RebornViewQuery {
@@ -9385,7 +9409,48 @@ async fn thread_artifact_rejects_oversized_thread_before_context_or_log_reads() 
             },
         )
         .await
-        .expect_err("oversized thread artifact must fail closed");
+        .expect("a small trajectory must not fail only because it has many messages");
+    let artifact: RebornThreadArtifact =
+        serde_json::from_value(page.payload).expect("artifact payload");
+
+    assert_eq!(artifact.messages.len(), 1_001);
+}
+
+#[tokio::test]
+async fn thread_artifact_still_maps_bounded_read_limit_to_413() {
+    let owner = caller();
+    let history = fake_thread_history(&owner, "thread-artifact-over-byte-budget");
+    let snapshot = BoundedThreadMessageSnapshot {
+        history: ThreadMessageRange {
+            thread: history.thread.clone(),
+            messages: Vec::new(),
+        },
+        context: ContextMessages {
+            thread_id: history.thread.thread_id.clone(),
+            messages: Vec::new(),
+        },
+    };
+    let thread_service = Arc::new(ScriptedThreadService::thread_artifact_limit_exceeded(
+        history, snapshot,
+    ));
+    let operator_logs = Arc::new(RecordingOperatorLogsService::default());
+    let services = session_services(thread_service, Arc::new(FakeTurnCoordinator::default()))
+        .with_operator_logs_service(operator_logs.clone());
+
+    let error = services
+        .query(
+            owner,
+            RebornViewQuery {
+                view_id: THREAD_ARTIFACT_VIEW.id.to_string(),
+                params: serde_json::to_value(RebornThreadArtifactRequest {
+                    thread_id: "thread-artifact-over-byte-budget".to_string(),
+                })
+                .expect("artifact params"),
+                cursor: None,
+            },
+        )
+        .await
+        .expect_err("a snapshot over the unchanged bounded-read budgets must fail closed");
 
     assert_eq!(error.status_code, 413);
     assert_eq!(error.kind, ProductSurfaceErrorKind::Validation);

--- a/crates/product/ironclaw_assistant/tests/reborn_services_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/reborn_services_contract.rs
@@ -2224,14 +2224,19 @@ impl SessionThreadService for ScopeMismatchThreadStub {
     }
 }
 
+enum BoundedReadOutcome {
+    Complete,
+    BackendError,
+    LimitExceeded,
+}
+
 enum ScriptedThreadBehavior {
     BackendHistory,
     History(Box<ThreadHistory>),
     ThreadArtifact {
         history: Box<ThreadHistory>,
         snapshot: Box<BoundedThreadMessageSnapshot>,
-        bounded_error: bool,
-        bounded_limit_exceeded: bool,
+        bounded_read_outcome: BoundedReadOutcome,
     },
     ListPages,
     SubmittedReplay {
@@ -2299,8 +2304,7 @@ impl ScriptedThreadService {
             behavior: ScriptedThreadBehavior::ThreadArtifact {
                 history: Box::new(history),
                 snapshot: Box::new(snapshot),
-                bounded_error: false,
-                bounded_limit_exceeded: false,
+                bounded_read_outcome: BoundedReadOutcome::Complete,
             },
             history_requests: Mutex::new(Vec::new()),
             bounded_requests: Mutex::new(Vec::new()),
@@ -2318,8 +2322,7 @@ impl ScriptedThreadService {
             behavior: ScriptedThreadBehavior::ThreadArtifact {
                 history: Box::new(history),
                 snapshot: Box::new(snapshot),
-                bounded_error: true,
-                bounded_limit_exceeded: false,
+                bounded_read_outcome: BoundedReadOutcome::BackendError,
             },
             history_requests: Mutex::new(Vec::new()),
             bounded_requests: Mutex::new(Vec::new()),
@@ -2337,8 +2340,7 @@ impl ScriptedThreadService {
             behavior: ScriptedThreadBehavior::ThreadArtifact {
                 history: Box::new(history),
                 snapshot: Box::new(snapshot),
-                bounded_error: false,
-                bounded_limit_exceeded: true,
+                bounded_read_outcome: BoundedReadOutcome::LimitExceeded,
             },
             history_requests: Mutex::new(Vec::new()),
             bounded_requests: Mutex::new(Vec::new()),
@@ -2728,22 +2730,17 @@ impl SessionThreadService for ScriptedThreadService {
         match &self.behavior {
             ScriptedThreadBehavior::ThreadArtifact {
                 snapshot,
-                bounded_error,
-                bounded_limit_exceeded,
+                bounded_read_outcome,
                 ..
-            } => {
-                if *bounded_error {
-                    Err(SessionThreadError::Backend(
-                        "bounded query unsupported".to_string(),
-                    ))
-                } else if *bounded_limit_exceeded {
-                    Ok(BoundedThreadMessages::LimitExceeded)
-                } else {
-                    Ok(BoundedThreadMessages::Complete(Box::new(
-                        snapshot.as_ref().clone(),
-                    )))
-                }
-            }
+            } => match bounded_read_outcome {
+                BoundedReadOutcome::Complete => Ok(BoundedThreadMessages::Complete(Box::new(
+                    snapshot.as_ref().clone(),
+                ))),
+                BoundedReadOutcome::BackendError => Err(SessionThreadError::Backend(
+                    "bounded query unsupported".to_string(),
+                )),
+                BoundedReadOutcome::LimitExceeded => Ok(BoundedThreadMessages::LimitExceeded),
+            },
             _ => scripted_stub_unreachable("list_thread_messages_bounded"),
         }
     }

--- a/crates/product/ironclaw_webui/CONTRACT.md
+++ b/crates/product/ironclaw_webui/CONTRACT.md
@@ -237,9 +237,11 @@ through this caller route.
 rules to every replayable message in the thread and queries logs at thread
 scope. Its `ironclaw.thread_artifact.v1` messages retain `run_id`, allowing the
 fixture importer to reconstruct multiple turns without mixing threads. Export
-is all-or-nothing and returns `413` when the thread exceeds 1,000 persisted
+is all-or-nothing and returns `413` when the thread exceeds 10,000 persisted
 messages, 16 MiB of stored message data, or 20 MiB after redaction and log
-assembly. The endpoint is limited to six requests per caller per minute.
+assembly. The higher row limit admits tool-heavy trajectories while both byte
+limits remain unchanged. The endpoint is limited to six requests per caller per
+minute.
 
 **Operator-gating.** LLM provider/configuration routes (including provider
 credentials and model-policy mutation), operator setup/config/service-control,

--- a/tests/fixtures/llm_traces/reborn_qa/README.md
+++ b/tests/fixtures/llm_traces/reborn_qa/README.md
@@ -13,7 +13,7 @@ Logs are diagnostic only: the buffer is bounded and process-local, so
 logs are not part of the self-service export.
 
 Full-thread export is intentionally all-or-nothing: it returns HTTP `413`
-instead of producing a silently partial fixture when the thread exceeds 1,000
+instead of producing a silently partial fixture when the thread exceeds 10,000
 messages, 16 MiB of stored message data, or 20 MiB after redaction and log
 assembly.
 


### PR DESCRIPTION
## Summary

- Raise the thread-artifact row cap from 1,000 to 10,000 messages so tool-heavy trajectories remain downloadable.
- Keep the 16 MiB stored-data and 20 MiB serialized-response caps unchanged.
- Add caller-level regression coverage for 1,001 small messages and preserve the bounded-read 413 contract.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #7918

## Validation

- [x] `cargo fmt --all -- --check`
- [x] Scoped clippy: `cargo clippy -p ironclaw_assistant --all-targets -- -D warnings` and `cargo clippy -p ironclaw_assistant -- -D warnings`
- [ ] `cargo build` — not run separately; tests and clippy compiled both test and production shapes.
- [x] Relevant tests pass: all seven `thread_artifact` contract tests.
- [ ] `cargo test -p <owning-crate> --features integration` — not applicable; no database or runtime-integration behavior changed.
- [ ] Manual testing — not applicable; the caller-level product contract reproduces the 413 and verifies the fixed export.
- [ ] Agent review workflow — not run; the patch is limited to one bound, its contract tests, and the owning WebUI contract.

The broader `cargo test -p ironclaw_assistant` run passed every suite except the existing credential-gated `trace_reads_are_available_as_product_views` test. That test refused to call Trace Commons because `TRACE_COMMONS_TEST_TOKEN` is not set (299 other tests in that binary passed).

## Test Strategy

User behavior:

A QA user or admin can download a small-content trajectory with more than 1,000 persisted messages. Oversized byte payloads still receive HTTP 413.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: caller-level thread-artifact export with 1,001 messages; bounded-read rejection remains mapped to 413 before log reads.
- Reborn integration: Not applicable; no runner or product composition wiring changed.
- Recorded fixture: Not applicable; no model behavior changed.
- Browser E2E: Not applicable; response shape and UI behavior are unchanged.
- Backend or runtime: Not applicable; backend bounded-read implementations are unchanged.
- Live canary: Not applicable; behavior is deterministic and provider-independent.

What the tests prove:

The previous 1,000-row boundary no longer blocks a byte-safe trajectory. Existing bounded-read failures still fail closed with 413 and do not query optional logs.

Commands run:

- `cargo test -p ironclaw_assistant --test reborn_services_contract thread_artifact`
- `cargo fmt --all -- --check`
- `cargo clippy -p ironclaw_assistant --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_assistant -- -D warnings`
- `cargo test -p ironclaw_assistant` (one credential-gated failure described above)

## Security Impact

The export routes remain authenticated, feature-gated, redacted, and rate-limited. The stored-data and serialized-response byte caps are unchanged. Only the independent row-count cap changes from 1,000 to 10,000.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: unchanged; `RebornServices` still constructs artifacts after caller authorization.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: N/A; this read path constructs no prompt.
- [x] Hashes declare purpose: N/A; no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: N/A; 413 behavior remains unchanged for bounded-read failures.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: N/A; no persisted or wire fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: row count remains bounded at 10,000; both byte bounds remain unchanged.
- [x] Driver/operator-visible errors have stable class semantics: existing non-retryable 413 mapping is preserved by contract test.
- [x] Sandbox/native/host names accurately describe trust boundary: N/A; no runtime boundary changed.

## Database Impact

None. No schema, migration, or backend implementation changed.

## Blast Radius

Thread-artifact exports only. The main risk is higher CPU and structural-memory use for many tiny rows, bounded by 10,000 rows plus the unchanged 16 MiB stored-data and 20 MiB serialized-output ceilings.

## Rollback Plan

Revert this commit to restore the 1,000-message cap. Deployments can also disable artifact export with `IRONCLAW_REBORN_REGRESSION_ARTIFACT_EXPORT`.

## Review Follow-Through

Please verify that 10,000 rows is the preferred balance between tool-heavy trajectory retrieval and structural-memory bounds.

---

**Review track**: B