### PR TITLE
fix(slack): admit human message subtypes, and stop channel mentions depending on app_mention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5165,6 +5165,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
+ "tracing-test",
  "url",
  "uuid",
 ]

--- a/crates/extensions/packages/slack/Cargo.toml
+++ b/crates/extensions/packages/slack/Cargo.toml
@@ -37,6 +37,9 @@ url = "2"
 [dev-dependencies]
 # Property testing for the ingress boundary (#6524 workstream 9).
 proptest = "1"
+# The ingress drop log is the only trace a discarded human message leaves, so
+# it is asserted rather than assumed.
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
 # `test-support` exposes the shared channel-adapter conformance fakes.
 ironclaw_host_api = { path = "../../../contracts/ironclaw_host_api", version = "0.1.0", features = ["test-support"] }
 # The exported channel-adapter conformance suite moved here with

--- a/crates/extensions/packages/slack/src/channel.rs
+++ b/crates/extensions/packages/slack/src/channel.rs
@@ -686,6 +686,7 @@ fn flatten_self_rooted_topic(message: &mut NormalizedInboundMessage) -> Result<(
 #[cfg(test)]
 mod tests {
     use ironclaw_extension_contracts::channel_adapter::ProductTriggerReason;
+    use tracing_test::traced_test;
 
     use super::*;
 
@@ -966,6 +967,78 @@ mod tests {
                 matches!(inbound(body).await, Ok(InboundOutcome::Ignore)),
                 "expected Ignore for {}",
                 String::from_utf8_lossy(body)
+            );
+        }
+    }
+
+    /// A dropped event is answered with a bare 200 that satisfies Slack's
+    /// retry machinery, so this log line is the only evidence it ever
+    /// happened. `thread_broadcast` was discarded for months precisely
+    /// because nothing recorded the reason — assert it, do not assume it.
+    #[tokio::test]
+    #[traced_test]
+    async fn every_ignored_event_records_why_it_was_dropped() {
+        for (body, expected_reason) in [
+            (
+                br#"{
+                    "type": "event_callback",
+                    "event_id": "EvReasonBot",
+                    "event": {
+                        "type": "message",
+                        "bot_id": "B123",
+                        "channel": "D123",
+                        "channel_type": "im",
+                        "text": "echo",
+                        "ts": "1710000000.000400"
+                    }
+                }"#
+                .as_slice(),
+                "BotAuthored",
+            ),
+            (
+                br#"{
+                    "type": "event_callback",
+                    "event_id": "EvReasonSubtype",
+                    "event": {
+                        "type": "message",
+                        "user": "U123",
+                        "channel": "D123",
+                        "channel_type": "im",
+                        "subtype": "message_changed",
+                        "text": "edited",
+                        "ts": "1710000000.000500"
+                    }
+                }"#
+                .as_slice(),
+                "message_changed",
+            ),
+            (
+                br#"{
+                    "type": "event_callback",
+                    "event_id": "EvReasonAmbient",
+                    "event": {
+                        "type": "message",
+                        "user": "U123",
+                        "channel": "C123",
+                        "text": "ambient chatter",
+                        "ts": "1710000000.000600"
+                    }
+                }"#
+                .as_slice(),
+                "AmbientChannelMessage",
+            ),
+        ] {
+            assert!(
+                matches!(inbound(body).await, Ok(InboundOutcome::Ignore)),
+                "expected Ignore for {expected_reason}"
+            );
+            assert!(
+                logs_contain("slack inbound event produced no message"),
+                "the drop must be logged for {expected_reason}"
+            );
+            assert!(
+                logs_contain(expected_reason),
+                "the log must name why it dropped: {expected_reason}"
             );
         }
     }

--- a/crates/extensions/packages/slack/src/channel.rs
+++ b/crates/extensions/packages/slack/src/channel.rs
@@ -55,8 +55,13 @@ impl ChannelIngress for SlackChannelAdapter {
                     reason: format!("invalid installation id: {error}"),
                 }
             })?;
