### PR TITLE
chore(release): cut 1.4.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0-rc.1] - 2026-08-26
+
+First release candidate for 1.4.0, covering the 81 commits since
+`ironclaw-v1.3.0`.
+
+### Added
+
+- Durable notification inbox: runs publish authoritative outcomes and
+  actionable gates to a per-user inbox, surfaced by the WebUI notification
+  center, so approvals and auth prompts survive a missed session.
+- Background subagents: a parent turn can spawn children that run and deliver
+  on their own, with per-child delivery, activation provenance, a derived cap
+  on autonomous wakes, and healing sweeps for orphaned children.
+- Persistent per-user sandbox containers on the local-Docker profile, reached
+  over Docker Exec so container-local installs and state survive between
+  commands. The Railway preview profile still runs an ephemeral worker per
+  command and keeps only its checkpointed workspace.
+- Managed per-user sandbox egress proxy, with manifest-declared direct-exec
+  credential bindings that stay behind it so secrets are never handed to
+  sandboxed code.
+- Run-now for automations, plus exact run capability facts.
+- Durable backend suggestions generated over the user's own no-approval,
+  read-only tools and gated on connected extensions.
+- Google Docs semantic editing tools; run timing evidence in downloadable
+  conversation artifacts.
+- Opt-in in-worker SSH in the runtime image (see Operators below).
+
+### Fixed
+
+- Structured finalization stalls are bounded, and OpenAI-compatible
+  reasoning-only responses are preserved.
+- Provider failures and auth diagnostics reach the model as readable context
+  instead of opaque errors.
+- libSQL write-lane starvation no longer cascades through the resource
+  governor as unrelated tool failures.
+- Telegram separates workspace-bot pairing from personal device linking, and
+  keeps paired channels ready while collapsing streaming reply drafts.
+- Slack delivers the unlinked-user connect nudge privately with a one-click
+  connect link.
+- Installation state written by 1.2.x is accepted and preserved, so a
+  deployment that skipped 1.3 upgrades directly.
+- Incremental compaction summary context is preserved.
+
+### Operators
+
+- The runtime image can start an in-worker SSH listener. It is **off unless**
+  `IRONCLAW_REBORN_SSH_PUBLIC_KEY` is set to an OpenSSH *public* key, which
+  enables public-key-only login as user `agent` on container port 2222; that
+  port must be published to be reachable. `agent` shares uid 1000 with the
+  `ironclaw` runtime user, so an SSH session holds the full runtime identity --
+  treat the private key like shell access to the service.
+- `IRONCLAW_REBORN_WORKSPACE_ROOT` is honored on both CLI boot paths. Neither
+  it nor `IRONCLAW_REBORN_HOME` may be set to the filesystem root.
+- New sandbox knobs: `IRONCLAW_REBORN_SANDBOX_PROXY_IMAGE` and
+  `IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS`.
+
+### Upgrading
+
+No migration steps from 1.3.0.
+
 ## [1.3.0] - 2026-08-19
 
 Stable promotion of `1.3.0-rc.2`, including the upgrade and container fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,7 +3684,7 @@ checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "ironclaw"
-version = "1.2.0"
+version = "1.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/app/ironclaw_cli/Cargo.toml
+++ b/crates/app/ironclaw_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw"
-version = "1.2.0"
+version = "1.4.0-rc.1"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"


### PR DESCRIPTION
## Summary

The `1.4.0-rc.1` cut commit, targeting `release/2026-08-26` (branched from `main` at `9bf094fb4`).

Three files, the same shape as every prior cut:

| File | Change |
|---|---|
| `crates/app/ironclaw_cli/Cargo.toml` | `1.2.0` → `1.4.0-rc.1` |
| `Cargo.lock` | the `ironclaw` package stanza only |
| `CHANGELOG.md` | a **populated** `## [1.4.0-rc.1]` section |

**`main` deliberately stays at `1.2.0`.** Version bumps live on the release branch only, exactly as they did for 1.3.0 and 1.3.1.

