### PR TITLE
ci: validate integration group topology

### DIFF
--- a/scripts/ci/lib/integration_test_inventory.py
+++ b/scripts/ci/lib/integration_test_inventory.py
@@ -19,7 +19,9 @@ GROUP_NAME_PREFIX = "reborn_group_"
 ROOT = pathlib.Path(__file__).resolve().parents[3]
 
 
-def _registered_tests(repo_root: str | pathlib.Path = ROOT) -> list[tuple[str, str]]:
+def _registered_test_records(
+    repo_root: str | pathlib.Path = ROOT,
+) -> list[tuple[str, str]]:
     root = pathlib.Path(repo_root)
     with (root / "Cargo.toml").open("rb") as manifest:
         data = tomllib.load(manifest)
@@ -29,7 +31,14 @@ def _registered_tests(repo_root: str | pathlib.Path = ROOT) -> list[tuple[str, s
         if isinstance(entry, dict)
         and isinstance(entry.get("name"), str)
         and isinstance(entry.get("path"), str)
-        and entry["path"].startswith(INTEGRATION_PATH_PREFIX)
+    ]
+
+
+def _registered_tests(repo_root: str | pathlib.Path = ROOT) -> list[tuple[str, str]]:
+    return [
+        (path, name)
+        for path, name in _registered_test_records(repo_root)
+        if path.startswith(INTEGRATION_PATH_PREFIX)
     ]
 
 
@@ -158,7 +167,7 @@ def main(argv: list[str] | None = None) -> int:
         try:
             root = pathlib.Path(args.repo_root)
             registered_names: set[str] = set()
-            for path, name in _registered_tests(root):
+            for path, name in _registered_test_records(root):
                 if not name.startswith(GROUP_NAME_PREFIX):
                     continue
                 suffix = name.removeprefix(GROUP_NAME_PREFIX)

--- a/scripts/ci/lib/integration_test_inventory.py
+++ b/scripts/ci/lib/integration_test_inventory.py
@@ -144,9 +144,68 @@ def validate_inventory_document(document: Any) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--json", action="store_true", help="print versioned JSON")
+    output = parser.add_mutually_exclusive_group()
+    output.add_argument("--json", action="store_true", help="print versioned JSON")
+    output.add_argument(
+        "--validate-group-topology",
+        action="store_true",
+        help="validate integration group registrations and entry points",
+    )
     parser.add_argument("repo_root", nargs="?", default=str(ROOT))
     args = parser.parse_args(argv)
+
+    if args.validate_group_topology:
+        try:
+            root = pathlib.Path(args.repo_root)
+            registered_names: set[str] = set()
+            for path, name in _registered_tests(root):
+                if not name.startswith(GROUP_NAME_PREFIX):
+                    continue
+                suffix = name.removeprefix(GROUP_NAME_PREFIX)
+                expected_path = f"{INTEGRATION_PATH_PREFIX}group_{suffix}/main.rs"
+                if path != expected_path:
+                    raise ValueError(
+                        f"group registration path mismatch for {name!r}: "
+                        f"expected {expected_path!r}, found {path!r}"
+                    )
+                registered_names.add(name)
+
+            integration_root = root / INTEGRATION_PATH_PREFIX
+            group_directories = sorted(
+                entry
+                for entry in integration_root.glob("group_*")
+                if entry.is_dir()
+            )
+            incomplete = [
+                entry.name for entry in group_directories if not (entry / "main.rs").is_file()
+            ]
+            if incomplete:
+                raise ValueError(
+                    "integration test group directory missing main.rs: "
+                    + ", ".join(incomplete)
+                )
+            filesystem_names = {
+                f"{GROUP_NAME_PREFIX}{entry.name.removeprefix('group_')}"
+                for entry in group_directories
+            }
+            unregistered = sorted(filesystem_names - registered_names)
+            if unregistered:
+                raise ValueError(
+                    "unregistered integration test group(s): "
+                    + ", ".join(unregistered)
+                )
+            missing = sorted(registered_names - filesystem_names)
+            if missing:
+                raise ValueError(
+                    "registered integration test group(s) missing main.rs: "
+                    + ", ".join(missing)
+                )
+            if not group_directories:
+                raise ValueError("No integration test group directories found")
+        except (OSError, tomllib.TOMLDecodeError, ValueError) as error:
+            print(f"integration group topology error: {error}", file=sys.stderr)
+            return 1
+        return 0
 
     if args.json:
         print(json.dumps(inventory_document(args.repo_root), sort_keys=True))

--- a/scripts/ci/reborn-coverage-lane-run.sh
+++ b/scripts/ci/reborn-coverage-lane-run.sh
@@ -87,6 +87,11 @@ for lane in "${lanes[@]}"; do
   fi
 done
 
+if [[ "${run_groups}" == "true" ]]; then
+  python3 "${script_dir}/lib/integration_test_inventory.py" \
+    --validate-group-topology "${PWD}"
+fi
+
 # reborn-coverage-int-tier-tests.sh prints alternating "--test"/"<name>"
 # lines; keep only the name lines (every 2nd line, portable awk — no GNU-only
 # `sed -n 2~2p`).

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -961,6 +961,7 @@ def build_plan(
         )
 
     for path in sorted(paths):
+        path_parts = PurePosixPath(path).parts
         if path == "Cargo.lock":
             if lockfile_manifest_owned:
                 reasons.append(
@@ -1128,6 +1129,14 @@ def build_plan(
         if any(path.startswith(prefix) for prefix in group_integration_prefixes):
             integration_lanes.add("groups")
             reasons.append(f"integration group scenario changed: {path}")
+            continue
+        if (
+            len(path_parts) >= 4
+            and path_parts[:2] == ("tests", "integration")
+            and path_parts[2].startswith("group_")
+        ):
+            integration_lanes.add("groups")
+            reasons.append(f"unregistered integration group path changed: {path}")
             continue
         if path in INTEGRATION_SUPPORT_OWNERS:
             owner = INTEGRATION_SUPPORT_OWNERS[path]

--- a/scripts/ci/run-reborn-group-tests.sh
+++ b/scripts/ci/run-reborn-group-tests.sh
@@ -10,16 +10,19 @@ set -euo pipefail
 # flag is required to exercise the libsql-backed shared store.
 
 test_timeout="${REBORN_GROUP_TEST_TIMEOUT:-28m}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ponytail: S2B makes this runner consume inventory-selected names and deletes
+# the independent find/sed projection retained by this behavior-only slice.
+python3 "${script_dir}/lib/integration_test_inventory.py" \
+  --validate-group-topology "${PWD}"
 
 # The directory basename is `group_<x>`; the `[[test]]` `name` field is
 # `reborn_group_<x>` (see Cargo.toml) — the two differ by the `reborn_` prefix,
 # so rewrite it explicitly rather than assuming dir basename == test name (e.g.
-# tests/integration/group_memory -> reborn_group_memory). The `sh -c` predicate
-# skips a half-scaffolded group dir (no main.rs yet) — returning false from
-# `-exec` just filters that dir, it does NOT make `find` exit non-zero, so no
-# `|| true` is needed; genuine `find` failures stay visible under `set -e`.
-# `sh -c` (not a bare `{}/main.rs`) avoids POSIX implementation-defined `{}`
-# substring substitution so discovery is portable across GNU/BSD find.
+# tests/integration/group_memory -> reborn_group_memory). Topology validation
+# rejects incomplete and unregistered groups before this portable GNU/BSD find
+# produces the existing sorted execution order.
 mapfile -t test_names < <(
   find tests/integration -mindepth 1 -maxdepth 1 -type d -name 'group_*' \
     -exec sh -c 'test -f "$1/main.rs"' _ {} ';' -print \

--- a/scripts/ci/test-ironclaw-integration-batch-runner.sh
+++ b/scripts/ci/test-ironclaw-integration-batch-runner.sh
@@ -46,10 +46,25 @@ if PATH="${missing_nextest_path}" command -v cargo-nextest >/dev/null 2>&1; then
 fi
 
 status=0
-mkdir -p "${sandbox}/group-only"
+mkdir -p "${sandbox}/group-only/lib"
 cp "${under_test}" "${sandbox}/group-only/reborn-coverage-lane-run.sh"
+cat >"${sandbox}/group-only/lib/integration_test_inventory.py" <<'STUB'
+import os
+import sys
+
+with open(os.environ["INTEGRATION_BATCH_LOG"], "a", encoding="utf-8") as log:
+    log.write("topology-check\n")
+if sys.argv[1:] != ["--validate-group-topology", os.getcwd()]:
+    sys.exit(24)
+if os.environ.get("FAIL_GROUP_TOPOLOGY") == "true":
+    sys.exit(23)
+STUB
 cat >"${sandbox}/group-only/reborn-coverage-int-tier-tests.sh" <<'STUB'
 #!/usr/bin/env bash
+if [[ "${VALID_GROUP_COVERAGE:-false}" == "true" ]]; then
+  printf '%s\n' --test reborn_group_valid
+  exit 0
+fi
 echo "FAIL: groups-only pass/fail batch rediscovered the coverage inventory" >&2
 exit 19
 STUB
@@ -57,7 +72,7 @@ cat >"${sandbox}/group-only/run-reborn-group-tests.sh" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' group-run >>"${INTEGRATION_BATCH_LOG}"
 STUB
-chmod +x "${sandbox}/group-only/"*.sh
+chmod +x "${sandbox}/group-only/"*.sh "${sandbox}/group-only/lib/"*.py
 
 if ! (
   PATH="${sandbox}/bin:/usr/bin:/bin" \
@@ -69,8 +84,38 @@ if ! (
 ); then
   echo "FAIL: groups-only pass/fail batch did not delegate directly to the canonical group runner" >&2
   status=1
-elif [[ "$(cat "${sandbox}/group-only.log")" != "group-run" ]]; then
+elif [[ "$(cat "${sandbox}/group-only.log")" != $'topology-check\ngroup-run' ]]; then
   echo "FAIL: groups-only pass/fail batch did not invoke the canonical group runner exactly once" >&2
+  status=1
+fi
+
+coverage_status=0
+FAIL_GROUP_TOPOLOGY=true \
+  PATH="${sandbox}/bin:/usr/bin:/bin" \
+  INTEGRATION_BATCH_LOG="${sandbox}/group-coverage.log" \
+  REBORN_COV_COLLECT=true \
+  REBORN_COV_LANES_JSON='["groups"]' \
+  REBORN_COV_LANE_PARTITIONS=4 \
+  bash "${sandbox}/group-only/reborn-coverage-lane-run.sh" \
+    "${sandbox}/unused-group-coverage.lcov" || coverage_status=$?
+if [[ "${coverage_status}" -ne 23 ]] ||
+   [[ "$(cat "${sandbox}/group-coverage.log" 2>/dev/null || true)" != "topology-check" ]]; then
+  echo "FAIL: coverage groups lane did not stop at topology validation" >&2
+  status=1
+fi
+
+if ! VALID_GROUP_COVERAGE=true \
+  PATH="${sandbox}/bin:/usr/bin:/bin" \
+  INTEGRATION_BATCH_LOG="${sandbox}/valid-group-coverage.log" \
+  REBORN_COV_COLLECT=true \
+  REBORN_COV_LANES_JSON='["groups"]' \
+  REBORN_COV_LANE_PARTITIONS=4 \
+  bash "${sandbox}/group-only/reborn-coverage-lane-run.sh" \
+    "${sandbox}/valid-group-coverage.lcov"; then
+  echo "FAIL: valid coverage groups lane did not reach llvm-cov" >&2
+  status=1
+elif ! grep -q '^llvm-cov .*--test reborn_group_valid' "${sandbox}/valid-group-coverage.log"; then
+  echo "FAIL: valid coverage groups lane omitted its registered target" >&2
   status=1
 fi
 if (

--- a/scripts/ci/test_integration_test_inventory.py
+++ b/scripts/ci/test_integration_test_inventory.py
@@ -130,6 +130,28 @@ test = [
                 with self.assertRaisesRegex(ValueError, field):
                     inventory.validate_inventory_document(malformed)
 
+    def test_live_repository_group_topology_is_valid(self) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "scripts/ci/lib/integration_test_inventory.py"),
+                "--validate-group-topology",
+                str(ROOT),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(
+            completed.returncode,
+            0,
+            "live integration group topology validation failed:\n"
+            f"stdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}",
+        )
+
     def test_group_runner_rejects_invalid_topology_before_execution(self) -> None:
         cases = (
             ([], (), "No integration test group directories"),
@@ -144,6 +166,14 @@ test = [
                 [("reborn_group_missing", "tests/integration/group_missing/main.rs")],
                 (),
                 "missing main.rs",
+            ),
+            (
+                [
+                    ("reborn_group_valid", "tests/integration/group_valid/main.rs"),
+                    ("reborn_group_outside", "tests/other.rs"),
+                ],
+                ("group_valid/main.rs",),
+                "group registration path mismatch",
             ),
         )
         for registrations, group_entries, error in cases:

--- a/scripts/ci/test_integration_test_inventory.py
+++ b/scripts/ci/test_integration_test_inventory.py
@@ -1,5 +1,7 @@
 """Contract tests for the canonical integration-test inventory."""
 
+import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -12,6 +14,58 @@ import integration_test_inventory as inventory  # noqa: E402
 
 
 class IntegrationTestInventoryTests(unittest.TestCase):
+    def run_group_runner(
+        self, root: Path, registrations: list[tuple[str, str]]
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        manifest = "".join(
+            f'[[test]]\nname = "{name}"\npath = "{path}"\n\n'
+            for name, path in registrations
+        )
+        (root / "Cargo.toml").write_text(manifest, encoding="utf-8")
+
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        command_log = root / "commands.log"
+        for command, body in (
+            (
+                "timeout",
+                """#!/usr/bin/env bash
+printf 'timeout:%s\\n' "$*" >>"${COMMAND_LOG}"
+while [[ "$1" == --* ]]; do shift; done
+shift
+"$@"
+""",
+            ),
+            (
+                "cargo",
+                """#!/usr/bin/env bash
+printf 'cargo:%s\\n' "$*" >>"${COMMAND_LOG}"
+""",
+            ),
+        ):
+            executable = bin_dir / command
+            executable.write_text(body, encoding="utf-8")
+            executable.chmod(0o755)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "COMMAND_LOG": str(command_log),
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "REBORN_GROUP_TEST_TIMEOUT": "9m",
+            }
+        )
+        completed = subprocess.run(
+            [str(ROOT / "scripts/ci/run-reborn-group-tests.sh")],
+            cwd=root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        log = command_log.read_text(encoding="utf-8") if command_log.exists() else ""
+        return completed, log
+
     def test_preserves_current_registration_projections(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -75,6 +129,69 @@ test = [
             with self.subTest(field=field, value=value):
                 with self.assertRaisesRegex(ValueError, field):
                     inventory.validate_inventory_document(malformed)
+
+    def test_group_runner_rejects_invalid_topology_before_execution(self) -> None:
+        cases = (
+            ([], (), "No integration test group directories"),
+            ([], ("group_orphan/main.rs",), "unregistered integration test group"),
+            ([], ("group_incomplete/scenario.rs",), "missing main.rs"),
+            (
+                [("reborn_group_declared", "tests/integration/group_actual/main.rs")],
+                ("group_actual/main.rs",),
+                "group registration path mismatch",
+            ),
+            (
+                [("reborn_group_missing", "tests/integration/group_missing/main.rs")],
+                (),
+                "missing main.rs",
+            ),
+        )
+        for registrations, group_entries, error in cases:
+            with self.subTest(error=error), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                for entry in group_entries:
+                    group_file = root / "tests/integration" / entry
+                    group_file.parent.mkdir(parents=True)
+                    group_file.touch()
+
+                completed, command_log = self.run_group_runner(root, registrations)
+
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn(error, completed.stderr)
+                self.assertEqual(command_log, "")
+
+    def test_group_runner_preserves_valid_execution_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for suffix in ("zeta", "alpha"):
+                group = root / f"tests/integration/group_{suffix}"
+                group.mkdir(parents=True)
+                (group / "main.rs").touch()
+
+            completed, command_log = self.run_group_runner(
+                root,
+                [
+                    ("reborn_group_zeta", "tests/integration/group_zeta/main.rs"),
+                    ("reborn_group_alpha", "tests/integration/group_alpha/main.rs"),
+                ],
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(
+                command_log.splitlines(),
+                [
+                    "timeout:--signal=INT --kill-after=30s 9m cargo test -p "
+                    "ironclaw_integration_tests --test reborn_group_alpha "
+                    "--ignore-rust-version -- --nocapture",
+                    "cargo:test -p ironclaw_integration_tests --test "
+                    "reborn_group_alpha --ignore-rust-version -- --nocapture",
+                    "timeout:--signal=INT --kill-after=30s 9m cargo test -p "
+                    "ironclaw_integration_tests --test reborn_group_zeta "
+                    "--ignore-rust-version -- --nocapture",
+                    "cargo:test -p ironclaw_integration_tests --test "
+                    "reborn_group_zeta --ignore-rust-version -- --nocapture",
+                ],
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -2171,6 +2171,15 @@ class RebornPrTestPlanTests(unittest.TestCase):
         self.assertEqual(plan["mode"], "selected")
         self.assertEqual(plan["integration_lanes"], ["groups"])
 
+    def test_unregistered_group_entrypoint_selects_validation_lane(self) -> None:
+        for path in (
+            "tests/integration/group_future/main.rs",
+            "tests/integration/group_/main.rs",
+        ):
+            with self.subTest(path=path):
+                plan = self.plan("pull_request", [path])
+                self.assertEqual(plan["integration_lanes"], ["groups"])
+
     def test_shared_test_support_uses_representative_pr_lanes(self) -> None:
         root_plan = self.plan(
             "pull_request", ["tests/support/reborn_parity_qa/assertions.rs"]


### PR DESCRIPTION
## Summary

- Validate Cargo group registrations against every `tests/integration/group_*` directory before group tests execute.
- Route new or malformed group-directory paths to the groups lane so topology errors cannot fall through to a generic partition.
- Apply the same fail-closed preflight to instrumented coverage, PR/merge-queue pass/fail, and direct group-runner entry paths.
- Preserve the existing sequential timeout/Cargo execution contract; S2B will make execution consume inventory-selected names and delete the remaining `find`/`sed` projection.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check` — not applicable; no Rust changed
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not applicable; no Rust changed
- [ ] `cargo build` — not applicable; no build inputs changed
- [x] Relevant tests pass: inventory contracts, planner contracts, integration batch runner, hermetic process contracts, and coverage helper suite
- [ ] `cargo test -p <owning-crate> --features integration` — not applicable; no database/runtime behavior changed
- [x] Manual testing: validated the repository's current topology and captured pre-fix failures for orphan, incomplete, empty, and misregistered group layouts
- [ ] If a coding agent was used and supports it, `pr-shepherd` was run before requesting review

## Test Strategy

User behavior: Not applicable; this changes CI topology validation only.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: process tests drive the real group runner with fake timeout/Cargo commands; planner tests pin unknown and malformed group-directory routing; batch-runner tests pin both failing and successful instrumented groups paths.
- Reborn integration: Not applicable; no product/runtime behavior changed.
- Recorded fixture: Not applicable.
- Browser E2E: Not applicable.
- Backend or runtime: Not applicable.
- Live canary: Not applicable.

What the tests prove:

- Unregistered, incomplete, empty, missing, and path-mismatched group topologies fail before timeout or Cargo.
- A newly added group path, including malformed `group_/`, selects the groups validation lane rather than lane 0.
- Instrumented coverage invokes the validator with the exact flag/root and still reaches `cargo llvm-cov --test reborn_group_valid` for valid topology.
- Valid sequential group order, timeout arguments, Cargo arguments, and failure behavior remain unchanged.

Commands run:

```text
python3 scripts/ci/test_integration_test_inventory.py
python3 scripts/ci/test_reborn_pr_test_plan.py
scripts/ci/test-ironclaw-integration-batch-runner.sh
scripts/ci/test-hermetic-test-process.sh
scripts/ci/test-reborn-coverage.sh  # 196/196 cases
python3 scripts/ci/lib/integration_test_inventory.py --validate-group-topology .
bash -n scripts/ci/reborn-coverage-lane-run.sh scripts/ci/run-reborn-group-tests.sh scripts/ci/test-ironclaw-integration-batch-runner.sh
```

Red/green evidence: before the implementation, invalid topology reached fake Cargo and returned success; unknown group paths selected lane 0; coverage mode never logged topology validation; incomplete and empty group directories passed validation. Each now fails at the intended boundary, and the full commands above pass.

## Security Impact

None. This reads checked-in Cargo metadata and test paths only.

## Reborn Trust-Boundary Checklist

N/A: CI test inventory and routing only; no product trust boundary, runtime status, policy, queue, or serialization contract changed.

## Database Impact

None.

## Blast Radius

Touches integration-test inventory validation, planner path routing, the coverage/pass-fail lane runner, and the sequential group runner. A bad topology now fails earlier; valid topology retains the existing commands and ordering.

## Rollback Plan

Revert this PR to restore the prior late/implicit Cargo failure behavior. No persisted state or compatibility migration is involved.

## Review Follow-Through

Local approach audit converged at 93/100 before its sole normal finding was fixed. Multi-lane Correctness, Security, Performance, Design, and Coverage review findings were addressed; exact-head follow-up review found no remaining issues.

Follow-up S2B will make group execution consume inventory-selected registered names and delete the intentionally retained runner-side `find`/`sed` projection marked with `ponytail:`.

---

**Review track**: C (CI)