-        match normalize_slack_inbound(request.body, request.headers, &installation_id)
-            .map_err(parse_error)?
+        match normalize_slack_inbound(
+            request.body,
+            request.headers,
+            &installation_id,
+            crate::payload::slack_bot_user_id(request.config),
+        )
+        .map_err(parse_error)?
         {
             SlackInboundEvent::UrlVerification { challenge } => {
                 Ok(InboundOutcome::Respond(ImmediateResponse {
@@ -755,7 +760,14 @@ mod tests {
         let message = &messages[0];
         assert_eq!(message.text, "hello there");
         assert_eq!(message.trigger, ProductTriggerReason::DirectChat);
-        assert_eq!(message.event_id.as_str(), "slack-install_alpha-Ev123");
+        // Identity is the message, not the delivery: Slack's per-event
+        // `event_id` (`Ev123` here) would give the `app_mention` and
+        // `message.*` announcements of one message two identities, and the
+        // durable admission dedupe keys on this value.
+        assert_eq!(
+            message.event_id.as_str(),
+            "slack-install_alpha-msg-T-A-D123-1710000000.000100"
+        );
         assert_eq!(message.actor.id(), "U123");
         assert_eq!(message.conversation.conversation_id(), "D123");
         assert!(message.reply_context.is_none());

--- a/crates/extensions/packages/slack/src/channel.rs
+++ b/crates/extensions/packages/slack/src/channel.rs
@@ -70,7 +70,16 @@ impl ChannelIngress for SlackChannelAdapter {
                 content_type: None,
                 body: Vec::new(),
             })),
-            SlackInboundEvent::Ignore => Ok(InboundOutcome::Ignore),
+            // Most drops here are ordinary noise — ambient channel chatter and
+            // this bot's own echoes. The one that matters is a human message
+            // dropped by mistake, which the router acknowledges with a bare
+            // 200 that satisfies Slack's retry machinery. Without this line
+            // that drop leaves no trace at all, which is exactly how
+            // `thread_broadcast` stayed invisible.
+            SlackInboundEvent::Ignore { reason } => {
+                tracing::debug!(?reason, "slack inbound event produced no message");
+                Ok(InboundOutcome::Ignore)
+            }
             SlackInboundEvent::Message(parsed) => {
                 let ParsedSlackInboundMessage {
                     mut message,

--- a/crates/extensions/packages/slack/src/lib.rs
+++ b/crates/extensions/packages/slack/src/lib.rs
@@ -28,8 +28,8 @@ pub const SLACK_V2_ADAPTER_ID: &str = "slack_v2";
 
 pub use channel::SlackChannelAdapter;
 pub use payload::{
-    SLACK_API_HOST, SLACK_USER_ACTOR_KIND, SlackInboundEvent, SlackPayloadParseError,
-    normalize_slack_event,
+    SLACK_API_HOST, SLACK_USER_ACTOR_KIND, SlackIgnoreReason, SlackInboundEvent,
+    SlackPayloadParseError, normalize_slack_event,
 };
 pub use preference_targets::{
     SlackPreferenceTargetCodec, SlackReplyTargetError,

--- a/crates/extensions/packages/slack/src/payload.rs
+++ b/crates/extensions/packages/slack/src/payload.rs
@@ -18,7 +18,32 @@ use thiserror::Error;
 
 pub const SLACK_API_HOST: &str = "slack.com";
 pub const SLACK_USER_ACTOR_KIND: &str = "slack_user";
-const SLACK_FILE_SHARE_SUBTYPE: &str = "file_share";
+/// Slack `subtype` values that are not one person's message.
+///
+/// The gate here used to be the inverse — an allowlist of "human" subtypes,
+/// holding only `None` and `file_share`. That is a standing bet that Slack
+/// will never add another way for a person to post, and this adapter already
+/// lost it: `thread_broadcast` (a threaded reply sent with "Also send to
+/// channel") was discarded as if it were a channel-join announcement, so a
+/// mention written that way silently never ran.
+///
+/// Inverting it means an unrecognized subtype is admitted, not dropped. That
+/// is safe because this list only has to name what the guards below cannot
+/// see for themselves. Slack's system subtypes (`channel_join`,
+/// `channel_topic`, `pinned_item`, …) are channel-scoped announcements with
+/// no thread anchor, so the ambient-chatter rule in [`normalize_slack_event`]
+/// already drops them; message mutations carry their author under a nested
+/// `message` object, so the author guard already drops them. What is named
+/// here is what would otherwise slip past both: bot-authored posts, because a
+/// mention loop between two apps does not terminate on its own, and mutations
+/// that do arrive with a thread anchor.
+const NON_USER_MESSAGE_SUBTYPES: &[&str] = &[
+    "bot_message",
+    "message_changed",
+    "message_deleted",
+    "message_replied",
+    "assistant_app_thread",
+];
 
 /// Maximum accepted byte length for any Slack inbound webhook payload.
 const MAX_SLACK_PAYLOAD_BYTES: usize = 1024 * 1024; // 1 MB
@@ -49,8 +74,37 @@ pub enum SlackInboundEvent {
     /// command (distinct from the Events API's `UrlVerification` challenge).
     /// Any 200 response satisfies it; the body is ignored.
     SslCheck,
-    Ignore,
+    Ignore {
+        reason: SlackIgnoreReason,
+    },
     Message(Box<ParsedSlackInboundMessage>),
+}
+
+/// Why a verified Slack event produced no message.
+///
+/// Carried rather than discarded so the adapter can log one line per drop.
+/// Every rejection on this path ends in [`SlackInboundEvent::Ignore`], the
+/// router maps that to a bare `200`, and Slack's retry machinery is satisfied
+/// — so a human message dropped by mistake leaves no trace anywhere unless
+/// the reason travels with it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlackIgnoreReason {
+    /// Envelope is not `event_callback` (`app_rate_limited`, …).
+    NotAnEventCallback,
+    /// `event_callback` with no `event` object.
+    MissingEventPayload,
+    /// An event type this channel does not act on.
+    UnsupportedEventType,
+    /// A channel message that neither mentions the bot nor replies in a
+    /// thread — bystander chatter.
+    AmbientChannelMessage,
+    /// Authored by an integration, including this bot's own echo.
+    BotAuthored,
+    /// A `subtype` in [`NON_USER_MESSAGE_SUBTYPES`].
+    NonUserMessageSubtype(String),
+    /// A field the normalized contract cannot be built without (`user` on a
+    /// message mutation, `channel`, `ts`).
+    MissingField(&'static str),
 }
 
 /// Pure payload-normalization result retained inside the Slack package until
@@ -106,10 +160,14 @@ pub fn normalize_slack_event(
         &wrapper.event_type,
     )?;
     if wrapper.event_type != "event_callback" {
-        return Ok(SlackInboundEvent::Ignore);
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::NotAnEventCallback,
+        });
     }
     let Some(event) = wrapper.event.as_ref() else {
-        return Ok(SlackInboundEvent::Ignore);
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::MissingEventPayload,
+        });
     };
     let team_id = wrapper.team_id.as_deref();
     let kind = match event.event_type.as_str() {
@@ -123,15 +181,18 @@ pub fn normalize_slack_event(
             } else if event.thread_ts.is_some() {
                 SlackMessageKind::ThreadReply
             } else {
-                return Ok(SlackInboundEvent::Ignore);
+                return Ok(SlackInboundEvent::Ignore {
+                    reason: SlackIgnoreReason::AmbientChannelMessage,
+                });
             }
         }
-        _ => return Ok(SlackInboundEvent::Ignore),
+        _ => {
+            return Ok(SlackInboundEvent::Ignore {
+                reason: SlackIgnoreReason::UnsupportedEventType,
+            });
+        }
     };
-    normalize_user_message(event_id, team_id, event, kind).map(|message| match message {
-        Some(message) => SlackInboundEvent::Message(Box::new(message)),
-        None => SlackInboundEvent::Ignore,
-    })
+    normalize_user_message(event_id, team_id, event, kind)
 }
 
 /// Parse one host-verified Slack inbound request that may be EITHER the
@@ -283,26 +344,40 @@ fn normalize_user_message(
     team_id: Option<&str>,
     event: &SlackEvent,
     kind: SlackMessageKind,
-) -> Result<Option<ParsedSlackInboundMessage>, SlackPayloadParseError> {
-    if event.bot_id.is_some() || !is_user_generated_message_subtype(event.subtype.as_deref()) {
-        return Ok(None);
+) -> Result<SlackInboundEvent, SlackPayloadParseError> {
+    if event.bot_id.is_some() {
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::BotAuthored,
+        });
     }
+    if let Some(subtype) = event.subtype.as_deref()
+        && NON_USER_MESSAGE_SUBTYPES.contains(&subtype)
+    {
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::NonUserMessageSubtype(subtype.to_string()),
+        });
+    }
+    // A message mutation (`message_changed`, `message_deleted`) keeps its
+    // author and text under a nested `message` object, so a missing top-level
+    // author is the structural half of the subtype rule above, not a
+    // redundant check.
     let Some(user) = event.user.as_deref() else {
-        return Ok(None);
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::MissingField("user"),
+        });
     };
     let Some(channel) = event.channel.as_deref() else {
-        return Ok(None);
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::MissingField("channel"),
+        });
     };
-    if matches!(kind, SlackMessageKind::Dm)
-        && !is_dm_channel(channel, event.channel_type.as_deref())
-    {
-        return Ok(None);
-    }
-    if matches!(kind, SlackMessageKind::ThreadReply) && event.thread_ts.is_none() {
-        return Ok(None);
-    }
+    // `kind` was derived from `channel_type` and `thread_ts` in
+    // `normalize_slack_event`, this function's only caller, so re-checking
+    // them here can only ever agree.
     let Some(ts) = event.ts.as_deref() else {
-        return Ok(None);
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::MissingField("ts"),
+        });
     };
 
     let raw_text = event.text.as_deref().unwrap_or_default();
@@ -333,19 +408,21 @@ fn normalize_user_message(
             descriptor,
         })
         .collect();
