### PR TITLE
fix(docker): repair home ownership so a root-written file cannot brick boot

### DIFF
--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -81,8 +81,17 @@ if [ "$(id -u)" = "0" ]; then
   # `ssh` is excluded deliberately: start-sshd.sh refuses to start when its
   # state directory is not root-owned, so recursing into it would trade this
   # crash loop for a broken SSH listener.
-  find "$IRONCLAW_REBORN_HOME" -mindepth 1 -maxdepth 1 ! -name ssh \
-    -exec chown -R ironclaw:ironclaw {} +
+  # `-H` follows the start path only: $IRONCLAW_REBORN_HOME may itself be a
+  # symlink (find's default physical walk would then match nothing under
+  # -mindepth 1 and silently repair nothing), while symlinks encountered
+  # *during* the walk are still never followed -- combined with `chown -h`,
+  # a symlink planted in the home cannot redirect ownership outside it.
+  # Deliberately NOT filtered with `! -user ironclaw`: that predicate resolves
+  # the name at find time and aborts the whole boot under `set -e` wherever it
+  # does not resolve, trading a rare ownership repair for a guaranteed crash.
+  find -H "$IRONCLAW_REBORN_HOME" -mindepth 1 \
+    -path "$IRONCLAW_REBORN_HOME/ssh" -prune -o \
+    -exec chown -h ironclaw:ironclaw {} +
   # ...but ONLY when the override provably lives inside a directory this
   # entrypoint already manages. The Railway containment check that validates an
   # operator-supplied workspace root runs after the privilege drop (it needs

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -69,6 +69,20 @@ if [ "$(id -u)" = "0" ]; then
   # $IRONCLAW_REBORN_HOME/ssh staying root-owned.
   mkdir -p "$IRONCLAW_REBORN_HOME" /workspace
   chown ironclaw:ironclaw "$IRONCLAW_REBORN_HOME" /workspace
+  # Repair ownership of pre-existing home CONTENTS, not just the directory.
+  # A persistent volume outlives the image, and this image ran as `ironclaw`
+  # until in-worker SSH required a root entrypoint -- so a volume can carry
+  # files a root-run wrote. One unreadable file is fatal rather than
+  # degraded: the provider-registry overlay is fail-closed, so a root-owned
+  # `providers.json` crash-loops the container with
+  # "failed to read provider registry overlay ...: Permission denied", while
+  # a sibling `config.toml` written earlier still loads fine.
+  #
+  # `ssh` is excluded deliberately: start-sshd.sh refuses to start when its
+  # state directory is not root-owned, so recursing into it would trade this
+  # crash loop for a broken SSH listener.
+  find "$IRONCLAW_REBORN_HOME" -mindepth 1 -maxdepth 1 ! -name ssh \
+    -exec chown -R ironclaw:ironclaw {} +
   # ...but ONLY when the override provably lives inside a directory this
   # entrypoint already manages. The Railway containment check that validates an
   # operator-supplied workspace root runs after the privilege drop (it needs

--- a/scripts/ci/test-reborn-docker-entrypoint.sh
+++ b/scripts/ci/test-reborn-docker-entrypoint.sh
@@ -500,14 +500,24 @@ for slash_var in IRONCLAW_REBORN_HOME IRONCLAW_REBORN_WORKSPACE_ROOT; do
   fi
 done
 
-# 9b. The root pass must repair ownership of pre-existing home CONTENTS, not
-#     just the home directory itself -- and must leave the `ssh` state
-#     directory alone. A persistent volume outlives the image, and this image
-#     ran as `ironclaw` until in-worker SSH required a root entrypoint, so a
-#     volume can carry root-written files. One unreadable file is fatal rather
-#     than degraded: the provider-registry overlay is fail-closed, so a
-#     root-owned providers.json crash-loops the container. `ssh` is excluded
-#     because start-sshd.sh refuses to start unless it owns that directory.
+# 9b. The root pass must repair ownership of pre-existing home CONTENTS --
+#     including NESTED ones -- while leaving the `ssh` state directory alone.
+#     A persistent volume outlives the image, and this image ran as `ironclaw`
+#     until in-worker SSH required a root entrypoint, so a volume can carry
+#     files a root run wrote. One unreadable file is fatal rather than
+#     degraded: the provider-registry overlay is fail-closed, so an
+#     unreadable providers.json crash-loops the container.
+#
+#     Two properties are easy to assert weakly and are therefore asserted
+#     explicitly here:
+#       - the NESTED file must appear, not just its top-level parent. A repair
+#         that passed only top-level entries to a non-recursive chown would
+#         still leave `nested/deep.db` broken while a parent-only assertion
+#         stayed green.
+#       - `ssh` must NOT appear: start-sshd.sh refuses to start unless it owns
+#         that directory, so over-repairing trades a boot loop for dead SSH.
+#     The run is also required to SUCCEED; swallowing its exit status would
+#     let a broken root boot path pass as long as the argv looked right.
 own_home="${WORK}/own-repair"
 mkdir -p "$own_home/ssh" "$own_home/nested"
 printf '%s' "$LEGACY_DISABLED" > "${own_home}/config.toml"
