### PR TITLE
fix(slack): admit a broadcast mention by exempting app_mention from the subtype gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5165,6 +5165,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
+ "tracing-test",
  "url",
  "uuid",
 ]

--- a/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
+++ b/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
@@ -820,7 +820,14 @@ async fn configured_channel_config() -> Arc<ChannelConfigService> {
                 ("slack_team_id".to_string(), TEAM.to_string()),
                 ("slack_api_app_id".to_string(), "A-E2E".to_string()),
                 ("slack_installation_id".to_string(), "I-E2E".to_string()),
-                ("slack_bot_user_id".to_string(), "U-BOT-E2E".to_string()),
+                // Must match the `<@…>` id every fixture's `text` mentions
+                // (`UBOT`, not e.g. "U-BOT-E2E"): the adapter's
+                // `strip_leading_bot_mention` now strips a leading mention
+                // only when it names THIS configured bot, so a mismatch here
+                // silently leaves the mention in the normalized text instead
+                // of failing loudly — re-check every `<@UBOT>` fixture below
+                // if this value ever changes.
+                ("slack_bot_user_id".to_string(), "UBOT".to_string()),
                 (
                     "slack_oauth_client_id".to_string(),
                     "e2e-slack-client".to_string(),

--- a/crates/extensions/packages/slack/Cargo.toml
+++ b/crates/extensions/packages/slack/Cargo.toml
@@ -35,6 +35,11 @@ tracing = "0.1"
 url = "2"
 
 [dev-dependencies]
+# The ingress drop log is the only trace a discarded human message leaves, so
+# it is asserted rather than assumed. `no-env-filter` because the drop log is
+# `debug!`, which the default filter would swallow — the assertion would then
+# pass vacuously.
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
 # Property testing for the ingress boundary (#6524 workstream 9).
 proptest = "1"
 # `test-support` exposes the shared channel-adapter conformance fakes.

--- a/crates/extensions/packages/slack/src/channel.rs
+++ b/crates/extensions/packages/slack/src/channel.rs
@@ -70,7 +70,15 @@ impl ChannelIngress for SlackChannelAdapter {
                 content_type: None,
                 body: Vec::new(),
             })),
-            SlackInboundEvent::Ignore => Ok(InboundOutcome::Ignore),
+            // One line per drop. The router answers an ignored event with a
+            // bare 200 to satisfy Slack's retry machinery, so without this a
+            // human message discarded by mistake leaves no trace anywhere —
+            // which is exactly how `thread_broadcast` stayed invisible until
+            // someone compared response latencies.
+            SlackInboundEvent::Ignore { reason } => {
+                tracing::debug!(?reason, "slack inbound event produced no message");
+                Ok(InboundOutcome::Ignore)
+            }
             SlackInboundEvent::Message(parsed) => {
                 let ParsedSlackInboundMessage {
                     mut message,
@@ -749,6 +757,72 @@ mod tests {
         assert_eq!(message.actor.id(), "U123");
         assert_eq!(message.conversation.conversation_id(), "D123");
         assert!(message.reply_context.is_none());
+    }
+
+    /// The incident's root symptom was not the drop — it was that the drop
+    /// left no trace. The router turns an ignore into a bare 200, so without
+    /// this log line a human message discarded by mistake is invisible in
+    /// every system we own. Deleting the `debug!` makes this fail.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn every_ignored_event_records_why_it_was_dropped() {
+        for (body, expected_reason) in [
+            (
+                br#"{
+                "type": "event_callback",
+                "event_id": "Ev-bot",
+                "team_id": "T-A",
+                "event": {
+                    "type": "message", "channel": "D1", "channel_type": "im",
+                    "user": "U1", "bot_id": "B1", "text": "echo",
+                    "ts": "1710000000.000300"
+                }
+            }"#
+                .as_slice(),
+                "BotAuthored",
+            ),
+            (
+                br#"{
+                "type": "event_callback",
+                "event_id": "Ev-subtype",
+                "team_id": "T-A",
+                "event": {
+                    "type": "message", "channel": "D1", "channel_type": "im",
+                    "user": "U1", "subtype": "channel_join",
+                    "text": "joined", "ts": "1710000000.000301"
+                }
+            }"#
+                .as_slice(),
+                "NonUserMessageSubtype",
+            ),
+            (
+                br#"{
+                "type": "event_callback",
+                "event_id": "Ev-ambient",
+                "team_id": "T-A",
+                "event": {
+                    "type": "message", "channel": "C1", "user": "U1",
+                    "text": "chatter", "ts": "1710000000.000302"
+                }
+            }"#
+                .as_slice(),
+                "AmbientChannelMessage",
+            ),
+        ] {
+            let outcome = inbound(body).await.expect("payload parses");
+            assert!(
+                matches!(outcome, InboundOutcome::Ignore),
+                "expected Ignore for {expected_reason}"
+            );
+            assert!(
+                logs_contain("slack inbound event produced no message"),
+                "the drop for {expected_reason} produced no log line"
+            );
+            assert!(
+                logs_contain(expected_reason),
+                "the drop log did not carry reason {expected_reason}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/extensions/packages/slack/src/channel.rs
+++ b/crates/extensions/packages/slack/src/channel.rs
@@ -55,8 +55,13 @@ impl ChannelIngress for SlackChannelAdapter {
                     reason: format!("invalid installation id: {error}"),
                 }
             })?;