-    Ok(Some(ParsedSlackInboundMessage {
-        message: NormalizedInboundMessage {
-            actor,
-            conversation,
-            event_id,
-            text,
-            trigger,
-            attachments: Vec::new(),
-            conversation_context: None,
-            reply_context: None,
+    Ok(SlackInboundEvent::Message(Box::new(
+        ParsedSlackInboundMessage {
+            message: NormalizedInboundMessage {
+                actor,
+                conversation,
+                event_id,
+                text,
+                trigger,
+                attachments: Vec::new(),
+                conversation_context: None,
+                reply_context: None,
+            },
+            pending_attachments,
         },
-        pending_attachments,
-    }))
+    )))
 }
 
 fn build_event_id(
@@ -445,10 +522,6 @@ fn strip_leading_bot_mention(text: &str) -> String {
         return trimmed[end + 1..].trim_start().to_string();
     }
     trimmed.to_string()
-}
-
-fn is_user_generated_message_subtype(subtype: Option<&str>) -> bool {
-    subtype.is_none_or(|value| value == SLACK_FILE_SHARE_SUBTYPE)
 }
 
 fn is_dm_channel(channel: &str, channel_type: Option<&str>) -> bool {

--- a/crates/extensions/packages/slack/src/payload.rs
+++ b/crates/extensions/packages/slack/src/payload.rs
@@ -18,6 +18,9 @@ use thiserror::Error;
 
 pub const SLACK_API_HOST: &str = "slack.com";
 pub const SLACK_USER_ACTOR_KIND: &str = "slack_user";
+/// Manifest admin-configuration handle carrying the bot's own member id.
+/// Declared `required = true`, so a configured installation always has it.
+const SLACK_BOT_USER_ID_HANDLE: &str = "slack_bot_user_id";
 /// Slack `subtype` values that are not one person's message.
 ///
 /// The gate here used to be the inverse — an allowlist of "human" subtypes,
@@ -129,6 +132,7 @@ impl std::ops::Deref for ParsedSlackInboundMessage {
 pub fn normalize_slack_event(
     raw_payload: &[u8],
     installation_id: &AdapterInstallationId,
+    bot_user_id: Option<&str>,
 ) -> Result<SlackInboundEvent, SlackPayloadParseError> {
     if raw_payload.len() > MAX_SLACK_PAYLOAD_BYTES {
         return Err(SlackPayloadParseError::InvalidJson {
@@ -154,11 +158,7 @@ pub fn normalize_slack_event(
         serde_json::from_slice(raw_payload).map_err(|err| SlackPayloadParseError::InvalidJson {
             reason: err.to_string(),
         })?;
-    let event_id = build_event_id(
-        installation_id,
-        wrapper.event_id.as_deref(),
-        &wrapper.event_type,
-    )?;
+    require_well_formed_envelope(wrapper.event_id.as_deref(), &wrapper.event_type)?;
     if wrapper.event_type != "event_callback" {
         return Ok(SlackInboundEvent::Ignore {
             reason: SlackIgnoreReason::NotAnEventCallback,
@@ -170,29 +170,63 @@ pub fn normalize_slack_event(
         });
     };
     let team_id = wrapper.team_id.as_deref();
-    let kind = match event.event_type.as_str() {
-        "app_mention" => SlackMessageKind::AppMention,
-        "message" => {
-            if is_dm_channel(
-                event.channel.as_deref().unwrap_or_default(),
-                event.channel_type.as_deref(),
-            ) {
-                SlackMessageKind::Dm
-            } else if event.thread_ts.is_some() {
-                SlackMessageKind::ThreadReply
-            } else {
+    let kind = if is_dm_channel(
+        event.channel.as_deref().unwrap_or_default(),
+        event.channel_type.as_deref(),
+    ) {
+        // A DM is a direct chat whichever of the two events announced it.
+        // Deciding that here, rather than letting whichever event happens to
+        // arrive first choose, is what keeps the collapsed pair deterministic.
+        SlackMessageKind::Dm
+    } else {
+        match event.event_type.as_str() {
+            "app_mention" => SlackMessageKind::Mention,
+            "message" => {
+                if mentions_bot(event.text.as_deref().unwrap_or_default(), bot_user_id) {
+                    // Recognizing the mention in the text makes the two events
+                    // redundant rather than making one of them load-bearing.
+                    // `BotMention` is the only channel trigger that starts a
+                    // run, so depending solely on `app_mention` arriving is one
+                    // vendor quirk away from silence — which is exactly how a
+                    // `thread_broadcast` mention went unanswered.
+                    SlackMessageKind::Mention
+                } else if event.thread_ts.is_some() {
+                    SlackMessageKind::ThreadReply
+                } else {
+                    return Ok(SlackInboundEvent::Ignore {
+                        reason: SlackIgnoreReason::AmbientChannelMessage,
+                    });
+                }
+            }
+            _ => {
                 return Ok(SlackInboundEvent::Ignore {
-                    reason: SlackIgnoreReason::AmbientChannelMessage,
+                    reason: SlackIgnoreReason::UnsupportedEventType,
                 });
             }
         }
-        _ => {
-            return Ok(SlackInboundEvent::Ignore {
-                reason: SlackIgnoreReason::UnsupportedEventType,
-            });
-        }
     };
-    normalize_user_message(event_id, team_id, event, kind)
+    normalize_user_message(installation_id, team_id, event, kind)
+}
+
+/// Slack renders a mention as `<@U…>` (or `<@U…|handle>`), so an explicit
+/// mention is detectable from the message text alone, without the
+/// `app_mention` event.
+fn mentions_bot(text: &str, bot_user_id: Option<&str>) -> bool {
+    let Some(bot) = bot_user_id.filter(|id| !id.is_empty()) else {
+        return false;
+    };
+    text.contains(&format!("<@{bot}>")) || text.contains(&format!("<@{bot}|"))
+}
+
+/// The bot's own member id from host-resolved, manifest-declared non-secret
+/// configuration. Absent only on an installation configured before the handle
+/// existed; mention detection then degrades to `app_mention` alone, which is
+/// the behavior that shipped before this.
+pub fn slack_bot_user_id(config: &[(String, String)]) -> Option<&str> {
+    config
+        .iter()
+        .find(|(handle, _)| handle == SLACK_BOT_USER_ID_HANDLE)
+        .map(|(_, value)| value.as_str())
 }
 
 /// Parse one host-verified Slack inbound request that may be EITHER the
@@ -206,11 +240,12 @@ pub(crate) fn normalize_slack_inbound(
     raw_payload: &[u8],
     headers: &[(String, String)],
     installation_id: &AdapterInstallationId,
+    bot_user_id: Option<&str>,
 ) -> Result<SlackInboundEvent, SlackPayloadParseError> {
     if is_form_urlencoded_content_type(headers) {
         return normalize_slack_slash_command(raw_payload, installation_id);
     }
-    normalize_slack_event(raw_payload, installation_id)
+    normalize_slack_event(raw_payload, installation_id, bot_user_id)
 }
 
 /// Case-insensitive Content-Type match for Slack's slash-command / ssl_check
@@ -334,13 +369,15 @@ fn build_slash_event_id(
 /// require `thread_ts`.
 #[derive(Debug, Clone, Copy)]
 enum SlackMessageKind {
-    AppMention,
+    /// The bot was named explicitly — via the `app_mention` event, or via its
+    /// member id in a channel message's text.
+    Mention,
     Dm,
     ThreadReply,
 }
 
 fn normalize_user_message(
-    event_id: ExternalEventId,
+    installation_id: &AdapterInstallationId,
     team_id: Option<&str>,
     event: &SlackEvent,
     kind: SlackMessageKind,
@@ -380,9 +417,11 @@ fn normalize_user_message(
         });
     };
 
+    let event_id = build_message_event_id(installation_id, team_id, channel, ts)?;
+
     let raw_text = event.text.as_deref().unwrap_or_default();
     let (text, thread_ts, trigger) = match kind {
-        SlackMessageKind::AppMention => (
+        SlackMessageKind::Mention => (
             strip_leading_bot_mention(raw_text),
             event.thread_ts.as_deref().or(Some(ts)),
             ProductTriggerReason::BotMention,
@@ -425,29 +464,43 @@ fn normalize_user_message(
     )))
 }
 
-fn build_event_id(
-    installation_id: &AdapterInstallationId,
+/// A signed `event_callback` without an `event_id` is malformed, and refusing
+/// it stays fail-closed. The value is no longer the dedupe key — see
+/// [`build_message_event_id`] — but a well-formed envelope is still required.
+fn require_well_formed_envelope(
     event_id: Option<&str>,
     wrapper_event_type: &str,
-) -> Result<ExternalEventId, SlackPayloadParseError> {
-    if wrapper_event_type == "event_callback" {
-        // event_callback must carry event_id to avoid dedup key collisions.
-        // Two signed events of the same type without event_id would share an
-        // identical ExternalEventId, silently dropping the second.
-        let id = event_id.ok_or_else(|| SlackPayloadParseError::InvalidExternalRef {
+) -> Result<(), SlackPayloadParseError> {
+    if wrapper_event_type == "event_callback" && event_id.is_none() {
+        return Err(SlackPayloadParseError::InvalidExternalRef {
             kind: "external_event_id",
             reason: "event_callback must carry event_id".to_string(),
-        })?;
-        ExternalEventId::new(format!("slack-{}-{id}", installation_id.as_str()))
-    } else {
-        // Non-event_callback types (team_join, url_verification, etc.) always
-        // route to noop. Use a noop-namespaced key so they never collide with
-        // real event_callback IDs.
-        ExternalEventId::new(format!(
-            "slack-{}-noop-{wrapper_event_type}",
-            installation_id.as_str()
-        ))
+        });
     }
+    Ok(())
+}
+
+/// Identity of the MESSAGE, not of the delivery.
+///
+/// Slack announces one person's message as up to two events — `app_mention`
+/// and the matching `message.*` — each carrying its own `event_id`. The
+/// durable admission dedupe keys on [`ExternalEventId`], so keying on
+/// `event_id` makes the pair look like two messages: before mention detection
+/// existed only one of them could start a run, which hid this; now that either
+/// can, per-delivery identity would run one mention twice. `(team, channel,
+/// ts)` names the message itself, so whichever events describe it collapse to
+/// one admission and the first to arrive wins.
+fn build_message_event_id(
+    installation_id: &AdapterInstallationId,
+    team_id: Option<&str>,
+    channel: &str,
+    ts: &str,
+) -> Result<ExternalEventId, SlackPayloadParseError> {
+    ExternalEventId::new(format!(
+        "slack-{}-msg-{}-{channel}-{ts}",
+        installation_id.as_str(),
+        team_id.unwrap_or("noteam"),
+    ))
     .map_err(|err| SlackPayloadParseError::InvalidExternalRef {
         kind: "external_event_id",
         reason: err.to_string(),

--- a/crates/extensions/packages/slack/src/payload.rs
+++ b/crates/extensions/packages/slack/src/payload.rs
@@ -181,16 +181,31 @@ pub fn normalize_slack_event(
     } else {
         match event.event_type.as_str() {
             "app_mention" => SlackMessageKind::Mention,
+            // Recognizing the mention in the text makes the two events
+            // redundant rather than making one of them load-bearing:
+            // `BotMention` is the only channel trigger that starts a run, so
+            // depending solely on `app_mention` arriving is one vendor quirk
+            // away from silence — which is how a `thread_broadcast` mention
+            // went unanswered.
+            //
+            // It is deliberately limited to messages carrying a `subtype`,
+            // which is exactly where that delivery is unestablished. A plain
+            // message needs no fallback — `app_mention` demonstrably arrives
+            // for it, that being the path in use today — and promoting it too
+            // would make BOTH events do the adapter's per-delivery vendor
+            // reads (attachment transfer, conversation context) for one
+            // message, since that enrichment happens before the admission
+            // dedupe can collapse them. Doubling Slack API calls on the most
+            // common interaction is too high a price for redundancy on a path
+            // that is not in doubt.
+            "message"
+                if event.subtype.is_some()
+                    && mentions_bot(event.text.as_deref().unwrap_or_default(), bot_user_id) =>
+            {
+                SlackMessageKind::Mention
+            }
             "message" => {
-                if mentions_bot(event.text.as_deref().unwrap_or_default(), bot_user_id) {
-                    // Recognizing the mention in the text makes the two events
-                    // redundant rather than making one of them load-bearing.
-                    // `BotMention` is the only channel trigger that starts a
-                    // run, so depending solely on `app_mention` arriving is one
-                    // vendor quirk away from silence — which is exactly how a
-                    // `thread_broadcast` mention went unanswered.
-                    SlackMessageKind::Mention
-                } else if event.thread_ts.is_some() {
+                if event.thread_ts.is_some() {
                     SlackMessageKind::ThreadReply
                 } else {
                     return Ok(SlackInboundEvent::Ignore {
@@ -348,10 +363,11 @@ fn build_slash_event_id(
     installation_id: &AdapterInstallationId,
     trigger_id: &str,
 ) -> Result<ExternalEventId, SlackPayloadParseError> {
-    // Namespaced separately from the Events API's `event_callback` id space
-    // (same defensive rationale as build_event_id's own `-noop-` namespace):
-    // a slash invocation and an Events API callback must never collide on
-    // dedup key even if some future id happened to coincide.
+    // Namespaced separately from the Events API's message id space (see
+    // [`build_message_event_id`]): a slash invocation and an Events API
+    // message must never collide on dedup key even if some future id happened
+    // to coincide. A slash command is an invocation rather than a message, so
+    // it is keyed per invocation and not by message identity.
     ExternalEventId::new(format!(
         "slack-{}-slash-{trigger_id}",
         installation_id.as_str()
@@ -363,7 +379,9 @@ fn build_slash_event_id(
 }
 
 /// Fixed user-message routing strategies in this first slice.
-/// `AppMention`: public channel, strip leading `@mention`, thread fallback to `ts`.
+/// `Mention`: public channel, strip leading `@mention`, thread fallback to
+/// `ts`. Reached from the `app_mention` event, or from a subtyped channel
+/// message naming the bot.
 /// `Dm`: direct-message channel required, keep text verbatim, no thread fallback.
 /// `ThreadReply`: channel thread reply, strip an optional leading `@mention`,
 /// require `thread_ts`.

--- a/crates/extensions/packages/slack/src/tests/payload_normalized.rs
+++ b/crates/extensions/packages/slack/src/tests/payload_normalized.rs
@@ -180,6 +180,24 @@ fn the_subtype_gate_admits_human_messages_and_drops_only_non_messages() {
             false,
         ),
         (
+            "message_replied",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": "replied", "subtype": "message_replied",
+                "thread_ts": "1710000000.000010", "ts": "1710000000.000015"
+            }),
+            false,
+        ),
+        (
+            "assistant_app_thread",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "D1", "channel_type": "im",
+                "text": "assistant thread", "subtype": "assistant_app_thread",
+                "ts": "1710000000.000016"
+            }),
+            false,
+        ),
+        (
             "ambient channel chatter",
             serde_json::json!({
                 "type": "message", "user": "U1", "channel": "C1", "text": "ambient",

--- a/crates/extensions/packages/slack/src/tests/payload_normalized.rs
+++ b/crates/extensions/packages/slack/src/tests/payload_normalized.rs
@@ -1,6 +1,9 @@
 use super::*;
 use proptest::prelude::*;
 
+/// Matches the `<@UBOT>` mentions the fixtures below already used.
+const TEST_BOT_USER_ID: &str = "UBOT";
+
 fn installation_id() -> AdapterInstallationId {
     AdapterInstallationId::new("install-alpha").expect("installation")
 }
@@ -9,6 +12,7 @@ fn normalize(value: serde_json::Value) -> SlackInboundEvent {
     normalize_slack_event(
         &serde_json::to_vec(&value).expect("payload"),
         &installation_id(),
+        Some(TEST_BOT_USER_ID),
     )
     .expect("normalizes")
 }
@@ -283,6 +287,7 @@ fn slash_command_forms_normalize_without_a_second_product_parser() {
         b"channel_id=D123&channel_name=directmessage&user_id=U123&command=%2Fironclaw&text=hello&trigger_id=trigger-1&team_id=T123",
         &headers,
         &installation_id(),
+        Some(TEST_BOT_USER_ID),
     )
     .expect("slash form");
     let SlackInboundEvent::Message(message) = event else {
@@ -295,11 +300,12 @@ fn slash_command_forms_normalize_without_a_second_product_parser() {
 #[test]
 fn oversized_payload_and_missing_event_id_fail_closed() {
     let oversized = vec![b'x'; MAX_SLACK_PAYLOAD_BYTES + 1];
-    assert!(normalize_slack_event(&oversized, &installation_id()).is_err());
+    assert!(normalize_slack_event(&oversized, &installation_id(), None).is_err());
     assert!(matches!(
         normalize_slack_event(
             br#"{"type":"event_callback","event":{"type":"message"}}"#,
-            &installation_id()
+            &installation_id(),
+            None
         ),
         Err(SlackPayloadParseError::InvalidExternalRef {
             kind: "external_event_id",
@@ -311,6 +317,153 @@ fn oversized_payload_and_missing_event_id_fail_closed() {
 proptest! {
     #[test]
     fn arbitrary_untrusted_bytes_never_panic(raw in proptest::collection::vec(any::<u8>(), 0..512)) {
-        let _ = normalize_slack_event(&raw, &installation_id());
+        let _ = normalize_slack_event(&raw, &installation_id(), Some(TEST_BOT_USER_ID));
     }
+}
+
+/// Slack announces one message as up to two events. Both must resolve to the
+/// same inbound identity, because the durable admission dedupe keys on it —
+/// otherwise a single mention runs twice.
+#[test]
+fn the_two_slack_events_for_one_message_share_one_inbound_identity() {
+    let app_mention = message(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "Ev-app-mention",
+        "event": {
+            "type": "app_mention",
+            "user": "U1",
+            "channel": "C1",
+            "text": "<@UBOT> same message",
+            "thread_ts": "1710000000.000010",
+            "ts": "1710000000.000011"
+        }
+    }));
+    let channel_message = message(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "Ev-message-channels",
+        "event": {
+            "type": "message",
+            "subtype": "thread_broadcast",
+            "user": "U1",
+            "channel": "C1",
+            "text": "<@UBOT> same message",
+            "thread_ts": "1710000000.000010",
+            "ts": "1710000000.000011"
+        }
+    }));
+    assert_eq!(
+        app_mention.event_id, channel_message.event_id,
+        "the twins of one message must dedupe against each other"
+    );
+    assert_eq!(app_mention.trigger, ProductTriggerReason::BotMention);
+    assert_eq!(
+        channel_message.trigger,
+        ProductTriggerReason::BotMention,
+        "the message twin must be able to start the run on its own"
+    );
+
+    let other_message = message(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "Ev-app-mention",
+        "event": {
+            "type": "app_mention",
+            "user": "U1",
+            "channel": "C1",
+            "text": "<@UBOT> a different message",
+            "ts": "1710000000.000099"
+        }
+    }));
+    assert_ne!(
+        app_mention.event_id, other_message.event_id,
+        "distinct messages must keep distinct identities"
+    );
+}
+
+/// The run-starting classification must not depend on `app_mention` arriving:
+/// it is the only channel trigger that starts a run, and Slack does not
+/// guarantee it for every message shape.
+#[test]
+fn an_explicit_mention_in_a_channel_message_starts_a_run_without_app_mention() {
+    let threaded = message(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "EvBroadcastOnly",
+        "event": {
+            "type": "message",
+            "subtype": "thread_broadcast",
+            "user": "U1",
+            "channel": "C1",
+            "text": "<@UBOT> what about Jalapeno?",
+            "thread_ts": "1710000000.000010",
+            "ts": "1710000000.000020"
+        }
+    }));
+    assert_eq!(threaded.trigger, ProductTriggerReason::BotMention);
+    assert_eq!(threaded.text, "what about Jalapeno?");
+    assert_eq!(threaded.conversation.topic_id(), Some("1710000000.000010"));
+
+    // Slack also renders mentions as `<@U…|handle>`.
+    let piped = message(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "EvPiped",
+        "event": {
+            "type": "message", "user": "U1", "channel": "C1",
+            "text": "hey <@UBOT|ironclaw> look", "ts": "1710000000.000021"
+        }
+    }));
+    assert_eq!(piped.trigger, ProductTriggerReason::BotMention);
+
+    // A thread reply that names nobody stays bystander chatter.
+    let bystander = message(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "EvBystander",
+        "event": {
+            "type": "message", "user": "U1", "channel": "C1",
+            "text": "agreed", "thread_ts": "1710000000.000010",
+            "ts": "1710000000.000022"
+        }
+    }));
+    assert_eq!(bystander.trigger, ProductTriggerReason::ReplyToBot);
+
+    // With no configured bot id, detection degrades to the pre-change behavior
+    // rather than guessing.
+    let unconfigured = normalize_slack_event(
+        &serde_json::to_vec(&serde_json::json!({
+            "type": "event_callback", "team_id": "T123", "event_id": "EvNoBotId",
+            "event": {
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": "<@UBOT> hello", "ts": "1710000000.000023"
+            }
+        }))
+        .expect("payload"),
+        &installation_id(),
+        None,
+    )
+    .expect("normalizes");
+    assert!(matches!(unconfigured, SlackInboundEvent::Ignore { .. }));
+}
+
+/// A DM is a direct chat whichever event announced it. Without this the
+/// collapsed pair would take its trigger from whichever event arrived first.
+#[test]
+fn a_dm_is_a_direct_chat_even_when_it_arrives_as_an_app_mention() {
+    let dm_mention = message(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "EvDmMention",
+        "event": {
+            "type": "app_mention",
+            "user": "U1",
+            "channel": "D1",
+            "channel_type": "im",
+            "text": "<@UBOT> hi",
+            "ts": "1710000000.000030"
+        }
+    }));
+    assert_eq!(dm_mention.trigger, ProductTriggerReason::DirectChat);
 }

--- a/crates/extensions/packages/slack/src/tests/payload_normalized.rs
+++ b/crates/extensions/packages/slack/src/tests/payload_normalized.rs
@@ -88,29 +88,141 @@ fn app_mention_strips_only_the_provider_mention_and_self_roots_a_thread() {
     assert_eq!(message.conversation.topic_id(), Some("1710000000.000002"));
 }
 
+/// Slack stamps `subtype` on two unrelated things: events that are not one
+/// person's message, and ordinary human messages that render specially. Only
+/// the first family may be dropped — dropping the second silences a real
+/// person behind a bare 200.
 #[test]
-fn bots_subtypes_and_ambient_channels_are_ignored() {
-    for event in [
-        serde_json::json!({
-            "type": "message", "user": "U1", "channel": "D1", "text": "loop",
-            "ts": "1.0", "bot_id": "B1"
-        }),
-        serde_json::json!({
-            "type": "message", "user": "U1", "channel": "D1", "text": "changed",
-            "ts": "1.0", "subtype": "message_changed"
-        }),
-        serde_json::json!({
-            "type": "message", "user": "U1", "channel": "C1", "text": "ambient",
-            "ts": "1.0"
-        }),
+fn the_subtype_gate_admits_human_messages_and_drops_only_non_messages() {
+    for (label, event, admitted) in [
+        // A reply sent with "Also send to channel" carries `thread_broadcast`
+        // on BOTH the app_mention and the message.channels event. The
+        // app_mention is the one that matters: a `ReplyToBot` thread reply is
+        // a NoOp at the product surface, so a mention that loses its
+        // app_mention never runs at all.
+        (
+            "thread_broadcast mention",
+            serde_json::json!({
+                "type": "app_mention", "user": "U1", "channel": "C1",
+                "text": "<@UBOT> broadcast question", "subtype": "thread_broadcast",
+                "thread_ts": "1710000000.000010", "ts": "1710000000.000011"
+            }),
+            true,
+        ),
+        (
+            "thread_broadcast channel message",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": "broadcast reply", "subtype": "thread_broadcast",
+                "thread_ts": "1710000000.000010", "ts": "1710000000.000011"
+            }),
+            true,
+        ),
+        (
+            "reply_broadcast, thread_broadcast's deprecated predecessor",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": "older broadcast", "subtype": "reply_broadcast",
+                "thread_ts": "1710000000.000010", "ts": "1710000000.000012"
+            }),
+            true,
+        ),
+        (
+            "me_message",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "D1", "channel_type": "im",
+                "text": "shrugs", "subtype": "me_message", "ts": "1710000000.000013"
+            }),
+            true,
+        ),
+        (
+            "file_share",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "D1", "channel_type": "im",
+                "text": "here it is", "subtype": "file_share", "ts": "1710000000.000014"
+            }),
+            true,
+        ),
+        // Not one user-authored message.
+        (
+            "bot echo",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "D1", "text": "loop",
+                "ts": "1.0", "bot_id": "B1"
+            }),
+            false,
+        ),
+        (
+            "bot_message carrying no bot_id",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "D1", "channel_type": "im",
+                "text": "loop", "ts": "1.0", "subtype": "bot_message"
+            }),
+            false,
+        ),
+        // Real edit/delete events carry no top-level author at all, so the
+        // author guard already rejects them; these synthesize one so the
+        // subtype denial itself is what stays pinned.
+        (
+            "message_changed",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "D1", "channel_type": "im",
+                "text": "changed", "ts": "1.0", "subtype": "message_changed"
+            }),
+            false,
+        ),
+        (
+            "message_deleted",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "D1", "channel_type": "im",
+                "text": "deleted", "ts": "1.0", "subtype": "message_deleted"
+            }),
+            false,
+        ),
+        (
+            "ambient channel chatter",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "C1", "text": "ambient",
+                "ts": "1.0"
+            }),
+            false,
+        ),
     ] {
-        assert!(matches!(
-            normalize(serde_json::json!({
-                "type": "event_callback", "event_id": "EvIgnored", "event": event
-            })),
-            SlackInboundEvent::Ignore
-        ));
+        let outcome = normalize(serde_json::json!({
+            "type": "event_callback", "team_id": "T123",
+            "event_id": "EvSubtype", "event": event
+        }));
+        assert_eq!(
+            matches!(outcome, SlackInboundEvent::Message(_)),
+            admitted,
+            "{label} normalized to {outcome:?}"
+        );
     }
+}
+
+/// The incident shape: an @mention written as a threaded reply with "Also send
+/// to channel" must reach the host as a `BotMention` still anchored to the
+/// thread it was written in.
+#[test]
+fn a_broadcast_mention_keeps_its_thread_anchor_and_bot_mention_trigger() {
+    let broadcast = message(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "EvBroadcast",
+        "event": {
+            "type": "app_mention",
+            "user": "U091135TNG6",
+            "channel": "C088U5W0CCA",
+            "subtype": "thread_broadcast",
+            "text": "<@UBOT> what do you think about OpenAI Jalapeno?",
+            "thread_ts": "1787687594.022139",
+            "ts": "1787756973.320549"
+        }
+    }));
+    assert_eq!(broadcast.text, "what do you think about OpenAI Jalapeno?");
+    assert_eq!(broadcast.trigger, ProductTriggerReason::BotMention);
+    assert_eq!(broadcast.conversation.topic_id(), Some("1787687594.022139"));
+    assert_eq!(broadcast.conversation.conversation_id(), "C088U5W0CCA");
 }
 
 #[test]