@@ -518,7 +528,7 @@ own_chown_record="${WORK}/own-chown-argv"
 
 rm -f "$own_chown_record"
 touch "$own_chown_record"
-(
+if ! (
   export PATH="${WORK}/root-bin:${WORK}/bin:${PATH}"
   export IRONCLAW_REBORN_HOME="$own_home"
   export IRONCLAW_REBORN_DEFAULT_CONFIG=/opt/ironclaw/reborn/config.toml
@@ -530,11 +540,15 @@ touch "$own_chown_record"
   unset IRONCLAW_REBORN_WORKSPACE_ROOT
   unset RAILWAY_ENVIRONMENT RAILWAY_PROJECT_ID RAILWAY_SERVICE_ID RAILWAY_VOLUME_MOUNT_PATH
   sh "$ENTRYPOINT" >/dev/null 2>"${own_home}/entrypoint.err"
-) || true
+); then
+  echo "FAIL[home_contents_ownership]: entrypoint failed during the root pass" >&2
+  cat "${own_home}/entrypoint.err" >&2
+  failures=$((failures + 1))
+fi
 
-# The chown stub records its argv rather than executing, so assert on what the
-# root pass asked for: every top-level home entry except `ssh`.
-for own_expected in config.toml providers.json nested; do
+# The chown stub records argv rather than executing, so assert on what the root
+# pass asked for. `nested/deep.db` is the discriminating one.
+for own_expected in config.toml providers.json nested/deep.db; do
   if ! grep -q "${own_home}/${own_expected}" "$own_chown_record"; then
     echo "FAIL[home_contents_ownership]: root pass never chowned ${own_expected}; a root-written file would crash-loop the container" >&2
     cat "$own_chown_record" >&2
@@ -544,6 +558,44 @@ done
 if grep -q "${own_home}/ssh" "$own_chown_record"; then
   echo "FAIL[home_contents_ownership]: root pass chowned the ssh state directory; start-sshd.sh requires it to stay root-owned" >&2
   cat "$own_chown_record" >&2
+  failures=$((failures + 1))
+fi
+
+# 9c. The home may itself be a SYMLINK. `find` defaults to a physical walk, so
+#     a symlinked start path has no descendants under -mindepth 1 and the
+#     repair silently does nothing -- the boot loop would persist with no
+#     diagnostic. `-H` follows the start path only, which is why symlinks
+#     planted *inside* the home still cannot redirect ownership outward.
+link_home_real="${WORK}/own-link-real"
+link_home="${WORK}/own-link"
+mkdir -p "$link_home_real"
+printf '%s' "$LEGACY_DISABLED" > "${link_home_real}/config.toml"
+printf '{}' > "${link_home_real}/providers.json"
+ln -sfn "$link_home_real" "$link_home"
+link_chown_record="${WORK}/own-link-chown-argv"
+
+rm -f "$link_chown_record"
+touch "$link_chown_record"
+if ! (
+  export PATH="${WORK}/root-bin:${WORK}/bin:${PATH}"
+  export IRONCLAW_REBORN_HOME="$link_home"
+  export IRONCLAW_REBORN_DEFAULT_CONFIG=/opt/ironclaw/reborn/config.toml
+  export IRONCLAW_STUB_ARGV_PATH="${link_home}/argv"
+  export IRONCLAW_STUB_WORKSPACE_PATH="${link_home}/workspace-root"
+  export IRONCLAW_STUB_CHOWN_PATH="$link_chown_record"
+  export IRONCLAW_STUB_GOSU_PATH="${link_home}/gosu-argv"
+  export IRONCLAW_STUB_UID=0
+  unset IRONCLAW_REBORN_WORKSPACE_ROOT
+  unset RAILWAY_ENVIRONMENT RAILWAY_PROJECT_ID RAILWAY_SERVICE_ID RAILWAY_VOLUME_MOUNT_PATH
+  sh "$ENTRYPOINT" >/dev/null 2>"${link_home}/entrypoint.err"
+); then
+  echo "FAIL[symlinked_home_ownership]: entrypoint failed with a symlinked home" >&2
+  cat "${link_home}/entrypoint.err" >&2
+  failures=$((failures + 1))
+fi
+if ! grep -q "providers.json" "$link_chown_record"; then
+  echo "FAIL[symlinked_home_ownership]: repair walked nothing through a symlinked home; the boot loop would persist silently" >&2
+  cat "$link_chown_record" >&2
   failures=$((failures + 1))
 fi
 