-        match normalize_slack_inbound(request.body, request.headers, &installation_id)
-            .map_err(parse_error)?
+        match normalize_slack_inbound(
+            request.body,
+            request.headers,
+            &installation_id,
+            crate::payload::slack_bot_user_id(request.config),
+        )
+        .map_err(parse_error)?
         {
             SlackInboundEvent::UrlVerification { challenge } => {
                 Ok(InboundOutcome::Respond(ImmediateResponse {
@@ -753,7 +758,16 @@ mod tests {
         let message = &messages[0];
         assert_eq!(message.text, "hello there");
         assert_eq!(message.trigger, ProductTriggerReason::DirectChat);
-        assert_eq!(message.event_id.as_str(), "slack-install_alpha-Ev123");
+        // Keyed on the MESSAGE (team, channel, ts), not on Slack's per-event
+        // `event_id` — the twins Slack sends for one post carry different
+        // `event_id`s and would otherwise each admit their own run. The
+        // envelope's `event_id` is still required (see
+        // `oversized_payload_and_missing_event_id_fail_closed`), it just no
+        // longer decides identity.
+        assert_eq!(
+            message.event_id.as_str(),
+            "slack-install_alpha-msg-T-A-D123-1710000000.000100"
+        );
         assert_eq!(message.actor.id(), "U123");
         assert_eq!(message.conversation.conversation_id(), "D123");
         assert!(message.reply_context.is_none());
@@ -891,6 +905,62 @@ mod tests {
             Some("1710000000.000010"),
             "a broadcast mention stays anchored to the thread it was written in, not its own ts"
         );
+    }
+
+    /// `inbound` with an explicit host-resolved config (the plain `inbound`
+    /// helper above always passes an empty config, so `mentions_bot` never
+    /// fires through it — this is the seam for driving a `message` event
+    /// that names the bot via text alone, with `slack_bot_user_id` resolved
+    /// the way the host actually resolves it).
+    async fn inbound_with_config(
+        body: &[u8],
+        config: &[(String, String)],
+    ) -> Result<InboundOutcome, ChannelError> {
+        SlackChannelAdapter
+            .receive(
+                VerifiedInbound {
+                    extension_id: "slack",
+                    installation_id: "install_alpha",
+                    config,
+                    body,
+                    headers: &[],
+                    can_reply_in_threads: true,
+                },
+                &ScriptedEgress::new(Vec::new()),
+            )
+            .await
+    }
+
+    /// The point of `TextMention` driven through the production caller: a
+    /// `message` event with NO `app_mention` twin, whose text names the bot,
+    /// still reaches `receive` as a `BotMention` rather than being dropped as
+    /// ambient chatter.
+    #[tokio::test]
+    async fn a_message_event_naming_the_bot_reaches_receive_as_a_bot_mention_with_no_app_mention_twin()
+     {
+        let config = vec![("slack_bot_user_id".to_string(), "UBOT".to_string())];
+        let outcome = inbound_with_config(
+            br#"{
+                "type": "event_callback",
+                "event_id": "EvTextMention",
+                "team_id": "T-A",
+                "event": {
+                    "type": "message",
+                    "user": "U123",
+                    "channel": "C123",
+                    "text": "<@UBOT> can you help",
+                    "ts": "1710000000.000950"
+                }
+            }"#,
+            &config,
+        )
+        .await
+        .expect("text mention parses");
+        let InboundOutcome::Messages(messages) = outcome else {
+            panic!("expected Messages, a message naming the bot must not be dropped");
+        };
+        assert_eq!(messages[0].text, "can you help");
+        assert_eq!(messages[0].trigger, ProductTriggerReason::BotMention);
     }
 
     /// The counterexample to the fix above: `app_mention` with

--- a/crates/extensions/packages/slack/src/channel.rs
+++ b/crates/extensions/packages/slack/src/channel.rs
@@ -855,6 +855,94 @@ mod tests {
         );
     }
 
+    /// Regression for the "Also send to channel" drop (#7925): Slack stamps
+    /// the SAME `app_mention` event with `subtype: "thread_broadcast"` when a
+    /// threaded reply is broadcast to the channel. Coverage previously lived
+    /// only on the private `normalize_slack_event` helper — this drives the
+    /// production caller, `SlackChannelAdapter::receive`, so a regression in
+    /// the `receive`-level admission guard (not just the helper) fails here.
+    #[tokio::test]
+    async fn a_broadcast_mention_reaches_receive_as_a_bot_mention_anchored_on_its_thread() {
+        let outcome = inbound(
+            br#"{
+                "type": "event_callback",
+                "event_id": "EvBroadcast",
+                "team_id": "T-A",
+                "event": {
+                    "type": "app_mention",
+                    "user": "U123",
+                    "channel": "C123",
+                    "subtype": "thread_broadcast",
+                    "text": "<@UBOT> what do you think?",
+                    "thread_ts": "1710000000.000010",
+                    "ts": "1710000000.000011"
+                }
+            }"#,
+        )
+        .await
+        .expect("broadcast mention parses");
+        let InboundOutcome::Messages(messages) = outcome else {
+            panic!("expected Messages, broadcast mention must not be dropped");
+        };
+        assert_eq!(messages[0].text, "what do you think?");
+        assert_eq!(messages[0].trigger, ProductTriggerReason::BotMention);
+        assert_eq!(
+            messages[0].conversation.topic_id(),
+            Some("1710000000.000010"),
+            "a broadcast mention stays anchored to the thread it was written in, not its own ts"
+        );
+    }
+
+    /// The counterexample to the fix above: `app_mention` with
+    /// `subtype: "document_mention"` is a canvas-body mention, not a person
+    /// addressing the bot in conversation. Slack writes `text` itself (a
+    /// caption); the person's real words live only in `blocks`, a field
+    /// this contract never reads. Fixture is Slack's own documented example
+    /// payload (<https://docs.slack.dev/reference/events/message/document_mention/>).
+    /// Drives the production caller, `SlackChannelAdapter::receive`, so a
+    /// regression that re-admits this shape through the `AppMention`
+    /// exemption fails here, not just on the private normalization helper.
+    #[tokio::test]
+    async fn a_canvas_document_mention_is_ignored_by_receive() {
+        let outcome = inbound(
+            br#"{
+                "event": {
+                    "user": "UA1BCD3EF",
+                    "subtype": "document_mention",
+                    "document_mention": {
+                        "file_id": "F123ABCDEFG",
+                        "section_id": "temp:C:GQL...",
+                        "mentioning_user_ids": ["UA1BCD3EF"]
+                    },
+                    "type": "app_mention",
+                    "ts": "1716411280.657549",
+                    "text": "<@U123456ABC7> was mentioned in a canvas",
+                    "blocks": [{
+                        "type": "section",
+                        "block_id": "gcn3v",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ">>>Hey <@U123456ABC7>",
+                            "verbatim": false
+                        }
+                    }],
+                    "team": "T1ABC2DE3",
+                    "channel": "C012ABCDEFG",
+                    "event_ts": "1716411280.657549"
+                },
+                "type": "event_callback",
+                "team_id": "T1ABC2DE3",
+                "event_id": "EvDocumentMention"
+            }"#,
+        )
+        .await
+        .expect("document mention parses");
+        assert!(
+            matches!(outcome, InboundOutcome::Ignore),
+            "a canvas-body mention must not start a turn on Slack-written caption text"
+        );
+    }
+
     /// `inbound` with an explicit `can_reply_in_threads` (the helpers above
     /// pin `true`, Slack's shipped manifest value) — the seam for proving the
     /// flag drives placement rather than decorating the manifest.

--- a/crates/extensions/packages/slack/src/lib.rs
+++ b/crates/extensions/packages/slack/src/lib.rs
@@ -28,8 +28,8 @@ pub const SLACK_V2_ADAPTER_ID: &str = "slack_v2";
 
 pub use channel::SlackChannelAdapter;
 pub use payload::{
-    SLACK_API_HOST, SLACK_USER_ACTOR_KIND, SlackInboundEvent, SlackPayloadParseError,
-    normalize_slack_event,
+    SLACK_API_HOST, SLACK_USER_ACTOR_KIND, SlackIgnoreReason, SlackInboundEvent,
+    SlackPayloadParseError, normalize_slack_event,
 };
 pub use preference_targets::{
     SlackPreferenceTargetCodec, SlackReplyTargetError,

--- a/crates/extensions/packages/slack/src/payload.rs
+++ b/crates/extensions/packages/slack/src/payload.rs
@@ -22,6 +22,22 @@ const SLACK_FILE_SHARE_SUBTYPE: &str = "file_share";
 /// Slack's marker for a post authored by an integration. Authorship, not
 /// rendering — see the guard in [`normalize_user_message`].
 const SLACK_BOT_MESSAGE_SUBTYPE: &str = "bot_message";
+/// Slack's marker for a canvas-body mention: a person mentions the bot
+/// inside a canvas document, and Slack fires `app_mention` for it — but with
+/// this `subtype` set, `text` holding a Slack-written caption ("was
+/// mentioned in a canvas") rather than what the person typed, and no
+/// `bot_id`. The person's actual words live only in `blocks`, a field this
+/// contract never reads. Documented at
+/// <https://docs.slack.dev/reference/events/message/document_mention/>,
+/// whose example payload is exactly this shape; the same docs note that a
+/// mention inside a threaded *comment* still arrives as an ordinary
+/// `app_mention` with no such subtype. That makes `document_mention` the
+/// one documented case where `app_mention` is not a person addressing the
+/// bot in conversation — checked in [`normalize_user_message`] ahead of the
+/// `AppMention` exemption, the same way `SLACK_BOT_MESSAGE_SUBTYPE` is
+/// checked ahead of it, so it is rejected on every path rather than
+/// exempted by it.
+const SLACK_DOCUMENT_MENTION_SUBTYPE: &str = "document_mention";
 
 /// Message `subtype` values that carry one person's own message, rendered
 /// specially.
@@ -102,6 +118,11 @@ pub enum SlackIgnoreReason {
     AmbientChannelMessage,
     /// Authored by an integration, including this bot's own echo.
     BotAuthored,
+    /// An `app_mention` whose `subtype` is `document_mention`: a person did
+    /// author the mention, but Slack — not that person — wrote the event's
+    /// `text`, and their actual words live only in a `blocks` field this
+    /// contract does not read. See [`SLACK_DOCUMENT_MENTION_SUBTYPE`].
+    SyntheticMentionText,
     /// A `message` whose `subtype` is not in [`HUMAN_MESSAGE_SUBTYPES`].
     /// Never reached from an `app_mention`.
     NonUserMessageSubtype(String),
@@ -358,6 +379,24 @@ fn normalize_user_message(
     if event.bot_id.is_some() || event.subtype.as_deref() == Some(SLACK_BOT_MESSAGE_SUBTYPE) {
         return Ok(SlackInboundEvent::Ignore {
             reason: SlackIgnoreReason::BotAuthored,
+        });
+    }
+    // Canvas-body mention. Checked HERE, ahead of the `AppMention`
+    // exemption below, for the same reason `bot_message` is checked ahead
+    // of it: the exemption below is a statement about *rendering*
+    // ("`subtype` doesn't gate an `app_mention`"), and this is not a
+    // rendering question. `document_mention` is the one documented case
+    // where Slack firing `app_mention` does NOT mean a person addressed
+    // the bot in conversation — a person did trigger it, but Slack itself
+    // wrote `text` (a caption such as "was mentioned in a canvas"), and
+    // the person's real words are only in `blocks`, which this contract
+    // never reads. Admitting it would start a full agent turn on
+    // Slack-generated text. See [`SLACK_DOCUMENT_MENTION_SUBTYPE`] for the
+    // docs citation; a mention in a threaded *comment* carries no such
+    // subtype and is unaffected.
+    if event.subtype.as_deref() == Some(SLACK_DOCUMENT_MENTION_SUBTYPE) {
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::SyntheticMentionText,
         });
     }
     // Content shape — deliberately NOT asked of an `app_mention`.

--- a/crates/extensions/packages/slack/src/payload.rs
+++ b/crates/extensions/packages/slack/src/payload.rs
@@ -19,6 +19,32 @@ use thiserror::Error;
 pub const SLACK_API_HOST: &str = "slack.com";
 pub const SLACK_USER_ACTOR_KIND: &str = "slack_user";
 const SLACK_FILE_SHARE_SUBTYPE: &str = "file_share";
+/// Slack's marker for a post authored by an integration. Authorship, not
+/// rendering — see the guard in [`normalize_user_message`].
+const SLACK_BOT_MESSAGE_SUBTYPE: &str = "bot_message";
+
+/// Message `subtype` values that carry one person's own message, rendered
+/// specially.
+///
+/// Slack stamps `subtype` on two unrelated families: these, and its own
+/// channel announcements (`channel_join`, `channel_topic`, `bot_add`, …).
+/// No field distinguishes the two, so the human family is named explicitly
+/// and everything else is treated as not-a-person-speaking.
+///
+/// This list governs `message` events only. An `app_mention` is exempt —
+/// see [`normalize_user_message`] — so a human subtype missing from here
+/// can never silence a channel mention.
+const HUMAN_MESSAGE_SUBTYPES: &[&str] = &[
+    SLACK_FILE_SHARE_SUBTYPE,
+    // A threaded reply sent with "Also send to channel". Slack stamps it on
+    // both events it emits for that one message.
+    "thread_broadcast",
+    // `thread_broadcast`'s deprecated predecessor, still emitted by older
+    // clients.
+    "reply_broadcast",
+    // `/me`-style italicized message.
+    "me_message",
+];
 
 /// Maximum accepted byte length for any Slack inbound webhook payload.
 const MAX_SLACK_PAYLOAD_BYTES: usize = 1024 * 1024; // 1 MB
@@ -49,8 +75,38 @@ pub enum SlackInboundEvent {
     /// command (distinct from the Events API's `UrlVerification` challenge).
     /// Any 200 response satisfies it; the body is ignored.
     SslCheck,
-    Ignore,
+    Ignore {
+        reason: SlackIgnoreReason,
+    },
     Message(Box<ParsedSlackInboundMessage>),
+}
+
+/// Why a verified Slack event produced no message.
+///
+/// Carried rather than discarded so the adapter can log one line per drop.
+/// Every rejection on this path ends in [`SlackInboundEvent::Ignore`], the
+/// router maps that to a bare `200`, and Slack's retry machinery is
+/// satisfied — so a human message dropped by mistake leaves no trace
+/// anywhere unless the reason travels with it. That is exactly how a
+/// `thread_broadcast` mention stayed invisible in production.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlackIgnoreReason {
+    /// Envelope is not `event_callback` (`app_rate_limited`, …).
+    NotAnEventCallback,
+    /// `event_callback` with no `event` object.
+    MissingEventPayload,
+    /// An event type this channel does not act on.
+    UnsupportedEventType,
+    /// A channel message that neither mentions the bot nor replies in a
+    /// thread — bystander chatter.
+    AmbientChannelMessage,
+    /// Authored by an integration, including this bot's own echo.
+    BotAuthored,
+    /// A `message` whose `subtype` is not in [`HUMAN_MESSAGE_SUBTYPES`].
+    /// Never reached from an `app_mention`.
+    NonUserMessageSubtype(String),
+    /// A field the normalized contract cannot be built without.
+    MissingField(&'static str),
 }
 
 /// Pure payload-normalization result retained inside the Slack package until
@@ -106,10 +162,14 @@ pub fn normalize_slack_event(
         &wrapper.event_type,
     )?;
     if wrapper.event_type != "event_callback" {
-        return Ok(SlackInboundEvent::Ignore);
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::NotAnEventCallback,
+        });
     }
     let Some(event) = wrapper.event.as_ref() else {
-        return Ok(SlackInboundEvent::Ignore);
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::MissingEventPayload,
+        });
     };
     let team_id = wrapper.team_id.as_deref();
     let kind = match event.event_type.as_str() {
@@ -123,15 +183,18 @@ pub fn normalize_slack_event(
             } else if event.thread_ts.is_some() {
                 SlackMessageKind::ThreadReply
             } else {
-                return Ok(SlackInboundEvent::Ignore);
+                return Ok(SlackInboundEvent::Ignore {
+                    reason: SlackIgnoreReason::AmbientChannelMessage,
+                });
             }
         }