--- a/crates/extensions/packages/slack/src/tests/payload_normalized.rs
+++ b/crates/extensions/packages/slack/src/tests/payload_normalized.rs
@@ -412,10 +412,34 @@ fn an_explicit_mention_in_a_channel_message_starts_a_run_without_app_mention() {
         "event_id": "EvPiped",
         "event": {
             "type": "message", "user": "U1", "channel": "C1",
-            "text": "hey <@UBOT|ironclaw> look", "ts": "1710000000.000021"
+            "subtype": "thread_broadcast", "text": "hey <@UBOT|ironclaw> look",
+            "thread_ts": "1710000000.000010", "ts": "1710000000.000021"
         }
     }));
     assert_eq!(piped.trigger, ProductTriggerReason::BotMention);
+
+    // A PLAIN mention is deliberately NOT promoted. `app_mention` demonstrably
+    // arrives for it, and promoting it would make both events perform the
+    // adapter's per-delivery vendor reads for one message — the enrichment
+    // runs before the admission dedupe can collapse them.
+    let plain_top_level = normalize(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "EvPlainTopLevel",
+        "event": {
+            "type": "message", "user": "U1", "channel": "C1",
+            "text": "<@UBOT> plain mention", "ts": "1710000000.000024"
+        }
+    }));
+    assert!(
+        matches!(
+            plain_top_level,
+            SlackInboundEvent::Ignore {
+                reason: SlackIgnoreReason::AmbientChannelMessage
+            }
+        ),
+        "got {plain_top_level:?}"
+    );
 
     // A thread reply that names nobody stays bystander chatter.
     let bystander = message(serde_json::json!({

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -1526,6 +1526,138 @@ async fn slack_final_reply_flows_through_the_real_delivery_coordinator(
     assert_eq!(authorization.1, format!("Bearer {SLACK_BOT_TOKEN}"));
 }
 
+/// Slack announces one person's message as up to two events, and since this
+/// channel now recognizes a mention from either, both can start a run. The
+/// durable admission dedupe is the only thing stopping one mention from
+/// running twice, and it keys on `ExternalEventId` — so this drives BOTH
+/// signed events for one message through the real ingress route and pins that
+/// exactly one run is admitted.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_two_slack_events_for_one_message_admit_exactly_one_run() {
+    let group = RebornIntegrationGroup::builder()
+        .storage(StorageMode::LibSql)
+        .extension_delivery()
+        .await
+        .expect("delivery group builds");
+    activate_slack(&group).await;
+    let services = reborn_services(&group);
+    assert!(
+        services.register_static_channel_egress_credentials_for_test(vec![(
+            "slack".to_string(),
+            "slack_bot_token".to_string(),
+            ironclaw_secrets::SecretMaterial::from(SLACK_BOT_TOKEN.to_string()),
+        )]),
+        "the composed runtime must expose channel-egress credential bridging"
+    );
+
+    let inbound = group
+        .thread("conv-slack-twin-collapse")
+        .script([RebornScriptedReply::text("unused")])
+        .build()
+        .await
+        .expect("inbound thread builds");
+    let delivery_services = delivery_run_services(&inbound, services, "slack");
+    let observer = Arc::new(RecordingForwardObserver::new(Arc::new(
+        RunDeliveryObserver::new(delivery_services),
+    )));
+    let adapter_config = [(
+        "slack_bot_user_id".to_string(),
+        SLACK_BOT_USER_ID.to_string(),
+    )];
+    let ingress = VendorIngress::register(
+        services
+            .extension_ingress_parts()
+            .expect("composition built the generic ingress"),
+        "slack",
+        SLACK_INSTALLATION,
+        SLACK_SIGNING_SECRET,
+        VerifiedEvidenceMint::RequestSignature {
+            signature_header: "X-Slack-Signature".to_string(),
+            timestamp_header: Some("X-Slack-Request-Timestamp".to_string()),
+        },
+        &inbound,
+        Arc::clone(&observer),
+        adapter_config.to_vec(),
+    );
+
+    // The same message, as Slack announces it: two event types, two distinct
+    // `event_id`s, one `(team, channel, ts)`.
+    let twin = |event_type: &str, event_id: &str| {
+        json!({
+            "type": "event_callback",
+            "event_id": event_id,
+            "team_id": "T-A",
+            "event": {
+                "type": event_type,
+                "subtype": "thread_broadcast",
+                "user": "U777",
+                "channel": "C777",
+                "text": "<@U-BOT> broadcast asked once",
+                "thread_ts": "1710000200.000050",
+                "ts": "1710000300.000777"
+            }
+        })
+        .to_string()
+    };
+    let app_mention_body = twin("app_mention", "Ev-twin-app-mention");
+    let channel_message_body = twin("message", "Ev-twin-message-channels");
+
+    let evidence = ProtocolAuthEvidence::test_verified(
+        AuthRequirement::RequestSignature {
+            header_name: "X-Slack-Signature".to_string(),
+            timestamp_header_name: Some("X-Slack-Request-Timestamp".to_string()),
+        },
+        SLACK_INSTALLATION,
+    );
+    let slack_binding_service = inbound
+        .binding_service_for_test()
+        .expect("group binding service");
+    let (vendor_scope, _) = preresolve_vendor_turn_scope(
+        &slack_binding_service,
+        &ironclaw_slack_extension::SlackChannelAdapter,
+        "slack",
+        SLACK_INSTALLATION,
+        &adapter_config,
+        &evidence,
+        &app_mention_body,
+        true,
+    )
+    .await;
+    inbound.register_scope_gateway_for_test(
+        vendor_scope.clone(),
+        Arc::new(StaticReplyGateway(SLACK_REPLY)),
+    );
+
+    for body in [&app_mention_body, &channel_message_body] {
+        let timestamp = now_unix().to_string();
+        let signature = slack_signature(&timestamp, body);
+        let status = ingress
+            .post(
+                SLACK_ROUTE,
+                body,
+                vec![
+                    ("X-Slack-Signature", signature),
+                    ("X-Slack-Request-Timestamp", timestamp),
+                ],
+            )
+            .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "both announcements of one message must be acknowledged"
+        );
+        ingress.drain().await;
+    }
+
+    assert_eq!(
+        observer.accepted_count(),
+        1,
+        "one message must admit exactly one run however many events announced \
+         it (errors: {:?})",
+        observer.errors()
+    );
+}
+
 /// DEL-10: the bundled Telegram package — one manifest plus the adapter
 /// crate, zero bespoke host code — installs through the production
 /// lifecycle tool, consumes the authorized manifest-driven administrator

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -110,6 +110,9 @@ const SLACK_ROUTE: &str = "/webhooks/extensions/slack/events";
 const SLACK_INSTALLATION: &str = "slack-itest-install";
 const SLACK_SIGNING_SECRET: &[u8] = b"itest-slack-signing-secret";
 const SLACK_BOT_TOKEN: &str = "xoxb-itest-bot-token";
+/// The installation's configured `slack_bot_user_id`: what the adapter matches
+/// `<@…>` against to recognize an explicit mention without an `app_mention`.
+const SLACK_BOT_USER_ID: &str = "U-BOT";
 const SLACK_REPLY: &str = "Here is the coordinated Slack reply.";
 const SLACK_CONNECT_REQUIRED: &str =
     "👋 Connect your Slack account in the IronClaw web app, then message me here again.";
@@ -498,6 +501,12 @@ impl VendorIngress {
         evidence: VerifiedEvidenceMint,
         harness: &RebornIntegrationHarness,
         observer: Arc<RecordingForwardObserver>,
+        // The manifest-declared non-secret configuration the router resolves
+        // for the verified installation, and hands the adapter. Seeded rather
+        // than left empty so the harness feeds the adapter what production
+        // does — an adapter that reads a required config handle behaves
+        // differently against a double that always answers "unconfigured".
+        non_secret_config: Vec<(String, String)>,
     ) -> Self {
         let surface = harness.product_surface_for_test() as Arc<dyn ChannelInboundProductSurface>;
         let sink = Arc::new(GenericChannelInboundSink::new(ChannelInboundSinkConfig {
@@ -515,7 +524,7 @@ impl VendorIngress {
                         secret: secret.to_vec(),
                     },
                 ])),
-                configuration: Arc::new(StaticIngressConfiguration::default()),
+                configuration: Arc::new(StaticIngressConfiguration::new(non_secret_config)),
                 sink: sink.clone() as Arc<dyn ironclaw_extension_host::ingress::InboundSink>,
                 drain: Some(sink as Arc<dyn ChannelIngressDrain>),
             },
@@ -1037,7 +1046,7 @@ async fn admin_configured_slack_unconnected_dm_gets_connect_notice_without_insta
             {"handle": "slack_team_id", "value": "T-A"},
             {"handle": "slack_api_app_id", "value": "A-ITEST"},
             {"handle": "slack_installation_id", "value": SLACK_INSTALLATION},
-            {"handle": "slack_bot_user_id", "value": "U-BOT"},
+            {"handle": "slack_bot_user_id", "value": SLACK_BOT_USER_ID},
             {"handle": "slack_oauth_client_id", "value": "slack-oauth-client"},
             {"handle": "slack_oauth_client_secret", "value": "slack-oauth-secret"}
         ]),
