### PR TITLE
chore(release): promote 1.4.0-rc.1 to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.0-rc.1] - 2026-08-26
+## [1.4.0] - 2026-08-27
 
-First release candidate for 1.4.0, covering the 81 commits since
-`ironclaw-v1.3.0`.
+Stable promotion of `1.4.0-rc.1`, covering the 81 commits since
+`ironclaw-v1.3.0` and the complete release-candidate scope below.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,9 +1402,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,7 +3684,7 @@ checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "ironclaw"
-version = "1.4.0-rc.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/app/ironclaw_cli/Cargo.toml
+++ b/crates/app/ironclaw_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw"
-version = "1.4.0-rc.1"
+version = "1.4.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"


### PR DESCRIPTION
## Summary

- Promote the QA-tested `1.4.0-rc.1` release line to stable `1.4.0`.
- Change only shipping version metadata and the release changelog heading.
- Preserve the complete RC scope with no product-code changes.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — Not applicable: no Rust source or dependency change.
- [x] `cargo metadata --locked --no-deps --format-version 1` resolves `ironclaw 1.4.0`.
- [x] Relevant tests pass: `python3.12 -m unittest scripts.ci.test_cut_ironclaw_release` (27 passed).
- [x] Stable changelog gate accepts `1.4.0`.
- [x] `python3 scripts/ci/check-guidance.py`.
- [ ] Manual testing — Not applicable: metadata-only promotion of the QA-tested RC.

## Test Strategy

User behavior: the stable release workflow accepts the promoted candidate as `1.4.0` while retaining the exact RC product scope.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: Not applicable; existing cutter contract tests cover manifest and stable changelog validation.
- Reborn integration: Not applicable; no runtime behavior changed.
- Recorded fixture: Not applicable; no model behavior changed.
- Browser E2E: Not applicable; no UI behavior changed.
- Backend or runtime: Not applicable; no backend or runtime behavior changed.
- Live canary: Not applicable to this metadata-only PR; the RC already completed QA.

What the tests prove: the manifest and lockfile agree on `1.4.0`, the cutter validation remains green, and the stable public changelog entry exists.

Commands run:
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3.12 -m unittest scripts.ci.test_cut_ironclaw_release`
- direct `ensure_stable_changelog_entry(..., "1.4.0")`
- `python3 scripts/ci/check-guidance.py`

## Security Impact

None.

## Reborn Trust-Boundary Checklist

N/A: release metadata and changelog only.

## Database Impact

None.

## Blast Radius

Release identity and generated GitHub release notes only. Product code and the tested RC behavior are unchanged.

## Rollback Plan

Before the immutable stable tag is approved, close or revert this PR. After publication, do not move the tag; cut a patch release if correction is required.

## Review Follow-Through

After merge, run `reborn-release-compile.yml` on the exact merged release-branch SHA. If all seven targets pass, dispatch `cut-ironclaw-release.yml` from `main` with `version=1.4.0` and that exact SHA, then obtain independent environment approval.

---

**Review track**: A (release metadata/chore)