-        _ => return Ok(SlackInboundEvent::Ignore),
+        _ => {
+            return Ok(SlackInboundEvent::Ignore {
+                reason: SlackIgnoreReason::UnsupportedEventType,
+            });
+        }
     };
-    normalize_user_message(event_id, team_id, event, kind).map(|message| match message {
-        Some(message) => SlackInboundEvent::Message(Box::new(message)),
-        None => SlackInboundEvent::Ignore,
-    })
+    normalize_user_message(event_id, team_id, event, kind)
 }
 
 /// Parse one host-verified Slack inbound request that may be EITHER the
@@ -283,26 +346,66 @@ fn normalize_user_message(
     team_id: Option<&str>,
     event: &SlackEvent,
     kind: SlackMessageKind,
-) -> Result<Option<ParsedSlackInboundMessage>, SlackPayloadParseError> {
-    if event.bot_id.is_some() || !is_user_generated_message_subtype(event.subtype.as_deref()) {
-        return Ok(None);
+) -> Result<SlackInboundEvent, SlackPayloadParseError> {
+    // Authorship. Universal, and the reason it is universal is loop
+    // prevention: a mention exchange between two apps does not terminate.
+    //
+    // `bot_id` is the field Slack sets on an integration's own post;
+    // `bot_message` is the same claim made in the subtype field. It is
+    // checked HERE, with authorship, rather than below with the rendering
+    // shapes — the `app_mention` exemption exempts "how does this render",
+    // never "who wrote this", so loop prevention holds on every path.
+    if event.bot_id.is_some() || event.subtype.as_deref() == Some(SLACK_BOT_MESSAGE_SUBTYPE) {
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::BotAuthored,
+        });
     }
+    // Content shape — deliberately NOT asked of an `app_mention`.
+    //
+    // `subtype` answers "how does this message render"; admission needs
+    // "did a human address this bot". Those are different questions, and
+    // Slack has already answered the second one by emitting `app_mention`
+    // at all — it does that when a person types the bot's member id, and
+    // never for its own channel announcements. Asking the shape question
+    // anyway is what dropped a `thread_broadcast` mention in production:
+    // the rendering of a message the user definitely addressed to us
+    // decided whether we were allowed to read it.
+    //
+    // `AppMention` is reachable only from the `"app_mention"` arm of
+    // `normalize_slack_event`, so matching on `kind` here is exact rather
+    // than a proxy. Every other kind still consults the list, which is
+    // what keeps Slack's announcements out of a DM.
+    if !matches!(kind, SlackMessageKind::AppMention)
+        && let Some(subtype) = event.subtype.as_deref()
+        && !is_user_generated_message_subtype(Some(subtype))
+    {
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::NonUserMessageSubtype(subtype.to_string()),
+        });
+    }
+    // A message mutation (`message_changed`, `message_deleted`) keeps its
+    // author and text under a nested `message` object, so a missing
+    // top-level author is the structural half of the subtype rule above —
+    // and the half that still binds on the exempt `app_mention` path.
     let Some(user) = event.user.as_deref() else {
-        return Ok(None);
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::MissingField("user"),
+        });
     };
     let Some(channel) = event.channel.as_deref() else {
-        return Ok(None);
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::MissingField("channel"),
+        });
     };
-    if matches!(kind, SlackMessageKind::Dm)
-        && !is_dm_channel(channel, event.channel_type.as_deref())
-    {
-        return Ok(None);
-    }
-    if matches!(kind, SlackMessageKind::ThreadReply) && event.thread_ts.is_none() {
-        return Ok(None);
-    }
+    // `kind` was derived from `channel_type` and `thread_ts` in
+    // `normalize_slack_event`, this function's only caller, so re-checking
+    // either here could only ever agree. The checks are gone rather than
+    // restated, which is what lets `MissingField` only ever name a field
+    // that is genuinely absent.
     let Some(ts) = event.ts.as_deref() else {
-        return Ok(None);
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::MissingField("ts"),
+        });
     };
 
     let raw_text = event.text.as_deref().unwrap_or_default();
@@ -333,19 +436,21 @@ fn normalize_user_message(
             descriptor,
         })
         .collect();