@@ -1292,17 +1301,24 @@ async fn telegram_identity_configuration_errors_are_retryable_on_the_real_router
 /// asserted on the wire recorder AND in the coordinator's outbound store.
 ///
 /// The `thread_broadcast` case is the same proof for a mention posted as a
-/// threaded reply with "Also send to channel". Slack stamps that message with
-/// a `subtype`, and an @mention that the adapter drops never runs at all — a
-/// `ReplyToBot` thread reply is a NoOp at the product surface, so `app_mention`
-/// is the only event that can start the run.
+/// threaded reply with "Also send to channel", which Slack stamps with a
+/// `subtype`.
+///
+/// The `message_only` case is the same message arriving WITHOUT an
+/// `app_mention` — the shape this channel cannot distinguish from the outside,
+/// because Slack does not guarantee `app_mention` for every message shape.
+/// `BotMention` is the only channel trigger that starts a run (a `ReplyToBot`
+/// thread reply is a NoOp at the product surface), so this pins that the run no
+/// longer depends on which of the two events Slack chose to send.
 #[rstest]
-#[case::libsql(StorageMode::LibSql, None)]
-#[case::libsql_thread_broadcast(StorageMode::LibSql, Some("thread_broadcast"))]
-#[case::postgres(StorageMode::Postgres, None)]
+#[case::libsql(StorageMode::LibSql, "app_mention", None)]
+#[case::libsql_thread_broadcast(StorageMode::LibSql, "app_mention", Some("thread_broadcast"))]
+#[case::libsql_message_only(StorageMode::LibSql, "message", Some("thread_broadcast"))]
+#[case::postgres(StorageMode::Postgres, "app_mention", None)]
 #[tokio::test(flavor = "multi_thread")]
 async fn slack_final_reply_flows_through_the_real_delivery_coordinator(
     #[case] storage: StorageMode,
+    #[case] event_type: &'static str,
     #[case] mention_subtype: Option<&'static str>,
 ) {
     let group = RebornIntegrationGroup::builder()
@@ -1331,6 +1347,12 @@ async fn slack_final_reply_flows_through_the_real_delivery_coordinator(
     let observer = Arc::new(RecordingForwardObserver::new(Arc::new(
         RunDeliveryObserver::new(delivery_services),
     )));
+    // Both the ingress route and the scope pre-resolver run the same adapter,
+    // so both get the same non-secret configuration production would resolve.
+    let adapter_config = [(
+        "slack_bot_user_id".to_string(),
+        SLACK_BOT_USER_ID.to_string(),
+    )];
     let ingress = VendorIngress::register(
         services
             .extension_ingress_parts()
@@ -1344,13 +1366,16 @@ async fn slack_final_reply_flows_through_the_real_delivery_coordinator(
         },
         &inbound,
         Arc::clone(&observer),
+        adapter_config.to_vec(),
     );
 
+    // `U-BOT` is this installation's configured `slack_bot_user_id`, so the
+    // `message` case is recognized as an explicit mention from the text alone.
     let mut event = json!({
-        "type": "app_mention",
+        "type": event_type,
         "user": "U777",
         "channel": "C777",
-        "text": "<@UBOT> please reply through the coordinator",
+        "text": "<@U-BOT> please reply through the coordinator",
         "thread_ts": "1710000200.000050",
         "ts": "1710000300.000100"
     });
@@ -1360,7 +1385,7 @@ async fn slack_final_reply_flows_through_the_real_delivery_coordinator(
     let body = json!({
         "type": "event_callback",
         "event_id": format!(
-            "Ev-delivery-slack-1-{}",
+            "Ev-delivery-slack-1-{event_type}-{}",
             mention_subtype.unwrap_or("plain")
         ),
         "team_id": "T-A",
@@ -1388,7 +1413,7 @@ async fn slack_final_reply_flows_through_the_real_delivery_coordinator(
         &ironclaw_slack_extension::SlackChannelAdapter,
         "slack",
         SLACK_INSTALLATION,
-        &[],
+        &adapter_config,
         &evidence,
         &body,
         true,

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -1290,12 +1290,20 @@ async fn telegram_identity_configuration_errors_are_retryable_on_the_real_router
 /// coordinated through the REAL factory-built `DeliveryCoordinator` to
 /// `chat.postMessage`, with the §11 bridged bot token injected host-side —
 /// asserted on the wire recorder AND in the coordinator's outbound store.
+///
+/// The `thread_broadcast` case is the same proof for a mention posted as a
+/// threaded reply with "Also send to channel". Slack stamps that message with
+/// a `subtype`, and an @mention that the adapter drops never runs at all — a
+/// `ReplyToBot` thread reply is a NoOp at the product surface, so `app_mention`
+/// is the only event that can start the run.
 #[rstest]
-#[case::libsql(StorageMode::LibSql)]
-#[case::postgres(StorageMode::Postgres)]
+#[case::libsql(StorageMode::LibSql, None)]
+#[case::libsql_thread_broadcast(StorageMode::LibSql, Some("thread_broadcast"))]
+#[case::postgres(StorageMode::Postgres, None)]
 #[tokio::test(flavor = "multi_thread")]
 async fn slack_final_reply_flows_through_the_real_delivery_coordinator(
     #[case] storage: StorageMode,
+    #[case] mention_subtype: Option<&'static str>,
 ) {
     let group = RebornIntegrationGroup::builder()
         .storage(storage)
@@ -1338,18 +1346,25 @@ async fn slack_final_reply_flows_through_the_real_delivery_coordinator(
         Arc::clone(&observer),
     );
 
+    let mut event = json!({
+        "type": "app_mention",
+        "user": "U777",
+        "channel": "C777",
+        "text": "<@UBOT> please reply through the coordinator",
+        "thread_ts": "1710000200.000050",
+        "ts": "1710000300.000100"
+    });
+    if let Some(subtype) = mention_subtype {
+        event["subtype"] = json!(subtype);
+    }
     let body = json!({
         "type": "event_callback",
-        "event_id": "Ev-delivery-slack-1",
+        "event_id": format!(
+            "Ev-delivery-slack-1-{}",
+            mention_subtype.unwrap_or("plain")
+        ),
         "team_id": "T-A",
-        "event": {
-            "type": "app_mention",
-            "user": "U777",
-            "channel": "C777",
-            "text": "<@UBOT> please reply through the coordinator",
-            "thread_ts": "1710000200.000050",
-            "ts": "1710000300.000100"
-        }
+        "event": event,
     })
     .to_string();
     // The run's scope is the vendor conversation's binding, not this harness


### PR DESCRIPTION
## The bug

A Slack mention posted as a threaded reply with **"Also send to channel"** was silently discarded at ingress. Slack stamps that message `subtype: "thread_broadcast"`; the adapter allowlisted exactly two subtypes — `None` and `file_share` — so the event became `SlackInboundEvent::Ignore`, which the generic router answers with a bare `200`. No turn, no reply, no log line anywhere.

### Verified in production

Railway deployment `9f917c13-8392-4355-9818-4e35953f9eb0` (env `libsql-prod`, commit `d112612840`), 2026-08-26:

```
15:09:33.320Z  user posts in #general, mentions the bot, "Also send to channel"
15:09:34.510Z  POST /webhooks/extensions/slack/events   200    10ms   Slackbot 1.0
15:09:35.785Z  POST /webhooks/extensions/slack/events   200     9ms   Slackbot 1.0
15:09:36.035Z  POST /webhooks/extensions/slack/events   200    12ms   Slackbot 1.0
               -- zero application log lines, zero turns
15:10:35.794Z  POST /webhooks/extensions/slack/events   200   534ms  -> a run (unrelated thread)
```

Every event that created a run in that window took **76-534 ms** (turn creation plus the conversation-context fetch). These three took **9-12 ms** — an HMAC and a JSON parse, i.e. `Ignore` before any I/O. `200` + silent is uniquely diagnostic: 404/405/413 cover route and limits, 401 verification, 429 rate, 503 transient; `acknowledged_discarded` always `warn!`s; `admit_messages` writes durably and creates the turn inside the request. `Ignore` is the only 200 that leaves nothing behind.

## Two defects, not one

**1. The subtype allowlist.** `is_user_generated_message_subtype` treated Slack's `subtype` as if it only marked non-human events. It marks two unrelated things — non-messages (`channel_join`, `bot_message`, `message_changed`) **and** ordinary human messages that render specially (`file_share`, `thread_broadcast`, `me_message`). The lone `file_share` exception was already evidence the enum had outgrown the rule once.

Inverted into `NON_USER_MESSAGE_SUBTYPES`, so an **unrecognized subtype is admitted, not dropped**. Safe because the list only names what the surrounding guards cannot see: Slack's system subtypes are channel-scoped announcements with no thread anchor (the ambient-chatter rule drops them) and mutations carry their author under a nested `message` (the author guard drops them). What is named is bot-authored posts — a mention loop between two apps does not terminate — and mutations that do arrive with a thread anchor. Anything still slipping through with empty text is rejected by `NormalizedInboundMessage::validate`, with a `warn!`.

**2. Every channel mention depended on one event arriving.** `build_channel_envelope` maps `ProductTriggerReason::ReplyToBot` to `NoOp`, so `BotMention` is the only channel trigger that starts a run — and only `app_mention` produced it. Slack does not guarantee `app_mention` for every message shape, and since Railway retains no request bodies, **whether the dropped `app_mention` even existed for the reported message cannot be established after the fact.** Fixing only the subtype gate would have left the outcome resting on that assumption.

`slack_bot_user_id` is a required, manifest-declared, non-secret admin config handle that **no production code read**. The adapter now reads it and treats `<@BOTID>` (or `<@BOTID|handle>`) anywhere in a channel message's text as an explicit mention, so either event can start the run and neither is load-bearing.

Detection is deliberately limited to messages carrying a `subtype` — exactly where `app_mention` delivery is unestablished. The adapter's per-delivery vendor reads (attachment transfer, conversation-context fetch) happen inside `receive()`, *before* the admission dedupe can collapse the pair, so promoting every mention-bearing message would make both events perform them for one message. A plain top-level mention's `message` twin was previously dropped as ambient chatter and cost nothing, so promoting it would have doubled Slack API calls and attachment bandwidth on the most common interaction there is. A plain message needs no fallback anyway: `app_mention` demonstrably arrives for it, that being the path in use today. Subtyped mentions can still pay for two deliveries — rare next to plain ones, and the price of not depending on a guarantee Slack does not make. This is also the shape every other Slack client converged on — [bolt-python#488](https://github.com/slackapi/bolt-python/issues/488), [openclaw#23064](https://github.com/openclaw/openclaw/issues/23064), [opencode#13251](https://github.com/anomalyco/opencode/issues/13251) — and the premise this repo already fixed once in [#1404](https://github.com/nearai/ironclaw/issues/1404) before the Reborn rewrite reintroduced it.

### Identity had to become the message, not the delivery

That second fix is only safe alongside this one. `ExternalEventId` is the durable admission dedupe key, and Slack gives each of the two announcements its own `event_id`. While only one of them could start a run the difference was invisible; with both able to, per-delivery identity would run a single mention **twice**. The id now derives from `(team, channel, ts)`, so the pair collapses to one admission and the first to arrive wins. A signed `event_callback` must still carry an `event_id` to be well-formed — that stays fail-closed — the value simply is not the key. The slash-command id is untouched and stays per-invocation, since a slash command is not a message.

Classification is also made order-independent: a DM is a `DirectChat` whichever event announced it, rather than `BotMention` when `app_mention` happens to arrive first.

## Audit of the rest of the path

| Site | Verdict |
|---|---|
| `subtype` not in `{None, file_share}` | **defect** — inverted to a deny list |
| Channel mention reachable only via `app_mention` | **defect** — mention now detected from text |
| `Dm` re-checks `channel_type`; `ThreadReply` re-checks `thread_ts` | **dead** — `kind` was derived from those predicates in the only caller; removed |
| `bot_id` present | keep — mention loops between apps do not terminate |
| missing `user` / `channel` / `ts` | keep — this is what rejects `message_changed` / `message_deleted` |
| channel message with no mention and no thread anchor | keep — bystander chatter |
| not `event_callback` / no event / unknown event type | keep |

Not changed, deliberately: `is_dm_channel` returns `false` for `channel_type: "mpim"`, so an unmentioned message in a group DM stays ambient (changing it would make the bot answer every message in every group DM). `strip_leading_bot_mention` still strips only a *leading* mention — in the incident five bots were named and ours was first; had it been second the mention would remain inline in the text. Cosmetic, never a drop. Telegram is the only other `ChannelIngress` and has no subtype allowlist, so **the first defect has no sibling** — it does share the silent-`Ignore` shape at four sites, which is follow-up.

`SlackInboundEvent::Ignore` now carries a `SlackIgnoreReason`, logged once at `debug` by the adapter, so no future drop is invisible.

## Test Strategy

**Integration** — `slack_final_reply_flows_through_the_real_delivery_coordinator` runs four cases through the production `extension_ingress_route_mount`, the real `SlackChannelAdapter`, durable admission, a real turn, and out to `chat.postMessage`: a plain mention (libsql + postgres), the same mention carrying `thread_broadcast`, and **`message_only`** — the incident's message with **no `app_mention` at all**.

`the_two_slack_events_for_one_message_admit_exactly_one_run` drives **both** signed events for one message through the real route and pins that exactly one run is admitted — the fix's central claim, which was previously only proven as a pure function that never reached the idempotency ledger.

**Crate** — the full admit/deny subtype matrix including every `NON_USER_MESSAGE_SUBTYPES` entry; the incident shape end to end; the two events of one message sharing an identity while distinct messages do not; `<@U…|handle>` recognition; a plain top-level mention deliberately NOT promoted, so the boundary is a tested decision; a thread reply naming nobody staying bystander chatter; an unconfigured bot id degrading to the previous behavior rather than guessing; and the drop log firing with its reason.

**Red before green, at both tiers**, and each new guarantee proven to bind by mutation:

```
crate:        assertion `left == right` failed: thread_broadcast mention normalized to Ignore
integration:  panicked at extension_delivery.rs:437: the vendor body must normalize to messages
mutation (mentions_bot -> false):   case_3_libsql_message_only FAILED, other 3 pass
mutation (identity salted per delivery): one message admitted 2 runs (left: 2, right: 1)
mutation (drop log deleted):        the drop must be logged for BotAuthored
```

`tracing-test` is declared with `no-env-filter`, matching the nine sibling crates — the drop log is `debug!`, which the default filter would swallow, and the assertion would otherwise pass vacuously.

**Harness fix:** the ingress test double seeded `StaticIngressConfiguration::default()`, feeding the adapter empty configuration where production resolves the installation's own. It now carries the same handles — which is what let the new case exercise the real classification path rather than a doubled one.

**E2E / WebUI** — Not applicable: the defect is entirely inside webhook payload normalization, and the integration tier already drives it through the production HTTP mount.

## Verification

```
cargo test -p ironclaw_slack_extension                       # 85 passed
cargo test -p ironclaw_integration_tests \
  --test reborn_integration_extension_delivery -- --test-threads=1
                                                             # 30 passed (libsql AND postgres)
cargo test -p ironclaw_architecture_tests                    # 42 sections, 0 failures
cargo clippy -p ironclaw_slack_extension --all-targets --all-features   # clean
cargo fmt --check
```

Both storage legs ran for real; no Postgres case was skipped.

## Compatibility and rollback

Behavior-only, at the ingress parse boundary. No schema, no persisted format, no config, no feature gate. Rollback is a straight revert.

One bounded upgrade effect worth naming: because `ExternalEventId` changes shape, a message admitted just before the deploy would not dedupe against a Slack redelivery arriving after it. Slack only redelivers after a non-2xx, within about an hour, so the exposure is a narrow window and the worst case is one duplicated turn.

Blast radius is wider admission of Slack inbound events. The unchanged `bot_id` guard plus the `bot_message` deny entry keep the bot-loop boundary exactly where it was, and the new message-identity dedupe is what keeps wider admission from multiplying runs.

## Review

Two full multi-agent passes.

First two commits: mechanical 0; correctness, security, performance, design 0 each; coverage 2, both confirmed and fixed in `d015ffe88b`.

Third commit (`e967881199`), reviewed separately because it carried the real risk: correctness 0, security 0; **performance 1 High** (the doubled per-delivery vendor reads described above — verified against the code, not taken on faith); **coverage 1 High** (the identity collapse never proven end-to-end); design 2 Low (comments left pointing at the renamed `AppMention` variant and the deleted `build_event_id`). All four fixed in `1e02216ada`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