--- a/scripts/ci/test-reborn-docker-entrypoint.sh
+++ b/scripts/ci/test-reborn-docker-entrypoint.sh
@@ -500,6 +500,53 @@ for slash_var in IRONCLAW_REBORN_HOME IRONCLAW_REBORN_WORKSPACE_ROOT; do
   fi
 done
 
+# 9b. The root pass must repair ownership of pre-existing home CONTENTS, not
+#     just the home directory itself -- and must leave the `ssh` state
+#     directory alone. A persistent volume outlives the image, and this image
+#     ran as `ironclaw` until in-worker SSH required a root entrypoint, so a
+#     volume can carry root-written files. One unreadable file is fatal rather
+#     than degraded: the provider-registry overlay is fail-closed, so a
+#     root-owned providers.json crash-loops the container. `ssh` is excluded
+#     because start-sshd.sh refuses to start unless it owns that directory.
+own_home="${WORK}/own-repair"
+mkdir -p "$own_home/ssh" "$own_home/nested"
+printf '%s' "$LEGACY_DISABLED" > "${own_home}/config.toml"
+printf '{}' > "${own_home}/providers.json"
+printf 'x' > "${own_home}/nested/deep.db"
+printf 'k' > "${own_home}/ssh/ssh_host_ed25519_key"
+own_chown_record="${WORK}/own-chown-argv"
+
+rm -f "$own_chown_record"
+touch "$own_chown_record"
+(
+  export PATH="${WORK}/root-bin:${WORK}/bin:${PATH}"
+  export IRONCLAW_REBORN_HOME="$own_home"
+  export IRONCLAW_REBORN_DEFAULT_CONFIG=/opt/ironclaw/reborn/config.toml
+  export IRONCLAW_STUB_ARGV_PATH="${own_home}/argv"
+  export IRONCLAW_STUB_WORKSPACE_PATH="${own_home}/workspace-root"
+  export IRONCLAW_STUB_CHOWN_PATH="$own_chown_record"
+  export IRONCLAW_STUB_GOSU_PATH="${own_home}/gosu-argv"
+  export IRONCLAW_STUB_UID=0
+  unset IRONCLAW_REBORN_WORKSPACE_ROOT
+  unset RAILWAY_ENVIRONMENT RAILWAY_PROJECT_ID RAILWAY_SERVICE_ID RAILWAY_VOLUME_MOUNT_PATH
+  sh "$ENTRYPOINT" >/dev/null 2>"${own_home}/entrypoint.err"
+) || true
+
+# The chown stub records its argv rather than executing, so assert on what the
+# root pass asked for: every top-level home entry except `ssh`.
+for own_expected in config.toml providers.json nested; do
+  if ! grep -q "${own_home}/${own_expected}" "$own_chown_record"; then
+    echo "FAIL[home_contents_ownership]: root pass never chowned ${own_expected}; a root-written file would crash-loop the container" >&2
+    cat "$own_chown_record" >&2
+    failures=$((failures + 1))
+  fi
+done
+if grep -q "${own_home}/ssh" "$own_chown_record"; then
+  echo "FAIL[home_contents_ownership]: root pass chowned the ssh state directory; start-sshd.sh requires it to stay root-owned" >&2
+  cat "$own_chown_record" >&2
+  failures=$((failures + 1))
+fi
+
 # 10. The dead variable has no reader left anywhere in the tree.
 if grep -rn 'IRONCLAW_REBORN_SLACK_ENABLED' \
   --include='*.rs' --include='*.sh' --include='*.toml' \


### PR DESCRIPTION
## Summary

A hosted instance crash-looped on every restart:

```
Error: could not resolve LLM environment fallback: Provider provider_registry request failed:
failed to read provider registry overlay `/data/ironclaw-reborn/providers.json`: Permission denied (os error 13)
```

`config.toml` in the **same directory** loaded fine, so this is one file's ownership, not directory traversal. The provider-registry overlay is fail-closed by design — an unreadable explicit overlay must not silently fall back to compiled-in defaults — so a single root-owned file ends the boot instead of degrading it.

**Root cause is the interaction of two deliberate choices, neither wrong on its own:**

1. #7723 changed the runtime image from `USER ironclaw` to `USER root`, because sshd must start as root before the entrypoint drops via `gosu`. For the first time, a root process can write to the persistent volume.
2. The root pass's `chown` is **non-recursive**, because `start-sshd.sh` refuses to run unless it owns `$IRONCLAW_REBORN_HOME/ssh`.

Together: the entrypoint repairs the home **directory** and leaves its **contents** untouched — and a persistent volume outlives the image that wrote it.

## Fix

The root pass now repairs ownership of the home's contents, excluding `ssh`. The exclusion is explicit rather than incidental: recursing into `ssh` would trade this crash loop for a broken SSH listener.

## Reproduced before fixing

