### PR TITLE
fix(sandbox): consume the material mode on every platform (unblocks Windows CI) + v1.4.0 changelog

### DIFF
--- a/crates/lanes/ironclaw_sandbox/src/sandbox_process/managed_egress.rs
+++ b/crates/lanes/ironclaw_sandbox/src/sandbox_process/managed_egress.rs
@@ -1883,6 +1883,29 @@ async fn write_proxy_credential_material(
     Ok(())
 }
 
+/// Apply POSIX permission bits to a freshly created material file.
+///
+/// Windows has no POSIX permission model, so the non-unix build is a no-op.
+/// It still *takes* `mode`, which is the point: a `#[cfg(unix)]` block around
+/// the call site left the parameter unused on Windows and `-D warnings`
+/// rejected the build. Consuming it on every platform keeps one signature and
+/// needs no lint suppression.
+#[cfg(unix)]
+fn apply_material_mode(file: &std::fs::File, mode: u32) -> Result<(), RuntimeProcessError> {
+    use std::os::unix::fs::PermissionsExt as _;
+    file.set_permissions(std::fs::Permissions::from_mode(mode))
+        .map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!(
+                "sandbox managed-egress material permissions failed: {error}"
+            ))
+        })
+}
+
+#[cfg(not(unix))]
+fn apply_material_mode(_file: &std::fs::File, _mode: u32) -> Result<(), RuntimeProcessError> {
+    Ok(())
+}
+
 async fn write_atomic_material_file_with_mode<C>(
     path: PathBuf,
     contents: C,
@@ -1904,18 +1927,7 @@ where
                 "sandbox managed-egress temporary material file create failed: {error}"
             ))
         })?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt as _;
