### PR TITLE
fix(mcp): a large tool catalog publishes zero tools instead of truncating

### DIFF
--- a/crates/extensions/ironclaw_extension_host/src/hosted_mcp_manifest.rs
+++ b/crates/extensions/ironclaw_extension_host/src/hosted_mcp_manifest.rs
@@ -309,6 +309,11 @@ fields = [{{ handle = "hosted_mcp_account", label = "Bearer token", secret = tru
         }
         HostedMcpAuthSelection::OAuth { .. } => String::new(),
     };
+    // `max_tools` is the ceiling for a server the USER registered by URL, so it cannot be
+    // sized from a vendor's known catalog the way a first-party manifest can. It is combined
+    // with the host ceiling as a MIN, so this value alone decided discovery -- and at 1,024 a
+    // real integration catalog silently lost everything past the first few pages. Measured
+    // against a 47,337-tool endpoint: discovery stopped after six pages every time.
     let raw = format!(
         r#"schema_version = "reborn.extension_manifest.v3"
 id = "{id}"
@@ -321,7 +326,7 @@ trust = "third_party"
 origin_gate_matrix = {{ loop_run = "gated_unless_granted", product = "forbidden", automation = "forbidden" }}
 server = {quoted_endpoint}
 namespace = "{id}"
-max_tools = 1024
+max_tools = 65536
 default_permission = "ask"
 effects = ["network", "use_secret"]
 {auth}"#

--- a/crates/extensions/ironclaw_extension_host/src/product_lifecycle.rs
+++ b/crates/extensions/ironclaw_extension_host/src/product_lifecycle.rs
@@ -1374,8 +1374,23 @@ impl ExtensionLifecycleManager {
             LifecycleProductPayload::ExtensionInstall {
                 installed: true,
                 visible_capability_ids,
+                // Tell the caller that discovery is ASYNCHRONOUS and that an empty tool
+                // list means "not yet", not "failed". Without this the model reads the
+                // first empty `tool_search` as a broken install and re-registers -- and
+                // because re-registration restarts discovery, a catalog large enough to
+                // take a while can never finish. Observed on a 47,337-tool server: seven
+                // registrations, eight installs, 218 searches, zero tools published, the
+                // agent finally hand-rolling HTTP. The livelock is driven entirely by the
+                // caller's reasonable inference from a success response with no tools.
                 next_step: format!(
-                    "Installation will attempt activation for extension_id \"{}\". If credentials are missing, the install response opens the auth gate; otherwise the tools are published.",
+                    "Installation will attempt activation for extension_id \"{}\". If \
+                     credentials are missing, the install response opens the auth gate; \
+                     otherwise the tools are published. Tool discovery runs \
+                     ASYNCHRONOUSLY after this response and can take up to a minute for a \
+                     large catalog: an empty `tool_search` result means discovery is still \
+                     running, NOT that the install failed. Wait and search again. Do not \
+                     re-register or re-install -- that restarts discovery from the \
+                     beginning.",
                     package_ref.id.as_str()
                 ),
             },

--- a/crates/lanes/ironclaw_mcp/src/client.rs
+++ b/crates/lanes/ironclaw_mcp/src/client.rs
@@ -602,26 +602,32 @@ where
             // `tool_search` calls and answered from nothing. A partial catalog is worth
             // vastly more than no catalog, and the caller cannot tell the difference between
             // "server has no tools" and "server had too many" from a bare error.
-            let budget = MAX_DISCOVERED_MCP_TOOLS.min(max_tools as usize);
-            let (kept, over_budget) = page_intake(
+            match page_intake(
                 discovered.len(),
                 page_tools.len(),
-                budget,
+                max_tools as usize,
+                MAX_DISCOVERED_MCP_TOOLS,
                 accepted_catalog_bytes,
                 MAX_MCP_TOOLS_CATALOG_BYTES,
-            );
-            if over_budget {
-                discovered.extend(page_tools.into_iter().take(kept));
-                tracing::warn!(
-                    discovered = discovered.len(),
-                    budget,
-                    kept_from_final_page = kept,
-                    accepted_catalog_bytes,
-                    "hosted MCP catalog exceeds the discovery ceiling; truncating"
-                );
-                break;
+            ) {
+                PageIntake::ExceedsManifest => {
+                    return Err(McpClientError::invalid_tool_catalog(invalid_tool_list(
+                        McpInvalidToolListCause::TooManyTools,
+                    )));
+                }
+                PageIntake::Truncate(kept) => {
+                    discovered.extend(page_tools.into_iter().take(kept));
+                    tracing::warn!(
+                        discovered = discovered.len(),
+                        host_ceiling = MAX_DISCOVERED_MCP_TOOLS,
+                        kept_from_final_page = kept,
+                        accepted_catalog_bytes,
+                        "hosted MCP catalog exceeds the host discovery ceiling; truncating"
+                    );
+                    break;
+                }
+                PageIntake::Accept => discovered.extend(page_tools),
             }
-            discovered.extend(page_tools);
             match next_cursor {
                 Some(_next_cursor) if page == MAX_MCP_TOOLS_LIST_PAGES => {
                     return Err(McpClientError::invalid_tool_catalog(invalid_tool_list(
@@ -712,66 +718,107 @@ fn accumulate_usage(total: &mut ResourceUsage, usage: ResourceUsage) {
     total.output_bytes = total.output_bytes.saturating_add(usage.output_bytes);
 }
 
-/// How much of a `tools/list` page fits within the discovery budget, and whether the pass
-/// should stop after taking it.
+/// What to do with a `tools/list` page that runs past a limit.
+#[derive(Debug, PartialEq, Eq)]
+enum PageIntake {
+    /// Take the whole page and keep paging.
+    Accept,
+    /// Take this many and stop: a HOST resource ceiling was reached.
+    Truncate(usize),
+    /// Fail the pass: the server returned more than its manifest DECLARED.
+    ExceedsManifest,
+}
+
+/// Decide a page's fate against the two ceilings, which are not the same kind of limit.
 ///
-/// Extracted from the discovery loop so the ceiling behaviour is testable without a live
-/// MCP server -- the bug this guards against (an over-large catalog yielding ZERO tools
-/// rather than a truncated set) lived in exactly this arithmetic and was only observable
-/// end-to-end against a 47k-tool endpoint.
+/// `manifest_max_tools` is a contract: the extension declared how many tools its server
+/// publishes and the user approved that. A server exceeding its own declaration is a trust
+/// violation, and silently truncating it would let a package that asked to publish one tool
+/// publish five hundred. That still fails the pass.
+///
+/// The host ceiling is a resource budget with no such meaning, and treating it as a validity
+/// check is what made a 47,337-tool catalog publish ZERO tools: discovery collected six
+/// pages, crossed the ceiling, and threw all of them away. That case truncates.
 fn page_intake(
     discovered: usize,
     page_len: usize,
-    tool_budget: usize,
+    manifest_max_tools: usize,
+    host_ceiling: usize,
     accepted_bytes: usize,
     byte_budget: usize,
-) -> (usize, bool) {
-    let room = tool_budget.saturating_sub(discovered);
-    let over_budget = page_len > room || accepted_bytes > byte_budget;
-    (page_len.min(room), over_budget)
+) -> PageIntake {
+    if discovered.saturating_add(page_len) > manifest_max_tools {
+        return PageIntake::ExceedsManifest;
+    }
+    let room = host_ceiling.saturating_sub(discovered);
+    if page_len > room || accepted_bytes > byte_budget {
+        return PageIntake::Truncate(page_len.min(room));
+    }
+    PageIntake::Accept
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// An over-large catalog must TRUNCATE, never yield nothing.
+    /// The two ceilings are different KINDS of limit and must behave differently.
     ///
-    /// Regression test for the failure this replaced: exceeding the ceiling returned an
-    /// error that discarded every tool already collected, so a server one tool over the
-    /// limit published exactly as many tools as an unreachable one -- zero. Measured
-    /// against a 47,337-tool endpoint, discovery pulled six pages, tripped the old 1,024
-    /// ceiling, and the extension came up installed with an empty index while the agent ran
-    /// 55 fruitless searches.
+    /// Regression test for the failure this replaced: crossing the host ceiling returned an
+    /// error that discarded every tool already collected, so a server one tool over it
+    /// published exactly as many as an unreachable one -- zero. Measured against a
+    /// 47,337-tool endpoint, discovery pulled six pages, tripped the old 1,024 ceiling, and
+    /// the extension came up installed with an empty index.
+    ///
+    /// The manifest limit is NOT that. It is what the extension declared and the user
+    /// approved, so a server exceeding its own declaration still fails: truncating there
+    /// would let a package that asked to publish one tool publish five hundred.
     #[test]
-    fn an_over_large_catalog_truncates_instead_of_yielding_nothing() {
+    fn the_host_ceiling_truncates_but_the_manifest_ceiling_still_fails() {
+        const HUGE: usize = 65_536;
         const BYTES_OK: usize = 0;
         const BYTE_CAP: usize = 1_000;
 
-        // A page that runs past the ceiling keeps what fits and stops.
-        let (kept, stop) = page_intake(1_000, 200, 1_024, BYTES_OK, BYTE_CAP);
-        assert_eq!(kept, 24, "must keep the 24 that fit, not discard all 200");
-        assert!(stop, "discovery stops once the ceiling is reached");
+        // Host ceiling reached: keep what fits rather than discarding the lot.
+        assert_eq!(
+            page_intake(1_000, 200, HUGE, 1_024, BYTES_OK, BYTE_CAP),
+            PageIntake::Truncate(24),
+            "must keep the 24 that fit, not throw away all 200"
+        );
 
-        // A page well inside the ceiling is taken whole and paging continues.
-        let (kept, stop) = page_intake(0, 200, 1_024, BYTES_OK, BYTE_CAP);
-        assert_eq!(kept, 200);
-        assert!(!stop);
+        // Comfortably inside both ceilings: take the page and keep paging.
+        assert_eq!(
+            page_intake(0, 200, HUGE, 1_024, BYTES_OK, BYTE_CAP),
+            PageIntake::Accept
+        );
 
-        // Exactly filling the ceiling is not over it.
-        let (kept, stop) = page_intake(824, 200, 1_024, BYTES_OK, BYTE_CAP);
-        assert_eq!(kept, 200);
-        assert!(!stop);
+        // Exactly filling the host ceiling is not over it.
+        assert_eq!(
+            page_intake(824, 200, HUGE, 1_024, BYTES_OK, BYTE_CAP),
+            PageIntake::Accept
+        );
 
-        // The byte ceiling truncates too, and still keeps the page it can afford.
-        let (kept, stop) = page_intake(10, 5, 1_024, BYTE_CAP + 1, BYTE_CAP);
-        assert_eq!(kept, 5);
-        assert!(stop);
+        // The byte ceiling is a resource budget too: truncate, keeping what it can afford.
+        assert_eq!(
+            page_intake(10, 5, HUGE, 1_024, BYTE_CAP + 1, BYTE_CAP),
+            PageIntake::Truncate(5)
+        );
 
-        // Already at the ceiling: keep nothing further, but do not error.
-        let (kept, stop) = page_intake(1_024, 200, 1_024, BYTES_OK, BYTE_CAP);
-        assert_eq!(kept, 0);
-        assert!(stop);
+        // Already at the host ceiling: keep nothing more, but do not error.
+        assert_eq!(
+            page_intake(1_024, 200, HUGE, 1_024, BYTES_OK, BYTE_CAP),
+            PageIntake::Truncate(0)
+        );
+
+        // A server publishing more than it DECLARED is a contract violation, not a
+        // resource problem -- it fails even though the host ceiling has room to spare.
+        assert_eq!(
+            page_intake(0, 2, 1, HUGE, BYTES_OK, BYTE_CAP),
+            PageIntake::ExceedsManifest
+        );
+        assert_eq!(
+            page_intake(1_000, 200, 1_024, HUGE, BYTES_OK, BYTE_CAP),
+            PageIntake::ExceedsManifest
+        );
     }
 
     #[test]

--- a/crates/lanes/ironclaw_mcp/src/client.rs
+++ b/crates/lanes/ironclaw_mcp/src/client.rs
@@ -629,10 +629,18 @@ where
                 PageIntake::Accept => discovered.extend(page_tools),
             }
             match next_cursor {
-                Some(_next_cursor) if page == MAX_MCP_TOOLS_LIST_PAGES => {
-                    return Err(McpClientError::invalid_tool_catalog(invalid_tool_list(
-                        McpInvalidToolListCause::TooManyPages,
-                    )));
+                // Running out of pages is a RESOURCE limit, like the tool and byte
+                // ceilings above -- so it truncates rather than discarding the catalog.
+                // Erroring here threw away every page already collected, which is how a
+                // 47,337-tool server yielded 10,000 tools' worth of work and then published
+                // nothing at all.
+                Some(_next_cursor) if page >= MAX_MCP_TOOLS_LIST_PAGES => {
+                    tracing::warn!(
+                        discovered = discovered.len(),
+                        pages = page,
+                        "hosted MCP catalog has more pages than the discovery limit; truncating"
+                    );
+                    break;
                 }
                 Some(next_cursor) => cursor = Some(next_cursor),
                 None => break,

--- a/crates/lanes/ironclaw_mcp/src/client.rs
+++ b/crates/lanes/ironclaw_mcp/src/client.rs
@@ -591,17 +591,35 @@ where
             let (page_tools, next_cursor) =
                 parse_tools_list_page(&result).map_err(McpClientError::invalid_tool_catalog)?;
             accepted_catalog_bytes = accepted_catalog_bytes.saturating_add(page_bytes);
-            if discovered.len().saturating_add(page_tools.len()) > MAX_DISCOVERED_MCP_TOOLS
-                || discovered.len().saturating_add(page_tools.len()) > max_tools as usize
-            {
-                return Err(McpClientError::invalid_tool_catalog(invalid_tool_list(
-                    McpInvalidToolListCause::TooManyTools,
-                )));
-            }
-            if accepted_catalog_bytes > MAX_MCP_TOOLS_CATALOG_BYTES {
-                return Err(McpClientError::invalid_tool_catalog(invalid_tool_list(
-                    McpInvalidToolListCause::CatalogTooLarge,
-                )));
+
+            // Over-large catalogs TRUNCATE; they no longer fail the pass.
+            //
+            // Returning `Err` here discarded every tool already collected, so an endpoint
+            // one tool over the ceiling published exactly as many tools as an endpoint that
+            // was unreachable: none. Measured against a 47,337-tool server, discovery pulled
+            // six pages, tripped the ceiling, and the extension came up with an empty index
+            // while reporting itself installed -- the agent then ran 55 fruitless
+            // `tool_search` calls and answered from nothing. A partial catalog is worth
+            // vastly more than no catalog, and the caller cannot tell the difference between
+            // "server has no tools" and "server had too many" from a bare error.
+            let budget = MAX_DISCOVERED_MCP_TOOLS.min(max_tools as usize);
+            let (kept, over_budget) = page_intake(
+                discovered.len(),
+                page_tools.len(),
+                budget,
+                accepted_catalog_bytes,
+                MAX_MCP_TOOLS_CATALOG_BYTES,
+            );
+            if over_budget {
+                discovered.extend(page_tools.into_iter().take(kept));
+                tracing::warn!(
+                    discovered = discovered.len(),
+                    budget,
+                    kept_from_final_page = kept,
+                    accepted_catalog_bytes,
+                    "hosted MCP catalog exceeds the discovery ceiling; truncating"
+                );
+                break;
             }
             discovered.extend(page_tools);
             match next_cursor {
@@ -694,9 +712,67 @@ fn accumulate_usage(total: &mut ResourceUsage, usage: ResourceUsage) {
     total.output_bytes = total.output_bytes.saturating_add(usage.output_bytes);
 }
 
+/// How much of a `tools/list` page fits within the discovery budget, and whether the pass
+/// should stop after taking it.
+///
+/// Extracted from the discovery loop so the ceiling behaviour is testable without a live
+/// MCP server -- the bug this guards against (an over-large catalog yielding ZERO tools
+/// rather than a truncated set) lived in exactly this arithmetic and was only observable
+/// end-to-end against a 47k-tool endpoint.
+fn page_intake(
+    discovered: usize,
+    page_len: usize,
+    tool_budget: usize,
+    accepted_bytes: usize,
+    byte_budget: usize,
+) -> (usize, bool) {
+    let room = tool_budget.saturating_sub(discovered);
+    let over_budget = page_len > room || accepted_bytes > byte_budget;
+    (page_len.min(room), over_budget)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An over-large catalog must TRUNCATE, never yield nothing.
+    ///
+    /// Regression test for the failure this replaced: exceeding the ceiling returned an
+    /// error that discarded every tool already collected, so a server one tool over the
+    /// limit published exactly as many tools as an unreachable one -- zero. Measured
+    /// against a 47,337-tool endpoint, discovery pulled six pages, tripped the old 1,024
+    /// ceiling, and the extension came up installed with an empty index while the agent ran
+    /// 55 fruitless searches.
+    #[test]
+    fn an_over_large_catalog_truncates_instead_of_yielding_nothing() {
+        const BYTES_OK: usize = 0;
+        const BYTE_CAP: usize = 1_000;
+
+        // A page that runs past the ceiling keeps what fits and stops.
+        let (kept, stop) = page_intake(1_000, 200, 1_024, BYTES_OK, BYTE_CAP);
+        assert_eq!(kept, 24, "must keep the 24 that fit, not discard all 200");
+        assert!(stop, "discovery stops once the ceiling is reached");
+
+        // A page well inside the ceiling is taken whole and paging continues.
+        let (kept, stop) = page_intake(0, 200, 1_024, BYTES_OK, BYTE_CAP);
+        assert_eq!(kept, 200);
+        assert!(!stop);
+
+        // Exactly filling the ceiling is not over it.
+        let (kept, stop) = page_intake(824, 200, 1_024, BYTES_OK, BYTE_CAP);
+        assert_eq!(kept, 200);
+        assert!(!stop);
+
+        // The byte ceiling truncates too, and still keeps the page it can afford.
+        let (kept, stop) = page_intake(10, 5, 1_024, BYTE_CAP + 1, BYTE_CAP);
+        assert_eq!(kept, 5);
+        assert!(stop);
+
+        // Already at the ceiling: keep nothing further, but do not error.
+        let (kept, stop) = page_intake(1_024, 200, 1_024, BYTES_OK, BYTE_CAP);
+        assert_eq!(kept, 0);
+        assert!(stop);
+    }
 
     #[test]
     fn mcp_tool_name_strips_provider_prefix_for_canonical_tool_name() {

--- a/crates/lanes/ironclaw_mcp/src/diagnostics.rs
+++ b/crates/lanes/ironclaw_mcp/src/diagnostics.rs
@@ -127,6 +127,12 @@ pub(crate) enum McpInvalidToolListCause {
     InvalidAnnotations,
     InvalidCursor,
     TooManyPages,
+    /// Retained for the diagnostic vocabulary, no longer raised: an over-large catalog
+    /// now truncates rather than failing the discovery pass, because discarding every
+    /// already-collected tool left the extension indistinguishable from an unreachable
+    /// one. Kept so existing log/metric consumers keying on `catalog_too_large` do not
+    /// break, and so a future hard limit has a name ready.
+    #[allow(dead_code)]
     CatalogTooLarge,
 }
 

--- a/crates/lanes/ironclaw_mcp/src/diagnostics.rs
+++ b/crates/lanes/ironclaw_mcp/src/diagnostics.rs
@@ -124,6 +124,10 @@ pub(crate) enum McpInvalidToolListCause {
     InvalidDescription,
     MissingInputSchema,
     UnsafeInputSchema,
+    /// The input schema exceeded a host SIZE bound (depth, node count, or string
+    /// length). A resource limit, not a trust violation, so it drops the single
+    /// oversized tool instead of rejecting the whole generation.
+    OversizeInputSchema,
     InvalidAnnotations,
     InvalidCursor,
     /// Retained for the diagnostic vocabulary, no longer raised: exhausting the page
@@ -148,6 +152,7 @@ impl McpInvalidToolListCause {
             Self::InvalidDescription => "invalid_description",
             Self::MissingInputSchema => "missing_input_schema",
             Self::UnsafeInputSchema => "unsafe_input_schema",
+            Self::OversizeInputSchema => "oversize_input_schema",
             Self::InvalidAnnotations => "invalid_annotations",
             Self::InvalidCursor => "invalid_cursor",
             Self::TooManyPages => "too_many_pages",

--- a/crates/lanes/ironclaw_mcp/src/diagnostics.rs
+++ b/crates/lanes/ironclaw_mcp/src/diagnostics.rs
@@ -126,6 +126,9 @@ pub(crate) enum McpInvalidToolListCause {
     UnsafeInputSchema,
     InvalidAnnotations,
     InvalidCursor,
+    /// Retained for the diagnostic vocabulary, no longer raised: exhausting the page
+    /// budget now truncates, for the same reason as the tool and byte ceilings.
+    #[allow(dead_code)]
     TooManyPages,
     /// Retained for the diagnostic vocabulary, no longer raised: an over-large catalog
     /// now truncates rather than failing the discovery pass, because discarding every

--- a/crates/lanes/ironclaw_mcp/src/discovery.rs
+++ b/crates/lanes/ironclaw_mcp/src/discovery.rs
@@ -33,7 +33,12 @@ pub(crate) const MAX_DISCOVERED_MCP_TOOLS: usize = 65_536;
 
 /// Maximum number of `tools/list` pagination pages followed during a single
 /// discovery pass.
-pub(crate) const MAX_MCP_TOOLS_LIST_PAGES: usize = 50;
+///
+/// Sized against [`MAX_DISCOVERED_MCP_TOOLS`], not chosen independently: a server free to
+/// pick its own page size needs enough pages to deliver the tool ceiling. At 50 pages this
+/// was the effective ceiling regardless of the tool limit -- a 47,337-tool catalog served
+/// 200 per page stopped at exactly 10,000 tools (21%), because 50 pages ran out first.
+pub(crate) const MAX_MCP_TOOLS_LIST_PAGES: usize = 512;
 
 /// Maximum aggregate serialized bytes accepted across all `tools/list` pages
 /// during a single discovery pass.

--- a/crates/lanes/ironclaw_mcp/src/discovery.rs
+++ b/crates/lanes/ironclaw_mcp/src/discovery.rs
@@ -164,13 +164,30 @@ fn classify_discovered_tool(
         .filter(|schema| schema.is_object())
         .cloned()
         .ok_or(McpInvalidToolListCause::MissingInputSchema)?;
-    if !is_supported_mcp_input_schema(
+    // A schema can fail for two unrelated reasons, and they deserve different
+    // blast radii. An UNSAFE construct (control characters smuggled into a key or
+    // string) is a trust violation: the provider is not behaving, so the whole
+    // generation is rejected. Merely OVERSIZE (too deep, too many nodes, one long
+    // string) is a resource limit, exactly like the page/byte/tool ceilings -- and
+    // resource limits already truncate rather than discard. Collapsing both into
+    // one bool meant a single tool with a long parameter description destroyed an
+    // otherwise valid catalog: measured against a 47,337-tool endpoint, three tools
+    // carried a >16 KiB parameter description, the first at index 9,325, and their
+    // presence published ZERO of the other 47,334. The agent then ran 91 fruitless
+    // `tool_search` calls against an empty index.
+    match classify_mcp_input_schema(
         &input_schema,
         max_schema_depth,
         max_schema_nodes,
         max_schema_string_bytes,
     ) {
-        return Err(McpInvalidToolListCause::UnsafeInputSchema);
+        SchemaVerdict::Ok => {}
+        SchemaVerdict::Unsafe => return Err(McpInvalidToolListCause::UnsafeInputSchema),
+        SchemaVerdict::Oversize => {
+            return Ok(DiscoveredToolClassification::SkippedShapeViolation(
+                McpInvalidToolListCause::OversizeInputSchema,
+            ));
+        }
     }
     // Discovered tool names become Reborn capability suffixes, so discovery
     // skips unsupported names instead of normalizing them into potentially
@@ -207,12 +224,21 @@ fn classify_discovered_tool(
     ))
 }
 
-fn is_supported_mcp_input_schema(
+/// Why a schema was rejected. `Oversize` is a resource limit (drop this tool);
+/// `Unsafe` is a trust violation (reject the generation).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SchemaVerdict {
+    Ok,
+    Oversize,
+    Unsafe,
+}
+
+fn classify_mcp_input_schema(
     schema: &Value,
     max_depth: u8,
     max_nodes: usize,
     max_string_bytes: usize,
-) -> bool {
+) -> SchemaVerdict {
     let mut nodes = 0usize;
     validate_mcp_schema_value(
         schema,
@@ -231,41 +257,66 @@ fn validate_mcp_schema_value(
     max_nodes: usize,
     max_string_bytes: usize,
     nodes: &mut usize,
-) -> bool {
+) -> SchemaVerdict {
     if depth > max_depth {
-        return false;
+        return SchemaVerdict::Oversize;
     }
     *nodes = nodes.saturating_add(1);
     if *nodes > max_nodes {
-        return false;
+        return SchemaVerdict::Oversize;
     }
     match value {
+        // Unsafe is checked before size so a string that is both oversized and
+        // carries control characters still classifies as the trust violation --
+        // preserving the "security evaluated first" property of the original.
         Value::String(value) => {
-            value.len() <= max_string_bytes && !value.chars().any(is_unsupported_description_char)
+            if value.chars().any(is_unsupported_description_char) {
+                SchemaVerdict::Unsafe
+            } else if value.len() > max_string_bytes {
+                SchemaVerdict::Oversize
+            } else {
+                SchemaVerdict::Ok
+            }
         }
-        Value::Array(values) => values.iter().all(|value| {
-            validate_mcp_schema_value(
-                value,
-                depth + 1,
-                max_depth,
-                max_nodes,
-                max_string_bytes,
-                nodes,
-            )
-        }),
-        Value::Object(values) => values.iter().all(|(key, value)| {
-            key.len() <= max_string_bytes
-                && !key.chars().any(is_unsupported_description_char)
-                && validate_mcp_schema_value(
+        Value::Array(values) => {
+            for value in values {
+                let verdict = validate_mcp_schema_value(
                     value,
                     depth + 1,
                     max_depth,
                     max_nodes,
                     max_string_bytes,
                     nodes,
-                )
-        }),
-        _ => true,
+                );
+                if verdict != SchemaVerdict::Ok {
+                    return verdict;
+                }
+            }
+            SchemaVerdict::Ok
+        }
+        Value::Object(values) => {
+            for (key, value) in values {
+                if key.chars().any(is_unsupported_description_char) {
+                    return SchemaVerdict::Unsafe;
+                }
+                if key.len() > max_string_bytes {
+                    return SchemaVerdict::Oversize;
+                }
+                let verdict = validate_mcp_schema_value(
+                    value,
+                    depth + 1,
+                    max_depth,
+                    max_nodes,
+                    max_string_bytes,
+                    nodes,
+                );
+                if verdict != SchemaVerdict::Ok {
+                    return verdict;
+                }
+            }
+            SchemaVerdict::Ok
+        }
+        _ => SchemaVerdict::Ok,
     }
 }
 
@@ -467,12 +518,35 @@ mod tests {
     }
 
     #[test]
-    fn parse_tools_list_result_rejects_unsafe_schema_strings_and_shape() {
+    fn parse_tools_list_result_rejects_schemas_carrying_control_characters() {
+        // A control character smuggled into a schema string or key is a TRUST
+        // violation, so it still rejects the whole generation.
         let cases = [
             valid_tool(
                 "control",
                 json!({"type": "object", "description": "bad\u{0008}schema"}),
             ),
+            valid_tool("control-key", json!({"type": "object", "ba\u{0008}d": "x"})),
+        ];
+
+        for tool in cases {
+            let error = parse_tools_list_result(&json!({ "tools": [tool] }), 128)
+                .expect_err("control characters in a schema must fail");
+
+            assert_eq!(error, "mcp_invalid_tool_list: unsafe_input_schema");
+        }
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn parse_tools_list_result_skips_oversize_schemas_and_publishes_the_rest() {
+        // Size bounds are RESOURCE limits, not trust violations: an oversized
+        // schema drops that one tool and the rest of the catalog still
+        // publishes. Conflating these two was catastrophic at scale -- a
+        // 47,337-tool endpoint carried three tools with a >16 KiB parameter
+        // description (first at index 9,325) and published none of the other
+        // 47,334.
+        let oversize = [
             valid_tool(
                 "long-string",
                 json!({"type": "object", "description": "a".repeat(16 * 1024 + 1)}),
@@ -481,12 +555,41 @@ mod tests {
             valid_tool("too-many-nodes", wide_schema(8193)),
         ];
 
-        for tool in cases {
-            let error = parse_tools_list_result(&json!({ "tools": [tool] }), 128)
-                .expect_err("unsafe schema strings and shape must fail");
+        for tool in oversize {
+            let name = tool["name"].as_str().expect("test tool name").to_string();
+            let tools = vec![
+                valid_tool("alpha", json!({"type": "object"})),
+                tool,
+                valid_tool("beta", json!({"type": "object"})),
+            ];
 
-            assert_eq!(error, "mcp_invalid_tool_list: unsafe_input_schema");
+            let published = parse_tools_list_result(&json!({ "tools": tools }), 128)
+                .expect("an oversized schema must not destroy its valid neighbors");
+
+            assert_eq!(published.len(), 2, "only the oversized tool is dropped");
+            assert!(
+                published.iter().all(|tool| tool.name != name),
+                "the oversized tool must not publish"
+            );
+            assert!(published.iter().any(|tool| tool.name == "alpha"));
+            assert!(published.iter().any(|tool| tool.name == "beta"));
         }
+        assert!(logs_contain("oversize_input_schema"));
+    }
+
+    #[test]
+    fn parse_tools_list_result_treats_oversize_and_unsafe_together_as_unsafe() {
+        // Fail closed when both apply: a string that is oversized AND carries a
+        // control character is a trust violation, not a resource limit, so the
+        // cosmetic size defect cannot downgrade it to a per-tool skip.
+        let mut payload = "a".repeat(16 * 1024 + 1);
+        payload.push('\u{0008}');
+        let tool = valid_tool("both", json!({"type": "object", "description": payload}));
+
+        let error = parse_tools_list_result(&json!({ "tools": [tool] }), 128)
+            .expect_err("a control character must win over the size bound");
+
+        assert_eq!(error, "mcp_invalid_tool_list: unsafe_input_schema");
     }
 
     #[test]
@@ -526,15 +629,22 @@ mod tests {
 
     #[test]
     fn parse_tools_list_result_fails_whole_catalog_when_unsafe_schema_amid_valid_tools() {
-        // Security/bounds violations are never downgraded to a per-tool skip:
-        // a single over-deep (DoS-shaped) input schema fails the entire
-        // generation even when it is surrounded by otherwise-valid tools, so a
-        // hostile entry cannot smuggle itself in by riding a valid catalog.
+        // Trust violations are never downgraded to a per-tool skip: a schema
+        // carrying a control character fails the entire generation even when
+        // surrounded by otherwise-valid tools, so a hostile entry cannot
+        // smuggle itself in by riding a valid catalog. (Size violations are a
+        // resource limit and DO drop per-tool -- covered separately above.)
         let mut tools = vec![
             valid_tool("alpha", json!({"type": "object"})),
             valid_tool("beta", json!({"type": "object"})),
         ];
-        tools.insert(1, valid_tool("too-deep", nested_schema(64)));
+        tools.insert(
+            1,
+            valid_tool(
+                "control",
+                json!({"type": "object", "description": "bad\u{0008}schema"}),
+            ),
+        );
 
         let error = parse_tools_list_result(&json!({ "tools": tools }), 128)
             .expect_err("an unsafe schema must fail the whole catalog even with valid neighbors");

--- a/crates/lanes/ironclaw_mcp/src/discovery.rs
+++ b/crates/lanes/ironclaw_mcp/src/discovery.rs
@@ -19,7 +19,17 @@ use crate::diagnostics::{McpInvalidToolListCause, invalid_tool_list};
 /// pass, across all pages. Shared by the discovery loop's running-total check
 /// and [`parse_tools_list_result`]'s per-page cap so the two enforcement
 /// points cannot drift apart.
-pub(crate) const MAX_DISCOVERED_MCP_TOOLS: usize = 1024;
+///
+/// Sized for a real integration catalog rather than a single vendor's server.
+/// At the previous 1,024 a large catalog did not degrade -- it FAILED: exceeding
+/// the cap aborted the whole discovery pass and the extension published zero
+/// tools. Measured against a 47,337-tool MCP endpoint, discovery pulled six
+/// pages, tripped the cap, and every `tool_search` afterwards ran against an
+/// empty index; the agent reported "the extension is registered and installed
+/// -- but the MCP server's tools are not publishing" and answered from nothing.
+/// The tools are deferred (definitions never enter the model's context), so the
+/// cost of a larger ceiling is host-side index memory, not prompt tokens.
+pub(crate) const MAX_DISCOVERED_MCP_TOOLS: usize = 65_536;
 
 /// Maximum number of `tools/list` pagination pages followed during a single
 /// discovery pass.
@@ -27,7 +37,12 @@ pub(crate) const MAX_MCP_TOOLS_LIST_PAGES: usize = 50;
 
 /// Maximum aggregate serialized bytes accepted across all `tools/list` pages
 /// during a single discovery pass.
-pub(crate) const MAX_MCP_TOOLS_CATALOG_BYTES: usize = 16 * 1024 * 1024;
+///
+/// Raised alongside [`MAX_DISCOVERED_MCP_TOOLS`]: a catalog large enough to need
+/// the higher tool ceiling also carries more schema bytes, and tripping this
+/// limit had the same all-or-nothing consequence. A 47,337-tool catalog
+/// serializes to roughly 44 MB.
+pub(crate) const MAX_MCP_TOOLS_CATALOG_BYTES: usize = 96 * 1024 * 1024;
 
 pub(crate) fn parse_tools_list_result(
     value: &Value,
@@ -368,7 +383,10 @@ mod tests {
 
     #[test]
     fn parse_tools_list_result_caps_manifest_budget_at_host_maximum() {
-        let tools = (0..1025)
+        // Derived from the constant, not a literal: this assertion hardcoded 1025 and broke
+        // the moment the ceiling moved, even though what it checks -- that a provider's
+        // declared budget is clamped to the host's -- was unaffected.
+        let tools = (0..=MAX_DISCOVERED_MCP_TOOLS)
             .map(|index| valid_tool(&format!("tool-{index}"), json!({"type": "object"})))
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
## The bug

Hosted-MCP discovery treats its resource ceilings as **validity checks**. Exceeding one returns `Err`, which discards every tool already collected — so a server one tool over a limit publishes exactly as many tools as a server that is unreachable: **none**.

Worse, the failure is silent from the agent's side. `extension_install` still reports **success**; only `tool_search` reveals anything, by returning `{"results":[]}` forever.

## Measured, same task and catalog, only this patch differing

A 1,200-tool MCP server — the size you reach by connecting one large API gateway, or a few big servers:

| | before | after |
|---|---|---|
| score | **0.00** | **1.00** |
| retrieval recall | 0.00 | **1.00** |
| ground-truth APIs called | **0 / 2** | **2 / 2** |
| model calls | **93** | **6** |
| what the agent did | 26 raw `http`, 23 `tool_search`, **11 install retries** | called the two tools it needed |

The before-run is the signature of an agent with no tools: it retries installation eleven times, then tries to hand-roll HTTP. **15× the model calls, and still the wrong answer.**

## What changed

Four ceilings were involved, and only fixing all of them helps — each one masks the next:

| limit | was | now |
|---|---|---|
| `MAX_DISCOVERED_MCP_TOOLS` | 1,024 | 65,536 |
| `MAX_MCP_TOOLS_CATALOG_BYTES` | 16 MB | 96 MB |
| `MAX_MCP_TOOLS_LIST_PAGES` | 50 | 512 |
| synthesized manifest `max_tools` | 1,024 | 65,536 |

The page budget deserves note: at 50 pages it was the *effective* ceiling regardless of the tool limit, capping discovery at 50 × page-size tools. It is now sized against `MAX_DISCOVERED_MCP_TOOLS` rather than chosen independently.

**Host resource limits now truncate. The manifest's declared `max_tools` still fails** — that distinction is deliberate. The manifest is a contract the user approved at install time, so a server publishing more than it declared is a trust violation; truncating there would let a package that asked for one tool publish five hundred. `page_intake` returns `Accept` / `Truncate(n)` / `ExceedsManifest` so the two kinds of limit cannot be conflated again.

Both retired causes (`CatalogTooLarge`, `TooManyPages`) are retained unraised so anything keying on those strings keeps working.

## Scope — verified at 47,337 tools, and the answer is "ranking, not ingestion"

These fixes are correct where discovery can finish, and they matter there. At a
47,337-tool endpoint they are inert — and the full-catalog measurement, once it was
finally possible, says why no ingestion fix can help.

**The 47k blocker was not any ceiling in this PR.** The benchmark catalog contained
nine tools with live credentials in their descriptions (upstream RapidAPI data). The
egress leak detector correctly blocked the page carrying one, which aborted discovery
and published nothing — see #8008 (blast radius) and #8009 (the cause was flattened to
`"response_error"`, which is what made it so hard to find). Redacting them let the full
catalog ingest for the first time: **46,443 of 46,443 tools, every task.**

With a complete 47k index, the score did not improve. It got worse:

| catalog | ingestion | score |
|---|---|---|
| 2,000 tools | 100% | **0.500** |
| 47,337 | ~10% (blocked) | 0.125 |
| 47,337 | **100%** | **0.000** |

Every task that passes at 2,000 tools fails at 47,337 holding an identical, complete
index:

| task | 2,000 (full) | 47,337 (full) |
|---|---|---|
| g1_3303 | 1.0 | 0.0 |
| g1_702 | 1.0 | 0.0 |
| g1_3976 | 1.0 | 0.0 |
| g1_4140 | 1.0 | 0.0 |

Same model, same tasks, same complete catalog; only size differs. **BM25F ranking
collapses between 2,000 and 47,337 tools.** That is the entire gap, and it is what a
server-side search facade sidesteps by ranking against its own index and returning two
tools — 0.572 there against 0.145 for the same agent loop on the same 435 tasks.

Worth stating plainly: perfect ingestion scored *lower* than broken ingestion. When
discovery fails fast the agent falls back to what it knows and occasionally answers
correctly; when it succeeds, the agent spends its budget searching an index whose
ranking cannot surface the answer.

**What this PR is, then:** three real bugs removing a cliff for realistic catalogs —
at 1,200 tools, 0.00 -> 1.00, recall 0.00 -> 1.00, model calls 93 -> 6. That is worth
landing on its own merits. It is not a scaling story, and nothing here touches ranking.

## A second failure, same shape: install says success while discovery is still running

`extension_install` returns before discovery runs — the package is republished with
its live capability set later, from `activate_with_credential_gate`. Nothing said so.
The agent read a successful install plus an empty `tool_search` as a broken install and
**re-registered**, which restarts discovery from the beginning. At catalog scale that
never converges: one observed run made 7 registrations, 8 installs, 218 searches, and
published 0 tools across 548 model calls.

The `next_step` message now states that discovery is asynchronous, that an empty
`tool_search` means "still running" rather than "failed", and that re-registering
restarts it. Registrations dropped 7 -> 1.

## A third: one oversized tool destroys the whole catalog

This is the one that actually gates large catalogs, and it is not a ceiling.

Schema validation collapsed two unrelated failures into a single bool:

- an **unsafe** construct (control characters in a schema key or string) - a trust violation
- a merely **oversize** one (too deep, too many nodes, one long string) - a resource limit

Both rejected the entire discovery generation. So a single tool with a long parameter
description silently published **zero** tools.

Measured against a 47,337-tool endpoint, three tools exceed the 16 KiB schema-string bound:

| catalog index | oversized string | tool |
|---|---|---|
| **9,325** | 17,910 B (1,526 over) | Data / Cars Data / Get Cars Data |
| 20,273 | 94,825 B | Finance / Supportnresistance / Monthly |
| 20,274 | 252,938 B | Finance / Supportnresistance / Weekly |

The first at index 9,325 published none of the other 47,334 tools — while install still
reported success. It also explains cleanly why every smaller catalog worked: 500, 1,200
and 2,000-tool slices all end before index 9,325.

Oversize now drops the single offending tool and records `oversize_input_schema`. Unsafe
still fails the generation, and is evaluated **first**, so a co-occurring size defect
cannot downgrade a trust violation.

## Tests

`page_intake` is extracted specifically so the ceiling behaviour is unit-testable without a live server — the bug lived in that arithmetic and was otherwise only visible end-to-end. New test covers keep-what-fits, exact-fill, byte ceiling, already-full, and both manifest-violation cases.

One existing test hardcoded `1025` and broke on the ceiling change; it now derives its size from the constant, since what it verifies — that a provider's declared budget is clamped to the host's — was unaffected.

New tests cover the oversize/unsafe split explicitly: oversized schemas drop per-tool and their valid neighbours still publish; control characters still fail the generation; and a string that is *both* oversized and unsafe classifies as unsafe (fail closed).

`ironclaw_mcp` 39 + 42 + 5 + 3 passing · `ironclaw_extension_host` 475 + 9 + 7 + 2 passing.

## Provenance

Found while benchmarking tool retrieval at catalog scale (nearai/benchmarks#357, epic nearai/benchmarks#433). Across nine runs the result was perfectly bimodal: every run where reborn was handed the tools individually scored 0.100–0.174 with recall ≈ 0.01; every run where search sat behind a two-tool facade scored 0.572–0.739 with recall ≈ 0.63–0.70. Reborn's own BM25F ranker is not implicated — at a 500-tool catalog it scores 0.583, right alongside the facade.


