### PR TITLE
perf(tool-search, github): stop offering tools that match one incidental query term

### DIFF
--- a/crates/extensions/packages/github/manifest.toml
+++ b/crates/extensions/packages/github/manifest.toml
@@ -53,7 +53,7 @@ placeholder_env = "GH_TOKEN"
 [[tools]]
 origin_gate_matrix = { loop_run = "gated_unless_granted", product = "forbidden", automation = "forbidden" }
 id = "github.list_issues"
-description = "List issues in one repository."
+description = "List issues in ONE repository. For a question spanning an organisation, prefer github.search_issues_pull_requests with an `org:` qualifier — it answers in a single call, where this tool needs one call per repository and returns full issue objects."
 effects = ["network", "use_secret"]
 default_permission = "allow"
 visibility = "model"
@@ -563,7 +563,7 @@ placeholder_env = "GH_TOKEN"
 [[tools]]
 origin_gate_matrix = { loop_run = "gated_unless_granted", product = "forbidden", automation = "forbidden" }
 id = "github.search_issues_pull_requests"
-description = "Search compact GitHub issue and pull request summaries."
+description = "Search compact GitHub issue and pull request summaries. Accepts GitHub search qualifiers including `org:`, `repo:`, `label:`, `is:open`, so one query can span every repository in an organisation; read `total_count` for counts."
 effects = ["network", "use_secret"]
 default_permission = "allow"
 visibility = "model"

--- a/crates/loop/ironclaw_loop_host/src/tool_search.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_search.rs
@@ -35,8 +35,8 @@ const EXACT_IDENTIFIER_BONUS: f64 = 1_000_000.0;
 /// 21 times and "data__" 12 times, each returning the same five unrelated hits, because a
 /// `data`-ish term appears somewhere in unrelated tools. The model reads "results exist" as
 /// "the tool is in here somewhere" and rephrases instead of stopping. A benchmark run
-/// reproduced it verbatim — `run shell command execute code python` returned
-/// `github.rerun_failed_workflow_run_jobs`, which shares only "run".
+/// reproduced it verbatim: "run shell command execute code python" returned a
+/// workflow-rerun capability from an unrelated provider, which shares only "run".
 ///
 /// Coverage is measured against the query's ANSWERABLE terms — those that appear anywhere in the
 /// index — not against every word typed. A term the catalog has never heard of ("vimeo", "noise0")
@@ -45,10 +45,10 @@ const EXACT_IDENTIFIER_BONUS: f64 = 1_000_000.0;
 /// `query_term_budget_uses_only_the_first_unique_terms` honest: a rare identifier plus 32 unknown
 /// words is 1-of-1 answerable coverage, not 1-of-33.
 ///
-/// So "slack send message" and "github list issues" match fully and are untouched, while
-/// "run shell command execute code python" — where several terms ARE answerable and a workflow
-/// tool matches only "run" — now yields `SearchQueryClass::NoMatch`, which is the honest answer
-/// and is already plumbed through.
+/// So short queries like "send message" or "list issues" match fully and are untouched, while
+/// "run shell command execute code python" — where several terms ARE answerable and a
+/// workflow-rerun tool matches only "run" — now yields `SearchQueryClass::NoMatch`, which is the
+/// honest answer and is already plumbed through.
 const MIN_QUERY_TERM_COVERAGE: f64 = 0.5;
 
 /// Below this many answerable terms, a single match is enough and coverage is not applied.

--- a/crates/loop/ironclaw_loop_host/src/tool_search.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_search.rs
@@ -27,6 +27,41 @@ const PARAMETER_WEIGHT: f64 = 5.0;
 const DESCRIPTION_WEIGHT: f64 = 1.0;
 const EXACT_IDENTIFIER_BONUS: f64 = 1_000_000.0;
 
