### PR TITLE
fix(webui): raise thread artifact byte limits

### DIFF
--- a/crates/product/ironclaw_assistant/src/reborn_services/thread_artifact.rs
+++ b/crates/product/ironclaw_assistant/src/reborn_services/thread_artifact.rs
@@ -25,13 +25,12 @@ use super::{
 pub const THREAD_ARTIFACT_SCHEMA: &str = "ironclaw.thread_artifact.v1";
 pub use ironclaw_product_contracts::product_wire::RebornThreadArtifactRequest;
 
-/// A tool-heavy run persists several small rows per invocation. Keep the
-/// independent row-count guard high enough for those trajectories while the
-/// 16 MiB stored-data and 20 MiB serialized-output caps remain the primary
-/// memory and response-size bounds.
+/// A tool-heavy run persists several rows and can retain substantial tool
+/// arguments and results per invocation. Keep the row and byte guards high
+/// enough for those trajectories while bounding memory and response size.
 pub const THREAD_ARTIFACT_MAX_MESSAGES: usize = 10_000;
-const THREAD_ARTIFACT_MAX_STORED_BYTES: usize = 16 * 1024 * 1024;
-const THREAD_ARTIFACT_MAX_SERIALIZED_BYTES: usize = 20 * 1024 * 1024;
+const THREAD_ARTIFACT_MAX_STORED_BYTES: usize = 64 * 1024 * 1024;
+const THREAD_ARTIFACT_MAX_SERIALIZED_BYTES: usize = 80 * 1024 * 1024;
 pub const THREAD_ARTIFACT_VIEW: RebornViewDescriptor = RebornViewDescriptor {
     id: "thread_artifact",
     paginated: false,

--- a/crates/product/ironclaw_assistant/tests/reborn_services_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/reborn_services_contract.rs
@@ -9360,7 +9360,7 @@ async fn thread_artifact_projects_messages_from_the_bounded_snapshot() {
         bounded_requests[0].max_messages,
         THREAD_ARTIFACT_MAX_MESSAGES
     );
-    assert_eq!(bounded_requests[0].max_bytes, 16 * 1024 * 1024);
+    assert_eq!(bounded_requests[0].max_bytes, 64 * 1024 * 1024);
 }
 
 #[tokio::test]
@@ -9411,6 +9411,57 @@ async fn thread_artifact_accepts_more_than_one_thousand_small_messages() {
         serde_json::from_value(page.payload).expect("artifact payload");
 
     assert_eq!(artifact.messages.len(), 1_001);
+}
+
+#[tokio::test]
+async fn thread_artifact_accepts_tool_heavy_trajectory_over_old_byte_limits() {
+    let owner = caller();
+    let thread_scope = thread_scope_for(&owner);
+    let thread_id = ThreadId::new("thread-artifact-tool-heavy").expect("thread id");
+    let run_id = TurnRunId::new();
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    thread_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: thread_scope.clone(),
+            thread_id: Some(thread_id.clone()),
+            created_by_actor_id: owner.user_id.as_str().to_string(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .expect("thread");
+    let tool_payload = "x".repeat(44 * 1024);
+    for sequence in 0..573 {
+        seed_submitted_message(
+            &thread_service,
+            &thread_scope,
+            &thread_id,
+            &run_id,
+            &format!("tool result {sequence}: {tool_payload}"),
+        )
+        .await;
+    }
+    let services = session_services(thread_service, Arc::new(FakeTurnCoordinator::default()))
+        .with_operator_logs_service(Arc::new(RecordingOperatorLogsService::default()));
+
+    let page = services
+        .query(
+            owner,
+            RebornViewQuery {
+                view_id: THREAD_ARTIFACT_VIEW.id.to_string(),
+                params: serde_json::to_value(RebornThreadArtifactRequest {
+                    thread_id: thread_id.to_string(),
+                })
+                .expect("artifact params"),
+                cursor: None,
+            },
+        )
+        .await
+        .expect("a tool-heavy trajectory within the raised byte limits must export");
+    let artifact: RebornThreadArtifact =
+        serde_json::from_value(page.payload).expect("artifact payload");
+
+    assert_eq!(artifact.messages.len(), 573);
 }
 
 #[tokio::test]

--- a/crates/product/ironclaw_webui/CONTRACT.md
+++ b/crates/product/ironclaw_webui/CONTRACT.md
@@ -238,10 +238,10 @@ rules to every replayable message in the thread and queries logs at thread
 scope. Its `ironclaw.thread_artifact.v1` messages retain `run_id`, allowing the
 fixture importer to reconstruct multiple turns without mixing threads. Export
 is all-or-nothing and returns `413` when the thread exceeds 10,000 persisted
-messages, 16 MiB of stored message data, or 20 MiB after redaction and log
-assembly. The higher row limit admits tool-heavy trajectories while both byte
-limits remain unchanged. The endpoint is limited to six requests per caller per
-minute.
+messages, 64 MiB of stored message data, or 80 MiB after redaction and log
+assembly. These temporary byte ceilings unblock large tool-heavy trajectories
+while a streaming export path is developed. The endpoint is limited to six
+requests per caller per minute.
 
 **Operator-gating.** LLM provider/configuration routes (including provider
 credentials and model-policy mutation), operator setup/config/service-control,

--- a/tests/fixtures/llm_traces/reborn_qa/README.md
+++ b/tests/fixtures/llm_traces/reborn_qa/README.md
@@ -14,7 +14,7 @@ logs are not part of the self-service export.
 
 Full-thread export is intentionally all-or-nothing: it returns HTTP `413`
 instead of producing a silently partial fixture when the thread exceeds 10,000
-messages, 16 MiB of stored message data, or 20 MiB after redaction and log
+messages, 64 MiB of stored message data, or 80 MiB after redaction and log
 assembly.
 
 Convert a download into a review-required replay candidate:


### PR DESCRIPTION
## Summary

- Raise full-thread artifact stored-data capacity from 16 MiB to 64 MiB and serialized-response capacity from 20 MiB to 80 MiB.
- Add caller-level regression coverage for a 573-message, approximately 25 MiB trajectory that reproduces the post-#7919 HTTP 413.
- Keep the 10,000-message, authorization, redaction, and rate limits unchanged; track the durable streaming replacement in #7938.
- Update the WebUI contract and QA fixture guidance with the temporary limits.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #7918
Related #7938

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build` — not run separately; focused tests and clippy compiled the changed production and test shapes.
- [x] Relevant tests pass: all eight `thread_artifact` contract tests.
- [ ] `cargo test -p <owning-crate> --features integration` — not applicable; no database or runtime-integration behavior changed.
- [ ] Manual testing — not applicable; the caller-level ProductSurface regression reproduces the 413 and verifies the raised limits.
- [ ] If a coding agent was used and supports it, `pr-shepherd` was run before requesting review.

Additional scoped checks:

- `cargo clippy -p ironclaw_assistant --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_assistant -- -D warnings`

## Test Strategy

User behavior:

An authorized user can download a tool-heavy full-thread artifact whose stored and serialized content exceeds the previous 16 MiB and 20 MiB ceilings but remains within the temporary 64 MiB and 80 MiB ceilings.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: caller-level ProductSurface export with 573 messages and approximately 25 MiB of content; existing message-count, ownership, bounded-read 413, backend-error, logs, and timing coverage remains green.
- Reborn integration: Not applicable; no runner or composition wiring changed.
- Recorded fixture: Not applicable; no model behavior or fixture schema changed.
- Browser E2E: Not applicable; frontend behavior is unchanged.
- Backend or runtime: Not applicable; bounded-read backend implementations are unchanged.
- Live canary: Not applicable; behavior is deterministic and provider-independent.

What the tests prove:

The new regression fails with the old 16/20 MiB limits as HTTP 413 and passes after both limits are raised. Existing limit exhaustion still fails closed, and ownership checks still run before log retrieval.

Commands run:

- `cargo test -p ironclaw_assistant --test reborn_services_contract thread_artifact`
- `cargo fmt --all -- --check`
- `cargo clippy -p ironclaw_assistant --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_assistant -- -D warnings`

## Security Impact

Authorized exports may now consume more bounded CPU and memory and return a larger response. Authentication, caller ownership, deterministic redaction, the 10,000-message ceiling, and six-requests-per-minute rate limit are unchanged.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: unchanged; `RebornServices` still constructs artifacts only after caller authorization.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: N/A; this read path constructs no prompt.
- [x] Hashes declare purpose: N/A; no hashes changed.
- [x] New/changed status, exit, policy, runtime, or error variants: none; the existing 413 class remains unchanged.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests: N/A; no persisted or wire fields changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic: 10,000 rows, 64 MiB stored data, and 80 MiB serialized output remain explicit bounds.
- [x] Driver/operator-visible errors have stable class semantics: existing non-retryable 413 behavior remains covered.
- [x] Sandbox/native/host names accurately describe trust boundary: N/A; no runtime boundary changed.

## Database Impact

None. No schema, migration, query, or backend implementation changed.

## Blast Radius

Full-thread artifact exports only. Authorized requests may use more CPU and memory before hitting the temporary caps. Run artifacts, normal timeline reads, persistence, and execution are unchanged.

## Rollback Plan

Revert this commit to restore the 16 MiB stored-data and 20 MiB serialized-response ceilings. Deployments can also disable artifact export with `IRONCLAW_REBORN_REGRESSION_ARTIFACT_EXPORT`.

## Review Follow-Through

Please confirm the 64/80 MiB ceilings are an acceptable temporary mitigation. #7938 owns the bounded streaming replacement and removal of whole-artifact server/browser allocations.

---

**Review track**: B