### PR TITLE
feat(mcp): normalize hosted tool results

### DIFF
--- a/crates/kernel/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -1320,6 +1320,7 @@ fn mcp_error_kind(error: &McpError) -> RuntimeDispatchErrorKind {
         McpError::Client { .. } => RuntimeDispatchErrorKind::Client,
         McpError::ProviderRejected(_) => RuntimeDispatchErrorKind::Client,
         McpError::InvalidToolCatalog { .. } => RuntimeDispatchErrorKind::OutputDecode,
+        McpError::InvalidToolResult(_) => RuntimeDispatchErrorKind::OutputDecode,
         McpError::AuthRequired { .. } => RuntimeDispatchErrorKind::Client,
         McpError::UnsupportedTransport { .. } => RuntimeDispatchErrorKind::UnsupportedRunner,
         McpError::HostHttpEgressRequired { .. } => RuntimeDispatchErrorKind::NetworkDenied,

--- a/crates/lanes/ironclaw_mcp/src/client.rs
+++ b/crates/lanes/ironclaw_mcp/src/client.rs
@@ -509,14 +509,8 @@ where
         } else if let Some(projected) = project_call_tool_result(&output) {
             projected
         } else {
-            return Err(McpClientError::ProviderRejected {
-                diagnostic: Box::new(ProviderDiagnostic {
-                    code: Some(provider_error_code(
-                        McpProviderRejectionCause::InvalidToolResult,
-                    )),
-                    message: None,
-                    retry_after: None,
-                }),
+            return Err(McpClientError::InvalidToolResult {
+                reason: response_error(McpResponseErrorCause::InvalidToolResult),
                 usage,
             });
         };
@@ -667,6 +661,13 @@ fn mcp_client_error_with_prior_usage(
             accumulate_usage(&mut prior_usage, usage);
             McpClientError::ProviderRejected {
                 diagnostic,
+                usage: prior_usage,
+            }
+        }
+        McpClientError::InvalidToolResult { reason, usage } => {
+            accumulate_usage(&mut prior_usage, usage);
+            McpClientError::InvalidToolResult {
+                reason,
                 usage: prior_usage,
             }
         }

--- a/crates/lanes/ironclaw_mcp/src/client.rs
+++ b/crates/lanes/ironclaw_mcp/src/client.rs
@@ -740,15 +740,15 @@ fn project_call_tool_result(result: &Value) -> Option<Value> {
 
 fn project_content_block(block: &Value) -> Option<Value> {
     let source = block.as_object()?;
-    let block_type = source.get("type").and_then(Value::as_str);
+    let block_type = source.get("type").and_then(Value::as_str)?;
     let mut projected = serde_json::Map::new();
     match block_type {
-        Some("text") => {
+        "text" => {
             let text = source.get("text").and_then(Value::as_str)?;
             projected.insert("type".to_string(), Value::String("text".to_string()));
             projected.insert("text".to_string(), Value::String(text.to_string()));
         }
-        Some(kind @ ("image" | "audio")) => {
+        kind @ ("image" | "audio") => {
             let mime_type = source.get("mimeType").and_then(Value::as_str)?;
             source.get("data").and_then(Value::as_str)?;
             projected.insert("type".to_string(), Value::String(kind.to_string()));
@@ -758,7 +758,7 @@ fn project_content_block(block: &Value) -> Option<Value> {
                 Value::String("binary_unsupported".to_string()),
             );
         }
-        Some("resource_link") => {
+        "resource_link" => {
             let (Some(name), Some(uri)) = (
                 source.get("name").and_then(Value::as_str),
                 source.get("uri").and_then(Value::as_str),
@@ -783,7 +783,7 @@ fn project_content_block(block: &Value) -> Option<Value> {
                 projected.insert("size".to_string(), Value::from(size));
             }
         }
-        Some("resource") => {
+        "resource" => {
             let resource = source.get("resource").and_then(Value::as_object)?;
             let uri = resource.get("uri").and_then(Value::as_str)?;
             let mut projected_resource = serde_json::Map::new();
@@ -811,28 +811,26 @@ fn project_content_block(block: &Value) -> Option<Value> {
         }
         other => {
             projected.insert("type".to_string(), Value::String("unsupported".to_string()));
-            if let Some(original_type) = other {
-                let mut normalized: String = original_type
-                    .chars()
-                    .map(|character| {
-                        if character.is_control() {
-                            ' '
-                        } else {
-                            character
-                        }
-                    })
-                    .collect();
-                if normalized.len() > MAX_MCP_CONTENT_TYPE_BYTES {
-                    const ELLIPSIS: &str = "...";
-                    let mut end = MAX_MCP_CONTENT_TYPE_BYTES - ELLIPSIS.len();
-                    while end > 0 && !normalized.is_char_boundary(end) {
-                        end -= 1;
+            let mut normalized: String = other
+                .chars()
+                .map(|character| {
+                    if character.is_control() {
+                        ' '
+                    } else {
+                        character
                     }
-                    normalized.truncate(end);
-                    normalized.push_str(ELLIPSIS);
+                })
+                .collect();
+            if normalized.len() > MAX_MCP_CONTENT_TYPE_BYTES {
+                const ELLIPSIS: &str = "...";
+                let mut end = MAX_MCP_CONTENT_TYPE_BYTES - ELLIPSIS.len();
+                while end > 0 && !normalized.is_char_boundary(end) {
+                    end -= 1;
                 }
-                projected.insert("original_type".to_string(), Value::String(normalized));
+                normalized.truncate(end);
+                normalized.push_str(ELLIPSIS);
             }
+            projected.insert("original_type".to_string(), Value::String(normalized));
             projected.insert(
                 "status".to_string(),
                 Value::String("unsupported_content_type".to_string()),

--- a/crates/lanes/ironclaw_mcp/src/client.rs
+++ b/crates/lanes/ironclaw_mcp/src/client.rs
@@ -48,6 +48,12 @@ use crate::jsonrpc::{
     validate_tools_call_credential_injections,
 };
 
+/// A defensive fan-out ceiling for one MCP `CallToolResult.content` array.
+/// The mediated response-body limit bounds bytes before parsing; this second
+/// bound prevents a tiny-block array from expanding during projection.
+const MAX_MCP_CONTENT_BLOCKS: usize = 1_024;
+const MAX_MCP_CONTENT_TYPE_BYTES: usize = 128;
+
 #[derive(Debug, Clone)]
 pub struct McpHostHttpClient<H, P> {
     http: H,
@@ -495,6 +501,26 @@ where
             })?;
         usage.output_bytes = usage.output_bytes.max(output_bytes);
 
+        // Tool-declared rejection keeps the existing diagnostic/accounting
+        // path. Successful output is projected at the MCP protocol boundary
+        // before the generic durable writer ever sees it.
+        let output = if provider_rejection.is_some() {
+            output
+        } else if let Some(projected) = project_call_tool_result(&output) {
+            projected
+        } else {
+            return Err(McpClientError::ProviderRejected {
+                diagnostic: Box::new(ProviderDiagnostic {
+                    code: Some(provider_error_code(
+                        McpProviderRejectionCause::InvalidToolResult,
+                    )),
+                    message: None,
+                    retry_after: None,
+                }),
+                usage,
+            });
+        };
+
         Ok(McpClientOutput {
             output,
             usage,
@@ -668,6 +694,168 @@ fn call_tool_rejection_message(result: &Value) -> Option<String> {
     } else {
         Some(text)
     }
+}
+
+/// Project an MCP `CallToolResult` into model-facing open JSON.
+///
+/// This is the protocol lane's output security boundary: it understands MCP
+/// content discriminators, not capability ids or vendor fields. Semantic JSON
+/// and text/resource metadata survive; inline binary and arbitrary future
+/// block payloads do not.
+fn project_call_tool_result(result: &Value) -> Option<Value> {
+    let source = result.as_object()?;
+    let content = source.get("content")?.as_array()?;
+    if content.len() > MAX_MCP_CONTENT_BLOCKS {
+        return None;
+    }
+    if source
+        .get("structuredContent")
+        .is_some_and(|value| !value.is_object())
+        || source
+            .get("isError")
+            .is_some_and(|value| !value.is_boolean())
+    {
+        return None;
+    }
+
+    let mut projected = serde_json::Map::new();
+    projected.insert(
+        "content".to_string(),
+        Value::Array(
+            content
+                .iter()
+                .map(project_content_block)
+                .collect::<Option<Vec<_>>>()?,
+        ),
+    );
+    if let Some(structured) = source.get("structuredContent") {
+        projected.insert("structuredContent".to_string(), structured.clone());
+    }
+    if let Some(is_error) = source.get("isError") {
+        projected.insert("isError".to_string(), is_error.clone());
+    }
+    Some(Value::Object(projected))
+}
+
+fn project_content_block(block: &Value) -> Option<Value> {
+    let source = block.as_object()?;
+    let block_type = source.get("type").and_then(Value::as_str);
+    let mut projected = serde_json::Map::new();
+    match block_type {
+        Some("text") => {
+            let text = source.get("text").and_then(Value::as_str)?;
+            projected.insert("type".to_string(), Value::String("text".to_string()));
+            projected.insert("text".to_string(), Value::String(text.to_string()));
+        }
+        Some(kind @ ("image" | "audio")) => {
+            let mime_type = source.get("mimeType").and_then(Value::as_str)?;
+            source.get("data").and_then(Value::as_str)?;
+            projected.insert("type".to_string(), Value::String(kind.to_string()));
+            projected.insert("mimeType".to_string(), Value::String(mime_type.to_string()));
+            projected.insert(
+                "encoding".to_string(),
+                Value::String("binary_unsupported".to_string()),
+            );
+        }
+        Some("resource_link") => {
+            let (Some(name), Some(uri)) = (
+                source.get("name").and_then(Value::as_str),
+                source.get("uri").and_then(Value::as_str),
+            ) else {
+                return None;
+            };
+            projected.insert(
+                "type".to_string(),
+                Value::String("resource_link".to_string()),
+            );
+            projected.insert("name".to_string(), Value::String(name.to_string()));
+            projected.insert("uri".to_string(), Value::String(uri.to_string()));
+            if !copy_optional_string_fields(
+                source,
+                &mut projected,
+                &["title", "description", "mimeType"],
+            ) {
+                return None;
+            }
+            if let Some(size) = source.get("size") {
+                let size = size.as_u64()?;
+                projected.insert("size".to_string(), Value::from(size));
+            }
+        }
+        Some("resource") => {
+            let resource = source.get("resource").and_then(Value::as_object)?;
+            let uri = resource.get("uri").and_then(Value::as_str)?;
+            let mut projected_resource = serde_json::Map::new();
+            projected_resource.insert("uri".to_string(), Value::String(uri.to_string()));
+            if !copy_optional_string_fields(resource, &mut projected_resource, &["mimeType"]) {
+                return None;
+            }
+            match (
+                resource.get("text").and_then(Value::as_str),
+                resource.get("blob").and_then(Value::as_str),
+            ) {
+                (Some(text), None) => {
+                    projected_resource.insert("text".to_string(), Value::String(text.to_string()));
+                }
+                (None, Some(_)) => {
+                    projected_resource.insert(
+                        "encoding".to_string(),
+                        Value::String("binary_unsupported".to_string()),
+                    );
+                }
+                _ => return None,
+            }
+            projected.insert("type".to_string(), Value::String("resource".to_string()));
+            projected.insert("resource".to_string(), Value::Object(projected_resource));
+        }
+        other => {
+            projected.insert("type".to_string(), Value::String("unsupported".to_string()));
+            if let Some(original_type) = other {
+                let mut normalized: String = original_type
+                    .chars()
+                    .map(|character| {
+                        if character.is_control() {
+                            ' '
+                        } else {
+                            character
+                        }
+                    })
+                    .collect();
+                if normalized.len() > MAX_MCP_CONTENT_TYPE_BYTES {
+                    const ELLIPSIS: &str = "...";
+                    let mut end = MAX_MCP_CONTENT_TYPE_BYTES - ELLIPSIS.len();
+                    while end > 0 && !normalized.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    normalized.truncate(end);
+                    normalized.push_str(ELLIPSIS);
+                }
+                projected.insert("original_type".to_string(), Value::String(normalized));
+            }
+            projected.insert(
+                "status".to_string(),
+                Value::String("unsupported_content_type".to_string()),
+            );
+        }
+    }
+    Some(Value::Object(projected))
+}
+
+fn copy_optional_string_fields(
+    source: &serde_json::Map<String, Value>,
+    projected: &mut serde_json::Map<String, Value>,
+    fields: &[&str],
+) -> bool {
+    for field in fields {
+        match source.get(*field) {
+            None => {}
+            Some(value) if value.is_string() => {
+                projected.insert((*field).to_string(), value.clone());
+            }
+            Some(_) => return false,
+        }
+    }
+    true
 }
 
 fn json_rpc_provider_diagnostic(code: Option<i64>, message: Option<String>) -> ProviderDiagnostic {

--- a/crates/lanes/ironclaw_mcp/src/contract.rs
+++ b/crates/lanes/ironclaw_mcp/src/contract.rs
@@ -178,6 +178,12 @@ pub enum McpClientError {
     InvalidToolCatalog {
         reason: String,
     },
+    /// The server completed `tools/call`, but its successful result violated
+    /// the MCP output contract. Usage is retained because transport completed.
+    InvalidToolResult {
+        reason: String,
+        usage: ResourceUsage,
+    },
     AuthRequired {
         usage: ResourceUsage,
     },
@@ -208,7 +214,9 @@ impl McpClientError {
 
     pub fn stable_reason(&self) -> &str {
         match self {
-            Self::Client { reason } | Self::InvalidToolCatalog { reason } => reason,
+            Self::Client { reason }
+            | Self::InvalidToolCatalog { reason }
+            | Self::InvalidToolResult { reason, .. } => reason,
             Self::AuthRequired { .. } | Self::AuthChallenge { .. } => "auth_required",
             Self::ProviderRejected { diagnostic, .. } => diagnostic
                 .code
@@ -243,6 +251,13 @@ impl std::fmt::Debug for McpProviderRejection {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpInvalidToolResult {
+    pub reason: String,
+    pub receipt: ResourceReceipt,
+    pub usage: ResourceUsage,
+}
+
 /// MCP runtime failures.
 #[derive(Debug, Error)]
 pub enum McpError {
@@ -254,6 +269,8 @@ pub enum McpError {
     ProviderRejected(Box<McpProviderRejection>),
     #[error("MCP server advertised an invalid tool catalog: {reason}")]
     InvalidToolCatalog { reason: String },
+    #[error("MCP server returned an invalid tool result: {}", .0.reason)]
+    InvalidToolResult(Box<McpInvalidToolResult>),
     #[error("MCP capability requires authentication")]
     AuthRequired {
         required_secrets: Vec<SecretHandle>,

--- a/crates/lanes/ironclaw_mcp/src/diagnostics.rs
+++ b/crates/lanes/ironclaw_mcp/src/diagnostics.rs
@@ -106,6 +106,7 @@ pub(crate) enum McpProviderRejectionCause {
     HttpStatus(u16),
     JsonRpcError(i64),
     ToolRejected,
+    InvalidToolResult,
 }
 
 pub(crate) fn provider_error_code(cause: McpProviderRejectionCause) -> ProviderErrorCode {
@@ -113,6 +114,7 @@ pub(crate) fn provider_error_code(cause: McpProviderRejectionCause) -> ProviderE
         McpProviderRejectionCause::HttpStatus(status) => format!("mcp_http_status_{status}"),
         McpProviderRejectionCause::JsonRpcError(code) => format!("mcp_jsonrpc_error_{code}"),
         McpProviderRejectionCause::ToolRejected => "mcp_tool_rejected".to_string(),
+        McpProviderRejectionCause::InvalidToolResult => "mcp_invalid_tool_result".to_string(),
     })
 }
 

--- a/crates/lanes/ironclaw_mcp/src/diagnostics.rs
+++ b/crates/lanes/ironclaw_mcp/src/diagnostics.rs
@@ -96,6 +96,8 @@ pub(crate) enum McpResponseErrorCause {
     NoPayload,
     /// Discovered `tools/list` result was malformed (shape/limits violation).
     InvalidToolList(McpInvalidToolListCause),
+    /// A successful `tools/call` result violated the MCP content contract.
+    InvalidToolResult,
 }
 
 /// Stable provider-rejection codes carried separately from the lane's private
@@ -106,7 +108,6 @@ pub(crate) enum McpProviderRejectionCause {
     HttpStatus(u16),
     JsonRpcError(i64),
     ToolRejected,
-    InvalidToolResult,
 }
 
 pub(crate) fn provider_error_code(cause: McpProviderRejectionCause) -> ProviderErrorCode {
@@ -114,7 +115,6 @@ pub(crate) fn provider_error_code(cause: McpProviderRejectionCause) -> ProviderE
         McpProviderRejectionCause::HttpStatus(status) => format!("mcp_http_status_{status}"),
         McpProviderRejectionCause::JsonRpcError(code) => format!("mcp_jsonrpc_error_{code}"),
         McpProviderRejectionCause::ToolRejected => "mcp_tool_rejected".to_string(),
-        McpProviderRejectionCause::InvalidToolResult => "mcp_invalid_tool_result".to_string(),
     })
 }
 
@@ -178,6 +178,7 @@ impl McpResponseErrorCause {
             Self::InvalidToolList(cause) => {
                 format!("mcp_invalid_tool_list: {}", cause.stable_token())
             }
+            Self::InvalidToolResult => "mcp_invalid_tool_result".to_string(),
         }
     }
 }

--- a/crates/lanes/ironclaw_mcp/src/runtime.rs
+++ b/crates/lanes/ironclaw_mcp/src/runtime.rs
@@ -235,6 +235,9 @@ fn mcp_error_from_client_error(error: McpClientError, auth_context: McpAuthConte
     match error {
         McpClientError::Client { reason } => McpError::Client { reason },
         McpClientError::InvalidToolCatalog { reason } => McpError::InvalidToolCatalog { reason },
+        McpClientError::InvalidToolResult { .. } => McpError::Client {
+            reason: request_denied(McpRequestDeniedCause::AccountingInvariant),
+        },
         McpClientError::AuthRequired { .. } | McpClientError::AuthChallenge { .. } => {
             McpError::AuthRequired {
                 required_secrets: auth_context.required_secrets,
@@ -251,7 +254,8 @@ fn mcp_client_attempt_usage(error: &McpClientError) -> Option<&ResourceUsage> {
     match error {
         McpClientError::AuthRequired { usage }
         | McpClientError::AuthChallenge { usage, .. }
-        | McpClientError::ProviderRejected { usage, .. } => Some(usage),
+        | McpClientError::ProviderRejected { usage, .. }
+        | McpClientError::InvalidToolResult { usage, .. } => Some(usage),
         McpClientError::Client { .. } | McpClientError::InvalidToolCatalog { .. } => None,
     }
 }
@@ -272,6 +276,13 @@ fn mcp_error_from_accounted_client_error(
         McpClientError::ProviderRejected { diagnostic, .. } => {
             McpError::ProviderRejected(Box::new(crate::contract::McpProviderRejection {
                 diagnostic: *diagnostic,
+                receipt,
+                usage,
+            }))
+        }
+        McpClientError::InvalidToolResult { reason, .. } => {
+            McpError::InvalidToolResult(Box::new(crate::contract::McpInvalidToolResult {
+                reason,
                 receipt,
                 usage,
             }))

--- a/crates/lanes/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/lanes/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -400,7 +400,7 @@ async fn concrete_mcp_http_client_rejects_malformed_success_result() {
         .expect_err("malformed successful CallToolResult must not reach durable output");
 
     assert_eq!(error.stable_reason(), "mcp_invalid_tool_result");
-    let McpClientError::ProviderRejected { usage, .. } = error else {
+    let McpClientError::InvalidToolResult { usage, .. } = error else {
         panic!("invalid CallToolResult must retain provider-attempt usage");
     };
     assert!(usage.output_bytes > 0);

--- a/crates/lanes/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/lanes/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -307,6 +307,106 @@ async fn concrete_mcp_http_client_routes_json_rpc_through_shared_egress() {
 }
 
 #[tokio::test]
+async fn concrete_mcp_http_client_projects_semantic_content_without_inline_binary() {
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(RecordingRuntimeEgress::mixed_content())),
+        RecordingEgressPlanner::new(host_http_plan()),
+    );
+
+    let output = client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "ironclaw"}),
+            max_output_bytes: 16_384,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        output.output,
+        json!({
+            "content": [
+                {"type": "text", "text": "readable answer"},
+                {"type": "image", "mimeType": "image/png", "encoding": "binary_unsupported"},
+                {"type": "audio", "mimeType": "audio/wav", "encoding": "binary_unsupported"},
+                {
+                    "type": "resource_link",
+                    "name": "report",
+                    "title": "Readable report",
+                    "uri": "file:///reports/summary.md",
+                    "description": "Generated summary",
+                    "mimeType": "text/markdown",
+                    "size": 42
+                },
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": "file:///reports/inline.txt",
+                        "mimeType": "text/plain",
+                        "text": "embedded readable text"
+                    }
+                },
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": "file:///reports/inline.pdf",
+                        "mimeType": "application/pdf",
+                        "encoding": "binary_unsupported"
+                    }
+                },
+                {
+                    "type": "unsupported",
+                    "original_type": "future_content",
+                    "status": "unsupported_content_type"
+                }
+            ],
+            "structuredContent": {"items": [{"id": 7, "title": "semantic JSON"}]},
+            "isError": false
+        })
+    );
+    let rendered = output.output.to_string();
+    assert!(!rendered.contains("IMAGE_BASE64_MUST_NOT_SURVIVE"));
+    assert!(!rendered.contains("AUDIO_BASE64_MUST_NOT_SURVIVE"));
+    assert!(!rendered.contains("BLOB_BASE64_MUST_NOT_SURVIVE"));
+    assert!(!rendered.contains("UNKNOWN_PAYLOAD_MUST_NOT_SURVIVE"));
+}
+
+#[tokio::test]
+async fn concrete_mcp_http_client_rejects_malformed_success_result() {
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(RecordingRuntimeEgress::invalid_tool_result())),
+        RecordingEgressPlanner::new(host_http_plan()),
+    );
+
+    let error = client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "ironclaw"}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .expect_err("malformed successful CallToolResult must not reach durable output");
+
+    assert_eq!(error.stable_reason(), "mcp_invalid_tool_result");
+    let McpClientError::ProviderRejected { usage, .. } = error else {
+        panic!("invalid CallToolResult must retain provider-attempt usage");
+    };
+    assert!(usage.output_bytes > 0);
+}
+
+#[tokio::test]
 async fn concrete_mcp_http_client_surfaces_call_tool_error_content() {
     let client = McpHostHttpClient::new(
         McpRuntimeHttpAdapter::new(Arc::new(RecordingRuntimeEgress::tool_error())),
@@ -1904,6 +2004,8 @@ impl McpClient for RecordingMcpClient {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RecordedResponseMode {
     Json,
+    MixedContent,
+    InvalidToolResult,
     ToolError,
     AuthRequired,
     InitializedAuthRequired,
@@ -1932,6 +2034,22 @@ impl RecordingRuntimeEgress {
         Self {
             mode: RecordedResponseMode::Json,
             protocol_version,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn mixed_content() -> Self {
+        Self {
+            mode: RecordedResponseMode::MixedContent,
+            protocol_version: "2025-06-18",
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn invalid_tool_result() -> Self {
+        Self {
+            mode: RecordedResponseMode::InvalidToolResult,
+            protocol_version: "2025-06-18",
             requests: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -2098,9 +2216,70 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
                         vec![],
                         request.body.len() as u64,
                     )),
+                    RecordedResponseMode::MixedContent => Ok(runtime_json_response(
+                        id,
+                        json!({
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "readable answer",
+                                    "annotations": {
+                                        "audience": ["assistant"],
+                                        "priority": 0.8,
+                                        "transport": "omit"
+                                    },
+                                    "_meta": {"transport": "omit"}
+                                },
+                                {"type": "image", "mimeType": "image/png", "data": "IMAGE_BASE64_MUST_NOT_SURVIVE"},
+                                {"type": "audio", "mimeType": "audio/wav", "data": "AUDIO_BASE64_MUST_NOT_SURVIVE"},
+                                {
+                                    "type": "resource_link",
+                                    "name": "report",
+                                    "title": "Readable report",
+                                    "uri": "file:///reports/summary.md",
+                                    "description": "Generated summary",
+                                    "mimeType": "text/markdown",
+                                    "size": 42,
+                                    "_meta": {"transport": "omit"}
+                                },
+                                {
+                                    "type": "resource",
+                                    "resource": {
+                                        "uri": "file:///reports/inline.txt",
+                                        "mimeType": "text/plain",
+                                        "text": "embedded readable text",
+                                        "_meta": {"transport": "omit"}
+                                    }
+                                },
+                                {
+                                    "type": "resource",
+                                    "resource": {
+                                        "uri": "file:///reports/inline.pdf",
+                                        "mimeType": "application/pdf",
+                                        "blob": "BLOB_BASE64_MUST_NOT_SURVIVE"
+                                    }
+                                },
+                                {
+                                    "type": "future_content",
+                                    "payload": "UNKNOWN_PAYLOAD_MUST_NOT_SURVIVE"
+                                }
+                            ],
+                            "structuredContent": {"items": [{"id": 7, "title": "semantic JSON"}]},
+                            "isError": false,
+                            "_meta": {"transport": "omit"}
+                        }),
+                        vec![],
+                        request.body.len() as u64,
+                    )),
                     RecordedResponseMode::Sse => Ok(runtime_sse_response(
                         id,
                         json!({"content":[{"type":"text","text":"ok from sse"}],"isError":false}),
+                        request.body.len() as u64,
+                    )),
+                    RecordedResponseMode::InvalidToolResult => Ok(runtime_json_response(
+                        id,
+                        json!({"content": [{"type": "text"}], "isError": false}),
+                        vec![],
                         request.body.len() as u64,
                     )),
                     RecordedResponseMode::ToolError => Ok(runtime_json_response(
@@ -2231,6 +2410,8 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
                 });
                 match self.mode {
                     RecordedResponseMode::Json
+                    | RecordedResponseMode::MixedContent
+                    | RecordedResponseMode::InvalidToolResult
                     | RecordedResponseMode::JsonMissingProtocolVersion
                     | RecordedResponseMode::DeepOpenApiSchema
                     | RecordedResponseMode::InvalidToolCatalog

--- a/crates/lanes/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/lanes/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -407,6 +407,74 @@ async fn concrete_mcp_http_client_rejects_malformed_success_result() {
 }
 
 #[tokio::test]
+async fn concrete_mcp_http_client_rejects_malformed_content_block_discriminators() {
+    for (egress, description) in [
+        (
+            RecordingRuntimeEgress::malformed_content_block_type(false),
+            "a content block without a discriminator",
+        ),
+        (
+            RecordingRuntimeEgress::malformed_content_block_type(true),
+            "a content block with a non-string discriminator",
+        ),
+    ] {
+        let error = call_recorded_tool(egress).await.expect_err(description);
+        assert_eq!(error.stable_reason(), "mcp_invalid_tool_result");
+    }
+}
+
+#[tokio::test]
+async fn concrete_mcp_http_client_enforces_content_block_boundaries() {
+    let output = call_recorded_tool(RecordingRuntimeEgress::content_blocks(1024))
+        .await
+        .expect("the configured content-block ceiling is inclusive");
+    assert_eq!(output.output["content"].as_array().unwrap().len(), 1024);
+
+    let error = call_recorded_tool(RecordingRuntimeEgress::content_blocks(1025))
+        .await
+        .expect_err("content above the configured block ceiling is malformed");
+    assert_eq!(error.stable_reason(), "mcp_invalid_tool_result");
+}
+
+#[tokio::test]
+async fn concrete_mcp_http_client_truncates_multibyte_unknown_type_at_utf8_boundary() {
+    let output = call_recorded_tool(RecordingRuntimeEgress::long_multibyte_unknown_type())
+        .await
+        .expect("an explicit unknown string discriminator remains unsupported content");
+
+    let original_type = output.output["content"][0]["original_type"]
+        .as_str()
+        .unwrap();
+    assert!(original_type.ends_with("..."));
+    assert!(original_type.len() <= 128);
+    let prefix = original_type.strip_suffix("...").unwrap();
+    assert!(!prefix.is_empty());
+    assert!(prefix.chars().all(|character| character == '界'));
+    assert_eq!(prefix.len() % "界".len(), 0);
+}
+
+async fn call_recorded_tool(
+    egress: RecordingRuntimeEgress,
+) -> Result<McpClientOutput, McpClientError> {
+    McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress)),
+        RecordingEgressPlanner::new(host_http_plan()),
+    )
+    .call_tool(McpClientRequest {
+        provider: ExtensionId::new("github-mcp").unwrap(),
+        capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+        scope: sample_scope(),
+        transport: "http".to_string(),
+        command: None,
+        args: vec![],
+        url: Some("https://mcp.example.test/mcp".to_string()),
+        input: json!({"query": "ironclaw"}),
+        max_output_bytes: 4096,
+    })
+    .await
+}
+
+#[tokio::test]
 async fn concrete_mcp_http_client_surfaces_call_tool_error_content() {
     let client = McpHostHttpClient::new(
         McpRuntimeHttpAdapter::new(Arc::new(RecordingRuntimeEgress::tool_error())),
@@ -2006,6 +2074,9 @@ enum RecordedResponseMode {
     Json,
     MixedContent,
     InvalidToolResult,
+    MalformedContentBlockType(bool),
+    ContentBlocks(usize),
+    LongMultibyteUnknownType,
     ToolError,
     AuthRequired,
     InitializedAuthRequired,
@@ -2049,6 +2120,30 @@ impl RecordingRuntimeEgress {
     fn invalid_tool_result() -> Self {
         Self {
             mode: RecordedResponseMode::InvalidToolResult,
+            protocol_version: "2025-06-18",
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn malformed_content_block_type(non_string: bool) -> Self {
+        Self {
+            mode: RecordedResponseMode::MalformedContentBlockType(non_string),
+            protocol_version: "2025-06-18",
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn content_blocks(count: usize) -> Self {
+        Self {
+            mode: RecordedResponseMode::ContentBlocks(count),
+            protocol_version: "2025-06-18",
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn long_multibyte_unknown_type() -> Self {
+        Self {
+            mode: RecordedResponseMode::LongMultibyteUnknownType,
             protocol_version: "2025-06-18",
             requests: Arc::new(Mutex::new(Vec::new())),
         }
@@ -2216,6 +2311,30 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
                         vec![],
                         request.body.len() as u64,
                     )),
+                    RecordedResponseMode::ContentBlocks(count) => {
+                        let content = (0..count)
+                            .map(|_| json!({"type":"text","text":"ok"}))
+                            .collect::<Vec<_>>();
+                        Ok(runtime_json_response(
+                            id,
+                            json!({"content": content, "isError": false}),
+                            vec![],
+                            request.body.len() as u64,
+                        ))
+                    }
+                    RecordedResponseMode::MalformedContentBlockType(non_string) => {
+                        let block = if non_string {
+                            json!({"type": 42, "text": "numeric type"})
+                        } else {
+                            json!({"text": "missing type"})
+                        };
+                        Ok(runtime_json_response(
+                            id,
+                            json!({"content": [block], "isError": false}),
+                            vec![],
+                            request.body.len() as u64,
+                        ))
+                    }
                     RecordedResponseMode::MixedContent => Ok(runtime_json_response(
                         id,
                         json!({
@@ -2267,6 +2386,15 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
                             "structuredContent": {"items": [{"id": 7, "title": "semantic JSON"}]},
                             "isError": false,
                             "_meta": {"transport": "omit"}
+                        }),
+                        vec![],
+                        request.body.len() as u64,
+                    )),
+                    RecordedResponseMode::LongMultibyteUnknownType => Ok(runtime_json_response(
+                        id,
+                        json!({
+                            "content": [{"type": "界".repeat(100)}],
+                            "isError": false
                         }),
                         vec![],
                         request.body.len() as u64,
@@ -2412,6 +2540,9 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
                     RecordedResponseMode::Json
                     | RecordedResponseMode::MixedContent
                     | RecordedResponseMode::InvalidToolResult
+                    | RecordedResponseMode::MalformedContentBlockType(_)
+                    | RecordedResponseMode::LongMultibyteUnknownType
+                    | RecordedResponseMode::ContentBlocks(_)
                     | RecordedResponseMode::JsonMissingProtocolVersion
                     | RecordedResponseMode::DeepOpenApiSchema
                     | RecordedResponseMode::InvalidToolCatalog

--- a/crates/lanes/ironclaw_mcp/tests/mcp_dispatch_integration.rs
+++ b/crates/lanes/ironclaw_mcp/tests/mcp_dispatch_integration.rs
@@ -99,6 +99,37 @@ async fn mcp_lane_invalid_tool_catalog_remains_typed_and_releases_reservation() 
 }
 
 #[tokio::test]
+async fn mcp_lane_invalid_tool_result_remains_typed_and_reconciles_attempt() {
+    let client = RecordingMcpClient::new(Err(McpClientError::InvalidToolResult {
+        reason: "mcp_invalid_tool_result".to_string(),
+        usage: ResourceUsage::default()
+            .set_network_egress_bytes(37)
+            .set_output_bytes(19),
+    }));
+    let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client);
+    let (governor, account) = mcp_governor();
+
+    let error = runtime
+        .execute_extension_json(
+            &GovernorRuntimeBudget::new(&governor),
+            mcp_request(json!({"query":"fail"})),
+        )
+        .await
+        .unwrap_err();
+
+    let McpError::InvalidToolResult(evidence) = error else {
+        panic!("invalid tool output must remain a typed output-contract failure");
+    };
+    assert_eq!(evidence.reason, "mcp_invalid_tool_result");
+    assert_eq!(evidence.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(evidence.usage.network_egress_bytes, 37);
+    assert_eq!(evidence.usage.output_bytes, 19);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account).network_egress_bytes, 37);
+    assert_eq!(governor.usage_for(&account).output_bytes, 19);
+}
+
+#[tokio::test]
 async fn mcp_lane_auth_failure_returns_context_and_accounts_the_provider_attempt() {
     let client = RecordingMcpClient::new(Err(McpClientError::AuthRequired {
         usage: ResourceUsage::default().set_network_egress_bytes(37),

--- a/docs/internal/reborn/contracts/mcp.md
+++ b/docs/internal/reborn/contracts/mcp.md
@@ -114,6 +114,24 @@ auth probe for hosted-MCP registration. It performs `initialize` plus
 `tools/list`; extension catalog discovery and admission remain lifecycle
 preparation work rather than part of registration.
 
+For a successful `tools/call`, the concrete client projects the MCP
+`CallToolResult` before it leaves the protocol lane. The projection remains
+open JSON rather than a host-wide content DTO:
+
+- `structuredContent` is preserved as JSON.
+- Text and embedded text resources retain their semantic fields.
+- Inline image, audio, and embedded blob base64 payloads are omitted and
+  represented as unsupported binary with their media type or resource URI.
+- Resource links retain their model-useful link metadata.
+- Unknown content-block types become a bounded unsupported marker; their
+  arbitrary payload does not cross into the generic output pipeline.
+
+The generic capability output path then applies its normal redaction, durable
+storage, preview, and `builtin.result_read` behavior to that projected value.
+Tool-declared `isError` results keep the provider-rejection path and accounting;
+malformed successful `CallToolResult` values fail with
+`mcp_invalid_tool_result` instead of being stored as if they were valid output.
+
 Important boundaries:
 
 - command, args, URL, and transport come from the validated manifest, not model text
@@ -121,6 +139,11 @@ Important boundaries:
 - raw secrets are not included
 - MCP server network/process behavior remains host-adapter policy, not dispatcher policy
 - stdio MCP usage is accounted as at least one process in V1
+
+Primary regression coverage:
+
+- `tests/integration/mcp.rs::mcp_mixed_content_is_normalized_before_durable_result_storage`
+- `RUST_MIN_STACK=8388608 cargo test -p ironclaw_integration_tests --test reborn_integration_mcp mcp_mixed_content_is_normalized_before_durable_result_storage -- --exact`
 
 ---
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -271,7 +271,7 @@ One thread, whole real turn. Grouped by what the user experiences.
 | Inspect a >100 KiB nested JSON capability result through bounded first-look, node/scalar, collection, credential-redaction, invalid-selection, and exact legacy-byte views | `tool_call.rs::{result_read_large_nested_result_first_look_is_bounded_and_parseable,result_read_selects_nested_json_node_and_scalar,result_read_pages_nested_json_collection,result_read_redacts_credential_json_within_requested_budget,invalid_json_result_selections_remain_model_correctable,result_read_preserves_exact_legacy_byte_reads}` |
 | Shell commands dispatch through the real path without spawning an OS process | `process_port.rs` |
 | A sandbox-profile shell turn executes as an unprivileged user in one reusable per-user Docker container, preserving workspace and container-local state across shell calls and sharing that container across the user's threads | `reborn_sandbox_shell_turn.rs` |
-| MCP tools work over a real loopback HTTP MCP server | `mcp.rs` |
+| MCP tools work over a real loopback HTTP server, and mixed text/structured/resource results are normalized before durable storage without retaining inline media/blob base64 | `mcp.rs` |
 | User-registered and bundled hosted MCP servers register, authenticate, project active, restore, and invoke | `hosted_mcp_registration.rs` |
 | Web search/fetch runs the real Exa MCP handshake | `web_access.rs` |
 | Outbound HTTP crosses the real security pipeline (network policy + leak scan) | `real_egress_pipeline.rs` |

--- a/tests/integration/mcp.rs
+++ b/tests/integration/mcp.rs
@@ -316,6 +316,153 @@ async fn mcp_tool_call_reaches_mock_server() {
         .expect("MCP output round-trips through durable result_read");
 }
 
+/// A mixed MCP result crosses the real loopback HTTP runtime and the unified
+/// durable result writer. Semantic JSON/text/resource fields remain readable,
+/// while protocol-owned inline binary never reaches the model or result_read.
+#[tokio::test]
+async fn mcp_mixed_content_is_normalized_before_durable_result_storage() {
+    const IMAGE_DATA: &str = "IMAGE_BASE64_MUST_NOT_REACH_DURABLE_STORAGE";
+    const AUDIO_DATA: &str = "AUDIO_BASE64_MUST_NOT_REACH_DURABLE_STORAGE";
+    const BLOB_DATA: &str = "BLOB_BASE64_MUST_NOT_REACH_DURABLE_STORAGE";
+    const UNKNOWN_DATA: &str = "UNKNOWN_PAYLOAD_MUST_NOT_REACH_DURABLE_STORAGE";
+
+    let server = start_mock_mcp_server(vec![MockToolResponse {
+        name: "search".to_string(),
+        content: serde_json::json!({"unused": "exact MCP result override follows"}),
+    }])
+    .await;
+    server.set_tool_call_result(
+        "search",
+        serde_json::json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": "readable MCP answer",
+                    "annotations": {
+                        "audience": ["assistant"],
+                        "priority": 0.8,
+                        "transport": "omit"
+                    },
+                    "_meta": {"transport": "omit"}
+                },
+                {"type": "image", "mimeType": "image/png", "data": IMAGE_DATA},
+                {"type": "audio", "mimeType": "audio/wav", "data": AUDIO_DATA},
+                {
+                    "type": "resource_link",
+                    "name": "report",
+                    "title": "Readable report",
+                    "uri": "file:///reports/summary.md",
+                    "description": "Generated summary",
+                    "mimeType": "text/markdown",
+                    "size": 42
+                },
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": "file:///reports/inline.txt",
+                        "mimeType": "text/plain",
+                        "text": "embedded readable text"
+                    }
+                },
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": "file:///reports/inline.pdf",
+                        "mimeType": "application/pdf",
+                        "blob": BLOB_DATA
+                    }
+                },
+                {"type": "future_content", "payload": UNKNOWN_DATA}
+            ],
+            "structuredContent": {"items": [{"id": 7, "title": "semantic JSON"}]},
+            "isError": false,
+            "_meta": {"transport": "omit"}
+        }),
+    );
+
+    let h = RebornIntegrationHarness::test_default()
+        .script([
+            RebornScriptedReply::tool_call(
+                "mock-mcp.search",
+                serde_json::json!({"query": "mixed-content"}),
+            ),
+            RebornScriptedReply::text("done"),
+        ])
+        .with_mock_mcp(server.mcp_url())
+        .build()
+        .await
+        .expect("harness builds");
+
+    h.submit_turn("read the mixed MCP result")
+        .await
+        .expect("turn completes");
+    assert_recorded_tools_call(&server, "search", "mixed-content");
+
+    let output = h
+        .tool_result_output("mock-mcp.search")
+        .await
+        .expect("normalized MCP result was durably recorded");
+    assert_eq!(
+        output,
+        serde_json::json!({
+            "content": [
+                {"type": "text", "text": "readable MCP answer"},
+                {"type": "image", "mimeType": "image/png", "encoding": "binary_unsupported"},
+                {"type": "audio", "mimeType": "audio/wav", "encoding": "binary_unsupported"},
+                {
+                    "type": "resource_link",
+                    "name": "report",
+                    "title": "Readable report",
+                    "uri": "file:///reports/summary.md",
+                    "description": "Generated summary",
+                    "mimeType": "text/markdown",
+                    "size": 42
+                },
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": "file:///reports/inline.txt",
+                        "mimeType": "text/plain",
+                        "text": "embedded readable text"
+                    }
+                },
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": "file:///reports/inline.pdf",
+                        "mimeType": "application/pdf",
+                        "encoding": "binary_unsupported"
+                    }
+                },
+                {
+                    "type": "unsupported",
+                    "original_type": "future_content",
+                    "status": "unsupported_content_type"
+                }
+            ],
+            "structuredContent": {"items": [{"id": 7, "title": "semantic JSON"}]},
+            "isError": false
+        })
+    );
+    let rendered = output.to_string();
+    for forbidden in [IMAGE_DATA, AUDIO_DATA, BLOB_DATA, UNKNOWN_DATA] {
+        assert!(
+            !rendered.contains(forbidden),
+            "encoded/unknown payload leaked into durable output: {forbidden}"
+        );
+        assert!(
+            h.assert_model_request_contains(forbidden).await.is_err(),
+            "encoded/unknown payload leaked into a model request: {forbidden}"
+        );
+    }
+    h.assert_model_request_contains("readable MCP answer")
+        .await
+        .expect("semantic MCP text reached the next model request");
+    h.assert_latest_result_json_round_trips("mock-mcp.search")
+        .await
+        .expect("builtin.result_read returns the normalized durable JSON");
+}
+
 /// Twin of `mcp_tool_call_reaches_mock_server`: same client `Accept:
 /// application/json, text/event-stream` header (`crates/lanes/ironclaw_mcp/src/lib.rs`),
 /// but here the mock server answers every leg with SSE framing instead of

--- a/tests/integration/mcp.rs
+++ b/tests/integration/mcp.rs
@@ -463,6 +463,50 @@ async fn mcp_mixed_content_is_normalized_before_durable_result_storage() {
         .expect("builtin.result_read returns the normalized durable JSON");
 }
 
+/// A successful JSON-RPC envelope with a malformed content block is a
+/// model-visible output-decode failure, never a successful durable result.
+#[tokio::test]
+async fn mcp_malformed_success_result_surfaces_output_decode_failure() {
+    let server = start_mock_mcp_server(vec![MockToolResponse {
+        name: "search".to_string(),
+        content: serde_json::json!({"results": []}),
+    }])
+    .await;
+    server.set_tool_call_result(
+        "search",
+        serde_json::json!({
+            "content": [{"text": "missing discriminator"}],
+            "isError": false
+        }),
+    );
+
+    let h = RebornIntegrationHarness::test_default()
+        .script([
+            RebornScriptedReply::tool_call("mock-mcp.search", serde_json::json!({"query": "x"})),
+            RebornScriptedReply::text("done"),
+        ])
+        .with_mock_mcp(server.mcp_url())
+        .build()
+        .await
+        .expect("harness builds");
+
+    h.submit_turn("search").await.expect("turn recovers");
+    assert_recorded_tools_call(&server, "search", "x");
+    h.assert_mcp_tool_called("search")
+        .await
+        .expect("MCP tool call reached the loopback server");
+    h.assert_tool_error(ToolErrorClass::Failed, "output_decode")
+        .await
+        .expect("malformed MCP output became a model-visible decode failure");
+    h.assert_reply_contains("done")
+        .await
+        .expect("run recovered and finalized");
+    assert!(
+        h.tool_result_output("mock-mcp.search").await.is_err(),
+        "malformed MCP output must not be recorded as successful durable output"
+    );
+}
+
 /// Twin of `mcp_tool_call_reaches_mock_server`: same client `Accept:
 /// application/json, text/event-stream` header (`crates/lanes/ironclaw_mcp/src/lib.rs`),
 /// but here the mock server answers every leg with SSE framing instead of

--- a/tests/support/mock_mcp_server.rs
+++ b/tests/support/mock_mcp_server.rs
@@ -98,6 +98,17 @@ impl MockMcpServer {
         *self.state.force_tool_call_error.lock().unwrap() = Some((code, message.into()));
     }
 
+    /// Override one tool's successful `tools/call.result` with an exact MCP
+    /// protocol value. Most tests use the convenience JSON-to-text wrapper;
+    /// content-block contract tests need to exercise the real mixed result.
+    pub fn set_tool_call_result(&self, tool_name: impl Into<String>, result: serde_json::Value) {
+        self.state
+            .tool_result_overrides
+            .lock()
+            .unwrap()
+            .insert(tool_name.into(), result);
+    }
+
     /// Switch every id-bearing JSON-RPC response to SSE framing:
     /// `Content-Type: text/event-stream` with the JSON-RPC body wrapped in a
     /// `data:` event, preceded by an empty `ping` keepalive event. This is a
@@ -150,6 +161,8 @@ struct MockState {
     tool_responses: HashMap<String, Vec<serde_json::Value>>,
     /// Counter for tool_responses consumption (per tool name).
     tool_response_idx: std::sync::Mutex<HashMap<String, usize>>,
+    /// Exact MCP `tools/call.result` values for protocol-shape tests.
+    tool_result_overrides: std::sync::Mutex<HashMap<String, serde_json::Value>>,
     /// Recorded MCP requests for auth/assertion tests.
     recorded_requests: std::sync::Mutex<Vec<RecordedMcpRequest>>,
     /// Monotonic counter for initialize responses; stamps a distinct
@@ -225,6 +238,7 @@ pub async fn start_mock_mcp_server(tool_responses: Vec<MockToolResponse>) -> Moc
         tools,
         tool_responses: response_map,
         tool_response_idx: std::sync::Mutex::new(HashMap::new()),
+        tool_result_overrides: std::sync::Mutex::new(HashMap::new()),
         recorded_requests: std::sync::Mutex::new(Vec::new()),
         session_counter: std::sync::Mutex::new(0),
         force_status: std::sync::Mutex::new(None),
@@ -306,6 +320,7 @@ pub async fn start_mock_mcp_server_with_specs(specs: Vec<MockToolSpec>) -> MockM
         tools,
         tool_responses: response_map,
         tool_response_idx: std::sync::Mutex::new(HashMap::new()),
+        tool_result_overrides: std::sync::Mutex::new(HashMap::new()),
         recorded_requests: std::sync::Mutex::new(Vec::new()),
         session_counter: std::sync::Mutex::new(0),
         force_status: std::sync::Mutex::new(None),
@@ -530,27 +545,36 @@ async fn handle_mcp(
                 .and_then(|n| n.as_str())
                 .unwrap_or("unknown");
 
-            let content = {
-                let mut idx_map = state.tool_response_idx.lock().unwrap();
-                let idx = idx_map.entry(tool_name.to_string()).or_insert(0);
-                let responses = state.tool_responses.get(tool_name);
-                let result = responses
-                    .and_then(|r| r.get(*idx))
-                    .cloned()
-                    .unwrap_or_else(|| serde_json::json!({"error": "no mock response configured"}));
-                *idx += 1;
-                result
-            };
-
-            let success_result = serde_json::json!({
-                "content": [
-                    {
-                        "type": "text",
-                        "text": serde_json::to_string(&content)
-                            .expect("serializing serde_json::Value for mock MCP content should not fail")
-                    }
-                ]
-            });
+            let success_result = state
+                .tool_result_overrides
+                .lock()
+                .unwrap()
+                .get(tool_name)
+                .cloned()
+                .unwrap_or_else(|| {
+                    let content = {
+                        let mut idx_map = state.tool_response_idx.lock().unwrap();
+                        let idx = idx_map.entry(tool_name.to_string()).or_insert(0);
+                        let responses = state.tool_responses.get(tool_name);
+                        let result = responses
+                            .and_then(|r| r.get(*idx))
+                            .cloned()
+                            .unwrap_or_else(|| {
+                                serde_json::json!({"error": "no mock response configured"})
+                            });
+                        *idx += 1;
+                        result
+                    };
+                    serde_json::json!({
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": serde_json::to_string(&content)
+                                    .expect("serializing serde_json::Value for mock MCP content should not fail")
+                            }
+                        ]
+                    })
+                });
             // Sticky tool-call error override: emit a top-level JSON-RPC `error`
             // object AND a valid `result`. A conformant client returns on the
             // `error` field; the `result` is present so that removing that guard


### PR DESCRIPTION
## Summary

- Project successful hosted MCP `CallToolResult` values at the MCP protocol boundary before the unified durable output writer sees them.
- Preserve text, structured JSON, resource text, and resource-link metadata while omitting inline image/audio/blob base64 and arbitrary unknown payloads.
- Keep the generic capability path unchanged: it still owns redaction, durable storage, first-look preview, and `builtin.result_read` for every tool runtime.
- Fail closed on malformed successful MCP results and preserve the existing `isError` provider-rejection/accounting path.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] Security

## Linked Issue

Related #7891

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] Full-workspace clippy; focused owning-crate clippy passed: `cargo clippy -p ironclaw_mcp --all-targets --all-features -- -D warnings`
- [ ] `cargo build` (covered by the test and clippy builds below)
- [x] Relevant tests pass: MCP crate, MCP integration, architecture, and mediated HTTP egress suites listed below
- [x] Runtime integration behavior: root production-wired `reborn_integration_mcp` target passed 27/27
- [ ] Manual testing: not applicable; automated loopback HTTP exercises the production composition path
- [x] Post-implementation `$approach-audit` run; shape verdict is sound, with one normal error-taxonomy follow-up noted below

## Test Strategy

User behavior: A model receives readable MCP semantic output and continuation references without opaque inline base64 or arbitrary future-block payloads.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [x] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: concrete HTTP client mixed-content projection and malformed-result rejection in `mcp_adapter_contract`
- Reborn integration: `mcp_mixed_content_is_normalized_before_durable_result_storage`
- Recorded fixture: not applicable; the loopback MCP server accepts an exact protocol result override
- Browser E2E: not applicable; no browser surface changes
- Backend or runtime: full MCP integration target and host-runtime HTTP egress contract
- Live canary: not applicable; no live provider credentials required

What the tests prove: Real loopback `tools/call` output crosses production composition into the single durable writer; semantic fields reach storage, model requests, and `result_read`, while image/audio/blob base64 and unknown payloads do not. Malformed known MCP content fails closed.

Commands run:

```text
cargo fmt --all -- --check
cargo clippy -p ironclaw_mcp --all-targets --all-features -- -D warnings
cargo test -p ironclaw_mcp
RUST_MIN_STACK=8388608 SKIP_FRONTEND_BUILD=1 cargo test -p ironclaw_integration_tests --test reborn_integration_mcp
cargo test -p ironclaw_architecture_tests
cargo test -p ironclaw_host_runtime --test runtime_http_egress_contract
python3 scripts/ci/docs_publication_boundary.py
git diff --check
```

## Security Impact

Reduces untrusted provider payload exposure: protocol-owned inline binary and arbitrary unknown content fields are removed before durable storage and model exposure. Network mediation, credential handling, authorization, and redaction remain unchanged.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new public types or constructors
- [x] Untrusted content enters prompts only through the existing result-reference/preview path after MCP projection
- [x] Hashes: not applicable
- [x] New/changed runtime or error variants: malformed tool results are typed as `mcp_invalid_tool_result`, retain reconciled attempt evidence, and map to the existing `OutputDecode` taxonomy
- [x] Security/durability `serde(default)` fields: not applicable
- [x] Queues/maps/buffers/counters: content block count and unknown type length are bounded; existing response byte limits remain authoritative
- [x] Driver/operator-visible errors: malformed successful result has a stable `mcp_invalid_tool_result` token
- [x] Sandbox/native/host names accurately describe the existing boundary

## Database Impact

None. No migrations or schema changes.

## Blast Radius

Successful hosted HTTP/SSE MCP tool results now have a smaller, semantic open-JSON shape before entering the unchanged runtime and durable output pipeline. MCP `isError`, JSON-RPC errors, discovery, sessions, credentials, resource limits, and non-MCP tools keep their existing paths.

## Rollback Plan

Revert the lane-local projection commit. There is no schema, feature flag, public trait, or migration to unwind. Previously stored results remain readable.

## Review Follow-Through

The post-implementation approach audit initially found one normal error-taxonomy issue. It was addressed in `be5447900` and revalidated: System Placement 95, System Trajectory 95, Structural Discipline 95, and Approach Integrity 95 (composite 95; sound). Malformed successful MCP results now map to the existing `OutputDecode` taxonomy while preserving reconciled provider-attempt evidence.

Generic JSON compaction/slash removal and HTML-to-Markdown remain measured performance follow-ups, not part of this MCP protocol slice.

---

**Review track**: C (runtime/security boundary)