+/// Fraction of a query's terms a document must match before it is offered at all.
+///
+/// BM25 alone scores a document above zero for sharing ONE term with the query, so a search
+/// for a capability that does not exist still returns a plausible-looking ranked list. Observed
+/// in production trace `10626679` (652 tool calls, 216 of them `tool_search`): "data" was asked
+/// 21 times and "data__" 12 times, each returning the same five unrelated hits, because a
+/// `data`-ish term appears somewhere in unrelated tools. The model reads "results exist" as
+/// "the tool is in here somewhere" and rephrases instead of stopping. A benchmark run
+/// reproduced it verbatim — `run shell command execute code python` returned
+/// `github.rerun_failed_workflow_run_jobs`, which shares only "run".
+///
+/// Coverage is measured against the query's ANSWERABLE terms — those that appear anywhere in the
+/// index — not against every word typed. A term the catalog has never heard of ("vimeo", "noise0")
+/// cannot be matched by any document, so counting it against every document would punish
+/// documents for the query's own vocabulary. This is also what keeps
+/// `query_term_budget_uses_only_the_first_unique_terms` honest: a rare identifier plus 32 unknown
+/// words is 1-of-1 answerable coverage, not 1-of-33.
+///
+/// So "slack send message" and "github list issues" match fully and are untouched, while
+/// "run shell command execute code python" — where several terms ARE answerable and a workflow
+/// tool matches only "run" — now yields `SearchQueryClass::NoMatch`, which is the honest answer
+/// and is already plumbed through.
+const MIN_QUERY_TERM_COVERAGE: f64 = 0.5;
+
+/// Below this many answerable terms, a single match is enough and coverage is not applied.
+///
+/// Short queries are where the coverage rule costs real recall: "list issues" or "send message"
+/// are two answerable terms, and demanding both drops legitimate results whose wording differs
+/// by a word. Measured against the committed corpus gate, applying coverage to every query took
+/// recall@10 to 0.9453 against a >= 0.95 floor — a real loss, correctly refused.
+///
+/// The waste this rule targets is long and descriptive — "run shell command execute code python"
+/// (six terms, matching a workflow tool on "run" alone) — so the rule only engages there.
+const MIN_ANSWERABLE_TERMS_FOR_COVERAGE: usize = 4;
+
 #[derive(Debug, Clone)]
 pub(crate) struct AuthorizedToolSearchIndex {
     documents: Vec<IndexedDocument>,
@@ -116,6 +151,19 @@ impl AuthorizedToolSearchIndex {
             };
         }
 
+        // Terms the catalog could answer at all. See `MIN_QUERY_TERM_COVERAGE`.
+        let answerable_terms = query_terms
+            .iter()
+            .filter(|term| {
+                self.document_frequencies
+                    .get(*term)
+                    .copied()
+                    .unwrap_or_default()
+                    > 0
+            })
+            .count();
+        let required_terms = required_term_coverage(answerable_terms);
+
         let exact = self
             .documents
             .iter()
@@ -127,10 +175,12 @@ impl AuthorizedToolSearchIndex {
             } else {
                 0.0
             };
+            let mut matched_terms = 0usize;
             for term in &query_terms {
                 let Some(term_weight) = document.term_weights.get(term) else {
                     continue;
                 };
+                matched_terms += 1;
                 let document_frequency = self
                     .document_frequencies
                     .get(term)
@@ -145,7 +195,9 @@ impl AuthorizedToolSearchIndex {
                 score += inverse_document_frequency * term_weight * (BM25_K1 + 1.0)
                     / (term_weight + length_normalization);
             }
-            if score > 0.0 {
+            // An exact identifier match is authoritative however few terms it shares.
+            let exact_match = document.exact_identifiers.contains(&normalized_query);
+            if score > 0.0 && (exact_match || matched_terms >= required_terms) {
                 scored.push((document.name.clone(), document.capability_id.clone(), score));
             }
         }
@@ -323,6 +375,17 @@ impl SearchDocumentBuilder {
             self.collect_schema(child, parent_depth.saturating_add(1), trusted_descriptions);
         }
     }