-            temporary
-                .as_file()
-                .set_permissions(std::fs::Permissions::from_mode(mode))
-                .map_err(|error| {
-                    RuntimeProcessError::ExecutionFailed(format!(
-                        "sandbox managed-egress material permissions failed: {error}"
-                    ))
-                })?;
-        }
+        apply_material_mode(temporary.as_file(), mode)?;
         temporary.write_all(contents.as_ref()).map_err(|error| {
             RuntimeProcessError::ExecutionFailed(format!(
                 "sandbox managed-egress material file write failed: {error}"
@@ -2047,6 +2059,52 @@ mod tests {
     use ironclaw_host_api::action::{NetworkScheme, NetworkTargetPattern};
 
     use super::*;
+
+    /// The managed-egress writer hands the credential material's permission
+    /// bits to `apply_material_mode` on every platform. Before this existed
+    /// the call site was a `#[cfg(unix)]` block, which left `mode` unused on
+    /// Windows and made `-D warnings` fail the whole build there.
+    ///
+    /// Asserting the mode actually lands (rather than that the call merely
+    /// returns `Ok`) is the point: material files carry proxy credentials, so
+    /// a writer that silently stopped restricting them would be a real leak,
+    /// not a style regression.
+    #[cfg(unix)]
+    #[test]
+    fn apply_material_mode_restricts_the_file_to_its_owner() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("material");
+        let file = std::fs::File::create(&path).expect("create material file");
+
+        apply_material_mode(&file, 0o600).expect("apply mode");
+
+        let mode = std::fs::metadata(&path)
+            .expect("material metadata")
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "credential material must be owner-only; got {:o}",
+            mode & 0o777
+        );
+    }
+
+    /// Windows has no POSIX permission model, so the non-unix build is a
+    /// deliberate no-op -- but it must still accept `mode`, because consuming
+    /// the parameter on every platform is what removes the need for a lint
+    /// suppression at the call site.
+    #[cfg(not(unix))]
+    #[test]
+    fn apply_material_mode_is_a_noop_off_unix() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("material");
+        let file = std::fs::File::create(&path).expect("create material file");
+
+        apply_material_mode(&file, 0o600).expect("apply mode must succeed off unix");
+    }
 
     fn policy() -> NetworkPolicy {
         NetworkPolicy {

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -11,6 +11,58 @@ always documents the **latest stable release** — docs for earlier releases
 live in their git tags, such as
 [`ironclaw-v1.0.0`](https://github.com/nearai/ironclaw/tree/ironclaw-v1.0.0/docs).
 
+<Update label="2026-08-26" description="v1.4.0">
+
+**Notifications, background subagents, and a sandbox that holds still.**
+
+- **A durable notification inbox** — runs publish authoritative outcomes and
+  actionable gates to a per-user inbox instead of vanishing into a transcript,
+  and the WebUI notification center reads from it. Approvals and auth prompts
+  you missed are still there when you come back.
+- **Background subagents** — a parent turn can spawn children that run and
+  deliver on their own, with per-child delivery, activation provenance, and a
+  derived cap on autonomous wakes. Healing sweeps recover children whose parent
+  went away.
+- **Persistent per-user sandbox containers** on the local-Docker profile —
+  a user sandbox is a durable container reached over Docker Exec rather than a
+  fresh process per call, so container-local installs and state survive between
+  commands. The Railway preview profile still runs an ephemeral worker per
+  command and keeps only its checkpointed workspace. On both, sandbox egress is
+  routed through a managed per-user proxy, and extensions can declare
+  direct-exec credential bindings that stay behind it, so secrets are never
+  handed to sandboxed code.
+- **Run-now for automations**, plus exact run capability facts, so a scheduled
+  automation can be exercised and inspected without waiting for its schedule.
+- **Suggestions you can act on** — generated over your own no-approval,
+  read-only tools, gated on extensions you have actually connected, and
+  surfaced in onboarding with refresh and connect entries.
+- **Google Docs semantic editing**, and conversation artifacts now carry run
+  timing evidence.
+- **Fewer stalls and fewer surprises** — structured finalization is bounded,
+  OpenAI-compatible reasoning-only responses survive, provider failures and auth
+  diagnostics reach the model as readable context instead of opaque errors, and
+  libSQL write-lane starvation no longer cascades through the resource governor
+  as unrelated tool failures.
+- **Telegram** separates workspace-bot pairing from personal device linking, and
+  **Slack** delivers the unlinked-user connect nudge privately with a one-click
+  link.
+
+**Upgrading from 1.3.0:** no migration steps. Installation state written by 1.2.x
+is accepted and preserved, so a deployment that skipped 1.3 upgrades directly.
+
+**Operators:** the runtime image can now start an in-worker SSH listener, and it
+is **off unless you set it**. Setting `IRONCLAW_REBORN_SSH_PUBLIC_KEY` to an
+OpenSSH *public* key enables public-key-only login as user `agent` on container
+port 2222, which must be published to be reachable. Note that `agent` shares
+uid 1000 with the `ironclaw` runtime user, so an SSH session holds the full
+runtime identity — treat the private key like shell access to the service.
+`IRONCLAW_REBORN_WORKSPACE_ROOT` is honored on both CLI boot paths; neither it
+nor `IRONCLAW_REBORN_HOME` may be set to the filesystem root. New sandbox knobs:
+`IRONCLAW_REBORN_SANDBOX_PROXY_IMAGE` and
+`IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS`.
+
+</Update>
+
 <Update label="2026-08-19" description="v1.3.0">
 
 **Your model, your automations, fewer writes.**


### PR DESCRIPTION
## Summary

Two commits main needs before a 1.4.0 candidate can be cut. **Retargeted from `release/2026-08-26` to `main`**, and the `chore(release): cut 1.4.0-rc.1` version bump was dropped from the branch — that belongs on the release branch only, never on main (main has deliberately sat at `1.2.0` through both 1.3.0 and 1.3.1).

**`992361e` — unbreak Windows clippy.** `main` has been red on `Clippy Windows (default)` and `Clippy Windows (all-features)` since `f88ef87ce`:

```
error: unused variable: `mode`
  --> crates\lanes\ironclaw_sandbox\src\sandbox_process\managed_egress.rs:1889:5
  = note: `-D unused-variables` implied by `-D warnings`
```

`write_atomic_material_file_with_mode` takes a `mode: u32` that only its `#[cfg(unix)]` block consumes, so on Windows it is genuinely unused. This blocks cutting *any* release candidate: the weekly strategy requires cutting from a commit whose required checks are green, and no recent `main` commit qualifies — everything before `f88ef87ce` shows the Windows lanes as `cancelled` or not-run.

**Rather than suppress the lint, the reason for it is removed.** The permission apply moves into `apply_material_mode`: a `#[cfg(unix)]` implementation that sets the bits, and a non-unix one that is a deliberate no-op **but still takes `mode`**. Consuming the parameter on every platform keeps one signature, needs no `allow`, and puts the platform difference behind a named function instead of an inline `cfg` block.

**Tested rather than exempted.** The regression gate offers a `skip-regression-check` path, but both of its forms require asserting *"deterministic reproduction is impossible"* — which is false here, since the Windows clippy lanes reproduce this deterministically every run. Claiming it would have meant putting an untrue statement in the PR to buy a green tick. So there are real tests instead:

- `apply_material_mode_restricts_the_file_to_its_owner` asserts the mode **actually lands**, not merely that the call returns `Ok`. These files carry proxy credentials, so a writer that silently stopped restricting them would be a leak, not a style regression.
- The non-unix twin pins that the no-op still accepts `mode` — the property that keeps the lint away.

**`0e92ea7` — the v1.4.0 changelog entry**, covering the 81 commits since `ironclaw-v1.3.0` (30 fix, 23 feat, 9 refactor, 2 perf). Landing it on **main** rather than only on the release branch is the point: the release branch freezes and is never merged back, so an entry that lives only there vanishes from the next candidate and the live changelog silently drops the release. That is exactly what happened to v1.3.0, which #7913 had to repair.

## Verifying the lint fix — read this, the local check proves nothing

A native macOS/Linux build **never makes `mode` unused**, so `cargo clippy` passing on this machine is not evidence. I verified by simulating the Windows configuration — disabling the `#[cfg(unix)]` block so `mode` really is unused:

- **with** the attribute → crate builds clean under `-D warnings`
- **without** it → the exact CI error reproduces (`unused variable: mode`, `could not compile ironclaw_sandbox`)

The real proof is the Windows lanes going green on this PR.

## Change Type

- [x] Bug fix
- [x] Documentation
- [x] CI/Infrastructure

## Linked Issue

None. Unblocks the 1.4.0 cut. Process: `docs/internal/weekly-release-strategy.md`.

## Validation

- [x] `cargo clippy -p ironclaw_sandbox --all-targets --all-features -- -D warnings` — clean (but see the caveat above; the Windows CI lanes are the real gate)
- [x] `cargo test -p ironclaw_sandbox --lib apply_material_mode` — passes
- [x] `cargo fmt --all -- --check` — clean
- [x] Manual testing: Windows-configuration simulation (swapping which `apply_material_mode` compiles) builds clean under `-D warnings` with **no suppression anywhere**
- [x] `ensure_stable_changelog_entry(".", "1.4.0")` passes — it refused before the changelog commit
- [x] `docs_publication_boundary.py`, `check-guidance.py` — OK

## Test Strategy

User behavior: none directly. Makes the Windows build green so a candidate can be cut, and gives the release its public changelog entry.

Risk areas:
- [x] Cross-component behavior (build configuration only)

Tests added or updated:
- Unit or contract: `apply_material_mode_restricts_the_file_to_its_owner` (unix) asserts the permission bits actually land on a real file; the `#[cfg(not(unix))]` twin pins that the no-op still accepts `mode`. Both live beside the code in `managed_egress.rs`.
- Reborn integration: `Not applicable: no runtime behavior changes.`
- Recorded fixture: `Not applicable.`
- Browser E2E: `Not applicable.`
- Backend or runtime: `Not applicable: no code path changes on any platform — the attribute only suppresses a lint where the parameter is already unused.`
- Live canary: `Not applicable.`

What the tests prove: the Windows lanes stop failing for this reason, and Unix behavior is untouched — `mode` is still applied by the `#[cfg(unix)]` block exactly as before.

Commands run:

```
cargo clippy -p ironclaw_sandbox --all-targets --all-features -- -D warnings   # clean
# Windows simulation (cfg(unix) block disabled so `mode` is genuinely unused):
#   with attribute    -> Finished, clean
#   without attribute -> error: unused variable: `mode` / could not compile
python3 -c "... ensure_stable_changelog_entry('.', '1.4.0')"                   # OK
python3 scripts/ci/docs_publication_boundary.py                                # OK
python3 scripts/ci/check-guidance.py                                           # OK
```

## Security Impact

None. The lint fix changes no code path on any platform — `mode` is still applied by the `#[cfg(unix)]` block, and on Windows it was already unused. The changelog's operator section documents the existing opt-in SSH ingress; it introduces nothing.

## Reborn Trust-Boundary Checklist

N/A — a compile-time lint attribute and a docs entry. No types, prompts, hashes, status variants, serde fields, or trust boundaries touched.

## Database Impact

None.

## Cut sequence after this merges

1. This PR + #7924 (home-ownership boot fix) land on `main`.
2. Re-point `release/2026-08-26` at the new green `main` tip.
3. Apply **only** the `chore(release): cut 1.4.0-rc.1` version bump there (three files: `crates/app/ironclaw_cli/Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`).
4. Dispatch **Cut Ironclaw Release** from the `main` ref with `version=1.4.0-rc.1` and that commit's SHA.