## The changelog section is populated on purpose

A review comment on #7923 caught that cargo-dist derives the GitHub Release **title and body** from `CHANGELOG.md` — `.github/workflows/README.md` says so, and `ironclaw-release.yml` passes `announcement_github_body` straight to `gh release create`. A bare `## [1.4.0-rc.1]` heading would therefore publish a candidate with **no release notes at all**, leaving QA nothing describing what they are validating. Verified both references before acting on it.

The notes cover the 81 commits since `ironclaw-v1.3.0` and carry the three operator facts this release actually changes:

- The in-worker SSH listener is **off unless** `IRONCLAW_REBORN_SSH_PUBLIC_KEY` is set — public-key-only as `agent` on port 2222, which must be published to be reachable, and `agent` shares uid 1000 with the `ironclaw` runtime user, so the private key is equivalent to shell access.
- `IRONCLAW_REBORN_WORKSPACE_ROOT` is honored on both CLI boot paths, and neither it nor `IRONCLAW_REBORN_HOME` may be the filesystem root.
- Two new sandbox knobs: `IRONCLAW_REBORN_SANDBOX_PROXY_IMAGE`, `IRONCLAW_SANDBOX_EXTRA_ALLOWED_DOMAINS`.

The sandbox persistence claim is **scoped to the local-Docker profile**: the Railway preview path builds its worker through `ephemeral_worker_argv` with `--rm`, so it keeps only its checkpointed workspace. (Also caught in review — the first draft overstated it.)

## Change Type

- [x] Documentation
- [x] CI/Infrastructure

## Linked Issue

None — release preparation. Process: `docs/internal/weekly-release-strategy.md`.

## Validation

- [x] `cargo metadata --format-version 1 --offline` resolves — `Cargo.lock` stays consistent with the bump
- [x] `ensure_release_tag(requested_version="1.4.0-rc.1", manifest_version="1.4.0-rc.1", …)` → accepted
- [x] `ensure_stable_changelog_entry(".", "1.4.0")` → passes, so the later stable promotion is not blocked
- [x] `check-guidance.py` → OK

No Rust source changed, so `clippy`/`test` are not applicable to this commit.

## Test Strategy

User behavior: none. This versions the candidate and gives its GitHub Release real notes.

Risk areas:
- [x] Cross-component behavior (release metadata only)

Tests added or updated:
- Unit or contract: `Not applicable: a version bump plus changelog prose. The release tooling's own gates are the checks, and both were exercised directly (see Validation).`
- Reborn integration / Recorded fixture / Browser E2E / Backend or runtime / Live canary: `Not applicable: no runtime behavior changes.`

What the tests prove: the candidate's manifest version matches the tag that will be requested, the lockfile agrees, and the eventual stable promotion will not be refused for a missing changelog entry.

Commands run:

```
cargo metadata --format-version 1 --offline                       # lock consistent
ensure_release_tag(... '1.4.0-rc.1' ...)  -> created ironclaw-v1.4.0-rc.1
ensure_stable_changelog_entry('.', '1.4.0') -> OK
python3 scripts/ci/check-guidance.py                              # OK
```

## Security Impact

None. No code changes. The changelog's operator section documents the existing opt-in SSH ingress and the workspace-root constraints; it introduces nothing.

## Reborn Trust-Boundary Checklist

N/A — a version bump and changelog prose. No types, prompts, hashes, status variants, serde fields, or trust boundaries touched.

## Database Impact

None.

## After merge

Dispatch **Cut Ironclaw Release** from the `main` ref (its tag job is gated on `github.ref == default_branch`) with `version=1.4.0-rc.1` and `commit_sha=` this PR's merge commit on `release/2026-08-26`.

**Blocking check before tagging:** `main` at `9bf094fb4` must be green, in particular `Clippy Windows (default)` and `Clippy Windows (all-features)` — those were the lanes #7923 fixed, and the weekly strategy requires cutting only from a commit whose required checks pass. They were still running when this PR was opened.