+}
+
+/// How many of a query's terms a document must match to be offered.
+///
+/// Takes the count of ANSWERABLE terms, not of typed words — see `MIN_QUERY_TERM_COVERAGE`.
+/// One answerable term needs that one match; everything else needs at least half, rounded up.
+fn required_term_coverage(answerable_term_count: usize) -> usize {
+    if answerable_term_count < MIN_ANSWERABLE_TERMS_FOR_COVERAGE {
+        return 1;
+    }
+    ((answerable_term_count as f64) * MIN_QUERY_TERM_COVERAGE).ceil() as usize
 }
 
 fn tokenize(value: &str) -> Vec<String> {


### PR DESCRIPTION
## Problem

`ironclaw.tool_search` admits any document BM25 scores above zero — which means sharing **one** term with the query. A search for a capability that does not exist therefore returns a plausible-looking ranked list instead of nothing, and the model reads "results exist" as "it is in here somewhere" and rephrases rather than stopping.

From real traces:

```
"run shell command execute code python"  ->  github.rerun_failed_workflow_run_jobs   (shares only "run")
"vimeo_channel"                          ->  builtin.outbound_delivery_targets_list  (shares only "channel")
"data" x21, "data__" x12 in one turn     ->  the same five unrelated hits every time
```

The last is production trace `10626679`: **652 tool calls, 216 of them `tool_search`**, hunting a `data` capability that does not exist, with 19 `tool_describe` failures ("target is unknown") that fed further searches instead of ending the hunt. 126 calls — 19% of the run — did any work.

A second, narrower version of the same problem: the GitHub catalog ranks `github.list_issues` first for any "list issues" phrasing, and neither issue tool's description mentioned **scope**. So an org-wide question takes the per-repository tool — one call per repo, plus `builtin.result_read` continuations, because `list_issues` returns full REST issue objects (a 51-issue repo is 156,436 B, of which number+title+labels is 5,290 B: 7 pages against the 24,576 B ceiling instead of 1).

## Changes

**1. A relevance floor in `tool_search`** (`ironclaw_loop_host`). A document must match at least half the query's **answerable** terms — those present anywhere in the index — before it is offered. When everything filters out the result is `SearchQueryClass::NoMatch`, which already existed and was simply unreachable for these queries.

Two constraints from the existing tests shaped this:

- Counting **unanswerable** words punishes documents for the query's own vocabulary. `tail_canary` plus 32 unknown words is 1-of-1 coverage, not 1-of-33 (`query_term_budget_uses_only_the_first_unique_terms`).
- Applying coverage to **short** queries costs real recall — recall@10 fell to 0.9453 against the committed `>= 0.95` gate. Coverage therefore engages only from four answerable terms up. Long descriptive hunts are the waste; "list issues" and "send message" are not.

All 19 `tool_search` tests pass, including the corpus quality gate and the 100/500/1000-tool scale baseline.

**2. Two `description` strings** in the GitHub manifest, naming which issue tool spans an organisation. No code, no schema.

## Measurement

`nearai/benchmarks` regressions suite, `deepseek-v4-flash-0731`. Built at `7618d195` + these two commits, against baselines from the same rev.

| task | before | after | delta |
|---|---|---|---|
| `item-listing-call-budget` (5-repo traversal) | 20.6 (n=9) | **8.0** (n=3) | **−61%** |
| `unconnected-tool-hidden` | 17.0 (n=4) | **14.7** (n=3) | −14% |
| `digest-call-budget-control` (single repo) | 9.7 (n=3) | **9.3** (n=3) | −4% |
| `digest-call-budget` (org-wide counts) | 11.7 (n=3) | **11.3** (n=3) | −3% |
| **suite mean** | **14.8** | **10.8** | **−27%** |

Every task down, none up, and **every run scored 1.00** — the same correct output for fewer calls.

## Caveats

- n=3 per task on the after side, one model. The `item-listing` effect is far outside noise; the −3% / −4% on the two already-efficient tasks are **not** distinguishable from zero and I do not claim them.
- Tasks whose runs do not finish are excluded deliberately: their call count measures how far they got before dying, so it *inverts* under improvement.
- This does **not** fix `'vimeo_channel'`-style hunts (16 identical repeats where the one matched term is genuinely answerable). That needs within-turn dedupe of identical queries — a separate change, and the obvious next one.
- Unrelated but adjacent: `list_issues` has no projection parameter, so a caller who legitimately needs per-repo listing still pays 7 pages for 1 page of signal. Dropping `user` to `login` and stripping `*_url` from the default projection would be ~50% with no schema change.