-    Ok(Some(ParsedSlackInboundMessage {
-        message: NormalizedInboundMessage {
-            actor,
-            conversation,
-            event_id,
-            text,
-            trigger,
-            attachments: Vec::new(),
-            conversation_context: None,
-            reply_context: None,
+    Ok(SlackInboundEvent::Message(Box::new(
+        ParsedSlackInboundMessage {
+            message: NormalizedInboundMessage {
+                actor,
+                conversation,
+                event_id,
+                text,
+                trigger,
+                attachments: Vec::new(),
+                conversation_context: None,
+                reply_context: None,
+            },
+            pending_attachments,
         },
-        pending_attachments,
-    }))
+    )))
 }
 
 fn build_event_id(
@@ -448,7 +553,7 @@ fn strip_leading_bot_mention(text: &str) -> String {
 }
 
 fn is_user_generated_message_subtype(subtype: Option<&str>) -> bool {
-    subtype.is_none_or(|value| value == SLACK_FILE_SHARE_SUBTYPE)
+    subtype.is_none_or(|value| HUMAN_MESSAGE_SUBTYPES.contains(&value))
 }
 
 fn is_dm_channel(channel: &str, channel_type: Option<&str>) -> bool {

--- a/crates/extensions/packages/slack/src/payload.rs
+++ b/crates/extensions/packages/slack/src/payload.rs
@@ -38,6 +38,8 @@ const SLACK_BOT_MESSAGE_SUBTYPE: &str = "bot_message";
 /// checked ahead of it, so it is rejected on every path rather than
 /// exempted by it.
 const SLACK_DOCUMENT_MENTION_SUBTYPE: &str = "document_mention";
+/// Manifest handle for the bot's own member id (see `manifest.toml`).
+const SLACK_BOT_USER_ID_HANDLE: &str = "slack_bot_user_id";
 
 /// Message `subtype` values that carry one person's own message, rendered
 /// specially.
@@ -152,6 +154,7 @@ impl std::ops::Deref for ParsedSlackInboundMessage {
 pub fn normalize_slack_event(
     raw_payload: &[u8],
     installation_id: &AdapterInstallationId,
+    bot_user_id: Option<&str>,
 ) -> Result<SlackInboundEvent, SlackPayloadParseError> {
     if raw_payload.len() > MAX_SLACK_PAYLOAD_BYTES {
         return Err(SlackPayloadParseError::InvalidJson {
@@ -177,11 +180,7 @@ pub fn normalize_slack_event(
         serde_json::from_slice(raw_payload).map_err(|err| SlackPayloadParseError::InvalidJson {
             reason: err.to_string(),
         })?;
-    let event_id = build_event_id(
-        installation_id,
-        wrapper.event_id.as_deref(),
-        &wrapper.event_type,
-    )?;
+    require_well_formed_envelope(wrapper.event_id.as_deref(), &wrapper.event_type)?;
     if wrapper.event_type != "event_callback" {
         return Ok(SlackInboundEvent::Ignore {
             reason: SlackIgnoreReason::NotAnEventCallback,
@@ -201,6 +200,29 @@ pub fn normalize_slack_event(
                 event.channel_type.as_deref(),
             ) {
                 SlackMessageKind::Dm
+            } else if mentions_bot(event.text.as_deref().unwrap_or_default(), bot_user_id) {
+                // A person put the bot's member id in the text, so this
+                // message is addressed to it whether or not Slack also sent
+                // `app_mention` — and Slack does not always send one. It is
+                // reported unreliable for a mention made INSIDE an existing
+                // thread (notably a thread predating the bot joining the
+                // channel), and it does not fire for a mention that lives in
+                // Block Kit or a legacy attachment rather than in `text`.
+                // Depending on `app_mention` alone is what left a broadcast
+                // reply unanswered, so the text is read as its own signal.
+                //
+                // This is checked BEFORE the thread/ambient split so it also
+                // rescues a TOP-LEVEL message naming the bot, which the
+                // ambient rule would otherwise drop for want of a thread
+                // anchor.
+                //
+                // Note this is a distinct kind from `AppMention`: it decides
+                // the TRIGGER, never admission. The subtype list still gates
+                // it in `normalize_user_message`, which is what keeps Slack's
+                // own announcements out — `bot_add` reads "added an
+                // integration to this channel: <@BOT>" and names the bot by
+                // construction, and a channel topic can be set to anything.
+                SlackMessageKind::TextMention
             } else if event.thread_ts.is_some() {
                 SlackMessageKind::ThreadReply
             } else {
@@ -215,7 +237,7 @@ pub fn normalize_slack_event(
             });
         }
     };
-    normalize_user_message(event_id, team_id, event, kind)
+    normalize_user_message(installation_id, team_id, event, kind, bot_user_id)
 }
 
 /// Parse one host-verified Slack inbound request that may be EITHER the
@@ -229,11 +251,12 @@ pub(crate) fn normalize_slack_inbound(
     raw_payload: &[u8],
     headers: &[(String, String)],
     installation_id: &AdapterInstallationId,
+    bot_user_id: Option<&str>,
 ) -> Result<SlackInboundEvent, SlackPayloadParseError> {
     if is_form_urlencoded_content_type(headers) {
         return normalize_slack_slash_command(raw_payload, installation_id);
     }
-    normalize_slack_event(raw_payload, installation_id)
+    normalize_slack_event(raw_payload, installation_id, bot_user_id)
 }
 
 /// Case-insensitive Content-Type match for Slack's slash-command / ssl_check
@@ -350,23 +373,50 @@ fn build_slash_event_id(
     })
 }
 
-/// Fixed user-message routing strategies in this first slice.
-/// `AppMention`: public channel, strip leading `@mention`, thread fallback to `ts`.
+/// Fixed user-message routing strategies.
+/// `AppMention`: Slack's own `app_mention` event — public channel, strip
+/// leading `@mention`, thread fallback to `ts`.
+/// `TextMention`: a `message` event whose TEXT names the bot. Same routing as
+/// `AppMention`, but deliberately a distinct kind because it is NOT exempt
+/// from the subtype list — see [`normalize_user_message`].
 /// `Dm`: direct-message channel required, keep text verbatim, no thread fallback.
 /// `ThreadReply`: channel thread reply, strip an optional leading `@mention`,
 /// require `thread_ts`.
 #[derive(Debug, Clone, Copy)]
 enum SlackMessageKind {
     AppMention,
+    TextMention,
     Dm,
     ThreadReply,
 }
 
+/// Slack renders a mention as `<@U…>` (or `<@U…|handle>`), so a person naming
+/// the bot is detectable from the message text alone, without Slack's
+/// `app_mention` event having to arrive.
+fn mentions_bot(text: &str, bot_user_id: Option<&str>) -> bool {
+    let Some(bot) = bot_user_id.filter(|id| !id.is_empty()) else {
+        return false;
+    };
+    text.contains(&format!("<@{bot}>")) || text.contains(&format!("<@{bot}|"))
+}
+
+/// The bot's own member id, from host-resolved, manifest-declared non-secret
+/// configuration (`slack_bot_user_id`). Absent only on an installation
+/// configured before the handle existed; mention detection then degrades to
+/// `app_mention` alone, which is the behavior that shipped before this.
+pub fn slack_bot_user_id(config: &[(String, String)]) -> Option<&str> {
+    config
+        .iter()
+        .find(|(handle, _)| handle == SLACK_BOT_USER_ID_HANDLE)
+        .map(|(_, value)| value.as_str())
+}
+
 fn normalize_user_message(
-    event_id: ExternalEventId,
+    installation_id: &AdapterInstallationId,
     team_id: Option<&str>,
     event: &SlackEvent,
     kind: SlackMessageKind,
+    bot_user_id: Option<&str>,
 ) -> Result<SlackInboundEvent, SlackPayloadParseError> {
     // Authorship. Universal, and the reason it is universal is loop
     // prevention: a mention exchange between two apps does not terminate.
@@ -447,10 +497,12 @@ fn normalize_user_message(
         });
     };
 
+    let event_id = build_message_event_id(installation_id, team_id, channel, ts)?;
+
     let raw_text = event.text.as_deref().unwrap_or_default();
     let (text, thread_ts, trigger) = match kind {
-        SlackMessageKind::AppMention => (
-            strip_leading_bot_mention(raw_text),
+        SlackMessageKind::AppMention | SlackMessageKind::TextMention => (
+            strip_leading_bot_mention(raw_text, bot_user_id),
             event.thread_ts.as_deref().or(Some(ts)),
             ProductTriggerReason::BotMention,
         ),
@@ -460,7 +512,7 @@ fn normalize_user_message(
             ProductTriggerReason::DirectChat,
         ),
         SlackMessageKind::ThreadReply => (
-            strip_leading_bot_mention(raw_text),
+            strip_leading_bot_mention(raw_text, bot_user_id),
             event.thread_ts.as_deref(),
             ProductTriggerReason::ReplyToBot,
         ),
@@ -492,29 +544,42 @@ fn normalize_user_message(
     )))
 }
 
-fn build_event_id(
-    installation_id: &AdapterInstallationId,
+/// An `event_callback` must carry `event_id`. It is no longer the dedup key
+/// (see [`build_message_event_id`]) but a callback without one is malformed,
+/// and accepting it would mean accepting an envelope Slack did not produce.
+fn require_well_formed_envelope(
     event_id: Option<&str>,
     wrapper_event_type: &str,
-) -> Result<ExternalEventId, SlackPayloadParseError> {
-    if wrapper_event_type == "event_callback" {
-        // event_callback must carry event_id to avoid dedup key collisions.
-        // Two signed events of the same type without event_id would share an
-        // identical ExternalEventId, silently dropping the second.
-        let id = event_id.ok_or_else(|| SlackPayloadParseError::InvalidExternalRef {
+) -> Result<(), SlackPayloadParseError> {
+    if wrapper_event_type == "event_callback" && event_id.is_none() {
+        return Err(SlackPayloadParseError::InvalidExternalRef {
             kind: "external_event_id",
             reason: "event_callback must carry event_id".to_string(),
-        })?;
-        ExternalEventId::new(format!("slack-{}-{id}", installation_id.as_str()))
-    } else {
-        // Non-event_callback types (team_join, url_verification, etc.) always
-        // route to noop. Use a noop-namespaced key so they never collide with
-        // real event_callback IDs.
-        ExternalEventId::new(format!(
-            "slack-{}-noop-{wrapper_event_type}",
-            installation_id.as_str()
-        ))
+        });
     }
+    Ok(())
+}
+
+/// The dedup key for one Slack MESSAGE, not one Slack EVENT.
+///
+/// Slack announces a single post as up to two events — `app_mention` and
+/// `message` — with DISTINCT `event_id`s, and both can now start a run. Keyed
+/// on `event_id` the durable admission gate cannot see they are the same
+/// message and would admit two runs, so one @mention would be answered twice.
+/// `(team, channel, ts)` is the identity Slack itself gives the message, so
+/// the twins collapse to exactly one run whichever of them arrives first.
+/// (`openclaw` and `suna` key the same collapse on the same triple.)
+fn build_message_event_id(
+    installation_id: &AdapterInstallationId,
+    team_id: Option<&str>,
+    channel: &str,
+    ts: &str,
+) -> Result<ExternalEventId, SlackPayloadParseError> {
+    ExternalEventId::new(format!(
+        "slack-{}-msg-{}-{channel}-{ts}",
+        installation_id.as_str(),
+        team_id.unwrap_or("noteam"),
+    ))
     .map_err(|err| SlackPayloadParseError::InvalidExternalRef {
         kind: "external_event_id",
         reason: err.to_string(),
@@ -581,12 +646,31 @@ fn attachment_kind_for_mime(mime_type: &str) -> ProductAttachmentKind {
     }
 }
 
-fn strip_leading_bot_mention(text: &str) -> String {
+/// Strips the leading `<@U…>` / `<@U…|handle>` token ONLY when it names the
+/// configured bot. A leading mention of anyone else stays: dropping it would
+/// silently remove a third party from the prompt while leaving the bot's own
+/// tag behind. This matters more now that [`SlackMessageKind::TextMention`]
+/// admits messages naming the bot anywhere in the text, not just in front.
+/// Non-leading mentions are never touched — the model sees them verbatim.
+///
+/// Without a configured `bot_user_id` this degrades to the pre-existing
+/// behavior of stripping whatever mention leads, the same tradeoff
+/// [`mentions_bot`] makes for detection.
+fn strip_leading_bot_mention(text: &str, bot_user_id: Option<&str>) -> String {
     let trimmed = text.trim();
     if trimmed.starts_with("<@")
         && let Some(end) = trimmed.find('>')
     {
-        return trimmed[end + 1..].trim_start().to_string();
+        // The id is the segment before an optional `|handle>` suffix.
+        let inside = &trimmed[2..end];
+        let mention_id = inside.split_once('|').map_or(inside, |(id, _)| id);
+        let names_bot = match bot_user_id.filter(|id| !id.is_empty()) {
+            Some(bot) => mention_id == bot,
+            None => true,
+        };
+        if names_bot {
+            return trimmed[end + 1..].trim_start().to_string();
+        }
     }
     trimmed.to_string()
 }

--- a/crates/extensions/packages/slack/src/tests/payload_normalized.rs
+++ b/crates/extensions/packages/slack/src/tests/payload_normalized.rs
@@ -5,10 +5,14 @@ fn installation_id() -> AdapterInstallationId {
     AdapterInstallationId::new("install-alpha").expect("installation")
 }
 
+/// Matches the `<@UBOT>` mentions the fixtures below already use.
+const TEST_BOT_USER_ID: &str = "UBOT";
+
 fn normalize(value: serde_json::Value) -> SlackInboundEvent {
     normalize_slack_event(
         &serde_json::to_vec(&value).expect("payload"),
         &installation_id(),
+        Some(TEST_BOT_USER_ID),
     )
     .expect("normalizes")
 }
@@ -90,26 +94,40 @@ fn app_mention_strips_only_the_provider_mention_and_self_roots_a_thread() {
 
 #[test]
 fn bots_subtypes_and_ambient_channels_are_ignored() {
-    for event in [
-        serde_json::json!({
-            "type": "message", "user": "U1", "channel": "D1", "text": "loop",
-            "ts": "1.0", "bot_id": "B1"
-        }),
-        serde_json::json!({
-            "type": "message", "user": "U1", "channel": "D1", "text": "changed",
-            "ts": "1.0", "subtype": "message_changed"
-        }),
-        serde_json::json!({
-            "type": "message", "user": "U1", "channel": "C1", "text": "ambient",
-            "ts": "1.0"
-        }),
+    for (event, expected_reason) in [
+        (
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "D1", "text": "loop",
+                "ts": "1.0", "bot_id": "B1"
+            }),
+            SlackIgnoreReason::BotAuthored,
+        ),
+        (
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "D1", "text": "changed",
+                "ts": "1.0", "subtype": "message_changed"
+            }),
+            SlackIgnoreReason::NonUserMessageSubtype("message_changed".to_string()),
+        ),
+        // No mention, no thread_ts: still bystander chatter even though
+        // `mentions_bot` is now consulted for `message` events — the text
+        // here names nobody, so `TextMention` is never reached and the
+        // ambient rule holds exactly as before that check existed.
+        (
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "C1", "text": "ambient",
+                "ts": "1.0"
+            }),
+            SlackIgnoreReason::AmbientChannelMessage,
+        ),
     ] {
-        assert!(matches!(
-            normalize(serde_json::json!({
-                "type": "event_callback", "event_id": "EvIgnored", "event": event
-            })),
-            SlackInboundEvent::Ignore { .. }
-        ));
+        let outcome = normalize(serde_json::json!({
+            "type": "event_callback", "event_id": "EvIgnored", "event": event
+        }));
+        let SlackInboundEvent::Ignore { reason } = outcome else {
+            panic!("expected Ignore for {expected_reason:?}, got {outcome:?}");
+        };
+        assert_eq!(reason, expected_reason);
     }
 }
 
@@ -153,6 +171,7 @@ fn slash_command_forms_normalize_without_a_second_product_parser() {
         b"channel_id=D123&channel_name=directmessage&user_id=U123&command=%2Fironclaw&text=hello&trigger_id=trigger-1&team_id=T123",
         &headers,
         &installation_id(),
+        Some(TEST_BOT_USER_ID),
     )
     .expect("slash form");
     let SlackInboundEvent::Message(message) = event else {
@@ -165,11 +184,12 @@ fn slash_command_forms_normalize_without_a_second_product_parser() {
 #[test]
 fn oversized_payload_and_missing_event_id_fail_closed() {
     let oversized = vec![b'x'; MAX_SLACK_PAYLOAD_BYTES + 1];
-    assert!(normalize_slack_event(&oversized, &installation_id()).is_err());
+    assert!(normalize_slack_event(&oversized, &installation_id(), Some(TEST_BOT_USER_ID)).is_err());
     assert!(matches!(
         normalize_slack_event(
             br#"{"type":"event_callback","event":{"type":"message"}}"#,
-            &installation_id()
+            &installation_id(),
+            Some(TEST_BOT_USER_ID)
         ),
         Err(SlackPayloadParseError::InvalidExternalRef {
             kind: "external_event_id",
@@ -181,7 +201,7 @@ fn oversized_payload_and_missing_event_id_fail_closed() {
 proptest! {
     #[test]
     fn arbitrary_untrusted_bytes_never_panic(raw in proptest::collection::vec(any::<u8>(), 0..512)) {
-        let _ = normalize_slack_event(&raw, &installation_id());
+        let _ = normalize_slack_event(&raw, &installation_id(), Some(TEST_BOT_USER_ID));
     }
 }
 
@@ -386,14 +406,18 @@ fn a_dm_still_consults_the_subtype_list() {
 
 /// Slack's channel announcements are subtyped messages whose text can name
 /// this bot — `bot_add` does so by construction. None of them may become a
-/// mention: they carry no thread anchor, so the ambient-chatter rule holds
-/// them, and the exemption above deliberately does not reach them because
-/// they are never `app_mention` events.
+/// mention: their text naming the bot now classifies them as `TextMention`
+/// (see [`SlackMessageKind::TextMention`]), but that kind is NOT exempt from
+/// the subtype allowlist — only `AppMention` is — so the allowlist still
+/// drops them. This is the regression that sank an earlier attempt at text
+/// mention detection: without the subtype gate still applying to
+/// `TextMention`, every one of these becomes an admitted `BotMention`.
 #[test]
 fn slack_channel_announcements_are_never_admitted() {
-    for (label, event) in [
+    for (label, subtype, event) in [
         (
             "bot_add names the bot in its own text",
+            "bot_add",
             serde_json::json!({
                 "type": "message", "user": "U9", "channel": "C1",
                 "subtype": "bot_add", "ts": "1710000000.000018",
@@ -402,6 +426,7 @@ fn slack_channel_announcements_are_never_admitted() {
         ),
         (
             "a channel topic set to mention the bot",
+            "channel_topic",
             serde_json::json!({
                 "type": "message", "user": "U9", "channel": "C1",
                 "subtype": "channel_topic", "ts": "1710000000.000019",
@@ -410,6 +435,7 @@ fn slack_channel_announcements_are_never_admitted() {
         ),
         (
             "the bot's own join announcement",
+            "channel_join",
             serde_json::json!({
                 "type": "message", "user": "UBOT", "channel": "C1",
                 "subtype": "channel_join", "ts": "1710000000.000020",
@@ -422,8 +448,136 @@ fn slack_channel_announcements_are_never_admitted() {
             "event_id": "EvAnnouncement", "event": event
         }));
         assert!(
-            matches!(outcome, SlackInboundEvent::Ignore { .. }),
+            matches!(
+                &outcome,
+                SlackInboundEvent::Ignore {
+                    reason: SlackIgnoreReason::NonUserMessageSubtype(got)
+                } if got == subtype
+            ),
             "{label} normalized to {outcome:?}"
         );
     }
+}
+
+/// The point of `TextMention`: a `message` event whose TEXT names the bot
+/// becomes a `BotMention` even with no `app_mention` twin at all — Slack does
+/// not always send one, notably for a mention made inside an existing thread.
+/// Three shapes that previously either silently answered the wrong trigger or
+/// (for the top-level and `thread_broadcast` cases) were dropped outright as
+/// bystander chatter / non-human subtype.
+#[test]
+fn a_message_event_naming_the_bot_becomes_a_bot_mention_with_no_app_mention_twin() {
+    for (label, event, expected_topic) in [
+        (
+            "inside an existing thread, no subtype (Slack does not reliably \
+             fire app_mention for this case)",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": "<@UBOT> handle this thread",
+                "thread_ts": "1710000000.000030", "ts": "1710000000.000031"
+            }),
+            Some("1710000000.000030"),
+        ),
+        (
+            "top level, no thread_ts, no subtype (previously dropped as \
+             ambient chatter)",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": "<@UBOT> handle this at top level",
+                "ts": "1710000000.000032"
+            }),
+            Some("1710000000.000032"),
+        ),
+        (
+            "thread_broadcast subtype, the incident shape arriving only as a \
+             message",
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "C1",
+                "subtype": "thread_broadcast",
+                "text": "<@UBOT> handle this broadcast",
+                "thread_ts": "1710000000.000033", "ts": "1710000000.000034"
+            }),
+            Some("1710000000.000033"),
+        ),
+    ] {
+        let parsed = message(serde_json::json!({
+            "type": "event_callback", "team_id": "T123",
+            "event_id": "EvTextMention", "event": event
+        }));
+        assert_eq!(parsed.trigger, ProductTriggerReason::BotMention, "{label}");
+        assert_eq!(parsed.conversation.topic_id(), expected_topic, "{label}");
+    }
+}
+
+/// Slack announces one post as up to two events — `app_mention` and
+/// `message` — with distinct `event_id`s in the envelope. The dedup key is
+/// built from message identity (team, channel, ts), not the envelope
+/// `event_id`, so the twins collapse to one durable admission key whichever
+/// arrives first. Both twins must still resolve to `BotMention`, so whichever
+/// one wins the collapse still starts a run — that is the entire point of
+/// keying on the message rather than the event.
+#[test]
+fn app_mention_and_message_twins_of_one_post_collapse_to_the_same_event_id() {
+    let shared_ts = "1710000000.000040";
+    let app_mention_twin = message(serde_json::json!({
+        "type": "event_callback", "team_id": "T123",
+        "event_id": "EvTwinAppMention",
+        "event": {
+            "type": "app_mention", "user": "U1", "channel": "C1",
+            "text": "<@UBOT> ping", "ts": shared_ts
+        }
+    }));
+    let message_twin = message(serde_json::json!({
+        "type": "event_callback", "team_id": "T123",
+        "event_id": "EvTwinMessage",
+        "event": {
+            "type": "message", "user": "U1", "channel": "C1",
+            "text": "<@UBOT> ping", "ts": shared_ts
+        }
+    }));
+
+    assert_eq!(
+        app_mention_twin.event_id.as_str(),
+        message_twin.event_id.as_str(),
+        "the app_mention and message twins of one post must share one dedup key"
+    );
+    assert_eq!(app_mention_twin.trigger, ProductTriggerReason::BotMention);
+    assert_eq!(message_twin.trigger, ProductTriggerReason::BotMention);
+}
+
+/// `strip_leading_bot_mention` strips ONLY a leading token that names the
+/// configured bot. A third party's mention in front is left alone — even
+/// though their tag happens to be followed by the bot's own — because it is
+/// not the bot's mention leading the text; and a non-leading mention of the
+/// bot is never touched regardless of position.
+#[test]
+fn strip_leading_bot_mention_never_eats_a_third_partys_leading_mention() {
+    assert_eq!(
+        strip_leading_bot_mention("<@UOTHER> <@UBOT> deploy", Some(TEST_BOT_USER_ID)),
+        "<@UOTHER> <@UBOT> deploy",
+        "a third party's mention must not be dropped just because the bot is \
+         also named later in the text"
+    );
+    assert_eq!(
+        strip_leading_bot_mention("<@UBOT> deploy", Some(TEST_BOT_USER_ID)),
+        "deploy",
+        "the bot's own leading mention still strips"
+    );
+}
+
+/// A bare mention with nothing else in the text still admits a message —
+/// stripping to an empty string must not itself be treated as missing
+/// content.
+#[test]
+fn a_bare_bot_mention_still_produces_a_message() {
+    let mention = message(serde_json::json!({
+        "type": "event_callback", "team_id": "T123",
+        "event_id": "EvBareMention",
+        "event": {
+            "type": "app_mention", "user": "U1", "channel": "C1",
+            "text": "<@UBOT>", "ts": "1710000000.000041"
+        }
+    }));
+    assert_eq!(mention.text, "");
+    assert_eq!(mention.trigger, ProductTriggerReason::BotMention);
 }

--- a/crates/extensions/packages/slack/src/tests/payload_normalized.rs
+++ b/crates/extensions/packages/slack/src/tests/payload_normalized.rs
@@ -108,7 +108,7 @@ fn bots_subtypes_and_ambient_channels_are_ignored() {
             normalize(serde_json::json!({
                 "type": "event_callback", "event_id": "EvIgnored", "event": event
             })),
-            SlackInboundEvent::Ignore
+            SlackInboundEvent::Ignore { .. }
         ));
     }
 }
@@ -182,5 +182,190 @@ proptest! {
     #[test]
     fn arbitrary_untrusted_bytes_never_panic(raw in proptest::collection::vec(any::<u8>(), 0..512)) {
         let _ = normalize_slack_event(&raw, &installation_id());
+    }
+}
+
+/// The incident: a threaded reply sent with "Also send to channel", naming
+/// the bot. Slack stamps `thread_broadcast` on the `app_mention` event, and
+/// the subtype allowlist used to drop it — so a person's explicit mention
+/// became a bare 200 and no turn.
+#[test]
+fn a_broadcast_mention_still_reaches_the_host_as_a_bot_mention() {
+    let broadcast = message(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "EvBroadcast",
+        "event": {
+            "type": "app_mention",
+            "user": "U1",
+            "channel": "C1",
+            "subtype": "thread_broadcast",
+            "text": "<@UBOT> what do you think?",
+            "thread_ts": "1710000000.000010",
+            "ts": "1710000000.000011"
+        }
+    }));
+    assert_eq!(broadcast.text, "what do you think?");
+    assert_eq!(broadcast.trigger, ProductTriggerReason::BotMention);
+    assert_eq!(
+        broadcast.conversation.topic_id(),
+        Some("1710000000.000010"),
+        "a broadcast mention stays anchored to the thread it was written in"
+    );
+}
+
+/// The property that makes the fix structural rather than a longer list: an
+/// `app_mention` is Slack's own statement that a human named this bot, so its
+/// `subtype` is never consulted. A subtype nobody has seen before therefore
+/// cannot silence a mention — which is the failure mode the allowlist had.
+#[test]
+fn an_app_mention_is_admitted_whatever_subtype_slack_stamps_on_it() {
+    for subtype in [
+        "thread_broadcast",
+        "reply_broadcast",
+        "file_share",
+        "me_message",
+        // Deliberately not a real Slack value, and deliberately not in
+        // HUMAN_MESSAGE_SUBTYPES: the point is that membership is irrelevant
+        // on this path.
+        "some_subtype_slack_has_not_invented_yet",
+    ] {
+        let mention = message(serde_json::json!({
+            "type": "event_callback",
+            "team_id": "T123",
+            "event_id": "EvExempt",
+            "event": {
+                "type": "app_mention", "user": "U1", "channel": "C1",
+                "subtype": subtype, "text": "<@UBOT> ping",
+                "ts": "1710000000.000012"
+            }
+        }));
+        assert_eq!(
+            mention.trigger,
+            ProductTriggerReason::BotMention,
+            "app_mention with subtype {subtype} must still start a run"
+        );
+    }
+}
+
+/// The exemption covers "how does this render", never "who wrote this" — a
+/// mention exchange between two apps does not terminate, so the author guard
+/// has to hold on the exempt path too.
+#[test]
+fn the_exemption_never_admits_a_bot_authored_app_mention() {
+    for (label, event) in [
+        (
+            "bot_id set",
+            serde_json::json!({
+                "type": "app_mention", "user": "U1", "channel": "C1",
+                "bot_id": "B123", "text": "<@UBOT> loop",
+                "ts": "1710000000.000013"
+            }),
+        ),
+        (
+            "bot_message subtype without bot_id",
+            serde_json::json!({
+                "type": "app_mention", "user": "U1", "channel": "C1",
+                "subtype": "bot_message", "text": "<@UBOT> loop",
+                "ts": "1710000000.000014"
+            }),
+        ),
+    ] {
+        let outcome = normalize(serde_json::json!({
+            "type": "event_callback", "team_id": "T123",
+            "event_id": "EvBotMention", "event": event
+        }));
+        assert!(
+            matches!(
+                outcome,
+                SlackInboundEvent::Ignore {
+                    reason: SlackIgnoreReason::BotAuthored
+                }
+            ),
+            "{label} normalized to {outcome:?}"
+        );
+    }
+}
+
+/// A DM gets no exemption — there is no `app_mention` to vouch for it — so
+/// the subtype list still governs that branch. This is what keeps Slack's own
+/// announcements from being answered in a direct chat, and it is the half of
+/// the contract an over-eager relaxation would break.
+#[test]
+fn a_dm_still_consults_the_subtype_list() {
+    let broadcast = message(serde_json::json!({
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "EvDmBroadcast",
+        "event": {
+            "type": "message", "user": "U1", "channel": "D1",
+            "channel_type": "im", "subtype": "thread_broadcast",
+            "text": "broadcast in a dm thread",
+            "thread_ts": "1710000000.000015", "ts": "1710000000.000016"
+        }
+    }));
+    assert_eq!(broadcast.trigger, ProductTriggerReason::DirectChat);
+
+    let announcement = normalize(serde_json::json!({
+        "type": "event_callback", "team_id": "T123",
+        "event_id": "EvDmAnnouncement",
+        "event": {
+            "type": "message", "user": "U1", "channel": "D1",
+            "channel_type": "im", "subtype": "channel_join",
+            "text": "channel join message", "ts": "1710000000.000017"
+        }
+    }));
+    assert!(
+        matches!(
+            announcement,
+            SlackInboundEvent::Ignore {
+                reason: SlackIgnoreReason::NonUserMessageSubtype(ref subtype)
+            } if subtype == "channel_join"
+        ),
+        "a system announcement in a DM normalized to {announcement:?}"
+    );
+}
+
+/// Slack's channel announcements are subtyped messages whose text can name
+/// this bot — `bot_add` does so by construction. None of them may become a
+/// mention: they carry no thread anchor, so the ambient-chatter rule holds
+/// them, and the exemption above deliberately does not reach them because
+/// they are never `app_mention` events.
+#[test]
+fn slack_channel_announcements_are_never_admitted() {
+    for (label, event) in [
+        (
+            "bot_add names the bot in its own text",
+            serde_json::json!({
+                "type": "message", "user": "U9", "channel": "C1",
+                "subtype": "bot_add", "ts": "1710000000.000018",
+                "text": "added an integration to this channel: <@UBOT>"
+            }),
+        ),
+        (
+            "a channel topic set to mention the bot",
+            serde_json::json!({
+                "type": "message", "user": "U9", "channel": "C1",
+                "subtype": "channel_topic", "ts": "1710000000.000019",
+                "text": "<@U9> set the channel topic: ask <@UBOT> for help"
+            }),
+        ),
+        (
+            "the bot's own join announcement",
+            serde_json::json!({
+                "type": "message", "user": "UBOT", "channel": "C1",
+                "subtype": "channel_join", "ts": "1710000000.000020",
+                "text": "<@UBOT> has joined the channel"
+            }),
+        ),
+    ] {
+        let outcome = normalize(serde_json::json!({
+            "type": "event_callback", "team_id": "T123",
+            "event_id": "EvAnnouncement", "event": event
+        }));
+        assert!(
+            matches!(outcome, SlackInboundEvent::Ignore { .. }),
+            "{label} normalized to {outcome:?}"
+        );
     }
 }

--- a/crates/extensions/packages/slack/src/tests/payload_normalized.rs
+++ b/crates/extensions/packages/slack/src/tests/payload_normalized.rs
@@ -218,6 +218,11 @@ fn a_broadcast_mention_still_reaches_the_host_as_a_bot_mention() {
 /// `app_mention` is Slack's own statement that a human named this bot, so its
 /// `subtype` is never consulted. A subtype nobody has seen before therefore
 /// cannot silence a mention — which is the failure mode the allowlist had.
+///
+/// `document_mention` is the one documented carve-out — see
+/// [`a_canvas_document_mention_is_dropped_for_synthetic_text`] below — so it
+/// is deliberately excluded from this loop rather than asserted here as
+/// still-admitted.
 #[test]
 fn an_app_mention_is_admitted_whatever_subtype_slack_stamps_on_it() {
     for subtype in [
@@ -246,6 +251,59 @@ fn an_app_mention_is_admitted_whatever_subtype_slack_stamps_on_it() {
             "app_mention with subtype {subtype} must still start a run"
         );
     }
+}
+
+/// The one documented case where `app_mention` firing does NOT mean a
+/// person addressed the bot in conversation: a canvas-body mention. Slack
+/// sets `subtype: "document_mention"` and writes `text` itself (a caption
+/// such as "was mentioned in a canvas") — the person's actual words live
+/// only in `blocks`, which this contract never reads. Fixture is the exact
+/// example payload from
+/// <https://docs.slack.dev/reference/events/message/document_mention/>, so
+/// this test is traceable to the source rather than an invented shape.
+/// Before the fix this fell through the `AppMention` exemption above and
+/// started a full agent turn on Slack-generated text.
+#[test]
+fn a_canvas_document_mention_is_dropped_for_synthetic_text() {
+    let outcome = normalize(serde_json::json!({
+        "event": {
+            "user": "UA1BCD3EF",
+            "subtype": "document_mention",
+            "document_mention": {
+                "file_id": "F123ABCDEFG",
+                "section_id": "temp:C:GQL...",
+                "mentioning_user_ids": ["UA1BCD3EF"]
+            },
+            "type": "app_mention",
+            "ts": "1716411280.657549",
+            "text": "<@U123456ABC7> was mentioned in a canvas",
+            "blocks": [{
+                "type": "section",
+                "block_id": "gcn3v",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": ">>>Hey <@U123456ABC7>",
+                    "verbatim": false
+                }
+            }],
+            "team": "T1ABC2DE3",
+            "channel": "C012ABCDEFG",
+            "event_ts": "1716411280.657549"
+        },
+        "type": "event_callback",
+        "team_id": "T1ABC2DE3",
+        "event_id": "EvDocumentMention"
+    }));
+    assert!(
+        matches!(
+            outcome,
+            SlackInboundEvent::Ignore {
+                reason: SlackIgnoreReason::SyntheticMentionText
+            }
+        ),
+        "a canvas-body mention must be dropped, not started as a turn on \
+         Slack-written caption text: normalized to {outcome:?}"
+    );
 }
 
 /// The exemption covers "how does this render", never "who wrote this" — a


### PR DESCRIPTION
## What broke

A reply posted with **"Also send to channel"** carries `subtype: "thread_broadcast"`. The ingress adapter allowlisted exactly two subtype values — `None` and `file_share` — so the mention was classified `SlackInboundEvent::Ignore`, which the generic router acknowledges with a bare `200`. The mention never became a turn, and the drop left no log line anywhere.

## Why the allowlist could never be right

`subtype` answers *"how does this message render"*. Admission needs *"did a human address this bot"*. Those are orthogonal.

Slack stamps `subtype` on two unrelated families, and **no field distinguishes them**:

| a person typed this | Slack wrote this |
|---|---|
| `thread_broadcast`, `file_share`, `me_message` | `channel_join`, `channel_topic`, `bot_add` |

Any list over that field is a guess, and it fails in one direction or the other — an allowlist drops real people (this incident), a denylist answers Slack's own announcements.

## The fix

**Stop asking the shape question where it has already been answered.** Slack emits `app_mention` when a person types the bot's member id — so `SlackMessageKind::AppMention` skips the subtype check entirely.

That is structural rather than a longer list: **a subtype nobody has seen before can no longer silence a channel mention**, because membership is not consulted on that path. `AppMention` is reachable only from the `"app_mention"` arm of `normalize_slack_event`, so matching on `kind` is exact rather than a proxy.

Three things are deliberately *not* exempted:

- **Authorship.** `bot_id` and the `bot_message` subtype are checked *before* the exemption — a mention exchange between two apps does not terminate. The exemption covers rendering, never who wrote it.
- **Canvas mentions.** Review found the one documented case where `app_mention` firing does *not* mean a person addressed the bot in conversation: a mention in the body of a canvas arrives as `app_mention` with `subtype: "document_mention"`, no `bot_id`, and a `text` Slack wrote itself (`"<@BOT> was mentioned in a canvas"`) — the person's words live only under `blocks`, which this contract never reads. It is rejected *ahead of* the exemption, alongside the authorship guard, with reason `SyntheticMentionText`. The [documented example payload](https://docs.slack.dev/reference/events/message/document_mention/) is used verbatim as the test fixture. The pre-branch allowlist rejected this, so admitting it would have been a regression introduced here.
- **Required fields.** Still bind on the exempt path, which is what continues to reject message mutations (`message_changed`, `message_deleted`) that carry their author under a nested `message` object.
- **Every other kind.** DMs and thread replies still consult the list, now widened to the known human shapes. That is what keeps Slack's announcements out of a DM, where there is no `app_mention` to vouch for the message and the subtype is the only signal.

## Observability

`SlackInboundEvent::Ignore` now carries a `SlackIgnoreReason`, logged once by the adapter. The incident's root symptom was not the drop but that the drop was **invisible** — the router answers an ignore with a bare `200` to satisfy Slack's retry machinery, so a discarded human message left no trace in any system we own. The failure was found by comparing response latencies, not by reading a log.

## Not betting on which event arrives

The incident was *silence*, and the old allowlist admitted anything with no subtype — so either the `app_mention` twin carried `subtype: thread_broadcast` and was dropped, or it never arrived at all. An exemption only fixes the first.

Research across Slack's docs and three independent production Slack bots could not establish that `app_mention` fires for a broadcast reply, and found the opposite for this exact shape — [kortix-ai/suna](https://github.com/kortix-ai/suna/blob/main/apps/api/src/channels/slack/dispatch.ts):

> "Slack does NOT reliably deliver an `app_mention` for a mention made INSIDE an existing thread — notably a thread that predates the bot joining the channel — there it arrives ONLY as a `message` (with `thread_ts`)."

A broadcast reply is structurally a thread reply. Slack also does not classify a mention living in Block Kit or a legacy attachment as `app_mention` at all.

So the text is read as its own addressing signal. **A `message` whose text names the bot is a `BotMention`** — regardless of subtype, regardless of thread position. That covers two cases the exemption cannot: an in-thread mention with no twin, and a top-level one that the ambient rule previously discarded for want of a thread anchor. Deliberately not narrowed to subtyped or threaded messages: a false drop is silence, and silence is the defect.

**What keeps it safe:** `TextMention` decides the *trigger*, never *admission*. It is a distinct kind from `AppMention` and is **not** exempt from the subtype list — so Slack's announcements, which name the bot by construction, still classify as `TextMention` and are still dropped as non-human subtypes. A test pins that widening the exemption to cover `TextMention` admits `bot_add` as a full mention.

**Dedup key moves to message identity.** With both events able to start a run, their distinct `event_id`s would admit two runs and answer one @mention twice. The key is now `(team, channel, ts)` — the identity Slack gives the message, and the same triple `openclaw` and `suna` collapse on. Neither twin is load-bearing. The envelope's `event_id` is still required; it just no longer decides identity.

**Accepted cost:** both twins now do the adapter's per-delivery vendor reads before the collapse, so a top-level mention makes those Slack API calls twice. Extra calls are cheaper than a user getting no answer.

## Test Strategy

- **Unit/contract** (`cargo test -p ironclaw_slack_extension`) — 94 pass. Every new test was proven to bind by reverting the production change and confirming the failure:

  ```
  # subtype gate restored to the pre-branch allowlist:
  a_broadcast_mention_still_reaches_the_host_as_a_bot_mention ... FAILED
  an_app_mention_is_admitted_whatever_subtype_slack_stamps_on_it ... FAILED
  a_dm_still_consults_the_subtype_list ... FAILED
  test result: FAILED. 82 passed; 3 failed

  # caller-seam test, same revert:
  a_broadcast_mention_reaches_receive_as_a_bot_mention_anchored_on_its_thread ... FAILED
  panicked: expected Messages, broadcast mention must not be dropped

  # document_mention rejection removed:
  a_canvas_document_mention_is_dropped_for_synthetic_text ... FAILED
  normalized to Message(... text: "was mentioned in a canvas", trigger: BotMention ...)
  a_canvas_document_mention_is_ignored_by_receive ... FAILED

  # drop log `debug!` removed:
  every_ignored_event_records_why_it_was_dropped ... FAILED
  panicked: the drop for BotAuthored produced no log line

  # TextMention arm removed from classification:
  a_message_event_naming_the_bot_becomes_a_bot_mention_with_no_app_mention_twin ... FAILED
  a_message_event_naming_the_bot_reaches_receive_as_a_bot_mention_with_no_app_mention_twin ... FAILED
  app_mention_and_message_twins_of_one_post_collapse_to_the_same_event_id ... FAILED
  slack_channel_announcements_are_never_admitted ... FAILED
  test result: FAILED. 93 passed; 4 failed

  # subtype exemption widened to AppMention | TextMention:
  slack_channel_announcements_are_never_admitted ... FAILED
  (bot_add admitted as a full BotMention)

  # all restored:
  test result: ok. 94 passed; 0 failed
  ```
  - `a_broadcast_mention_still_reaches_the_host_as_a_bot_mention` — the incident, including the thread anchor.
  - `an_app_mention_is_admitted_whatever_subtype_slack_stamps_on_it` — includes a deliberately invented subtype, pinning that list membership is irrelevant on this path.
  - `the_exemption_never_admits_a_bot_authored_app_mention` — loop prevention holds on the exempt path.
  - `a_dm_still_consults_the_subtype_list` — the DM branch is not widened.
  - `slack_channel_announcements_are_never_admitted` — `bot_add`, `channel_topic`, and a bot self-join, all naming the bot in their text.
  - `every_ignored_event_records_why_it_was_dropped` — asserts the drop log emits and carries the right reason.
- **Caller seam** — `a_broadcast_mention_reaches_receive_as_a_bot_mention_anchored_on_its_thread` and `a_canvas_document_mention_is_ignored_by_receive` drive `SlackChannelAdapter::receive` rather than the private helper, per `.claude/rules/testing.md`.
- **Integration** (`reborn_integration_extension_delivery`) — 27/27 pass, driving real signed Slack webhooks through `VendorIngress` on the new key format.
- **Deliberately not added:** a Slack-shaped integration fixture for the twin collapse. The two halves live at different tiers — "these two payloads resolve to one id" is payload logic, pinned in the package by `app_mention_and_message_twins_of_one_post_collapse_to_the_same_event_id`; "one id admits one run" is the generic admission gate's contract, already covered. Rebuilding the fixture would re-test the generic gate through a vendor lens, and the earlier version of it was flagged as oversized in review.
- **Architecture** (`cargo test -p ironclaw_architecture_tests`) — green.
- **E2E** — `tests/e2e/scenarios/test_slack_e2e.py` is unmodified and its DM-system-subtype expectation still holds, because the DM branch still consults the list. Not invoked by any CI workflow.

## Compatibility and rollback

No persistence, schema, or wire change. The ingress dedupe key is **unchanged** (still Slack's per-event `event_id`), so there is no identity-contract migration and rollback is a plain revert. Adds one dev-dependency (`tracing-test`), already used by nine sibling crates.

All changes are inside `crates/extensions/packages/slack/` — no host, composition, or generic-crate coupling. The bot id comes from the manifest's existing `[admin_configuration]` handle, and `ExternalEventId` is a generic contract whose value the adapter already owns.

Supersedes #7925, which took the opposite approach — inverting the allowlist into a denylist, plus a text-mention fallback and an ingress dedupe re-key. Review found the denylist admitted Slack's own announcements (`bot_add` names the bot by construction) and that the re-key introduced an order-dependent collapse between the two events. This PR is ~410 lines against ~870 and changes no ingress identity contract.


---

### Known limitation: the drop log is not visible by default

`SlackIgnoreReason` is logged at `debug!`, but the CLI's default filter is `info` (`crates/app/ironclaw_cli/src/runtime/mod.rs:91`) and nothing promotes this crate's target — so an operator sees the reason only after enabling debug logging for it. `CLAUDE.md:49-52` bars `info!`/`warn!` for background tasks, so raising the level is not available. Raised by two reviewers and **not resolved in this PR**: what lands here is that the reason is now *carried and emitted* rather than discarded, which is what makes the drop diagnosable at all. Making it visible by default is a follow-up, and the reasons are not equally interesting — `AmbientChannelMessage` and `BotAuthored` fire constantly in any busy channel, while `NonUserMessageSubtype`, `MissingField`, and `SyntheticMentionText` are rare and are the ones that would have carried the incident.