Seeded a volume the way the failing instance looks, in `debian:bookworm-slim`:

```
BEFORE  -rw-r--r-- ironclaw ironclaw  config.toml
        -rw------- root     root      providers.json
AFTER entrypoint (root pass ran):     unchanged
uid 1000 reading providers.json:      Permission denied     ← matches the log exactly
```

With the fix: `providers.json` and nested files become `ironclaw`-owned and readable; `ssh/` and its host key stay `root:root`.

## ⚠️ Scope note — what this PR does and does not claim

This is a **robustness fix, not a diagnosis of one box.** I could not inspect the instance, so I have **not** proven how its `providers.json` became root-owned — only that this mechanism produces exactly the logged error, and that `USER root` is what makes root-owned files possible at all. Worth confirming with `ls -l /data/ironclaw-reborn/` on the affected instance.

The fix stands either way: a persistent volume shared across image versions with differing runtime users should not be able to brick boot, regardless of which write created the file.

**This also applies to the 1.3 line**, which has carried `USER root` since #7723 — any 1.3.x instance with a root-written file in its home has the same latent crash.

## Change Type

- [x] Bug fix

## Linked Issue

Follow-up to #7915 (which forward-ported #7723's `USER root` to main). None to close.

## Validation

- [x] Relevant tests pass: entrypoint self-tests on `debian:bookworm-slim` as a **non-root** user (as CI runs them)
- [x] Manual testing: reproduced the crash, applied the fix, confirmed resolution — see above
- [x] Real-sshd regression harness: **16/16** against the `release/1.3.1` baseline
- [x] Full `entrypoint.sh` → `start-sshd.sh` → real SSH login still succeeds as `agent:1000`, ssh state dir still root-owned
- [x] `shellcheck -s sh` clean apart from two pre-existing SC2016 notices

`cargo` checks not applicable: no Rust changed.

## Test Strategy

User behavior: a hosted instance whose persistent volume holds a root-written file boots normally instead of crash-looping, and SSH access keeps working.

Risk areas:
- [x] Persistence
- [x] Security or permissions
- [x] Side effect

Tests added or updated:
- Unit or contract: `scripts/ci/test-reborn-docker-entrypoint.sh` — `home_contents_ownership` asserts **both halves**: every top-level home entry is handed to `chown`, and `ssh` is **not**. The chown stub records argv rather than executing, so the test pins what the root pass asks for.
- Reborn integration: `Not applicable: container startup shape, below the Rust runtime the integration harness drives.`
- Recorded fixture: `Not applicable.`
- Browser E2E: `Not applicable.`
- Backend or runtime: covered — `platform-and-compat.yml` builds the image and exercises the real SSH path at merge-queue time, which is what would catch a regression in the `ssh` exclusion.
- Live canary: `Not applicable: the canary does not carry a persistent volume with stale ownership.`

What the tests prove: the root pass repairs home contents so a root-written file cannot brick boot, and it still leaves the SSH state directory root-owned so the listener keeps working. Proven discriminating — removing the fix fails all three ownership assertions.

Commands run:

```
bash scripts/ci/test-reborn-docker-entrypoint.sh    # green with fix
# without the fix:
#   FAIL[home_contents_ownership]: root pass never chowned config.toml
#   FAIL[home_contents_ownership]: root pass never chowned providers.json
#   FAIL[home_contents_ownership]: root pass never chowned nested
#   3 entrypoint self-test failure(s)
sshd regression harness vs release/1.3.1 baseline   # 16/16
entrypoint -> start-sshd -> ssh agent@...           # agent:1000
```

## Security Impact

The root pass now chowns the home's contents to the unprivileged runtime user — that is the direction that **reduces** privilege: files move from root to uid 1000, the identity the service already runs as, inside the service's own home. Nothing gains access it did not have.

`ssh` is excluded, so the SSH host key and `authorized_keys` keep their root ownership and `start-sshd.sh`'s fail-closed state checks continue to hold. Verified explicitly by the regression test and by a real SSH login.

The `chown` is scoped to `$IRONCLAW_REBORN_HOME`, which the entrypoint already validated and owns; it does not traverse outside it.

## Reborn Trust-Boundary Checklist

- Public policy/evidence/trust-bearing types: none touched.
- Untrusted content into prompts: N/A.
- Hashes declare purpose: N/A.
- New/changed status/exit/policy/runtime/error variants: none.
- Security/durability `serde(default)` fields: N/A — no serde changes. The behavior removes a fail-closed boot abort caused by stale filesystem ownership, without weakening the check that produced it.
- Queues/maps/buffers/counters bounds: N/A.
- Driver/operator-visible error class semantics: unchanged; this removes an error rather than adding one.
- Sandbox/native/host names accurately describe trust boundary: yes — `ssh` state stays root-owned precisely so the SSH boundary keeps its meaning.

## Database Impact

None.
