### PR TITLE
fix(threads): project untagged observations safely

### DIFF
--- a/crates/domains/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/domains/ironclaw_threads/src/tool_result_reference.rs
@@ -258,6 +258,44 @@ impl ToolResultReferenceEnvelope {
         Ok(envelope)
     }
 
+    /// Decode a durable reference for model projection without letting a legacy
+    /// observation whose detail lacks the required typed `kind` tag poison the
+    /// whole prompt.
+    ///
+    /// The transcript row remains unchanged. Only this in-memory projection
+    /// omits the untagged observation; the reference and its safe summary still
+    /// validate and remain model-visible. Other malformed observations fail
+    /// closed as before.
+    pub fn from_json_str_for_model_projection(value: &str) -> Result<Self, String> {
+        let mut envelope: Self = serde_json::from_str(value).map_err(|error| error.to_string())?;
+        match envelope.validate() {
+            Ok(()) => Ok(envelope),
+            Err(observation_error)
+                if envelope
+                    .model_observation
+                    .as_ref()
+                    .is_some_and(model_observation_detail_is_untagged) =>
+            {
+                let model_observation = envelope.model_observation.take();
+                match envelope.validate() {
+                    Ok(()) => {
+                        tracing::debug!(
+                            reason = %observation_error,
+                            result_ref = %envelope.result_ref,
+                            "ignoring untagged durable model observation during prompt projection"
+                        );
+                        Ok(envelope)
+                    }
+                    Err(_) => {
+                        envelope.model_observation = model_observation;
+                        Err(observation_error)
+                    }
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     pub fn model_visible_content_or_safe_summary(&self) -> String {
         let Some(model_observation) = self.model_observation.as_ref() else {
             tracing::debug!(
@@ -406,6 +444,13 @@ fn normalized_model_observation(
             }
         }
     }
+}
+
+fn model_observation_detail_is_untagged(observation: &serde_json::Value) -> bool {
+    observation
+        .get("detail")
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|detail| !detail.contains_key("kind"))
 }
 
 fn observation_detail_of_kind<'a>(

--- a/crates/loop/ironclaw_loop_host/src/lib.rs
+++ b/crates/loop/ironclaw_loop_host/src/lib.rs
@@ -3210,7 +3210,10 @@ where
                 MessageKind::User => (SystemInferenceContextRole::User, message.content),
                 MessageKind::Assistant => (SystemInferenceContextRole::Assistant, message.content),
                 MessageKind::ToolResultReference => {
-                    let envelope = ToolResultReferenceEnvelope::from_json_str(&message.content)
+                    let envelope =
+                        ToolResultReferenceEnvelope::from_json_str_for_model_projection(
+                            &message.content,
+                        )
                         .map_err(|error| {
                             tracing::debug!(%error, "structured finalization tool result context is invalid");
                             AgentLoopHostError::new(
@@ -3484,16 +3487,18 @@ fn tool_result_content_for_context_message(
     if message.kind != MessageKind::ToolResultReference {
         return Ok(None);
     }
-    let envelope =
-        ToolResultReferenceEnvelope::from_json_str(&message.content).map_err(|error| {
-            raw_agent_loop_host_error(
-                "model_context",
-                "decode_tool_result_reference",
-                AgentLoopHostErrorKind::InvalidInvocation,
-                "tool result reference transcript content is invalid",
-                error,
-            )
-        })?;
+    let envelope = ToolResultReferenceEnvelope::from_json_str_for_model_projection(
+        &message.content,
+    )
+    .map_err(|error| {
+        raw_agent_loop_host_error(
+            "model_context",
+            "decode_tool_result_reference",
+            AgentLoopHostErrorKind::InvalidInvocation,
+            "tool result reference transcript content is invalid",
+            error,
+        )
+    })?;
     Ok(Some(HostManagedToolResultContent::Reference { envelope }))
 }
 

--- a/crates/loop/ironclaw_loop_host/tests/thread_loop_host_contract.rs
+++ b/crates/loop/ironclaw_loop_host/tests/thread_loop_host_contract.rs
@@ -5057,6 +5057,85 @@ async fn model_port_round_trips_tool_result_reference_context_as_typed_model_inp
 }
 
 #[tokio::test]
+async fn model_port_projects_legacy_untagged_observation_as_safe_summary_without_rewriting_record()
+{
+    let fixture = ThreadFixture::new().await;
+    let tool_result_ref = LoopMessageRef::new("msg:33333333-3333-3333-3333-333333333333").unwrap();
+    let envelope_content = serde_json::json!({
+        "version": 1,
+        "result_ref": "result:legacy-untagged-observation",
+        "safe_summary": "legacy tool result remains available",
+        "model_observation": {
+            "schema_version": 1,
+            "status": "success",
+            "summary": "Tool completed.",
+            "detail": {
+                "result_ref": "result:legacy-untagged-observation",
+                "byte_len": 42
+            },
+            "trust": "untrusted_tool_output"
+        }
+    })
+    .to_string();
+    let thread_service = Arc::new(StaticContextThreadService::new(ContextMessage {
+        message_id: Some(ThreadMessageId::parse("33333333-3333-3333-3333-333333333333").unwrap()),
+        summary_id: None,
+        sequence: 1,
+        kind: MessageKind::ToolResultReference,
+        tool_result_provider_call: None,
+        content: envelope_content.clone(),
+        image_attachments: Vec::new(),
+    }));
+    let gateway = Arc::new(RecordingGateway::reply("model says hi"));
+    let model_port = ThreadBackedLoopModelPort::new(
+        thread_service,
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        gateway.clone(),
+        16,
+    );
+    let messages = vec![LoopModelMessage {
+        role: "tool_result_reference".to_string(),
+        content_ref: tool_result_ref,
+    }];
+    issue_prompt_grant(&fixture.run_context, &messages);
+
+    model_port
+        .stream_model(LoopModelRequest {
+            inline_messages: Vec::new(),
+            messages,
+            surface_version: None,
+            model_preference: None,
+            fallback_index: 0,
+            iteration: 0,
+            capability_view: None,
+            tool_choice: None,
+        })
+        .await
+        .expect("an untagged legacy observation must not poison prompt projection");
+
+    let calls = gateway.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1, "prompt projection must call the model once");
+    assert_eq!(
+        calls[0].messages[0].content, envelope_content,
+        "the durable transcript content must remain byte-for-byte available"
+    );
+    let Some(HostManagedToolResultContent::Reference { envelope }) =
+        calls[0].messages[0].tool_result_content.as_ref()
+    else {
+        panic!("tool result must remain a typed reference");
+    };
+    assert_eq!(
+        envelope.safe_summary.as_str(),
+        "legacy tool result remains available"
+    );
+    assert!(
+        envelope.model_observation.is_none(),
+        "the untagged detail is not a valid typed observation"
+    );
+}
+
+#[tokio::test]
 async fn model_port_rejects_malformed_tool_result_reference_content() {
     let fixture = ThreadFixture::new().await;
     let tool_result_ref = LoopMessageRef::new("msg:22222222-2222-2222-2222-222222222222").unwrap();


### PR DESCRIPTION
## Summary

- Detect the legacy observation shape whose `detail` lacks the required typed `kind` tag.
- During model projection only, omit that invalid observation and retain the durable result reference plus safe summary.
- Keep all other malformed observations fail-closed.
- Replace a REPL-corrupting warning with bounded debug diagnostics.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Related #7824

## Validation

- [x] `cargo fmt --all`
- [x] `cargo clippy -p ironclaw_threads -p ironclaw_loop_host --all-targets --all-features -- -D warnings`
- [x] `cargo test -p ironclaw_threads tool_result_reference` — 49 passed
- [x] Focused caller/prompt-seam integration tests passed
- [ ] Full workspace gates: CI

## Test Strategy

User behavior: a legacy untagged observation no longer poisons every prompt build; the model still receives the durable safe summary. Other corrupt reference content still fails.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: existing `tool_result_reference` suite retained.
- Reborn integration: caller-level `ThreadBackedLoopModelPort` regression for the exact legacy JSON shape; malformed-content rejection remains pinned.
- Recorded fixture: Not applicable.
- Browser E2E: Not applicable.
- Backend or runtime: durable transcript content is asserted byte-for-byte unchanged.
- Live canary: Not applicable.

What the tests prove: only missing `detail.kind` receives the compatibility projection, the safe summary remains typed/model-visible, the durable JSON is unchanged, and unrelated malformed observations fail closed.

Commands run:
- focused prompt-seam regression tests
- `cargo test -p ironclaw_threads tool_result_reference`
- `cargo clippy -p ironclaw_threads -p ironclaw_loop_host --all-targets --all-features -- -D warnings`
- `git diff --check`

## Security Impact

Fail-closed behavior remains for every malformed shape except the one identified legacy untagged detail. Provider/tool content is not logged. The diagnostic logs only the bounded validation reason and opaque result reference at debug level.

## Reborn Trust-Boundary Checklist

- [x] No public trust-bearing type changed.
- [x] Durable untrusted content remains unchanged and uses the existing safe summary contract.
- [x] No hashes or authenticity checks changed.
- [x] No status, policy, runtime, or serde shape changed.
- [x] The compatibility predicate is exact: object detail present, `kind` absent.
- [x] All unrelated validation failures remain terminal at projection.

## Database Impact

None. No row is rewritten, deleted, or migrated.

## Blast Radius

Tool-result reference decoding at the two model-context projection call sites.

## Rollback Plan

Revert this commit. Durable data requires no rollback.

## Review Follow-Through

No compaction budget/cut, replay-dedup, overflow recovery, or persistence behavior changed.

---

**Review track**: B