### PR TITLE
fix(tools): size tool_search replies to the first-look envelope

### DIFF
--- a/crates/app/ironclaw_composition/src/runtime/capability_host.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host.rs
@@ -76,6 +76,8 @@ pub(crate) use ironclaw_assistant::{
 use ironclaw_extension_host::capability_surface::{
     ExtensionCapabilitySurface, ExtensionCapabilitySurfaceSource,
 };
+#[cfg(test)]
+use ironclaw_host_api::model_result_preview::MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES;
 #[cfg(feature = "test-support")]
 pub(crate) use ironclaw_loop_host::RESULT_READ_CAPABILITY_ID_FOR_TEST;
 #[cfg(any(test, feature = "test-support"))]
@@ -83,8 +85,6 @@ pub(crate) use ironclaw_loop_host::SKILL_ACTIVATE_CAPABILITY_ID;
 use refreshing_capability_port::{
     RefreshingCapabilityPortConfig, create_refreshing_capability_port,
 };
-#[cfg(test)]
-use result_preview::RESULT_PREVIEW_MAX_BYTES;
 use result_preview::{first_look_result_preview, result_reference_observation};
 
 #[cfg(feature = "test-support")]

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/result_preview.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/result_preview.rs
@@ -1,3 +1,4 @@
+use ironclaw_host_api::model_result_preview::MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES;
 use ironclaw_loop_contracts::{
     MODEL_VISIBLE_TOOL_OBSERVATION_SCHEMA_VERSION, ModelVisibleArtifact,
     ModelVisibleToolObservation, ObservationTrust, ToolObservationDetail, ToolObservationStatus,
@@ -5,7 +6,6 @@ use ironclaw_loop_contracts::{
 use ironclaw_threads::render_json_tool_result_page as render_json_page;
 use ironclaw_turns::LoopResultRef;
 
-pub(super) const RESULT_PREVIEW_MAX_BYTES: usize = 3 * 1024;
 const RESULT_OBSERVATION_MAX_BYTES: usize = 4 * 1024;
 const RESULT_JSON_VIEW_MIN_BYTES: usize = 4;
 const RESULT_LEGACY_PREVIEW_MAX_BYTES: usize = 2 * 1024;
@@ -29,7 +29,7 @@ pub(super) fn first_look_result_preview(
     let Ok(full_text) = std::str::from_utf8(serialized) else {
         return None;
     };
-    if full_text.len() <= RESULT_PREVIEW_MAX_BYTES {
+    if full_text.len() <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES {
         return Some(FirstLookResultPreview {
             text: full_text.to_string(),
             next_offset: None,
@@ -37,7 +37,7 @@ pub(super) fn first_look_result_preview(
         });
     }
     let mut lower = RESULT_JSON_VIEW_MIN_BYTES;
-    let mut upper = RESULT_PREVIEW_MAX_BYTES;
+    let mut upper = MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES;
     let mut best = None;
     let result_ref_text = result_ref.as_str();
     while lower <= upper {
@@ -60,7 +60,7 @@ pub(super) fn first_look_result_preview(
                 break;
             }
         };
-        if text.len() <= RESULT_PREVIEW_MAX_BYTES
+        if text.len() <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES
             && structured_preview_fits_observation(result_ref, serialized.len(), &text, item_count)
         {
             best = Some(FirstLookResultPreview {

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/tests.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/tests.rs
@@ -2098,7 +2098,9 @@ mod tests {
     /// independently-maintained copy that a shape-only rename (no size change) could silently break.
     #[test]
     fn tool_search_worst_case_reply_wrapped_observation_fits_the_first_look_ceiling() {
-        use ironclaw_host_api::model_result_preview::MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES;
+        use ironclaw_host_api::model_result_preview::{
+            MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES, MODEL_OBSERVATION_MAX_BYTES,
+        };
 
         /// Locally-derived expectation for the wrapped observation's fixed JSON scaffolding
         /// (schema_version/status/summary/detail tag/artifacts/trust, plus `result_ref` carried
@@ -2135,8 +2137,14 @@ mod tests {
              (94 '\"' characters at 2,482 B) -- if it drops below that, the test is no longer proving \
              what its own doc comment claims"
         );
-        let result_ref =
-            LoopResultRef::new("result:tool-search-worst-case").expect("valid result ref");
+        // Production-length ref, not a short literal. `result_reference_observation` carries the
+        // ref TWICE (`detail.result_ref` and `artifacts[0].artifact_ref`), so its length is a
+        // direct term in the envelope this test measures. Refs minted in a real run are 80 chars
+        // (1,164 of 1,167 observed in a pinchbench trace); a 29-char literal understates the
+        // envelope by ~100 B and would let the allowance look tighter than it is.
+        let ref_id = format!("result:{}", "t".repeat(73));
+        assert_eq!(ref_id.len(), 80, "keep this at the production ref length");
+        let result_ref = LoopResultRef::new(&ref_id).expect("valid result ref");
         let preview = first_look_result_preview(&serialized, &result_ref, None)
             .expect("worst-case reply is <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES, so it takes the verbatim pass-through branch, not the JSON pager");
         let observation =
@@ -2151,7 +2159,18 @@ mod tests {
         // change across magnitudes, a longer/shorter result_ref, a future added observation field)
         // without becoming flaky, while still failing if the allowance is raised without a matching
         // re-measurement.
-        let overhead = observation_bytes.saturating_sub(serialized.len());
+        // Isolate the FIXED envelope from the content-dependent escaping. `observation_bytes`
+        // contains the payload already JSON-string-escaped, so subtracting the RAW length would
+        // fold escaping into the measurement — and the producer charges escaping separately, via
+        // its own exact `json_string_escaped_len`. Subtracting the ESCAPED length is what leaves
+        // the fixed scaffolding this allowance is actually supposed to cover.
+        let escaped_len = serde_json::to_string(&serde_json::Value::String(
+            String::from_utf8_lossy(&serialized).into_owned(),
+        ))
+        .expect("escaped payload serializes")
+        .len()
+            - 2; // the enclosing quotes belong to the envelope, not the payload
+        let overhead = observation_bytes.saturating_sub(escaped_len);
         let slack = OBSERVATION_WRAPPER_ALLOWANCE_FOR_TEST.saturating_sub(overhead);
         assert!(
             overhead <= OBSERVATION_WRAPPER_ALLOWANCE_FOR_TEST,
@@ -2161,9 +2180,19 @@ mod tests {
             slack <= 100,
             "wrapper allowance ({OBSERVATION_WRAPPER_ALLOWANCE_FOR_TEST} B) is {slack} B more than the measured overhead ({overhead} B) -- the allowance is now wastefully generous, eating into rank 1's headroom for no reason; lower it (or justify the growth) rather than leaving slack unexplained"
         );
+        // The WRAPPED observation is bounded by MODEL_OBSERVATION_MAX_BYTES (4 KiB) — the ceiling
+        // above which `result_reference_observation` drops `preview`. It is NOT bounded by
+        // MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES (3 KiB); that one governs the RAW reply, upstream, and
+        // asserting the wrapped size against it is the same raw-vs-wrapped conflation this test
+        // exists to pin. A worst-case reply legitimately wraps to ~3.1 KB and is delivered intact.
         assert!(
-            observation_bytes <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES,
-            "got {observation_bytes} bytes, over the shared first-look ceiling"
+            observation_bytes <= MODEL_OBSERVATION_MAX_BYTES,
+            "got {observation_bytes} bytes, over the observation ceiling ({MODEL_OBSERVATION_MAX_BYTES}) — preview would be dropped"
+        );
+        assert!(
+            serialized.len() <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES,
+            "raw reply {} B is over the first-look ceiling, so it would take the paging path",
+            serialized.len()
         );
     }
 

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/tests.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/tests.rs
@@ -2098,12 +2098,21 @@ mod tests {
     /// independently-maintained copy that a shape-only rename (no size change) could silently break.
     #[test]
     fn tool_search_worst_case_reply_wrapped_observation_fits_the_first_look_ceiling() {
-        use ironclaw_host_api::model_result_preview::{
-            MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES, MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES,
-        };
-        // Both inputs are the same public constants tool_disclosure_port.rs's
-        // TOOL_SEARCH_REPLY_BUDGET_BYTES derives from (T1) -- no independent literal restated here.
-        let budget = MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES - MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES;
+        use ironclaw_host_api::model_result_preview::MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES;
+
+        /// Locally-derived expectation for the wrapped observation's fixed JSON scaffolding
+        /// (schema_version/status/summary/detail tag/artifacts/trust, plus `result_ref` carried
+        /// twice). Previously imported as
+        /// `ironclaw_host_api::model_result_preview::MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES`;
+        /// PR #7984 (review thread 11) moved that constant into
+        /// `ironclaw_loop_host::tool_disclosure_port` as `OBSERVATION_ENVELOPE_SCAFFOLDING_BYTES`
+        /// -- its one production consumer, and no longer a model-result contract `host_api` owns.
+        /// This test does not need tool_search's own budget arithmetic; it only needs a target
+        /// raw-reply size close to the first-look ceiling to measure the wrapper's overhead
+        /// against, so it keeps its own local copy of the same value instead of reaching into
+        /// loop_host's private tool_search internals.
+        const OBSERVATION_WRAPPER_ALLOWANCE_FOR_TEST: usize = 512;
+        let budget = MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES - OBSERVATION_WRAPPER_ALLOWANCE_FOR_TEST;
 
         // Grow only the `note` field until the whole payload hits the target byte size -- the other
         // fields are fixed and are what supplies the quote density (108 `"` characters at this size,
@@ -2143,14 +2152,14 @@ mod tests {
         // without becoming flaky, while still failing if the allowance is raised without a matching
         // re-measurement.
         let overhead = observation_bytes.saturating_sub(serialized.len());
-        let slack = MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES.saturating_sub(overhead);
+        let slack = OBSERVATION_WRAPPER_ALLOWANCE_FOR_TEST.saturating_sub(overhead);
         assert!(
-            overhead <= MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES,
-            "wrapper overhead was {overhead} bytes -- MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES no longer covers the real envelope, raise it in ironclaw_host_api and re-check TOOL_SEARCH_REPLY_BUDGET_BYTES still leaves room for a genuine large schema"
+            overhead <= OBSERVATION_WRAPPER_ALLOWANCE_FOR_TEST,
+            "wrapper overhead was {overhead} bytes -- OBSERVATION_WRAPPER_ALLOWANCE_FOR_TEST no longer covers the real envelope, raise it here and in ironclaw_loop_host::tool_disclosure_port::OBSERVATION_ENVELOPE_SCAFFOLDING_BYTES"
         );
         assert!(
             slack <= 100,
-            "wrapper allowance ({MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES} B) is {slack} B more than the measured overhead ({overhead} B) -- the allowance is now wastefully generous, eating into rank 1's headroom for no reason; lower it (or justify the growth) rather than leaving slack unexplained"
+            "wrapper allowance ({OBSERVATION_WRAPPER_ALLOWANCE_FOR_TEST} B) is {slack} B more than the measured overhead ({overhead} B) -- the allowance is now wastefully generous, eating into rank 1's headroom for no reason; lower it (or justify the growth) rather than leaving slack unexplained"
         );
         assert!(
             observation_bytes <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES,

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/tests.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/tests.rs
@@ -2057,9 +2057,104 @@ mod tests {
             .expect("text result has a first look");
 
         assert!(
-            preview.text.len() <= RESULT_PREVIEW_MAX_BYTES,
+            preview.text.len() <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES,
             "redacted first look was {} bytes",
             preview.text.len()
+        );
+    }
+
+    /// A payload whose `note` field grows with `pad_len` (the caller grows it to hit a target byte size)
+    /// and whose quote-character density is a deliberate UPPER BOUND on tool_search's own worst-case
+    /// escaping cost (94 `"` characters at 2,482 B, computed by
+    /// `bounded_search_output_compact_worst_case_fits_the_first_look_ceiling` in
+    /// `ironclaw_loop_host::tool_disclosure_port`) -- not a mirror of tool_search's shape. Generic
+    /// field names only (`alpha`/`beta`/.../`items`/`tag`/`flag`); none of
+    /// `query`/`results`/`guidance`/`name`/`capability_id`/`description`/`required`/`schema_complete`
+    /// appear here, so a rename of any of those in production cannot silently desync this test.
+    fn escaping_upper_bound_payload(pad_len: usize) -> serde_json::Value {
+        let entry = || {
+            serde_json::json!({
+                "alpha": "a".repeat(12),
+                "beta": "b".repeat(8),
+                "gamma": "g".repeat(8),
+                "delta": vec!["x".repeat(6); 6],
+                "epsilon": false,
+                "zeta": "z".repeat(8),
+            })
+        };
+        serde_json::json!({
+            "note": "n".repeat(pad_len),
+            "items": [entry(), entry(), entry()],
+            "tag": "sometag",
+            "flag": true,
+        })
+    }
+
+    /// This test measures wrapper overhead as an ESCAPING UPPER BOUND, not tool_search's reply
+    /// shape -- it deliberately does not mirror `query`/`results`/`guidance` or the compact-entry
+    /// field names. The integration test `tool_search_reply_rides_the_first_look_preview_inline`
+    /// (`tests/integration/tool_disclosure.rs`) is what exercises the real reply shape end to end;
+    /// coupling this byte-arithmetic test to that shape too would make it a second,
+    /// independently-maintained copy that a shape-only rename (no size change) could silently break.
+    #[test]
+    fn tool_search_worst_case_reply_wrapped_observation_fits_the_first_look_ceiling() {
+        use ironclaw_host_api::model_result_preview::{
+            MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES, MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES,
+        };
+        // Both inputs are the same public constants tool_disclosure_port.rs's
+        // TOOL_SEARCH_REPLY_BUDGET_BYTES derives from (T1) -- no independent literal restated here.
+        let budget = MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES - MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES;
+
+        // Grow only the `note` field until the whole payload hits the target byte size -- the other
+        // fields are fixed and are what supplies the quote density (108 `"` characters at this size,
+        // >= the 94 tool_search's own real worst case carries).
+        let mut pad_len = 0usize;
+        let raw_reply = loop {
+            let candidate = escaping_upper_bound_payload(pad_len);
+            let bytes = serde_json::to_vec(&candidate)
+                .expect("candidate serializes")
+                .len();
+            if bytes >= budget {
+                break candidate;
+            }
+            pad_len += 1;
+        };
+        let serialized = serde_json::to_vec(&raw_reply).expect("reply serializes");
+        assert!(
+            serialized.iter().filter(|&&b| b == b'"').count() >= 94,
+            "this payload's quote density must stay an upper bound on tool_search's real worst case \
+             (94 '\"' characters at 2,482 B) -- if it drops below that, the test is no longer proving \
+             what its own doc comment claims"
+        );
+        let result_ref =
+            LoopResultRef::new("result:tool-search-worst-case").expect("valid result ref");
+        let preview = first_look_result_preview(&serialized, &result_ref, None)
+            .expect("worst-case reply is <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES, so it takes the verbatim pass-through branch, not the JSON pager");
+        let observation =
+            result_reference_observation(&result_ref, serialized.len() as u64, Some(preview), None);
+        let observation_bytes = serde_json::to_vec(&observation)
+            .expect("observation serializes")
+            .len();
+
+        // Two-sided: `overhead <= allowance` alone only proves the allowance isn't too SMALL; it
+        // never proves it isn't wastefully large (an allowance of 5,000 would pass that assertion
+        // identically). The 100 B tolerance band absorbs ordinary jitter (a byte_len digit-width
+        // change across magnitudes, a longer/shorter result_ref, a future added observation field)
+        // without becoming flaky, while still failing if the allowance is raised without a matching
+        // re-measurement.
+        let overhead = observation_bytes.saturating_sub(serialized.len());
+        let slack = MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES.saturating_sub(overhead);
+        assert!(
+            overhead <= MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES,
+            "wrapper overhead was {overhead} bytes -- MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES no longer covers the real envelope, raise it in ironclaw_host_api and re-check TOOL_SEARCH_REPLY_BUDGET_BYTES still leaves room for a genuine large schema"
+        );
+        assert!(
+            slack <= 100,
+            "wrapper allowance ({MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES} B) is {slack} B more than the measured overhead ({overhead} B) -- the allowance is now wastefully generous, eating into rank 1's headroom for no reason; lower it (or justify the growth) rather than leaving slack unexplained"
+        );
+        assert!(
+            observation_bytes <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES,
+            "got {observation_bytes} bytes, over the shared first-look ceiling"
         );
     }
 

--- a/crates/contracts/ironclaw_host_api/src/ids.rs
+++ b/crates/contracts/ironclaw_host_api/src/ids.rs
@@ -68,6 +68,18 @@ fn is_name_char(byte: u8) -> bool {
     byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_' || byte == b'-'
 }
 
+/// This caps each dot-segment at 128 bytes, but nothing here (nor
+/// [`CapabilityId::new`] below, which calls this per segment) caps a
+/// `CapabilityId`'s *total* length across all its segments. `ironclaw_loop_host`'s
+/// `tool_search` compact-entry reply budget (`bounded_search_output` in
+/// `tool_disclosure_port.rs`) is sized against today's observed real-corpus
+/// maximum `capability_id` length (39 B), not against any guarantee this
+/// function or `CapabilityId::new` enforces — a future segment- or
+/// total-length change here should re-check
+/// `bounded_search_output_compact_worst_case_fits_the_first_look_ceiling` in
+/// that file before shipping, the same way `EXTERNAL_TOOL_CAPABILITY_PREFIX`
+/// above points a `ProviderToolName` change at `ironclaw_loop_host`'s
+/// `external_tool_capability_id`.
 fn validate_name_segment(kind: &'static str, value: &str) -> Result<(), HostApiError> {
     if value.is_empty() {
         return Err(HostApiError::invalid_id(kind, value, "must not be empty"));

--- a/crates/contracts/ironclaw_host_api/src/model_result_preview.rs
+++ b/crates/contracts/ironclaw_host_api/src/model_result_preview.rs
@@ -38,6 +38,19 @@ pub const MODEL_RESULT_JSON_PAGE_VIEW: &str = "ironclaw.json_page.v1";
 /// MODEL_RESULT_PREVIEW_MAX_BYTES (24 KiB result_read page bound).
 pub const MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES: usize = 3 * 1024;
 
+/// Ceiling the *wrapped* `ModelVisibleToolObservation` is measured against: above
+/// it, `result_reference_observation` drops `detail.preview` entirely and the model
+/// gets a reference-only "use result_read" observation instead of the content.
+///
+/// Distinct from [`MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES`], and the distinction is
+/// load-bearing: that constant bounds the RAW reply (it selects verbatim
+/// pass-through over the paging path), while this one bounds the raw reply once
+/// JSON-string-escaped into `preview` PLUS the observation's own envelope. A
+/// producer sizing itself to ride inline must satisfy both, each against the
+/// quantity it actually governs — checking the wrapped size against the raw
+/// ceiling rejects replies that would have been delivered intact.
+pub const MODEL_OBSERVATION_MAX_BYTES: usize = 4 * 1024;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ModelResultJsonPageView {
     #[serde(rename = "ironclaw.json_page.v1")]

--- a/crates/contracts/ironclaw_host_api/src/model_result_preview.rs
+++ b/crates/contracts/ironclaw_host_api/src/model_result_preview.rs
@@ -38,16 +38,6 @@ pub const MODEL_RESULT_JSON_PAGE_VIEW: &str = "ironclaw.json_page.v1";
 /// MODEL_RESULT_PREVIEW_MAX_BYTES (24 KiB result_read page bound).
 pub const MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES: usize = 3 * 1024;
 
-/// Estimated byte overhead the `ModelVisibleToolObservation` envelope adds on top of a
-/// raw capability reply body when `first_look_result_preview` passes it through verbatim
-/// (fixed JSON scaffolding — schema_version/status/summary/detail tag/artifacts/trust — plus
-/// the `result_ref` string carried twice, plus JSON-string-escaping the embedded reply text
-/// itself, which is proportional to how many `"` characters the raw reply contains).
-/// A producer that must size its OWN raw reply so the wrapped envelope still fits
-/// `MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES` subtracts this. Keep this as the one named
-/// definition — do not restate the value as a bare literal at either call site.
-pub const MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES: usize = 512;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ModelResultJsonPageView {
     #[serde(rename = "ironclaw.json_page.v1")]

--- a/crates/contracts/ironclaw_host_api/src/model_result_preview.rs
+++ b/crates/contracts/ironclaw_host_api/src/model_result_preview.rs
@@ -33,6 +33,21 @@ use serde_json::Value;
 pub const MODEL_RESULT_PREVIEW_MAX_BYTES: usize = 24 * 1024;
 pub const MODEL_RESULT_JSON_PAGE_VIEW: &str = "ironclaw.json_page.v1";
 
+/// Ceiling first_look_result_preview measures raw output against — whether a
+/// result rides inline with zero follow-up. Distinct from
+/// MODEL_RESULT_PREVIEW_MAX_BYTES (24 KiB result_read page bound).
+pub const MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES: usize = 3 * 1024;
+
+/// Estimated byte overhead the `ModelVisibleToolObservation` envelope adds on top of a
+/// raw capability reply body when `first_look_result_preview` passes it through verbatim
+/// (fixed JSON scaffolding — schema_version/status/summary/detail tag/artifacts/trust — plus
+/// the `result_ref` string carried twice, plus JSON-string-escaping the embedded reply text
+/// itself, which is proportional to how many `"` characters the raw reply contains).
+/// A producer that must size its OWN raw reply so the wrapped envelope still fits
+/// `MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES` subtracts this. Keep this as the one named
+/// definition — do not restate the value as a bare literal at either call site.
+pub const MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES: usize = 512;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ModelResultJsonPageView {
     #[serde(rename = "ironclaw.json_page.v1")]

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
@@ -570,7 +570,10 @@ static BRIDGE_TOOL_DEFINITIONS: LazyLock<Vec<(ProviderToolDefinition, u32)>> = L
                         },
                         "limit": {
                             "type": "integer",
-                            "description": "Maximum number of matching tool names to return; the bridged reply returns at most 3, ranked.",
+                            "description": format!(
+                                "Maximum number of matching tool names to return; the bridged reply returns at most {}, ranked.",
+                                crate::tool_disclosure_port::TOOL_SEARCH_INLINE_RESULT_LIMIT
+                            ),
                             "default": crate::tool_disclosure_port::TOOL_SEARCH_INLINE_RESULT_LIMIT,
                             "minimum": 1
                         }

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
@@ -998,7 +998,7 @@ fn select_promoted_definitions(
             if advertised_tokens.saturating_add(entry.est_schema_tokens)
                 > caps.defer_threshold_tokens()
             {
-                break;
+                continue;
             }
             included_names.insert(entry.definition.name.to_string());
             selected.push((entry.definition.clone(), entry.est_schema_tokens));
@@ -1908,6 +1908,84 @@ mod tests {
             ]
         );
         assert!(!names.contains(&"denied_promoted"));
+    }
+
+    /// T6 (B4, #7892 item 3): the promotion budget walk must SKIP an oversized
+    /// promoted entry and keep considering later, smaller ones -- not
+    /// `break` and drop every entry that follows it regardless of size.
+    #[test]
+    fn select_active_set_admits_a_small_promoted_entry_after_skipping_an_oversized_one() {
+        let definitions = vec![
+            fixture_tool("read_file", "Allowed core", medium_schema(0)),
+            fixture_tool("oversized_00", "Oversized promoted", large_nested_schema(1)),
+            fixture_tool("small_01", "Small promoted", medium_schema(2)),
+        ];
+        let catalog = CapabilityCatalog::new(&definitions, &[]);
+        let mut promoted = PromotedSet::default();
+        promoted.push("oversized_00");
+        promoted.push("small_01");
+
+        let bridge_tokens =
+            advertised_bridge_tool_definitions(&catalog, &CapabilitySurfacePolicy::allow_all())
+                .iter()
+                .fold(0_u32, |total, (_definition, est_schema_tokens)| {
+                    total.saturating_add(*est_schema_tokens)
+                });
+        let read_file_tokens = catalog
+            .entry_by_name("read_file")
+            .expect("read_file entry")
+            .est_schema_tokens;
+        let oversized_tokens = catalog
+            .entry_by_name("oversized_00")
+            .expect("oversized entry")
+            .est_schema_tokens;
+        let small_tokens = catalog
+            .entry_by_name("small_01")
+            .expect("small entry")
+            .est_schema_tokens;
+        assert!(
+            oversized_tokens > small_tokens,
+            "fixture setup: the oversized promoted entry must actually be larger \
+             than the small one, or this test proves nothing (oversized={oversized_tokens}, small={small_tokens})"
+        );
+
+        // Derive the budget so that core+bridges+oversized_00 crosses it but
+        // core+bridges+small_01 does not -- this is the exact boundary
+        // select_promoted_definitions checks per promoted entry.
+        let baseline = bridge_tokens.saturating_add(read_file_tokens);
+        let max_tokens = baseline.saturating_add(small_tokens);
+        assert!(
+            baseline.saturating_add(oversized_tokens) > max_tokens,
+            "fixture setup: oversized_00 alone must cross the derived budget \
+             (baseline={baseline}, oversized={oversized_tokens}, max_tokens={max_tokens})"
+        );
+
+        let active = select_active_set(
+            &catalog,
+            &promoted,
+            DisclosureCaps {
+                max_tokens,
+                max_tools: 10,
+                ctx_limit: None,
+            },
+            &CapabilitySurfacePolicy::allow_all(),
+        );
+        let names: Vec<&str> = active
+            .definitions
+            .iter()
+            .map(|definition| definition.name.as_str())
+            .collect();
+
+        assert!(active.deferred);
+        assert!(
+            names.contains(&"small_01"),
+            "small_01 must be admitted once the oversized entry ahead of it is \
+             skipped, not dropped along with it: {names:?}"
+        );
+        assert!(
+            !names.contains(&"oversized_00"),
+            "oversized_00 itself must still be excluded -- it alone still doesn't fit: {names:?}"
+        );
     }
 
     #[test]

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
@@ -571,7 +571,7 @@ static BRIDGE_TOOL_DEFINITIONS: LazyLock<Vec<(ProviderToolDefinition, u32)>> = L
                         "limit": {
                             "type": "integer",
                             "description": "Maximum number of matching tool names to return.",
-                            "default": 10,
+                            "default": crate::tool_disclosure_port::TOOL_SEARCH_INLINE_RESULT_LIMIT,
                             "minimum": 1
                         }
                     },
@@ -1664,6 +1664,11 @@ mod tests {
         assert_eq!(
             bridges[0].description,
             "Search deferred tools by name, provider, capability, or parameter vocabulary."
+        );
+        assert_eq!(
+            bridges[0].parameters["properties"]["limit"]["default"],
+            json!(crate::tool_disclosure_port::TOOL_SEARCH_INLINE_RESULT_LIMIT),
+            "tool_search's schema default must match invoke_tool_search's runtime fallback and bounded_search_output's .take() limit"
         );
     }
 

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure.rs
@@ -570,7 +570,7 @@ static BRIDGE_TOOL_DEFINITIONS: LazyLock<Vec<(ProviderToolDefinition, u32)>> = L
                         },
                         "limit": {
                             "type": "integer",
-                            "description": "Maximum number of matching tool names to return.",
+                            "description": "Maximum number of matching tool names to return; the bridged reply returns at most 3, ranked.",
                             "default": crate::tool_disclosure_port::TOOL_SEARCH_INLINE_RESULT_LIMIT,
                             "minimum": 1
                         }

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -10,7 +10,7 @@ use ironclaw_common::truncate_preview;
 use ironclaw_host_api::{
     capability_surface::CapabilitySurfacePolicy,
     ids::{AgentId, CapabilityId, InvocationId, ProjectId, ProviderToolName, TenantId, ThreadId},
-    model_result_preview::MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES,
+    model_result_preview::{MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES, MODEL_OBSERVATION_MAX_BYTES},
     resolution::{Resolution, ResolutionBatch},
     result_meta::FailureKind,
 };
@@ -376,16 +376,24 @@ fn json_string_escaped_len(raw: &str) -> usize {
 /// #7984 defect: a reply that fit under the old raw-byte check could still blow the embedded
 /// observation's budget once escaped.
 ///
-/// **Why checking only this one rule is sufficient AND conservative:** `raw_len <= escaped_len`
-/// always (escaping only ever adds bytes, never removes them), so any candidate passing this
-/// check also satisfies `first_look_result_preview`'s raw-bytes-<=-3,072-B verbatim-pass-through
-/// condition; and `MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES` (3,072 B) is itself well under
-/// `RESULT_OBSERVATION_MAX_BYTES` (4,096 B,
-/// `crates/app/ironclaw_composition/src/runtime/capability_host/result_preview.rs:9`) — a
-/// candidate that fits inside 3,072 B leaves >1 KiB of margin for the observation's own fixed
-/// JSON scaffolding (schema_version/status/summary/detail tag/artifacts/trust, plus `result_ref`
-/// carried twice), so it also fits inside the observation. One rule, both constraints, no new
-/// cross-crate constant.
+/// **Two ceilings, each checked against the quantity it actually governs.** They are different
+/// limits on different values, and collapsing them into one conservative rule silently degrades
+/// replies that would have been delivered intact:
+///
+/// 1. `raw_len <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES` (3,072 B) — `first_look_result_preview`
+///    measures the RAW reply to choose verbatim pass-through over the paging path. Fail this and
+///    the pager replaces `results` with one `omitted` descriptor (the #7928 defect).
+/// 2. `escaped_len + envelope <= MODEL_OBSERVATION_MAX_BYTES` (4,096 B) —
+///    `result_reference_observation` re-embeds the reply as a JSON-escaped string inside
+///    `detail.preview`. Fail this and it drops `preview` entirely, which reaches the model as the
+///    same nothing.
+///
+/// Escaping is content-dependent (~1 extra byte per `"` or `\`, and ordinary JSON is dense with
+/// `"`), so only check 2 can model it — that gap is the review finding this function closes. But
+/// check 2's ceiling is 4,096, NOT 3,072: measuring the *wrapped* size against the *raw* ceiling
+/// costs ~1 KiB of real headroom. Against the observed first-party corpus that alone degraded 7 of
+/// 121 replies out of their rank-1 schema for no delivery reason — every one of them wrapped to
+/// ~3.1 KB, comfortably inside 4,096.
 fn wrapped_reply_fits(candidate: &Value) -> bool {
     let Ok(serialized) = serde_json::to_vec(candidate) else {
         return false;
@@ -393,8 +401,11 @@ fn wrapped_reply_fits(candidate: &Value) -> bool {
     let Ok(raw) = std::str::from_utf8(&serialized) else {
         return false;
     };
+    if serialized.len() > MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES {
+        return false;
+    }
     json_string_escaped_len(raw).saturating_add(OBSERVATION_ENVELOPE_SCAFFOLDING_BYTES)
-        <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES
+        <= MODEL_OBSERVATION_MAX_BYTES
 }
 
 /// Builds the tool_search reply through an ordered degradation ladder — the first candidate whose

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -82,6 +82,24 @@ pub(crate) const TOOL_SEARCH_INLINE_RESULT_LIMIT: usize = 3;
 /// headroom.
 const COMPACT_DESCRIPTION_MAX_BYTES: usize = 160;
 
+/// Description cap for **rank 1 only** — the rank `TOOL_SEARCH_INVOKE_DIRECTLY_GUIDANCE` tells
+/// the model to invoke.
+///
+/// This catalog encodes routing guidance in description *tails*, and a flat 160 B cap amputates
+/// exactly that half. `builtin.http.save`'s description
+/// (`crates/kernel/ironclaw_host_runtime/src/first_party_tools/http.rs`, `WEB_SEARCH_PREFERENCE`)
+/// runs 559 B and ends "For general web research or retrieving human-facing web pages, prefer an
+/// available `web_search` tool" — the sentence that answers "which tool do I use for this?". At
+/// 160 B the model sees "...Use this capability for structure" and never learns the answer. A
+/// pinchbench trace at a791c14e59 caught the consequence: `task_eu_regulation_research` issued 9
+/// searches hunting for a web tool, never saw that sentence, abandoned the tool path and fell back
+/// to 322 `builtin.shell` calls (vs 61), scoring 0.00 against 0.89.
+///
+/// Rank 1 alone gets the larger cap because rank 1 is the entry the model is directed to act on,
+/// and because the budget cannot afford it for all three: at 640 B each the reply reaches ~3,720 B
+/// and the ladder degrades it, losing rank 1's schema. Asymmetric, deliberately.
+const RANK_ONE_DESCRIPTION_MAX_BYTES: usize = 640;
+
 /// Cap on how many `required` parameter names ride in a degraded compact entry
 /// (`RequiredParamsShape::Capped`). Untrusted, hosted-MCP tool schemas can declare an
 /// arbitrarily large `required` array — #7984 measured 20 names x 40 chars producing a
@@ -275,6 +293,17 @@ fn compact_result_entry(result: &CatalogSearchResult) -> Value {
     compact_result_entry_shaped(result, RequiredParamsShape::Full)
 }
 
+/// Rank 1's compact entry: identical to `compact_result_entry` except the description keeps its
+/// routing tail (`RANK_ONE_DESCRIPTION_MAX_BYTES`). Used for the entry rank-1 guidance points at.
+fn rank_one_compact_entry(result: &CatalogSearchResult) -> Value {
+    let mut entry = compact_result_entry_shaped(result, RequiredParamsShape::Full);
+    entry["description"] = Value::String(truncate_preview(
+        &result.description,
+        RANK_ONE_DESCRIPTION_MAX_BYTES,
+    ));
+    entry
+}
+
 /// The per-entry `required`-field degradation rungs `bounded_search_output` tries in order.
 /// Untrusted, hosted-MCP tool schemas can declare an arbitrarily large `required` array (#7984
 /// measured 20 names x 40 chars alone producing a 6,332 B RAW compact reply, over the ceiling
@@ -430,10 +459,22 @@ fn bounded_search_output(query: &str, results: Vec<CatalogSearchResult>) -> Valu
 
     // Rung a: rank 1 complete, ranks 2-3 compact with `required` full — the measured object IS
     // the returned object, no probe/clone-and-swap step for the fit check to disagree with.
+    //
+    // Rank 1 keeps its description tail (`RANK_ONE_DESCRIPTION_MAX_BYTES`): it is the entry both
+    // guidance strings point the model at, and this catalog puts "use X instead" routing at the
+    // END of descriptions, which a 160 B cap amputates. Ranks 2-3 stay at the tighter cap —
+    // affording the larger one for all three overruns the ceiling and costs rank 1 its schema.
     let compact_full: Vec<Value> = results
         .iter()
         .take(TOOL_SEARCH_INLINE_RESULT_LIMIT)
-        .map(compact_result_entry)
+        .enumerate()
+        .map(|(rank, result)| {
+            if rank == 0 {
+                rank_one_compact_entry(result)
+            } else {
+                compact_result_entry(result)
+            }
+        })
         .collect();
     let mut complete = compact_full.clone();
     complete[0]["schema_complete"] = Value::Bool(true);
@@ -4706,16 +4747,31 @@ mod tests {
             Value::Bool(false),
             "test setup must exercise the compact-fallback branch, not the schema-complete one"
         );
+        // Rank 1 keeps its routing tail: the fixture's 200 B description is under
+        // RANK_ONE_DESCRIPTION_MAX_BYTES, so it rides untruncated. This is the half of the rule
+        // that matters for tool selection -- this catalog puts "use X instead" at the END of a
+        // description, and truncating rank 1 to 160 B amputates exactly that.
         assert_eq!(
             output["results"][0]["description"]
                 .as_str()
                 .expect("description is a string")
                 .len(),
+            200,
+            "rank 1 must keep its FULL description (under RANK_ONE_DESCRIPTION_MAX_BYTES) -- this \
+             catalog puts routing guidance at the END of a description, so truncating rank 1 \
+             amputates the sentence that answers which tool to use"
+        );
+        // Ranks 2-3 stay on the tighter cap and DO cross truncate_preview's <= boundary
+        // (util.rs:34-38): 200 B in, 160 B cap, +3 B ellipsis = 163 B out. Affording rank 1's
+        // larger cap for all three ranks overruns the ceiling and costs rank 1 its schema -- the
+        // asymmetry is deliberate; if this drifts, re-check the budget arithmetic, not this line.
+        assert_eq!(
+            output["results"][1]["description"]
+                .as_str()
+                .expect("description is a string")
+                .len(),
             163,
-            "the fixture must actually cross truncate_preview's <= boundary (util.rs:34-38) -- a \
-             163 B description is the true worst case this test and the Goal section's arithmetic \
-             are built on; if this drifts back to 160 B the fixture is silently exercising the \
-             untruncated case again, not the worst case"
+            "ranks 2-3 stay capped at COMPACT_DESCRIPTION_MAX_BYTES + 3"
         );
         let bytes = serde_json::to_vec(&output).expect("reply serializes").len();
         assert!(

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -10,9 +10,7 @@ use ironclaw_common::truncate_preview;
 use ironclaw_host_api::{
     capability_surface::CapabilitySurfacePolicy,
     ids::{AgentId, CapabilityId, InvocationId, ProjectId, ProviderToolName, TenantId, ThreadId},
-    model_result_preview::{
-        MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES, MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES,
-    },
+    model_result_preview::MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES,
     resolution::{Resolution, ResolutionBatch},
     result_meta::FailureKind,
 };
@@ -39,13 +37,20 @@ use crate::tool_search::{
 
 const DISCLOSURE_INPUT_PREFIX: &str = "input:tool-disclosure:";
 
-/// The byte ceiling tool_search's own raw JSON (before the ModelVisibleToolObservation
-/// wrapper adds its envelope) must fit under. Derived from two named, imported constants —
-/// see T1 and "Wrapper-allowance measurement" below for where the allowance comes from and
-/// how it is checked two-sidedly, not merely assumed. Do not restate this subtraction as a
-/// bare literal anywhere else.
-const TOOL_SEARCH_REPLY_BUDGET_BYTES: usize =
-    MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES - MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES;
+/// Fixed JSON scaffolding a `ModelVisibleToolObservation` embedding a tool_search reply adds
+/// beyond the reply's own JSON-string-escaped size: schema_version/status/summary/detail tag/
+/// artifacts/trust fields, plus the `result_ref` string carried twice
+/// (`crates/app/ironclaw_composition/src/runtime/capability_host/result_preview.rs::result_reference_observation`).
+///
+/// **Moved here from `ironclaw_host_api::model_result_preview::MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES`
+/// (PR #7984 review thread 11).** Before this fix the allowance had to double as an estimate of
+/// escaping overhead too — content-dependent, and therefore never exact — because nothing measured
+/// the real embedding cost. Now that `wrapped_reply_fits` computes the exact escaped size itself
+/// (see below), this constant only needs to cover the truly fixed envelope, so it is no longer a
+/// content-dependent fudge factor and no longer belongs to `host_api`'s shared model-result
+/// contract: it has exactly one production consumer (this module), so it lives beside that
+/// consumer.
+const OBSERVATION_ENVELOPE_SCAFFOLDING_BYTES: usize = 512;
 
 /// How many ranks reach the model in one tool_search reply. The single definition used at
 /// BOTH the `.take(...)` below AND `invoke_tool_search`'s runtime fallback AND the advertised
@@ -72,9 +77,22 @@ pub(crate) const TOOL_SEARCH_INLINE_RESULT_LIMIT: usize = 3;
 ///
 /// **This cap is also rank 1's real competitor for budget, not a cosmetic detail** (see the Goal
 /// section's arithmetic): every byte this constant lets ranks 2-3's descriptions grow by is a byte
-/// rank 1's own schema no longer has room for under `TOOL_SEARCH_REPLY_BUDGET_BYTES`. Raising this
-/// constant without re-checking the boundary test above would silently shrink rank 1's headroom.
+/// rank 1's own schema no longer has room for under `wrapped_reply_fits`'s escaped-size check.
+/// Raising this constant without re-checking the boundary test above would silently shrink rank 1's
+/// headroom.
 const COMPACT_DESCRIPTION_MAX_BYTES: usize = 160;
+
+/// Cap on how many `required` parameter names ride in a degraded compact entry
+/// (`RequiredParamsShape::Capped`). Untrusted, hosted-MCP tool schemas can declare an
+/// arbitrarily large `required` array — #7984 measured 20 names x 40 chars producing a
+/// 6,332 B RAW compact reply on its own, over the first-look ceiling outright regardless of
+/// escaping. 8 names at the largest realistic name length (`ProviderToolName::MAX_BYTES`,
+/// 64 B) is ~576 B for the array across all three ranks combined even before this cap's own
+/// escaping accounting, comfortably inside the budget `bounded_search_output`'s later,
+/// smaller-count rungs still have to share with everything else in the reply. When even the
+/// capped array does not fit, the next rung drops the field entirely
+/// (`RequiredParamsShape::Omitted`).
+const REQUIRED_PARAMS_COMPACT_CAP: usize = 8;
 
 /// A SUCCESS results[] entry name, not a failure diagnostic (#5712 covers describe/call FAILURE branches only).
 const TOOL_SEARCH_INVOKE_DIRECTLY_GUIDANCE: &str = "rank 1 has a complete parameters schema; invoke it directly with the schema above, or via tool_call";
@@ -85,6 +103,14 @@ const TOOL_SEARCH_INVOKE_DIRECTLY_GUIDANCE: &str = "rank 1 has a complete parame
 /// Tracked as follow-up, not yet fixed.
 const TOOL_SEARCH_DESCRIBE_FOR_SCHEMA_GUIDANCE: &str = "rank 1 matched but its schema is too large to show inline; call tool_describe on it to get the full parameters schema, then invoke it";
 const TOOL_SEARCH_NO_MATCH_GUIDANCE: &str = "no deferred tool matches this query; do not search again for it; tell the user the capability is unavailable";
+/// #7984: one or more results' `required` parameter list was too large (or too many results
+/// together were too large) to show in full — an untrusted, hosted-MCP tool schema can declare
+/// an arbitrarily large `required` array. Used by the `RequiredParamsShape::Capped`/`Omitted`
+/// rungs and by the fewer-results rung, all of which still return real matches.
+const TOOL_SEARCH_TRIMMED_RESULTS_GUIDANCE: &str = "matched results' parameter lists were too large to show in full; call tool_describe on a result to see its complete required parameters, then invoke it";
+/// The floor rung: even a single trimmed result did not fit. Returned with an empty `results`
+/// array, so unlike every guidance string above, this one must not imply any result is present.
+const TOOL_SEARCH_QUERY_TOO_BROAD_GUIDANCE: &str = "no result fit within the reply size limit; narrow the query (e.g. a more specific tool name) and search again";
 
 /// Internal bridge name for an auto-loaded schema (describe-first) response.
 ///
@@ -223,42 +249,6 @@ enum BridgeKind {
     Call,
 }
 
-struct BoundedCountingWriter {
-    bytes_written: usize,
-    limit: usize,
-}
-
-impl std::io::Write for BoundedCountingWriter {
-    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
-        let Some(next) = self.bytes_written.checked_add(buffer.len()) else {
-            return Err(std::io::Error::other(
-                "serialized schema exceeds byte limit",
-            ));
-        };
-        if next > self.limit {
-            return Err(std::io::Error::other(
-                "serialized schema exceeds byte limit",
-            ));
-        }
-        self.bytes_written = next;
-        Ok(buffer.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-fn serialized_len_within(value: &Value, limit: usize) -> Option<usize> {
-    let mut writer = BoundedCountingWriter {
-        bytes_written: 0,
-        limit,
-    };
-    serde_json::to_writer(&mut writer, value)
-        .ok()
-        .map(|()| writer.bytes_written)
-}
-
 /// Shared 4-field core: D11's `compact_search_results` and tool_search's own `compact_result_entry` both build from here, then diverge.
 fn compact_result_fields(result: &CatalogSearchResult) -> Value {
     json!({"name": result.name, "capability_id": result.capability_id.as_str(), "description": result.description, "required": result.required_params})
@@ -282,54 +272,213 @@ fn compact_search_results(results: Vec<CatalogSearchResult>) -> Vec<Value> {
 /// module-private, not part of `dispatch`'s public surface) — do NOT add a fourth; this is exactly the
 /// class of duplication `truncate_preview` reuse here avoids repeating.
 fn compact_result_entry(result: &CatalogSearchResult) -> Value {
+    compact_result_entry_shaped(result, RequiredParamsShape::Full)
+}
+
+/// The per-entry `required`-field degradation rungs `bounded_search_output` tries in order.
+/// Untrusted, hosted-MCP tool schemas can declare an arbitrarily large `required` array (#7984
+/// measured 20 names x 40 chars alone producing a 6,332 B RAW compact reply, over the ceiling
+/// outright) — this is the escape hatch that keeps one pathological schema from taking the whole
+/// tool_search reply over budget, on every return path, not only the schema-complete one.
+#[derive(Debug, Clone, Copy)]
+enum RequiredParamsShape {
+    /// Every declared required-param name, unmodified.
+    Full,
+    /// At most `REQUIRED_PARAMS_COMPACT_CAP` names; the rest are dropped silently (the entry
+    /// still declares `schema_complete: false`, so the model already knows to call
+    /// `tool_describe` for the authoritative full schema).
+    Capped,
+    /// The `required` field is absent from the entry entirely.
+    Omitted,
+}
+
+/// One rank's compact entry: D11's core fields plus a truncated description,
+/// `schema_complete:false`, and `required` shaped per `shape`. `name`/`description` are capped by
+/// construction (name <= `ProviderToolName::MAX_BYTES` 64 B, description <=
+/// `COMPACT_DESCRIPTION_MAX_BYTES` + 3 = 163 B worst case, per the note above — `truncate_preview`
+/// appends "..." after the cap, not within it); `capability_id`/`required` are NOT bounded by
+/// construction (an untrusted hosted-MCP schema controls both), which is exactly why the caller
+/// (`bounded_search_output`) always re-measures the candidate it builds from this rather than
+/// trusting a per-entry cap alone.
+///
+/// Truncation uses the EXISTING `ironclaw_common::truncate_preview` (`crates/contracts/ironclaw_common/src/util.rs:34`)
+/// rather than a new helper — `ironclaw_common` is already a dependency of `ironclaw_loop_host`
+/// (`crates/loop/ironclaw_loop_host/Cargo.toml:31`) and the function is already live production code,
+/// used at `crates/domains/ironclaw_llm/src/nearai_chat.rs:768`. Note: `truncate_preview` appends
+/// `"..."` on truncation and re-closes a `<tool_output>` tag if truncation cut through one — the
+/// tag-closing branch is a no-op for a plain description string, and the `"..."` suffix is a
+/// (desirable) behavior change from the earlier no-suffix sketch: it signals to the model that the
+/// description was cut. A THIRD copy of this byte-boundary-walk already exists as a private helper —
+/// `ironclaw_host_api::dispatch::truncate_at_char_boundary` (`crates/contracts/ironclaw_host_api/src/dispatch.rs:91`,
+/// module-private, not part of `dispatch`'s public surface) — do NOT add a fourth; this is exactly the
+/// class of duplication `truncate_preview` reuse here avoids repeating.
+fn compact_result_entry_shaped(result: &CatalogSearchResult, shape: RequiredParamsShape) -> Value {
     let mut entry = compact_result_fields(result);
     entry["description"] = Value::String(truncate_preview(
         &result.description,
         COMPACT_DESCRIPTION_MAX_BYTES,
     ));
     entry["schema_complete"] = Value::Bool(false);
+    match shape {
+        RequiredParamsShape::Full => {}
+        RequiredParamsShape::Capped => {
+            if result.required_params.len() > REQUIRED_PARAMS_COMPACT_CAP {
+                entry["required"] = Value::Array(
+                    result
+                        .required_params
+                        .iter()
+                        .take(REQUIRED_PARAMS_COMPACT_CAP)
+                        .cloned()
+                        .map(Value::String)
+                        .collect(),
+                );
+            }
+        }
+        RequiredParamsShape::Omitted => {
+            if let Value::Object(fields) = &mut entry {
+                fields.remove("required");
+            }
+        }
+    }
     entry
 }
 
 /// Build the JSON reply carrying `guidance`. Every caller passes the exact guidance string the
 /// returned value will carry: the value measured here is the value returned — do not reintroduce
 /// a probe that measures a different object than it returns.
-///
-/// Only the schema-complete branch (below) re-measures its candidate at runtime via
-/// `serialized_len_within`. The no-match and compact-fallback branches carry no runtime byte
-/// check — their bound rests on the compact-entry field caps (`name`/`description` enforced by
-/// construction, `capability_id`/`required` bounded only by today's observed corpus — see the
-/// Goal section's "Compact-path worst case" table) plus `MAX_SEARCH_QUERY_BYTES`, and are pinned
-/// only by `bounded_search_output_compact_worst_case_fits_the_first_look_ceiling` and the
-/// `over_output`/no-match test assertions below — a test-time pin, not a runtime guard.
 fn search_reply(query: &str, results: Vec<Value>, guidance: &'static str) -> Value {
     json!({"query": query, "results": results, "guidance": guidance})
 }
 
-/// Ranks 1..=TOOL_SEARCH_INLINE_RESULT_LIMIT always ride compact (bounded by construction); rank 1
-/// gets exactly ONE additional check: does the reply carrying its own full schema, WITH its real
-/// guidance string already in place, fit the budget? The value tested for fit and the value
-/// returned are the same value — no probe, no clone-and-swap, no separate "what guidance would we
-/// use if this fit" step for the fit check to silently disagree with. This is the ONLY branch with
-/// a runtime fit check; see `search_reply`'s doc comment immediately above for what that does and
-/// does not mean for the other two branches.
+/// Exact number of bytes `raw` occupies once JSON-string-escaped, quotes excluded. Computed by
+/// asking serde_json to perform the escaping (NOT approximated by a per-`"`-or-`\` multiplier):
+/// serializing a `Value::String(raw)` performs the exact same escaping
+/// `result_reference_observation`'s embedding of the reply into `detail.preview` performs
+/// (`crates/app/ironclaw_composition/src/runtime/capability_host/result_preview.rs`), so this
+/// measurement cannot drift from the embedding cost it predicts.
+fn json_string_escaped_len(raw: &str) -> usize {
+    match serde_json::to_string(&Value::String(raw.to_string())) {
+        Ok(quoted) => quoted.len().saturating_sub(2), // strip the wrapping `"` .. `"`
+        // Serializing a `Value::String` cannot fail in practice (no custom Serialize impl, no
+        // writer I/O) — this arm exists only so the function has no panic path. Treat the
+        // impossible error as an infinite cost so a candidate is never mistakenly accepted.
+        Err(_) => usize::MAX,
+    }
+}
+
+/// Whether returning `candidate` as the tool_search reply keeps the resulting
+/// `ModelVisibleToolObservation.detail.preview` within `MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES`.
+///
+/// Bounds the ESCAPED size, not the raw size: the reply does not reach the model as raw bytes —
+/// `result_reference_observation` re-embeds it as a JSON-escaped string inside `detail.preview`,
+/// and escaping cost is content-dependent (~1 extra byte per `"` or `\` in the raw reply, and
+/// ordinary JSON is dense with `"`), so a fixed raw-byte budget cannot model it. That gap is the
+/// #7984 defect: a reply that fit under the old raw-byte check could still blow the embedded
+/// observation's budget once escaped.
+///
+/// **Why checking only this one rule is sufficient AND conservative:** `raw_len <= escaped_len`
+/// always (escaping only ever adds bytes, never removes them), so any candidate passing this
+/// check also satisfies `first_look_result_preview`'s raw-bytes-<=-3,072-B verbatim-pass-through
+/// condition; and `MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES` (3,072 B) is itself well under
+/// `RESULT_OBSERVATION_MAX_BYTES` (4,096 B,
+/// `crates/app/ironclaw_composition/src/runtime/capability_host/result_preview.rs:9`) — a
+/// candidate that fits inside 3,072 B leaves >1 KiB of margin for the observation's own fixed
+/// JSON scaffolding (schema_version/status/summary/detail tag/artifacts/trust, plus `result_ref`
+/// carried twice), so it also fits inside the observation. One rule, both constraints, no new
+/// cross-crate constant.
+fn wrapped_reply_fits(candidate: &Value) -> bool {
+    let Ok(serialized) = serde_json::to_vec(candidate) else {
+        return false;
+    };
+    let Ok(raw) = std::str::from_utf8(&serialized) else {
+        return false;
+    };
+    json_string_escaped_len(raw).saturating_add(OBSERVATION_ENVELOPE_SCAFFOLDING_BYTES)
+        <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES
+}
+
+/// Builds the tool_search reply through an ordered degradation ladder — the first candidate whose
+/// ESCAPED size (see `wrapped_reply_fits`) fits the shared first-look ceiling wins, so the reply
+/// fits by construction for ANY input, including an adversarial/untrusted hosted-MCP schema:
+///
+/// a. rank 1 complete: its own full parameter schema, ranks 2-3 compact with `required` full.
+/// b. all-compact: no rank carries a schema, `required` still full.
+/// c. all-compact with `required` capped (`RequiredParamsShape::Capped`), then omitted entirely
+///    (`RequiredParamsShape::Omitted`) if capping alone still does not fit.
+/// d. progressively fewer results (3 -> 2 -> 1), `required` omitted.
+/// e. the floor: query + guidance + an empty `results` array. Always fits (bounded query, no
+///    result content, a static guidance string), so the ladder always terminates.
+///
+/// Every non-floor rung keeps a real, non-empty `results` array and a guidance string that stays
+/// true for what it actually returns — the floor rung is the only one that returns zero results,
+/// and the only one using `TOOL_SEARCH_QUERY_TOO_BROAD_GUIDANCE`.
 fn bounded_search_output(query: &str, results: Vec<CatalogSearchResult>) -> Value {
-    let compact: Vec<Value> = results
+    let Some(rank_one) = results.first() else {
+        return search_reply(query, Vec::new(), TOOL_SEARCH_NO_MATCH_GUIDANCE);
+    };
+
+    // Rung a: rank 1 complete, ranks 2-3 compact with `required` full — the measured object IS
+    // the returned object, no probe/clone-and-swap step for the fit check to disagree with.
+    let compact_full: Vec<Value> = results
         .iter()
         .take(TOOL_SEARCH_INLINE_RESULT_LIMIT)
         .map(compact_result_entry)
         .collect();
-    let Some(rank_one) = results.first() else {
-        return search_reply(query, compact, TOOL_SEARCH_NO_MATCH_GUIDANCE);
-    };
-    let mut complete = compact.clone();
+    let mut complete = compact_full.clone();
     complete[0]["schema_complete"] = Value::Bool(true);
     complete[0]["parameters"] = rank_one.parameters.clone();
     let candidate = search_reply(query, complete, TOOL_SEARCH_INVOKE_DIRECTLY_GUIDANCE);
-    if serialized_len_within(&candidate, TOOL_SEARCH_REPLY_BUDGET_BYTES).is_some() {
-        return candidate; // the measured object IS the returned object
+    if wrapped_reply_fits(&candidate) {
+        return candidate;
     }
-    search_reply(query, compact, TOOL_SEARCH_DESCRIBE_FOR_SCHEMA_GUIDANCE)
+
+    // Rung b: all-compact, `required` still full.
+    let candidate = search_reply(
+        query,
+        compact_full,
+        TOOL_SEARCH_DESCRIBE_FOR_SCHEMA_GUIDANCE,
+    );
+    if wrapped_reply_fits(&candidate) {
+        return candidate;
+    }
+
+    // Rung c (capped): all-compact, `required` capped to REQUIRED_PARAMS_COMPACT_CAP names.
+    let compact_capped: Vec<Value> = results
+        .iter()
+        .take(TOOL_SEARCH_INLINE_RESULT_LIMIT)
+        .map(|result| compact_result_entry_shaped(result, RequiredParamsShape::Capped))
+        .collect();
+    let candidate = search_reply(query, compact_capped, TOOL_SEARCH_TRIMMED_RESULTS_GUIDANCE);
+    if wrapped_reply_fits(&candidate) {
+        return candidate;
+    }
+
+    // Rung c (omitted): all-compact, `required` dropped entirely — the smallest per-entry shape.
+    let compact_omitted: Vec<Value> = results
+        .iter()
+        .take(TOOL_SEARCH_INLINE_RESULT_LIMIT)
+        .map(|result| compact_result_entry_shaped(result, RequiredParamsShape::Omitted))
+        .collect();
+    let candidate = search_reply(
+        query,
+        compact_omitted.clone(),
+        TOOL_SEARCH_TRIMMED_RESULTS_GUIDANCE,
+    );
+    if wrapped_reply_fits(&candidate) {
+        return candidate;
+    }
+
+    // Rung d: progressively fewer of the smallest-shape entries (2, then 1).
+    for keep in (1..TOOL_SEARCH_INLINE_RESULT_LIMIT).rev() {
+        let subset: Vec<Value> = compact_omitted.iter().take(keep).cloned().collect();
+        let candidate = search_reply(query, subset, TOOL_SEARCH_TRIMMED_RESULTS_GUIDANCE);
+        if wrapped_reply_fits(&candidate) {
+            return candidate;
+        }
+    }
+
+    // Rung e: the floor. Always fits — bounded query, no result content, static guidance.
+    search_reply(query, Vec::new(), TOOL_SEARCH_QUERY_TOO_BROAD_GUIDANCE)
 }
 
 impl BridgeKind {
@@ -1300,12 +1449,26 @@ impl ToolDisclosureCapabilityPort {
             let mut guard = self.turn_state()?;
             let Some(state) = guard.as_mut() else {
                 return Ok(failed_recoverable(
-                    FailureKind::InputEncode,
+                    FailureKind::Unavailable,
                     "tool catalog is unavailable",
                 ));
             };
+            // In complete-signature mode the reply carries at most
+            // TOOL_SEARCH_INLINE_RESULT_LIMIT results regardless of the caller's `limit` (see
+            // `bounded_search_output`'s own `.take(...)`), and `AuthorizedToolSearchIndex::search`
+            // scores the WHOLE corpus before truncating to `limit` — so narrowing `limit` here
+            // cannot change which ranks come first, only how many the index bothers to
+            // canonicalize (`state.catalog.search_result`) below. Capping avoids materializing and
+            // immediately discarding ranks 4-50 on every complete-signature search. The Compact
+            // control arm (unbounded by design, see below) must keep using the caller's full
+            // `limit`.
+            let limit_for_search = if self.mode.includes_complete_signatures() {
+                limit.min(TOOL_SEARCH_INLINE_RESULT_LIMIT)
+            } else {
+                limit
+            };
             let search_started_at = std::time::Instant::now();
-            let outcome = state.search_index.search(query, limit);
+            let outcome = state.search_index.search(query, limit_for_search);
             debug!(
                 target: "ironclaw::reborn::tool_search",
                 query_class = outcome.query_class.as_str(),
@@ -1375,7 +1538,7 @@ impl ToolDisclosureCapabilityPort {
             let mut guard = self.turn_state()?;
             let Some(state) = guard.as_mut() else {
                 return Ok(failed_recoverable(
-                    FailureKind::InputEncode,
+                    FailureKind::Unavailable,
                     "tool catalog is unavailable",
                 ));
             };
@@ -1435,13 +1598,13 @@ impl ToolDisclosureCapabilityPort {
             let mut guard = self.turn_state()?;
             let Some(state) = guard.as_mut() else {
                 return Ok(failed_recoverable(
-                    FailureKind::InputEncode,
+                    FailureKind::Unavailable,
                     "tool catalog is unavailable",
                 ));
             };
             let Some(result) = state.catalog.search_result(name) else {
                 return Ok(failed_recoverable(
-                    FailureKind::InputEncode,
+                    FailureKind::UnknownCapability,
                     "auto-schema target is unknown",
                 ));
             };
@@ -4256,6 +4419,46 @@ mod tests {
         );
     }
 
+    /// Test-only now: production's fit check moved from a fixed raw-byte comparison
+    /// (`serialized_len_within` against a byte ceiling) to the exact escaped-size check
+    /// `wrapped_reply_fits` performs (see #7984). Kept here as a focused unit test of the
+    /// bounded-writer byte-counting mechanics themselves.
+    struct BoundedCountingWriter {
+        bytes_written: usize,
+        limit: usize,
+    }
+
+    impl std::io::Write for BoundedCountingWriter {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            let Some(next) = self.bytes_written.checked_add(buffer.len()) else {
+                return Err(std::io::Error::other(
+                    "serialized schema exceeds byte limit",
+                ));
+            };
+            if next > self.limit {
+                return Err(std::io::Error::other(
+                    "serialized schema exceeds byte limit",
+                ));
+            }
+            self.bytes_written = next;
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn serialized_len_within(value: &Value, limit: usize) -> Option<usize> {
+        let mut writer = BoundedCountingWriter {
+            bytes_written: 0,
+            limit,
+        };
+        serde_json::to_writer(&mut writer, value)
+            .ok()
+            .map(|()| writer.bytes_written)
+    }
+
     #[test]
     fn bounded_schema_measurement_stops_at_the_limit() {
         let schema = json!({"value": "x".repeat(1_000_000)});
@@ -4364,25 +4567,43 @@ mod tests {
         let rank_two = search_result_with_schema("rank_two", json!({"type": "object"}));
         let rank_three = search_result_with_schema("rank_three", json!({"type": "object"}));
 
-        // Measure the reply at pad_len=0 to derive the exact byte where it crosses the
-        // budget -- padding is an unescaped ASCII string, so it grows the reply
-        // byte-for-byte; this DERIVES the boundary instead of guessing at it.
-        let baseline = search_result_with_schema("rank_one", schema_of_pad_len(0));
-        let baseline_output = bounded_search_output(
-            "query",
-            vec![baseline.clone(), rank_two.clone(), rank_three.clone()],
-        );
-        assert_eq!(
-            baseline_output["results"][0]["schema_complete"],
-            Value::Bool(true),
+        // Whether rank 1's own complete-schema candidate (rung a) fits at a given pad_len.
+        // Padding is unescaped ASCII, so it grows both the raw AND the JSON-string-escaped size
+        // byte-for-byte -- `fits_at` is therefore monotonic decreasing in pad_len, so binary
+        // search finds the EXACT byte the escaped-size check flips at, deriving the boundary
+        // from the real (fixed) check rather than assuming raw bytes == embedded bytes (the
+        // assumption #7984's escaping defect broke).
+        let fits_at = |pad_len: usize| -> bool {
+            let rank_one = search_result_with_schema("rank_one", schema_of_pad_len(pad_len));
+            let output = bounded_search_output(
+                "query",
+                vec![rank_one, rank_two.clone(), rank_three.clone()],
+            );
+            output["results"][0]["schema_complete"] == Value::Bool(true)
+        };
+
+        assert!(
+            fits_at(0),
             "pad_len=0 baseline must itself fit, or the derived boundary below is meaningless"
         );
-        let baseline_bytes = serde_json::to_vec(&baseline_output)
-            .expect("reply serializes")
-            .len();
-        let headroom = TOOL_SEARCH_REPLY_BUDGET_BYTES - baseline_bytes;
+        let mut lower = 0usize; // known to fit
+        let mut upper = 8192usize; // must not fit -- checked next
+        assert!(
+            !fits_at(upper),
+            "search upper bound must itself not fit; widen it if this assertion fires"
+        );
+        while upper - lower > 1 {
+            let mid = lower + (upper - lower) / 2;
+            if fits_at(mid) {
+                lower = mid;
+            } else {
+                upper = mid;
+            }
+        }
+        // `lower` = the largest pad_len that still fits ("just under"); `upper` = `lower + 1`,
+        // the smallest pad_len that does not ("just over").
 
-        let just_under = search_result_with_schema("rank_one", schema_of_pad_len(headroom));
+        let just_under = search_result_with_schema("rank_one", schema_of_pad_len(lower));
         let under_output = bounded_search_output(
             "query",
             vec![just_under.clone(), rank_two.clone(), rank_three.clone()],
@@ -4404,7 +4625,7 @@ mod tests {
                 <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES
         );
 
-        let just_over = search_result_with_schema("rank_one", schema_of_pad_len(headroom + 1));
+        let just_over = search_result_with_schema("rank_one", schema_of_pad_len(upper));
         let over_output = bounded_search_output("query", vec![just_over, rank_two, rank_three]);
         assert_eq!(
             over_output["results"][0]["schema_complete"],
@@ -4507,6 +4728,104 @@ mod tests {
             required_params: vec!["value".to_string()],
             parameters,
         }
+    }
+
+    /// #7984 defect 2: escaping cost is content-dependent, so a fixed raw-byte budget cannot
+    /// model it. Build a result whose `required` names and `description` are saturated with `"`
+    /// and `\` -- each occurrence costs an EXTRA byte once JSON-string-escaped into
+    /// `detail.preview`, on top of the escaping the raw candidate's own JSON serialization
+    /// already performs on them (a `"`/`\` inside a JSON string value is escaped once building
+    /// the raw reply, then escaped AGAIN embedding that raw reply as a string) -- so a handful of
+    /// these characters costs far more than their raw byte count suggests.
+    fn escape_heavy_required_name(seed: usize) -> String {
+        format!(
+            "\"param_{seed}\"_with\\backslash_and_\"quotes\"_{}",
+            "\\\"".repeat(6)
+        )
+    }
+
+    #[test]
+    fn bounded_search_output_degrades_for_escape_heavy_content() {
+        let mut rank_one = search_result_with_schema("rank_one", json!({"type": "object"}));
+        rank_one.description = format!(
+            "\"escape\\heavy\" description with lots of \\\"quoted\\\" segments: {}",
+            "\\\"".repeat(40)
+        );
+        rank_one.required_params = (0..10).map(escape_heavy_required_name).collect();
+        let mut rank_two = search_result_with_schema("rank_two", json!({"type": "object"}));
+        rank_two.description = rank_one.description.clone();
+        rank_two.required_params = rank_one.required_params.clone();
+        let mut rank_three = search_result_with_schema("rank_three", json!({"type": "object"}));
+        rank_three.description = rank_one.description.clone();
+        rank_three.required_params = rank_one.required_params.clone();
+
+        let output = bounded_search_output("query", vec![rank_one, rank_two, rank_three]);
+
+        // A real, non-empty reply -- not a panic, and not the empty floor rung.
+        let results = output["results"]
+            .as_array()
+            .expect("results is an array")
+            .clone();
+        assert!(
+            !results.is_empty(),
+            "escape-heavy content must still return real matches, not the empty floor"
+        );
+        // The SAME escaped-size check production enforces -- proves the reply fits by
+        // construction, not merely that this test forgot to check.
+        assert!(
+            wrapped_reply_fits(&output),
+            "escape-heavy reply must fit the escaped-size budget: {}",
+            serde_json::to_string(&output).expect("serializes")
+        );
+    }
+
+    #[test]
+    fn bounded_search_output_degrades_for_wide_required_array() {
+        // #7984 defect 1: an untrusted/dynamic (e.g. hosted-MCP) tool schema can declare an
+        // arbitrarily large `required` array. 20 names x 40 chars alone produces a 6,332 B RAW
+        // compact reply -- over the 3,072 B first-look ceiling outright, regardless of escaping,
+        // so the compact fallback (which previously had NO runtime check at all) must itself
+        // degrade.
+        let wide_required: Vec<String> = (0..20)
+            .map(|index: usize| format!("required_param_name_{index:02}_{}", "p".repeat(17)))
+            .collect();
+        assert_eq!(
+            wide_required[0].len(),
+            40,
+            "fixture must actually be 40 B per name, matching the Goal section's worst case"
+        );
+        let mut rank_one = search_result_with_schema("rank_one", json!({"type": "object"}));
+        rank_one.required_params = wide_required.clone();
+        let mut rank_two = search_result_with_schema("rank_two", json!({"type": "object"}));
+        rank_two.required_params = wide_required.clone();
+        let mut rank_three = search_result_with_schema("rank_three", json!({"type": "object"}));
+        rank_three.required_params = wide_required;
+
+        let output = bounded_search_output("query", vec![rank_one, rank_two, rank_three]);
+
+        let results = output["results"]
+            .as_array()
+            .expect("results is an array")
+            .clone();
+        assert!(
+            !results.is_empty(),
+            "a wide required array must still return real matches, not the empty floor"
+        );
+        assert!(
+            wrapped_reply_fits(&output),
+            "wide-required-array reply must fit the escaped-size budget: {}",
+            serde_json::to_string(&output).expect("serializes")
+        );
+        // The degradation actually fired: the 20-name array did not ride through unbounded.
+        let required_len = results[0]["required"]
+            .as_array()
+            .map(|array| array.len())
+            .unwrap_or(0);
+        assert!(
+            required_len < 20,
+            "required array must have been capped or omitted, not passed through unbounded \
+             (got {required_len} entries)"
+        );
     }
 
     fn disclosure_port(

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -6,9 +6,13 @@ use std::{
 use crate::{CapabilityResultWrite, DurablePersistence, LoopCapabilityResultWriter};
 use async_trait::async_trait;
 use futures::future::join_all;
+use ironclaw_common::truncate_preview;
 use ironclaw_host_api::{
     capability_surface::CapabilitySurfacePolicy,
     ids::{AgentId, CapabilityId, InvocationId, ProjectId, ProviderToolName, TenantId, ThreadId},
+    model_result_preview::{
+        MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES, MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES,
+    },
     resolution::{Resolution, ResolutionBatch},
 };
 use ironclaw_loop_contracts::{
@@ -34,15 +38,46 @@ use crate::tool_search::{
 
 const DISCLOSURE_INPUT_PREFIX: &str = "input:tool-disclosure:";
 
-/// Maximum canonical JSON bytes for the complete `tool_search` response.
-/// This mirrors the model-visible inline result ceiling: a result may claim a
-/// complete schema only when the query, metadata, schemas, and JSON envelope
-/// all fit in the bytes the model receives without a follow-up `result_read`.
-const MAX_SEARCH_RESPONSE_BYTES: usize = 24 * 1024;
+/// The byte ceiling tool_search's own raw JSON (before the ModelVisibleToolObservation
+/// wrapper adds its envelope) must fit under. Derived from two named, imported constants —
+/// see T1 and "Wrapper-allowance measurement" below for where the allowance comes from and
+/// how it is checked two-sidedly, not merely assumed. Do not restate this subtraction as a
+/// bare literal anywhere else.
+const TOOL_SEARCH_REPLY_BUDGET_BYTES: usize =
+    MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES - MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES;
 
-/// A single schema above this ceiling stays discoverable but requires
-/// `tool_describe`; this prevents one result from consuming the whole budget.
-const MAX_SEARCH_SIGNATURE_BYTES_PER_RESULT: usize = 8 * 1024;
+/// How many ranks reach the model in one tool_search reply. The single definition used at
+/// BOTH the `.take(...)` below AND `invoke_tool_search`'s runtime fallback AND the advertised
+/// schema `"default"` in tool_disclosure.rs — keep all three reading this one constant so
+/// drift between them is a compile-time impossibility, not a silent mismatch.
+pub(crate) const TOOL_SEARCH_INLINE_RESULT_LIMIT: usize = 3;
+
+/// One-line description cap (UTF-8 char boundary). Live GitHub tool descriptions run up to
+/// 116 B today (independently scanning every `description = "..."` in
+/// `crates/extensions/packages/github/manifest.toml`'s 50 tool entries finds 3 over 70 B, the
+/// longest 116 B, `github.list_repos`'s description at manifest.toml:500; 47 of 50 stay
+/// <=70 B). This constant guards a future longer one, bounding every compact entry by
+/// construction regardless — 116 B is still well under the 163 B worst case below.
+///
+/// **Byte-accounting note:** `truncate_preview` (`crates/contracts/ironclaw_common/src/util.rs:34`)
+/// appends its `"..."` ellipsis AFTER truncating to `max_bytes` rather than reserving room for it,
+/// and its `<tool_output>` re-close branch is inert here (a tool/schema description never starts
+/// with `<tool_output`). So the true worst case is `COMPACT_DESCRIPTION_MAX_BYTES + 3` = **163 B**,
+/// not 160. We pass 160 as the cap; the helper may return up to 163; every byte accounting below
+/// (the compact-entry bound and the required/capability_id comparison) uses 163 B, not 160, as the
+/// worst case. We do not shrink this constant to 157 to force a round 160 B result — that would be
+/// a cosmetic bandaid over the same helper behavior.
+///
+/// **This cap is also rank 1's real competitor for budget, not a cosmetic detail** (see the Goal
+/// section's arithmetic): every byte this constant lets ranks 2-3's descriptions grow by is a byte
+/// rank 1's own schema no longer has room for under `TOOL_SEARCH_REPLY_BUDGET_BYTES`. Raising this
+/// constant without re-checking the boundary test above would silently shrink rank 1's headroom.
+const COMPACT_DESCRIPTION_MAX_BYTES: usize = 160;
+
+/// A SUCCESS results[] entry name, not a failure diagnostic (#5712 covers describe/call FAILURE branches only).
+const TOOL_SEARCH_INVOKE_DIRECTLY_GUIDANCE: &str = "rank 1 has a complete parameters schema; invoke it directly with the schema above, or via tool_call";
+const TOOL_SEARCH_DESCRIBE_FOR_SCHEMA_GUIDANCE: &str = "rank 1 matched but its schema is too large to show inline; call tool_describe on it to get the full parameters schema, then invoke it";
+const TOOL_SEARCH_NO_MATCH_GUIDANCE: &str = "no deferred tool matches this query; do not search again for it; tell the user the capability is unavailable";
 
 /// Internal bridge name for an auto-loaded schema (describe-first) response.
 ///
@@ -217,65 +252,77 @@ fn serialized_len_within(value: &Value, limit: usize) -> Option<usize> {
         .map(|()| writer.bytes_written)
 }
 
-fn bounded_search_output(
-    query: &str,
-    results: Vec<CatalogSearchResult>,
-    total_response_bytes: usize,
-    per_signature_bytes: usize,
-) -> Value {
-    let mut output_results = Vec::new();
-    for result in results {
-        let output = json!({
-            "name": result.name,
-            "capability_id": result.capability_id.as_str(),
-            "description": result.description,
-            "required": result.required_params,
-            "schema_complete": false,
-        });
-        let schema_fits = serialized_len_within(&result.parameters, per_signature_bytes).is_some();
-        if schema_fits {
-            let mut complete = output.clone();
-            complete["schema_complete"] = Value::Bool(true);
-            complete["parameters"] = result.parameters;
-            let mut candidate_results = output_results.clone();
-            candidate_results.push(complete.clone());
-            if serialized_len_within(
-                &json!({"query": query, "results": candidate_results}),
-                total_response_bytes,
-            )
-            .is_some()
-            {
-                output_results.push(complete);
-                continue;
-            }
-        }
-        let mut candidate_results = output_results.clone();
-        candidate_results.push(output.clone());
-        if serialized_len_within(
-            &json!({"query": query, "results": candidate_results}),
-            total_response_bytes,
-        )
-        .is_none()
-        {
-            break;
-        }
-        output_results.push(output);
-    }
-    json!({"query": query, "results": output_results})
+/// Shared 4-field core: D11's `compact_search_results` and tool_search's own `compact_result_entry` both build from here, then diverge.
+fn compact_result_fields(result: &CatalogSearchResult) -> Value {
+    json!({"name": result.name, "capability_id": result.capability_id.as_str(), "description": result.description, "required": result.required_params})
 }
 
 fn compact_search_results(results: Vec<CatalogSearchResult>) -> Vec<Value> {
-    results
-        .into_iter()
-        .map(|result| {
-            json!({
-                "name": result.name,
-                "capability_id": result.capability_id.as_str(),
-                "description": result.description,
-                "required": result.required_params,
-            })
-        })
-        .collect()
+    results.iter().map(compact_result_fields).collect()
+}
+
+/// One rank's compact entry: D11's core fields plus a truncated description and schema_complete:false. Capped by construction (name <= ProviderToolName::MAX_BYTES 64 B, description <= COMPACT_DESCRIPTION_MAX_BYTES + 3 = 163 B worst case, per the note above — truncate_preview appends "..." after the cap, not within it) — never needs a fit check.
+///
+/// Truncation uses the EXISTING `ironclaw_common::truncate_preview` (`crates/contracts/ironclaw_common/src/util.rs:34`)
+/// rather than a new helper — `ironclaw_common` is already a dependency of `ironclaw_loop_host`
+/// (`crates/loop/ironclaw_loop_host/Cargo.toml:31`) and the function is already live production code,
+/// used at `crates/domains/ironclaw_llm/src/nearai_chat.rs:768`. Note: `truncate_preview` appends
+/// `"..."` on truncation and re-closes a `<tool_output>` tag if truncation cut through one — the
+/// tag-closing branch is a no-op for a plain description string, and the `"..."` suffix is a
+/// (desirable) behavior change from the earlier no-suffix sketch: it signals to the model that the
+/// description was cut. A THIRD copy of this byte-boundary-walk already exists as a private helper —
+/// `ironclaw_host_api::dispatch::truncate_at_char_boundary` (`crates/contracts/ironclaw_host_api/src/dispatch.rs:91`,
+/// module-private, not part of `dispatch`'s public surface) — do NOT add a fourth; this is exactly the
+/// class of duplication `truncate_preview` reuse here avoids repeating.
+fn compact_result_entry(result: &CatalogSearchResult) -> Value {
+    let mut entry = compact_result_fields(result);
+    entry["description"] = Value::String(truncate_preview(
+        &result.description,
+        COMPACT_DESCRIPTION_MAX_BYTES,
+    ));
+    entry["schema_complete"] = Value::Bool(false);
+    entry
+}
+
+/// Build the JSON reply carrying `guidance`. Every caller passes the exact guidance string the
+/// returned value will carry: the value measured here is the value returned — do not reintroduce
+/// a probe that measures a different object than it returns.
+///
+/// Only the schema-complete branch (below) re-measures its candidate at runtime via
+/// `serialized_len_within`. The no-match and compact-fallback branches carry no runtime byte
+/// check — their bound rests on the compact-entry field caps (`name`/`description` enforced by
+/// construction, `capability_id`/`required` bounded only by today's observed corpus — see the
+/// Goal section's "Compact-path worst case" table) plus `MAX_SEARCH_QUERY_BYTES`, and are pinned
+/// only by `bounded_search_output_compact_worst_case_fits_the_first_look_ceiling` and the
+/// `over_output`/no-match test assertions below — a test-time pin, not a runtime guard.
+fn search_reply(query: &str, results: Vec<Value>, guidance: &'static str) -> Value {
+    json!({"query": query, "results": results, "guidance": guidance})
+}
+
+/// Ranks 1..=TOOL_SEARCH_INLINE_RESULT_LIMIT always ride compact (bounded by construction); rank 1
+/// gets exactly ONE additional check: does the reply carrying its own full schema, WITH its real
+/// guidance string already in place, fit the budget? The value tested for fit and the value
+/// returned are the same value — no probe, no clone-and-swap, no separate "what guidance would we
+/// use if this fit" step for the fit check to silently disagree with. This is the ONLY branch with
+/// a runtime fit check; see `search_reply`'s doc comment immediately above for what that does and
+/// does not mean for the other two branches.
+fn bounded_search_output(query: &str, results: Vec<CatalogSearchResult>) -> Value {
+    let compact: Vec<Value> = results
+        .iter()
+        .take(TOOL_SEARCH_INLINE_RESULT_LIMIT)
+        .map(compact_result_entry)
+        .collect();
+    let Some(rank_one) = results.first() else {
+        return search_reply(query, compact, TOOL_SEARCH_NO_MATCH_GUIDANCE);
+    };
+    let mut complete = compact.clone();
+    complete[0]["schema_complete"] = Value::Bool(true);
+    complete[0]["parameters"] = rank_one.parameters.clone();
+    let candidate = search_reply(query, complete, TOOL_SEARCH_INVOKE_DIRECTLY_GUIDANCE);
+    if serialized_len_within(&candidate, TOOL_SEARCH_REPLY_BUDGET_BYTES).is_some() {
+        return candidate; // the measured object IS the returned object
+    }
+    search_reply(query, compact, TOOL_SEARCH_DESCRIBE_FOR_SCHEMA_GUIDANCE)
 }
 
 impl BridgeKind {
@@ -1229,7 +1276,7 @@ impl ToolDisclosureCapabilityPort {
             .get("limit")
             .and_then(Value::as_u64)
             .and_then(|value| usize::try_from(value).ok())
-            .unwrap_or(10)
+            .unwrap_or(TOOL_SEARCH_INLINE_RESULT_LIMIT)
             .clamp(1, 50);
         let output = {
             let mut guard = self.turn_state()?;
@@ -1256,12 +1303,7 @@ impl ToolDisclosureCapabilityPort {
                 }
             }
             let output = if self.mode.includes_complete_signatures() {
-                bounded_search_output(
-                    query,
-                    ranked_results,
-                    MAX_SEARCH_RESPONSE_BYTES,
-                    MAX_SEARCH_SIGNATURE_BYTES_PER_RESULT,
-                )
+                bounded_search_output(query, ranked_results)
             } else {
                 json!({
                     "query": query,
@@ -4101,27 +4143,33 @@ mod tests {
     }
 
     #[test]
-    fn bounded_search_signatures_respect_exact_and_overflow_budgets() {
-        let result = search_result_with_schema("alpha", json!({"type": "object"}));
-        let unlimited =
-            bounded_search_output("alpha", vec![result.clone()], usize::MAX, usize::MAX);
-        let response_bytes = serde_json::to_vec(&unlimited)
-            .expect("test response serializes")
-            .len();
-
-        let exact =
-            bounded_search_output("alpha", vec![result.clone()], response_bytes, usize::MAX);
-        assert_eq!(exact["results"][0]["schema_complete"], true);
-        assert_eq!(exact["results"][0]["parameters"], result.parameters);
-
-        let overflow = bounded_search_output(
-            "alpha",
-            vec![result],
-            response_bytes.saturating_sub(1),
-            usize::MAX,
+    fn bounded_search_output_fits_or_degrades_to_compact() {
+        let small_result = search_result_with_schema("alpha", json!({"type": "object"}));
+        let small_output = bounded_search_output("alpha", vec![small_result.clone()]);
+        assert_eq!(
+            small_output["results"][0]["schema_complete"],
+            Value::Bool(true)
         );
-        assert_eq!(overflow["results"][0]["schema_complete"], false);
-        assert!(overflow["results"][0].get("parameters").is_none());
+        assert_eq!(
+            small_output["results"][0]["parameters"],
+            small_result.parameters
+        );
+        assert_eq!(
+            small_output["guidance"],
+            TOOL_SEARCH_INVOKE_DIRECTLY_GUIDANCE
+        );
+
+        let large_result = search_result_with_schema("alpha", json!({"value": "x".repeat(4096)}));
+        let large_output = bounded_search_output("alpha", vec![large_result]);
+        assert_eq!(
+            large_output["results"][0]["schema_complete"],
+            Value::Bool(false)
+        );
+        assert!(large_output["results"][0].get("parameters").is_none());
+        assert_eq!(
+            large_output["guidance"],
+            TOOL_SEARCH_DESCRIBE_FOR_SCHEMA_GUIDANCE
+        );
     }
 
     #[test]
@@ -4148,79 +4196,182 @@ mod tests {
     }
 
     #[test]
-    fn bounded_search_signatures_preserve_rank_and_skip_oversized_schemas() {
-        let oversized = search_result_with_schema("first", json!({"value": "x".repeat(64)}));
-        let small = search_result_with_schema("second", json!({"type": "object"}));
-        let small_bytes = serde_json::to_vec(&small.parameters)
-            .expect("test schema serializes")
-            .len();
-        let results = bounded_search_output(
-            "query",
-            vec![oversized, small.clone()],
-            usize::MAX,
-            small_bytes,
-        );
+    fn bounded_search_output_only_rank_one_can_be_schema_complete() {
+        let first = search_result_with_schema("first", json!({"type": "object"}));
+        let second = search_result_with_schema("second", json!({"type": "string"}));
+        let output = bounded_search_output("query", vec![first, second]);
 
-        assert_eq!(results["results"][0]["name"], "first");
-        assert_eq!(results["results"][0]["schema_complete"], false);
-        assert_eq!(results["results"][1]["name"], "second");
-        assert_eq!(results["results"][1]["schema_complete"], true);
-        assert_eq!(results["results"][1]["parameters"], small.parameters);
+        assert_eq!(output["results"][0]["name"], "first");
+        assert_eq!(output["results"][0]["schema_complete"], Value::Bool(true));
+        assert_eq!(output["results"][1]["name"], "second");
+        assert_eq!(output["results"][1]["schema_complete"], Value::Bool(false));
     }
 
     #[test]
-    fn bounded_search_signatures_are_deterministic_for_empty_and_multiple_results() {
-        assert_eq!(
-            bounded_search_output("query", Vec::new(), 100, 100)["results"],
-            json!([])
+    fn bounded_search_output_is_deterministic_for_empty_and_multiple_results() {
+        let empty_output = bounded_search_output("query", Vec::new());
+        assert_eq!(empty_output["results"], json!([]));
+        assert_eq!(empty_output["guidance"], TOOL_SEARCH_NO_MATCH_GUIDANCE);
+        assert!(
+            serde_json::to_vec(&empty_output).expect("serializes").len()
+                <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES
         );
+
         let first = search_result_with_schema("first", json!({"type": "object"}));
         let second = search_result_with_schema("second", json!({"type": "string"}));
-        let total_bytes = [&first, &second]
-            .into_iter()
-            .map(|result| {
-                serde_json::to_vec(&result.parameters)
-                    .expect("test schema serializes")
-                    .len()
-            })
-            .sum();
         let inputs = vec![first, second];
-        let complete = bounded_search_output("query", inputs.clone(), usize::MAX, total_bytes);
-        assert!(
-            complete["results"]
-                .as_array()
-                .expect("results array")
-                .iter()
-                .all(|result| result["schema_complete"] == true)
-        );
-        let first_only_bytes = serde_json::to_vec(&bounded_search_output(
-            "query",
-            vec![inputs[0].clone()],
-            usize::MAX,
-            total_bytes,
-        ))
-        .expect("first result serializes")
-        .len();
-        let overflow =
-            bounded_search_output("query", inputs.clone(), first_only_bytes, total_bytes);
-        assert_eq!(overflow["results"][0]["schema_complete"], true);
-        assert_eq!(overflow["results"].as_array().expect("results").len(), 1);
-
         assert_eq!(
-            serde_json::to_vec(&bounded_search_output(
-                "query",
-                inputs.clone(),
-                usize::MAX,
-                usize::MAX
-            ))
-            .expect("first result serializes"),
-            serde_json::to_vec(&bounded_search_output(
-                "query",
-                inputs,
-                usize::MAX,
-                usize::MAX
-            ))
-            .expect("second result serializes")
+            serde_json::to_vec(&bounded_search_output("query", inputs.clone()))
+                .expect("first result serializes"),
+            serde_json::to_vec(&bounded_search_output("query", inputs))
+                .expect("second result serializes")
+        );
+    }
+
+    /// A `parameters` schema whose compact-serialized size is controlled precisely: a fixed shape
+    /// plus one `description` field padded to add exactly `pad_len` unescaped ASCII bytes.
+    fn schema_of_pad_len(pad_len: usize) -> Value {
+        json!({
+            "type": "object",
+            "properties": {"value": {"type": "string"}, "padding": {"type": "string"}},
+            "description": "x".repeat(pad_len),
+            "required": ["value"],
+        })
+    }
+
+    #[test]
+    fn bounded_search_output_promotes_rank_one_exactly_at_the_shared_budget_boundary() {
+        let rank_two = search_result_with_schema("rank_two", json!({"type": "object"}));
+        let rank_three = search_result_with_schema("rank_three", json!({"type": "object"}));
+
+        // Measure the reply at pad_len=0 to derive the exact byte where it crosses the
+        // budget -- padding is an unescaped ASCII string, so it grows the reply
+        // byte-for-byte; this DERIVES the boundary instead of guessing at it.
+        let baseline = search_result_with_schema("rank_one", schema_of_pad_len(0));
+        let baseline_output = bounded_search_output(
+            "query",
+            vec![baseline.clone(), rank_two.clone(), rank_three.clone()],
+        );
+        assert_eq!(
+            baseline_output["results"][0]["schema_complete"],
+            Value::Bool(true),
+            "pad_len=0 baseline must itself fit, or the derived boundary below is meaningless"
+        );
+        let baseline_bytes = serde_json::to_vec(&baseline_output)
+            .expect("reply serializes")
+            .len();
+        let headroom = TOOL_SEARCH_REPLY_BUDGET_BYTES - baseline_bytes;
+
+        let just_under = search_result_with_schema("rank_one", schema_of_pad_len(headroom));
+        let under_output = bounded_search_output(
+            "query",
+            vec![just_under.clone(), rank_two.clone(), rank_three.clone()],
+        );
+        assert_eq!(
+            under_output["results"][0]["schema_complete"],
+            Value::Bool(true)
+        );
+        assert_eq!(
+            under_output["results"][0]["parameters"], just_under.parameters,
+            "complete rank 1 is untruncated (D5)"
+        );
+        assert_eq!(
+            under_output["guidance"],
+            TOOL_SEARCH_INVOKE_DIRECTLY_GUIDANCE
+        );
+        assert!(
+            serde_json::to_vec(&under_output).expect("serializes").len()
+                <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES
+        );
+
+        let just_over = search_result_with_schema("rank_one", schema_of_pad_len(headroom + 1));
+        let over_output = bounded_search_output("query", vec![just_over, rank_two, rank_three]);
+        assert_eq!(
+            over_output["results"][0]["schema_complete"],
+            Value::Bool(false)
+        );
+        assert!(
+            over_output["results"][0].get("parameters").is_none(),
+            "compact rank 1 carries no partial schema (D5)"
+        );
+        assert_eq!(
+            over_output["guidance"],
+            TOOL_SEARCH_DESCRIBE_FOR_SCHEMA_GUIDANCE
+        );
+        // The compact-fallback path gets its own byte assertion — every return path is measured.
+        assert!(
+            serde_json::to_vec(&over_output).expect("serializes").len()
+                <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES,
+            "compact-fallback reply must itself stay under the first-look ceiling"
+        );
+    }
+
+    /// One compact entry at the practical worst-case field sizes derived in the Goal section's
+    /// "Compact-path worst case" table: name at ProviderToolName::MAX_BYTES (64 B, enforced by
+    /// construction), capability_id at the largest real capability id observed across every
+    /// extension manifest (39 B -- NOT enforced by construction), description at
+    /// COMPACT_DESCRIPTION_MAX_BYTES's true 163 B worst case (enforced by truncate_preview),
+    /// required at the largest real required-params array observed across every committed
+    /// extension schema (6 params, google-sheets/format_cells.input.v1.json).
+    fn worst_case_compact_result() -> crate::tool_disclosure::CatalogSearchResult {
+        crate::tool_disclosure::CatalogSearchResult {
+            name: "n".repeat(64),
+            capability_id: CapabilityId::new(format!("fixture.{}", "c".repeat(31)))
+                .expect("valid capability id"), // "fixture." (8) + 31 B -> 39 B total, matching the observed real max
+            // truncate_preview (util.rs:34-38) is a strict `<=`: `if s.len() <= max_bytes { return
+            // s.to_string(); }`. At exactly 160 B (== COMPACT_DESCRIPTION_MAX_BYTES) that condition
+            // is TRUE, so the string is returned UNCHANGED -- no "..." appended, field stays 160 B,
+            // not 163 B. Truncation only actually fires, and only then does the unreserved 3-byte
+            // "..." land, once the input exceeds 160 B. 200 is comfortably past that boundary so the
+            // intent (exercise the true 163 B worst case) is unmistakable, not an off-by-one away
+            // from silently drifting back onto it.
+            description: "d".repeat(200),
+            required_params: vec!["r".repeat(10); 6], // 6 entries, matches the observed real worst case
+            parameters: json!({"type": "object"}),
+        }
+    }
+
+    /// Proves the compact fallback path (rank 1's OWN schema forced not to fit, so every rank rides
+    /// compact at once) stays under the shared first-look ceiling at the practical worst-case field
+    /// sizes computed in the Goal section, not just the small fixtures the other tests use.
+    #[test]
+    fn bounded_search_output_compact_worst_case_fits_the_first_look_ceiling() {
+        let query = "q".repeat(MAX_SEARCH_QUERY_BYTES); // 1_024 B, the real cap (tool_search.rs:12)
+        let results: Vec<_> = (0..TOOL_SEARCH_INLINE_RESULT_LIMIT)
+            .map(|n| {
+                let mut r = worst_case_compact_result();
+                if n == 0 {
+                    // Force rank 1's OWN schema to miss the budget so every rank, including rank 1,
+                    // rides compact -- the actual fallback branch this test exists to pin.
+                    r.parameters = schema_of_pad_len(4096);
+                }
+                r
+            })
+            .collect();
+        let output = bounded_search_output(&query, results);
+        assert_eq!(
+            output["results"][0]["schema_complete"],
+            Value::Bool(false),
+            "test setup must exercise the compact-fallback branch, not the schema-complete one"
+        );
+        assert_eq!(
+            output["results"][0]["description"]
+                .as_str()
+                .expect("description is a string")
+                .len(),
+            163,
+            "the fixture must actually cross truncate_preview's <= boundary (util.rs:34-38) -- a \
+             163 B description is the true worst case this test and the Goal section's arithmetic \
+             are built on; if this drifts back to 160 B the fixture is silently exercising the \
+             untruncated case again, not the worst case"
+        );
+        let bytes = serde_json::to_vec(&output).expect("reply serializes").len();
+        assert!(
+            bytes <= MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES,
+            "worst-case compact-fallback reply was {bytes} B, over the {MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES} B \
+             first-look ceiling -- see the Goal section's compact-path worst-case arithmetic (computed \
+             at 2,482 B for this exact construction; if this fails, that arithmetic and the corpus \
+             maxima it's based on need re-deriving, not this assertion loosening)"
         );
     }
 

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -78,6 +78,11 @@ const COMPACT_DESCRIPTION_MAX_BYTES: usize = 160;
 
 /// A SUCCESS results[] entry name, not a failure diagnostic (#5712 covers describe/call FAILURE branches only).
 const TOOL_SEARCH_INVOKE_DIRECTLY_GUIDANCE: &str = "rank 1 has a complete parameters schema; invoke it directly with the schema above, or via tool_call";
+/// Steers the model to `tool_describe` when rank 1's schema is too large to inline here. NOTE:
+/// `tool_describe`'s own reply is NOT bounded by this file's first-look-envelope fix — it still
+/// rides the generic pager and can itself collapse behind an `omitted` marker for a large enough
+/// schema (same defect class as D21 in `docs/internal/tool-discovery-subjective-decisions.md`).
+/// Tracked as follow-up, not yet fixed.
 const TOOL_SEARCH_DESCRIBE_FOR_SCHEMA_GUIDANCE: &str = "rank 1 matched but its schema is too large to show inline; call tool_describe on it to get the full parameters schema, then invoke it";
 const TOOL_SEARCH_NO_MATCH_GUIDANCE: &str = "no deferred tool matches this query; do not search again for it; tell the user the capability is unavailable";
 
@@ -1321,6 +1326,14 @@ impl ToolDisclosureCapabilityPort {
             let output = if self.mode.includes_complete_signatures() {
                 bounded_search_output(query, ranked_results)
             } else {
+                // ToolDisclosureMode::Compact is a deliberately unbounded measurement control
+                // arm (tool_disclosure_mode.rs), reachable only via REBORN_TOOL_DISCLOSURE=compact
+                // (production default is Namespaces). compact_search_results maps every ranked
+                // result through compact_result_fields with no description truncation, no
+                // `.take(...)`, and no byte-budget check, on purpose: truncating here would
+                // change the control arm's wire bytes and invalidate the A/B comparison it exists
+                // to run. The bounded, first-look-envelope construction above applies only to the
+                // production arms.
                 json!({
                     "query": query,
                     "results": compact_search_results(ranked_results),
@@ -4296,6 +4309,42 @@ mod tests {
                 .expect("first result serializes"),
             serde_json::to_vec(&bounded_search_output("query", inputs))
                 .expect("second result serializes")
+        );
+    }
+
+    /// Proves the `.take(TOOL_SEARCH_INLINE_RESULT_LIMIT)` cap in `bounded_search_output` actually
+    /// drops a 4th+ ranked result rather than merely happening to line up with every existing
+    /// test's fixture count: every other `bounded_search_output_*` test above passes at most
+    /// `TOOL_SEARCH_INLINE_RESULT_LIMIT` results, so none of them can fail if the cap were removed
+    /// or widened. This one passes 5 small (well under budget) results and asserts both that the
+    /// array is truncated to exactly the limit AND that survivors are ranks 1-3 in order, not an
+    /// arbitrary subset -- and that no panic occurs when more results are supplied than the limit.
+    #[test]
+    fn bounded_search_output_drops_results_beyond_the_inline_limit() {
+        let results: Vec<_> = (1..=5)
+            .map(|rank| {
+                search_result_with_schema(&format!("rank{rank}"), json!({"type": "object"}))
+            })
+            .collect();
+
+        let output = bounded_search_output("query", results);
+
+        let names: Vec<&str> = output["results"]
+            .as_array()
+            .expect("results is an array")
+            .iter()
+            .map(|entry| entry["name"].as_str().expect("name is a string"))
+            .collect();
+
+        assert_eq!(
+            names.len(),
+            TOOL_SEARCH_INLINE_RESULT_LIMIT,
+            "a 4th+ ranked result must be dropped, not carried through"
+        );
+        assert_eq!(
+            names,
+            vec!["rank1", "rank2", "rank3"],
+            "survivors must be exactly the first three ranks, in rank order"
         );
     }
 

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -14,6 +14,7 @@ use ironclaw_host_api::{
         MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES, MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES,
     },
     resolution::{Resolution, ResolutionBatch},
+    result_meta::FailureKind,
 };
 use ironclaw_loop_contracts::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityCallCandidate, CapabilityFailureDetail,
@@ -1246,11 +1247,13 @@ impl ToolDisclosureCapabilityPort {
             BridgeKind::Describe => self.invoke_tool_describe(&request, &bridge).await,
             BridgeKind::DescribeFirst => self.invoke_describe_first(&request, &bridge).await,
             BridgeKind::Call if decode_tool_call_arguments(&bridge.arguments).is_none() => {
-                Ok(failed_invalid_input(
+                Ok(failed_recoverable(
+                    FailureKind::InputEncode,
                     "tool_call arguments must be a JSON object encoded as a string",
                 ))
             }
-            BridgeKind::Call => Ok(failed_invalid_input(
+            BridgeKind::Call => Ok(failed_recoverable(
+                FailureKind::UnknownCapability,
                 "tool_call target is not a known tool; use tool_search to find the correct tool name",
             )),
         }
@@ -1262,14 +1265,23 @@ impl ToolDisclosureCapabilityPort {
         bridge: &BridgeInvocation,
     ) -> Result<Resolution, AgentLoopHostError> {
         let Some(query) = bridge.arguments.get("query").and_then(Value::as_str) else {
-            return Ok(failed_invalid_input("tool_search requires query"));
+            return Ok(failed_recoverable(
+                FailureKind::InputEncode,
+                "tool_search requires query",
+            ));
         };
         let query = query.trim();
         if query.is_empty() {
-            return Ok(failed_invalid_input("tool_search requires query"));
+            return Ok(failed_recoverable(
+                FailureKind::InputEncode,
+                "tool_search requires query",
+            ));
         }
         if query.len() > MAX_SEARCH_QUERY_BYTES {
-            return Ok(failed_invalid_input("tool_search query is too long"));
+            return Ok(failed_recoverable(
+                FailureKind::InputEncode,
+                "tool_search query is too long",
+            ));
         }
         let limit = bridge
             .arguments
@@ -1281,7 +1293,10 @@ impl ToolDisclosureCapabilityPort {
         let output = {
             let mut guard = self.turn_state()?;
             let Some(state) = guard.as_mut() else {
-                return Ok(failed_invalid_input("tool catalog is unavailable"));
+                return Ok(failed_recoverable(
+                    FailureKind::InputEncode,
+                    "tool catalog is unavailable",
+                ));
             };
             let search_started_at = std::time::Instant::now();
             let outcome = state.search_index.search(query, limit);
@@ -1331,25 +1346,38 @@ impl ToolDisclosureCapabilityPort {
         bridge: &BridgeInvocation,
     ) -> Result<Resolution, AgentLoopHostError> {
         let Some(name) = bridge.arguments.get("name").and_then(Value::as_str) else {
-            return Ok(failed_invalid_input("tool_describe requires name"));
+            return Ok(failed_recoverable(
+                FailureKind::InputEncode,
+                "tool_describe requires name",
+            ));
         };
         if is_bridge_name(name) {
-            return Ok(failed_invalid_input(
+            return Ok(failed_recoverable(
+                FailureKind::InputEncode,
                 "tool_describe target must not be a bridge",
             ));
         }
         let output = {
             let mut guard = self.turn_state()?;
             let Some(state) = guard.as_mut() else {
-                return Ok(failed_invalid_input("tool catalog is unavailable"));
+                return Ok(failed_recoverable(
+                    FailureKind::InputEncode,
+                    "tool catalog is unavailable",
+                ));
             };
             let Some(result) = state.catalog.search_result(name) else {
-                return Ok(failed_invalid_input("tool_describe target is unknown"));
+                return Ok(failed_recoverable(
+                    FailureKind::UnknownCapability,
+                    "tool_describe target is unknown; use tool_search to find the correct tool name",
+                ));
             };
             // #5712: same message as a truly unknown name — a narrowed profile
             // must not learn that a non-allowlisted tool exists.
             if !self.policy.permits_capability_id(&result.capability_id) {
-                return Ok(failed_invalid_input("tool_describe target is unknown"));
+                return Ok(failed_recoverable(
+                    FailureKind::UnknownCapability,
+                    "tool_describe target is unknown; use tool_search to find the correct tool name",
+                ));
             }
             if let Some(selected_rank) = state.search_ranks.get(&result.name).copied() {
                 debug!(
@@ -1384,15 +1412,24 @@ impl ToolDisclosureCapabilityPort {
         bridge: &BridgeInvocation,
     ) -> Result<Resolution, AgentLoopHostError> {
         let Some(name) = bridge.arguments.get("name").and_then(Value::as_str) else {
-            return Ok(failed_invalid_input("auto-schema requires a target name"));
+            return Ok(failed_recoverable(
+                FailureKind::InputEncode,
+                "auto-schema requires a target name",
+            ));
         };
         let output = {
             let mut guard = self.turn_state()?;
             let Some(state) = guard.as_mut() else {
-                return Ok(failed_invalid_input("tool catalog is unavailable"));
+                return Ok(failed_recoverable(
+                    FailureKind::InputEncode,
+                    "tool catalog is unavailable",
+                ));
             };
             let Some(result) = state.catalog.search_result(name) else {
-                return Ok(failed_invalid_input("auto-schema target is unknown"));
+                return Ok(failed_recoverable(
+                    FailureKind::InputEncode,
+                    "auto-schema target is unknown",
+                ));
             };
             state.disclosed_names.insert(result.name.clone());
             json!({
@@ -1688,9 +1725,9 @@ fn decode_tool_call_arguments(bridge_arguments: &Value) -> Option<Value> {
     }
 }
 
-fn failed_invalid_input(summary: &'static str) -> Resolution {
+fn failed_recoverable(kind: FailureKind, summary: &'static str) -> Resolution {
     resolution::failed(
-        ironclaw_host_api::result_meta::FailureKind::InputEncode,
+        kind,
         summary.to_string(),
         CapabilityFailureDetail::Diagnostic {
             text: summary.to_string(),
@@ -3716,6 +3753,10 @@ mod tests {
             })
             .await
             .expect("bridge handles the fallback");
+        // T5 (#5712/#7892): a target that fails registration falls back to the
+        // same "not a known tool" bridge branch as a genuinely unknown target,
+        // now carrying FailureKind::UnknownCapability so the model's structured
+        // hint agrees with the free text (both say "not a known tool").
         assert!(
             matches!(
                 outcome,
@@ -3723,12 +3764,12 @@ mod tests {
                     if matches!(
                         o.verdict,
                         ToolVerdict::RecoverableFailure {
-                            error_kind: FailureKind::InputEncode,
+                            error_kind: FailureKind::UnknownCapability,
                             ..
                         }
                     )
             ),
-            "fallback must be a recoverable InvalidInput failure, not run death"
+            "fallback must be a recoverable UnknownCapability failure, not run death"
         );
     }
 
@@ -3780,6 +3821,9 @@ mod tests {
             })
             .await
             .expect("bridge handles recursion");
+        // T5 (#5712/#7892): recursing into a bridge name hits the same "not a
+        // known tool" branch as any other unresolvable tool_call target, now
+        // FailureKind::UnknownCapability.
         assert!(
             matches!(
                 outcome,
@@ -3787,12 +3831,12 @@ mod tests {
                     if matches!(
                         o.verdict,
                         ToolVerdict::RecoverableFailure {
-                            error_kind: FailureKind::InputEncode,
+                            error_kind: FailureKind::UnknownCapability,
                             ..
                         }
                     )
             ),
-            "recursive tool_call must be a recoverable InvalidInput failure, not run death"
+            "recursive tool_call must be a recoverable UnknownCapability failure, not run death"
         );
         assert!(
             inner
@@ -3834,16 +3878,26 @@ mod tests {
             .await
             .expect("surface builds turn state");
 
-        for (arguments, expected) in [
-            (json!({}), "tool_describe requires name"),
-            (json!({"name": 42}), "tool_describe requires name"),
+        for (arguments, expected, expected_kind) in [
+            (
+                json!({}),
+                "tool_describe requires name",
+                FailureKind::InputEncode,
+            ),
+            (
+                json!({"name": 42}),
+                "tool_describe requires name",
+                FailureKind::InputEncode,
+            ),
             (
                 json!({"name": TOOL_SEARCH_NAME}),
                 "tool_describe target must not be a bridge",
+                FailureKind::InputEncode,
             ),
             (
                 json!({"name": "does_not_exist"}),
-                "tool_describe target is unknown",
+                "tool_describe target is unknown; use tool_search to find the correct tool name",
+                FailureKind::UnknownCapability,
             ),
         ] {
             let candidate =
@@ -3874,6 +3928,18 @@ mod tests {
                         )
                 ),
                 "unexpected tool_describe outcome for {expected}: {outcome:?}"
+            );
+            assert!(
+                matches!(
+                    outcome,
+                    Resolution::Done(ref output)
+                        if matches!(
+                            &output.verdict,
+                            ToolVerdict::RecoverableFailure { error_kind, .. }
+                                if *error_kind == expected_kind
+                        )
+                ),
+                "unexpected FailureKind for {expected}: {outcome:?}"
             );
         }
 
@@ -3943,6 +4009,10 @@ mod tests {
             })
             .await
             .expect("bridge handles unknown target");
+        // T5 (#5712/#7892): an unresolvable tool_call target carries
+        // FailureKind::UnknownCapability so the structured hint agrees with
+        // the free text ("not a known tool"), instead of steering the model
+        // to fix arguments on a target that was never a real tool.
         assert!(
             matches!(
                 outcome,
@@ -3950,12 +4020,12 @@ mod tests {
                     if matches!(
                         o.verdict,
                         ToolVerdict::RecoverableFailure {
-                            error_kind: FailureKind::InputEncode,
+                            error_kind: FailureKind::UnknownCapability,
                             ..
                         }
                     )
             ),
-            "unknown-target tool_call must be a recoverable InvalidInput failure"
+            "unknown-target tool_call must be a recoverable UnknownCapability failure"
         );
         assert!(
             inner

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -53,12 +53,13 @@ const TOOL_SEARCH_REPLY_BUDGET_BYTES: usize =
 /// drift between them is a compile-time impossibility, not a silent mismatch.
 pub(crate) const TOOL_SEARCH_INLINE_RESULT_LIMIT: usize = 3;
 
-/// One-line description cap (UTF-8 char boundary). Live GitHub tool descriptions run up to
-/// 116 B today (independently scanning every `description = "..."` in
-/// `crates/extensions/packages/github/manifest.toml`'s 50 tool entries finds 3 over 70 B, the
-/// longest 116 B, `github.list_repos`'s description at manifest.toml:500; 47 of 50 stay
-/// <=70 B). This constant guards a future longer one, bounding every compact entry by
-/// construction regardless — 116 B is still well under the 163 B worst case below.
+/// One-line description cap (UTF-8 char boundary). The longest single-line
+/// `description = "..."` across every committed first-party extension
+/// manifest runs up to 116 B today (independently scanned across all
+/// `crates/extensions/packages/*/manifest.toml` tool entries; only a handful
+/// exceed 70 B, and the great majority of entries stay <=70 B). This constant
+/// guards a future longer one, bounding every compact entry by construction
+/// regardless — 116 B is still well under the 163 B worst case below.
 ///
 /// **Byte-accounting note:** `truncate_preview` (`crates/contracts/ironclaw_common/src/util.rs:34`)
 /// appends its `"..."` ellipsis AFTER truncating to `max_bytes` rather than reserving room for it,

--- a/docs/internal/tool-discovery-subjective-decisions.md
+++ b/docs/internal/tool-discovery-subjective-decisions.md
@@ -77,6 +77,10 @@ especially for side-effecting tools.
 budgets while collecting the end-to-end comparison. Schemas are complete or
 omitted, never truncated.
 
+**Superseded by D21 (2026-08-28):** rank-1-only is now the production
+rule. D5's "several complete candidates" rationale doesn't survive contact
+with the first-look pager ceiling — see D21.
+
 **Why:** The per-schema ceiling guarantees one result cannot consume the whole
 response, while the total ceiling bounds context growth. The benchmark must
 decide whether the total should be reduced or biased more strongly toward rank
@@ -398,3 +402,42 @@ workflow mix.
 7.0s lower. Rejected because the completion gate failed and the median mixes
 very different provider-tail behavior across task classes. A latency win does
 not compensate for a lower end-to-end success rate.
+
+## D21 — tool_search's reply is sized to the first-look envelope, not an independent cap
+
+**Supersedes D5.** D5 kept several-complete-schemas as production policy
+and explicitly declined rank-1-only, reasoning that "ambiguous tasks may
+benefit from several complete candidates." That reasoning no longer holds:
+the spike proved the model never saw the array *at all* once it crossed
+the 3 KiB first-look pager — a second or third complete schema couldn't
+help an ambiguous task if the whole reply already collapsed to "omitted."
+Ranks 2-3 don't disappear, they just stop being pre-expanded: their
+compact entry (name/capability_id/description/required) is enough to pick
+one, and `tool_describe` returns its complete schema on demand.
+
+**Decision:** Delete D5's MAX_SEARCH_RESPONSE_BYTES (24 KiB) and
+MAX_SEARCH_SIGNATURE_BYTES_PER_RESULT (8 KiB). Build the reply against the
+shared MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES ceiling instead: rank 1 complete
+when the reply carrying its own schema (with ranks 2-3's compact entries and
+the guidance field already in place) fits the ceiling minus a fixed 512 B
+wrapper allowance, ranks 2-3 always compact (default limit 3, was 10), a
+`guidance` field tells the model to invoke a complete rank 1, call
+`tool_describe` on a compact-but-matched rank 1, or stop searching when
+nothing matched. Whether rank 1 rides complete is a property of the WHOLE
+reply, not of rank 1's schema size alone — see the plan's Goal section for
+the exact arithmetic and why the three largest committed GitHub schemas
+(individually well under budget) still land compact together.
+
+**Why:** Spike measured a 16,066 B reply collapsed to 857 B model-visible
+content, entire results array omitted — D5's budgets never looked at the
+3 KiB pager ceiling that actually gates inline delivery.
+
+**Alternative rejected — lower D5's two numbers to fit under 3 KiB:** a second hand-tuned number duplicating the pager's real ceiling is the exact drift class that caused this bug.
+
+**Alternative rejected — admit as many complete schemas as fit under the shared ceiling, not just rank 1:** the D5-preserving middle ground the new ceiling itself makes possible. Rejected: (a) it re-opens, by intuition, the exact question D5 deferred to a benchmark — bias toward rank 1 or not — now under a ceiling ~8x tighter than D5's original 24 KiB; (b) a result's shape would then depend on a neighbour's schema size, making the reply non-deterministic from the model's own perspective and unauditable without re-serializing every candidate; (c) nothing is lost by not doing it — ranks 2-3 stay selectable from their compact entry and `tool_describe` returns the complete schema on demand.
+
+**Alternative rejected — inline no schema at all, for any rank (require `tool_describe` unconditionally):** the strictly simpler option this Decision must also name. Hermes (`hermes-agent`'s own `tool_search` bridge, a separate agent codebase, not this one) never inlines a parameters schema in a search reply for ANY rank — `tools/tool_search.py`'s `_format_search_hit` (~:852-859) returns only `name`/`source`/`source_name`/a 400-char-capped `description`; a schema reaches the model exclusively through a follow-up `tool_describe` call, for every rank including the top one. This is proven, working prior art at Hermes' own ~830-tool catalog scale, and it would eliminate this plan's entire cross-rank byte-coupling problem outright: with zero schemas inlined, rank 1's fate never depends on ranks 2-3's compact-entry sizes, because no rank's reply size depends on any schema at all. **Rejected, but only as a reasoned bet, not a measured one:** #7892's B1 documents a real production run where the model searched and then never invoked the matched tool — forcing every rank through a second mandatory `tool_describe` hop before it can act risks worsening exactly that failure mode, trading a byte-coupling problem for a steering problem. `TOOL_SEARCH_INVOKE_DIRECTLY_GUIDANCE` plus an inline rank-1 schema exists specifically to let the model act immediately on the one candidate most likely to be right, rather than adding a hop between every search and every invocation. IronClaw does not have Hermes' benchmark data isolating whether zero-inline actually costs more invocations in practice than rank-1-complete does — this is this plan's own judgment call, stated as such.
+
+**Why a single spike, not a D13/D14-style benchmark, is enough evidence here:** D5's deferral and D13/D14's live-run comparisons are the right bar for a ranking-quality or latency tradeoff, where intuition alone cannot separate a real gain from noise. This is not that: the spike is a correctness defect (the model saw zero results, not a worse-ranked set), and a benchmark against a baseline that already delivers nothing would measure nothing — D5's own "never truncate mid-schema" invariant is exactly what the pager's `omitted` collapse violated, one layer downstream of D5's budgets. A correctness fix doesn't need the evidence bar for choosing among working alternatives. **Hermes' data does not settle this choice either way:** Hermes' own benchmark modes (`eager`/`bridge`/`listing`) vary how the *whole tool catalog* is presented, never how many results a single search reply returns or whether a result's schema is complete versus compact — it has no experimental axis comparable to rank-1-only versus several-complete-schemas, so it can neither validate nor refute D21's specific choice; it is cited above only for the zero-inline-schema alternative, which is a real, working design Hermes does run, not for the rank-count choice.
+
+**Divergent from Hermes, deliberately (see T5):** unlike this reply-shape choice, the #5712 byte-identical denied-vs-nonexistent invariant this plan preserves is a place IronClaw *knowingly* diverges from Hermes' prior art rather than following it — see T5 below for why.

--- a/docs/internal/tool-discovery-subjective-decisions.md
+++ b/docs/internal/tool-discovery-subjective-decisions.md
@@ -413,7 +413,11 @@ the 3 KiB first-look pager — a second or third complete schema couldn't
 help an ambiguous task if the whole reply already collapsed to "omitted."
 Ranks 2-3 don't disappear, they just stop being pre-expanded: their
 compact entry (name/capability_id/description/required) is enough to pick
-one, and `tool_describe` returns its complete schema on demand.
+one, and `tool_describe` returns its complete schema on demand. That
+on-demand path is not itself bounded by this decision: `tool_describe`'s
+reply still rides the generic first-look pager and can collapse behind an
+`omitted` marker for a large schema, the same defect class D21 fixes for
+`tool_search` — tracked as follow-up, not yet fixed.
 
 **Decision:** Delete D5's MAX_SEARCH_RESPONSE_BYTES (24 KiB) and
 MAX_SEARCH_SIGNATURE_BYTES_PER_RESULT (8 KiB). Build the reply against the

--- a/tests/integration/tool_disclosure.rs
+++ b/tests/integration/tool_disclosure.rs
@@ -1090,6 +1090,14 @@ async fn unnarrowed_policy_keeps_full_tool_search_catalog() {
 /// whole reply to 2,811 B against the 2,560 B budget (over by 251 B), so it
 /// takes the compact-fallback branch instead and `schema_complete: true` never
 /// appears -- the plan's own Goal-section arithmetic, not this test's mistake.
+///
+/// Fragility note: this test selects its branch (schema-complete vs.
+/// compact-fallback) from the LIVE github manifest's byte sizes, so an
+/// ordinary manifest edit elsewhere can flip which branch it exercises. If a
+/// github manifest change trips this test, re-derive the boundary from
+/// `bounded_search_output_compact_worst_case_fits_the_first_look_ceiling`
+/// (crate-tier, synthetic worst case) rather than re-tuning the query string
+/// here until it happens to pass again.
 #[tokio::test]
 async fn tool_search_reply_rides_the_first_look_preview_inline() {
     let harness = RebornIntegrationHarness::test_default()
@@ -1137,6 +1145,13 @@ async fn tool_search_reply_rides_the_first_look_preview_inline() {
 /// instead of an inline schema. Proves the OTHER production return path is
 /// still never collapsed by the pager, even though it carries no complete
 /// schema.
+///
+/// Fragility note: like its sibling test above, this test's branch selection
+/// depends on `github.search_issues_pull_requests`'s LIVE compact-serialized
+/// size staying on the compact-fallback side of the budget. If a github
+/// manifest edit trips this test, re-derive the boundary from
+/// `bounded_search_output_compact_worst_case_fits_the_first_look_ceiling`
+/// (crate-tier, synthetic worst case), not by re-tuning the query string.
 #[tokio::test]
 async fn tool_search_reply_falls_back_to_compact_when_rank_one_does_not_fit() {
     let harness = RebornIntegrationHarness::test_default()

--- a/tests/integration/tool_disclosure.rs
+++ b/tests/integration/tool_disclosure.rs
@@ -1176,3 +1176,57 @@ async fn tool_search_reply_falls_back_to_compact_when_rank_one_does_not_fit() {
         .await
         .expect("must never fall back to the JSON-page view");
 }
+
+/// T7: tool_search replies (any query shape -- no-match, repeated, or
+/// case-varied) must never perturb the cached system prompt prefix or the
+/// advertised `tools` array. Promotion (and the prefix churn that earns) only
+/// happens when a deferred tool is actually dispatched via `tool_call` --
+/// searching and describing never promote anything (#6986).
+#[tokio::test]
+async fn tool_search_replies_never_perturb_the_cached_prompt_prefix() {
+    let harness = RebornIntegrationHarness::test_default()
+        .with_tool_disclosure_bridged()
+        .with_github_issue_tools()
+        .script([
+            RebornScriptedReply::tool_call(
+                TOOL_SEARCH_NAME,
+                serde_json::json!({"query": "no such capability zzz"}),
+            ),
+            RebornScriptedReply::tool_call(
+                TOOL_SEARCH_NAME,
+                serde_json::json!({"query": "no such capability zzz"}),
+            ),
+            RebornScriptedReply::tool_call(
+                TOOL_SEARCH_NAME,
+                serde_json::json!({"query": "get repository"}),
+            ),
+            RebornScriptedReply::tool_call(
+                TOOL_SEARCH_NAME,
+                serde_json::json!({"query": "Get Repository"}),
+            ),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    harness
+        .submit_turn("find repo tools")
+        .await
+        .expect("turn completes");
+    harness
+        .assert_system_prompts_identical()
+        .await
+        .expect("no branch edits TOOL_DISCLOSURE_PROTOCOL_PROMPT");
+    harness
+        .assert_prompt_cache_prefix_stable()
+        .await
+        .expect("tool_search/tool_describe promote nothing (#6986)");
+    harness
+        .assert_model_tools_contains(TOOL_SEARCH_NAME)
+        .await
+        .expect("tool_search itself stays advertised");
+    harness
+        .assert_model_tools_excludes("github__list_issues")
+        .await
+        .expect("no non-promoted deferred tool leaks into tools array");
+}

--- a/tests/integration/tool_disclosure.rs
+++ b/tests/integration/tool_disclosure.rs
@@ -1064,3 +1064,103 @@ async fn unnarrowed_policy_keeps_full_tool_search_catalog() {
         "an unrestricted policy must surface the full catalog's matches, got only {ids:?}"
     );
 }
+
+/// T2 (#7928 fix), fits path: "get repository" ranks `github.get_repo` at rank
+/// 1 -- a 476 B compact-serialized schema, well inside the 2,560 B budget even
+/// with ranks 2-3's compact entries and JSON scaffolding riding along (measured
+/// total: 1,173 B). Proves the production ranking + reply-construction +
+/// first-look-pager chain delivers a complete schema end-to-end for a
+/// realistic query, never falling back to the pager's `omitted`/`json_page`
+/// views. Replaces the plan's original
+/// `tool_search_reply_rides_the_first_look_preview_inline` draft, which used
+/// "issues pull requests repository" -- that query's rank-1 tool
+/// (`github.search_issues_pull_requests`, a 2,652 B compact schema) pushes the
+/// whole reply to 2,811 B against the 2,560 B budget (over by 251 B), so it
+/// takes the compact-fallback branch instead and `schema_complete: true` never
+/// appears -- the plan's own Goal-section arithmetic, not this test's mistake.
+#[tokio::test]
+async fn tool_search_reply_rides_the_first_look_preview_inline() {
+    let harness = RebornIntegrationHarness::test_default()
+        .with_tool_disclosure_bridged()
+        .with_github_issue_tools()
+        .script([
+            RebornScriptedReply::tool_call(
+                TOOL_SEARCH_NAME,
+                serde_json::json!({"query": "get repository", "limit": 10}),
+            ),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    harness
+        .submit_turn("find a repo tool")
+        .await
+        .expect("turn completes");
+    // The model-visible tool result envelope wraps the raw reply as a JSON
+    // string (`detail.preview`), so every `"` in the raw reply is escaped once
+    // more inside `message.content` -- the needle below matches the actual
+    // bytes (`\"schema_complete\":true`), verified empirically against the
+    // captured content, not the unescaped JSON shape.
+    harness
+        .assert_model_tool_result_content_occurrences(r#"\"schema_complete\":true"#, 1)
+        .await
+        .expect("exactly one rank-1 complete schema reaches the model");
+    harness
+        .assert_model_tool_result_content_occurrences("omitted", 0)
+        .await
+        .expect("pager elision path must never fire for tool_search");
+    harness
+        .assert_model_tool_result_content_occurrences("json_page", 0)
+        .await
+        .expect("must never fall back to the JSON-page view");
+}
+
+/// T2 (#7928 fix), compact-fallback path: the heavy query from the plan's
+/// original draft. `github.search_issues_pull_requests` ranks 1 with a 2,652 B
+/// compact-serialized schema -- together with ranks 2-3's compact entries and
+/// scaffolding the complete-schema candidate would serialize to 2,811 B,
+/// 251 B over `TOOL_SEARCH_REPLY_BUDGET_BYTES` (2,560 B), so every rank rides
+/// compact and the model gets `TOOL_SEARCH_DESCRIBE_FOR_SCHEMA_GUIDANCE`
+/// instead of an inline schema. Proves the OTHER production return path is
+/// still never collapsed by the pager, even though it carries no complete
+/// schema.
+#[tokio::test]
+async fn tool_search_reply_falls_back_to_compact_when_rank_one_does_not_fit() {
+    let harness = RebornIntegrationHarness::test_default()
+        .with_tool_disclosure_bridged()
+        .with_github_issue_tools()
+        .script([
+            RebornScriptedReply::tool_call(
+                TOOL_SEARCH_NAME,
+                serde_json::json!({"query": "issues pull requests repository", "limit": 10}),
+            ),
+            RebornScriptedReply::text("done"),
+        ])
+        .build()
+        .await
+        .expect("harness builds");
+    harness
+        .submit_turn("find an issues tool")
+        .await
+        .expect("turn completes");
+    harness
+        .assert_model_tool_result_content_occurrences(r#"\"schema_complete\":true"#, 0)
+        .await
+        .expect("rank 1's own schema misses the budget, so no rank rides complete");
+    harness
+        .assert_model_tool_result_content_occurrences(
+            "call tool_describe on it to get the full parameters schema",
+            1,
+        )
+        .await
+        .expect("the describe-then-invoke guidance string reaches the model");
+    harness
+        .assert_model_tool_result_content_occurrences("omitted", 0)
+        .await
+        .expect("the bounded compact-fallback reply must never be large enough for the pager to elide it");
+    harness
+        .assert_model_tool_result_content_occurrences("json_page", 0)
+        .await
+        .expect("must never fall back to the JSON-page view");
+}

--- a/tests/integration/tool_disclosure.rs
+++ b/tests/integration/tool_disclosure.rs
@@ -97,10 +97,18 @@ async fn assert_deferred_bridge_flow(harness: &RebornIntegrationHarness) {
         .assert_model_tool_result_content_occurrences("get repository", 1)
         .await
         .expect("bounded search result reaches the next production model request");
+    // T2 (#7928 fix): tool_search's own reply is now bounded to fit the first-look
+    // ceiling, so rank 1's complete schema (github.get_repo, containing
+    // "additionalProperties") rides inline in the search reply itself, in
+    // addition to the same schema returned by the later tool_describe call --
+    // two distinct call results now genuinely carry it, not one. Before T2,
+    // tool_search's unbounded ~3.9 KB reply collapsed entirely behind the
+    // first-look pager's "omitted" marker (the exact #7928 defect this plan
+    // fixes), silently hiding this first occurrence.
     harness
-        .assert_model_tool_result_content_occurrences("additionalProperties", 1)
+        .assert_model_tool_result_content_occurrences("additionalProperties", 2)
         .await
-        .expect("describe schema reaches the next production model request");
+        .expect("bounded search's own complete rank-1 schema and the describe schema both reach the model");
     harness
         .assert_tool_invoked("github.get_repo")
         .await
@@ -286,10 +294,14 @@ async fn discovery_batch_classifies_parallel_and_preserves_valid_siblings() {
         .assert_model_tool_result_content_occurrences("get repository", 1)
         .await
         .expect("valid bounded search sibling reaches the next model request");
+    // T2 (#7928 fix): see the comment on the identical assertion in
+    // `assert_deferred_bridge_flow` above -- tool_search's own bounded reply now
+    // carries rank 1's complete schema (github.get_repo) inline, in addition to
+    // the same schema returned by the sibling tool_describe call.
     harness
-        .assert_model_tool_result_content_occurrences("additionalProperties", 1)
+        .assert_model_tool_result_content_occurrences("additionalProperties", 2)
         .await
-        .expect("valid describe schema sibling reaches the next model request");
+        .expect("bounded search's own complete rank-1 schema and the describe schema sibling both reach the model");
     harness
         .assert_model_tool_result_content_occurrences("tool_describe target is unknown", 1)
         .await

--- a/tests/integration/tool_disclosure.rs
+++ b/tests/integration/tool_disclosure.rs
@@ -963,6 +963,12 @@ async fn narrowed_policy_denies_tool_describe_of_non_allowlisted_id() {
         "non-allowlisted vs nonexistent tool_describe must read byte-identical model_observation \
          — a differing diagnostic/status here would be an existence oracle the safe_summary check alone would miss"
     );
+    // T5: the reroute hint (FailureKind::UnknownCapability -> UseDifferentCapability)
+    // reaches the persisted model observation for both branches identically.
+    harness
+        .assert_denial_recovery_hint("use_different_capability")
+        .await
+        .expect("unknown/denied tool_describe target carries the reroute hint");
 }
 
 /// A host-exempt `tool_call` bridge must not expose whether a requested target
@@ -1024,6 +1030,12 @@ async fn narrowed_policy_denies_tool_call_of_non_allowlisted_id_without_existenc
         non_allowlisted.model_observation, nonexistent.model_observation,
         "non-allowlisted and nonexistent tool_call targets must have identical model observations"
     );
+    // T5: the reroute hint (FailureKind::UnknownCapability -> UseDifferentCapability)
+    // reaches the persisted model observation for both branches identically.
+    harness
+        .assert_denial_recovery_hint("use_different_capability")
+        .await
+        .expect("unknown/denied tool_call target carries the reroute hint");
 }
 
 /// #5712 control: an unnarrowed (All) caller keeps the full search catalog —


### PR DESCRIPTION
## Summary

- **`tool_search`'s reply is now sized to the model's first-look envelope, not to an independent budget.** A spike on `c8bdbfa5f7` measured a 10-hit reply serializing to **16,066 B** and reaching the model as **857 B**, with the entire `results` array replaced by a single `omitted` marker — the model saw *zero* results, not worse results. The reply is now bounded by construction: rank 1 carries a complete schema only when the reply containing it actually fits, ranks 2–3 always ride compact, and a `guidance` field names the model's next hop.
- **One shared ceiling replaces three private copies.** `MODEL_FIRST_LOOK_PREVIEW_MAX_BYTES` and `MODEL_OBSERVATION_WRAPPER_ALLOWANCE_BYTES` live in `ironclaw_host_api::model_result_preview` — the lowest crate both consumers already depend on. `ironclaw_composition`'s private `RESULT_PREVIEW_MAX_BYTES` alias and `ironclaw_loop_host`'s `MAX_SEARCH_RESPONSE_BYTES` / `MAX_SEARCH_SIGNATURE_BYTES_PER_RESULT` are deleted outright.
- **Unknown and denied `tool_describe` / `tool_call` targets now reroute instead of misleading.** `failed_invalid_input` is widened into `failed_recoverable(kind, summary)` across all 14 call sites; the three unknown-target sites use `FailureKind::UnknownCapability`, which maps to `CapabilityRecoveryHint::UseDifferentCapability`. Production run `e3513a4e` replayed "tool_describe target is unknown" 19× while the structured hint told the model to fix its arguments.
- **The promotion budget walk no longer drops a small entry that follows an oversized one** (`break` → `continue`, #7892 item B4).
- **D21 records the decision and supersedes D5.**

## Change Type

- [x] Bug fix

## Linked Issue

Related #7928 (primary driver), #7891 (A6), #7892 (B4 fixed; **B1 not closed**).

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_loop_host -p ironclaw_host_api -p ironclaw_composition -p ironclaw_integration_tests --all-targets --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `ironclaw_loop_host` (111), `ironclaw_host_api`, `reborn_integration_tool_disclosure` (41), `reborn_integration_prompt_prefix_stability` (20), `ironclaw_architecture_tests` (42 binaries)
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no database-backed or runtime-integration behavior changed.
- [x] Manual testing: byte arithmetic independently reconstructed and confirmed against live struct definitions before and after implementation.

## Test Strategy

User behavior: a model searching the deferred tool catalog receives usable results inline instead of an `omitted` placeholder, and is told what to do next.

Risk areas:
- [x] Model behavior
- [x] Security or permissions
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `bounded_search_output_*` (boundary promotion, compact worst case, inline-limit truncation, determinism), `select_active_set_admits_a_small_promoted_entry_after_skipping_an_oversized_one`, `tool_search_worst_case_reply_wrapped_observation_fits_the_first_look_ceiling` (composition tier)
- Reborn integration: `tool_search_reply_rides_the_first_look_preview_inline` (fits path), `tool_search_reply_falls_back_to_compact_when_rank_one_does_not_fit` (compact path), `tool_search_replies_never_perturb_the_cached_prompt_prefix`, plus `assert_denial_recovery_hint` on both #5712 tests
- Recorded fixture: Not applicable: no LLM trace behavior changed.
- Browser E2E: Not applicable: no frontend surface.
- Backend or runtime: covered by the integration tier above.
- Live canary: Not applicable: no external provider path changed.

What the tests prove: the model-visible content carries **zero** `omitted` and **zero** `json_page` occurrences on both the fits and the compact-fallback paths — the spike's failure mode is now a permanent regression pin. The worst-case compact reply measures **2,482 B against a 2,560 B budget**, and the wrapped observation's envelope overhead measures **465 B against a 512 B allowance** (two-sided assertion, so an over-generous allowance also fails).

Commands run: see Validation.

## Security Impact

**Issue #5712's existence-oracle invariant is preserved and now additionally pinned.** A denied `tool_describe` / `tool_call` target must remain indistinguishable from a nonexistent one. Both branches receive the identical `FailureKind`, identical message literal, and identical `CapabilityFailureDetail`; `allowed_tool_call_target` returns `None` uniformly for catalog-unknown and policy-denied *before* either reaches a differentiated path. The pre-existing full-value `model_observation` equality assertions still hold, and `assert_denial_recovery_hint` was added to both tests so the new `recovery_hint` field is covered explicitly.

No new network calls, secrets, file access, or sandbox policy changes.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: none added. The two new `pub const`s are plain byte ceilings in a neutral contracts crate.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: unchanged; the reply flows through the existing `first_look_result_preview` → `result_reference_observation` path with no bridge-specific bypass.
- [x] Hashes: N/A — no hashing added or changed.
- [x] New/changed status/exit/policy/runtime/error variants: `FailureKind::UnknownCapability` is pre-existing and its `CapabilityRecoveryHint` mapping is a fixed, wildcard-free match. All 14 `failed_recoverable` call sites audited by compile-time signature change. Command: `rg -n 'failed_recoverable' crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs`
- [x] `serde(default)`: N/A — no serialized struct fields added.
- [x] Bounds and overflow-safe arithmetic: the reply is bounded by construction; the budget derivation is a `const` subtraction of two compile-time constants; slack uses `saturating_sub`.
- [x] Operator-visible error class semantics: unchanged — `FailureKind` variants and their recovery-hint mapping are pre-existing.
- [x] Sandbox/native/host names: N/A.

## Database Impact

None.

## Blast Radius

`ironclaw_loop_host`'s tool-disclosure bridge (the `tool_search` / `tool_describe` / `tool_call` reply path and promotion selection), `ironclaw_composition`'s capability-result preview writer, and two byte constants in `ironclaw_host_api`.

Two **deploy-time** changes to the advertised tools array, both intentional and neither a mid-run mutation (`BRIDGE_TOOL_DEFINITIONS` is a `LazyLock` static resolved once at process start, so #6986's within-a-run byte-identity constraint is unaffected):
1. `tool_search`'s `limit` schema default 10 → 3, plus a description that now states the inline ceiling truthfully.
2. `select_promoted_definitions`' `break` → `continue` changes *which* already-promoted entries land in the array.

**Known gaps, deliberately not fixed here** (both recorded in-repo, not only in this description):
- `tool_describe`'s own reply is still unbounded and rides the generic pager, so a schema over ~2.5 KB can still collapse behind an `omitted` node — and `TOOL_SEARCH_DESCRIBE_FOR_SCHEMA_GUIDANCE` steers the model at exactly that hop. Noted in D21 and beside the constant.
- `ToolDisclosureMode::Compact` is a measurement control arm and is deliberately left unbounded; bounding it would change its wire bytes and invalidate the A/B comparison it exists to run. Noted at the branch.
- The compact path's worst case leaves a **78 B (~3%) margin** that rests on `capability_id` and `required`, which have no enforced total cap and are authored per extension package. Disclosed with a manual revisit trigger; there is no automated detection.

## Rollback Plan

Plain `git revert`. No schema, migration, or persisted-state change. Reverting restores the previous advertised `limit` default and description; D21 would need its supersession note reverted alongside if the whole series is rolled back.

## Review Follow-Through

**Not closing #7892 item B1.** B1 is a *steering* defect — in the cited run the model saw `schema_complete: true` on every result, there was no pager collapse, and it still never invoked. The `guidance` field is a generic partial mitigation, not B1's targeted remedy.

Follow-ups to file separately:
- Relevance floor + repeated-query short-circuit (deferred #7892/#7891 work). `MIN_RELEVANCE_SCORE` needs evaluation against the committed retrieval corpus before it can ship.
- Teach the shared result-preview pager (`render_object_page` / `render_array_page`) to recurse into an oversized array field instead of replacing it wholesale — the generic fix that would close the `tool_describe` gap too.
- A static catalog-listing manifest. Prior-art benchmarks on an ~830-tool catalog show it targets the failure mode that actually occurs (discovery/selection, not schema comprehension): weaker-model success 75% → 90%, pure-discovery scenarios 74% → 89%, and average searches per run 3.96 → 0.19.

Reviewer judgment would be most useful on the 78 B compact-path margin and on whether the `Compact` control arm should stay unbounded.

---

**Review track**: C (runtime + security-relevant invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
