### PR TITLE
fix(memory): a missing document is a domain failure, not a malformed request

### DIFF
--- a/crates/domains/ironclaw_memory/src/service.rs
+++ b/crates/domains/ironclaw_memory/src/service.rs
@@ -438,6 +438,21 @@ impl MemoryServiceError {
             source: None,
         }
     }
+    /// No document exists at the requested path.
+    ///
+    /// A domain failure, not a malformed request: the caller asked a
+    /// well-formed question and the answer is that the document is not there.
+    /// Classifying it as `Input` tells the model to re-encode a request that
+    /// was already correct, which is the one thing it must not do here, since
+    /// probing for a document that does not exist yet is how setup-marker
+    /// skills decide whether to run.
+    pub fn not_found() -> Self {
+        Self {
+            kind: MemoryServiceErrorKind::Operation,
+            message: "no memory document at that path",
+            source: None,
+        }
+    }
 
     pub fn unavailable() -> Self {
         Self {
@@ -477,6 +492,12 @@ impl MemoryServiceError {
 
     pub fn kind(&self) -> MemoryServiceErrorKind {
         self.kind
+    }
+
+    /// The sanitized, model-safe description of the failure. Never carries the
+    /// backend cause: that lives on `source`, which stays host-side.
+    pub fn message(&self) -> &'static str {
+        self.message
     }
 }
 

--- a/crates/extensions/packages/memory-native/src/service.rs
+++ b/crates/extensions/packages/memory-native/src/service.rs
@@ -655,11 +655,14 @@ impl NativeMemoryService {
     /// The standing [`MEMORY_PATH`] document, split into snippet-sized chunks
     /// for the head of the long-term lane. Empty when there is nothing saved.
     ///
-    /// Absence is the NORMAL state — a user who has never saved anything — and
-    /// [`NativeMemoryService::read`] reports it as an `Input` error, so this
-    /// degrades to no curated prefix rather than failing the lane. A backend
-    /// fault degrades the same way, with a `debug!`: memory is best-effort
-    /// context and must never take a turn down with it.
+    /// Absence is the NORMAL state — a user who has never saved anything — so
+    /// this reads the backend directly and treats `Ok(None)` as an empty
+    /// prefix. It deliberately does not go through
+    /// [`NativeMemoryService::read`], which raises absence as a domain failure
+    /// (`Operation`, "no memory document at that path") for a caller that asked
+    /// for one specific document. A backend fault degrades the same way, with a
+    /// `debug!`: memory is best-effort context and must never take a turn down
+    /// with it.
     async fn curated_standing_snippets(
         &self,
         invocation: &MemoryInvocation,

--- a/crates/extensions/packages/memory-native/src/service.rs
+++ b/crates/extensions/packages/memory-native/src/service.rs
@@ -384,7 +384,7 @@ impl NativeMemoryService {
             .await
             .map_err(MemoryServiceError::operation_from)?
         else {
-            return Err(MemoryServiceError::input());
+            return Err(MemoryServiceError::not_found());
         };
         let content = String::from_utf8(bytes).map_err(MemoryServiceError::operation_from)?;
         Ok(MemoryServiceReadResponse {
@@ -759,7 +759,7 @@ impl NativeMemoryService {
                 .await
                 .map_err(MemoryServiceError::operation_from)?
             else {
-                return Err(MemoryServiceError::operation());
+                return Err(MemoryServiceError::not_found());
             };
             let existing = String::from_utf8(bytes).map_err(MemoryServiceError::operation_from)?;
             let current_hash = content_bytes_sha256(existing.as_bytes());

--- a/crates/extensions/packages/memory-native/tests/memory_service_contract.rs
+++ b/crates/extensions/packages/memory-native/tests/memory_service_contract.rs
@@ -1775,3 +1775,90 @@ fn memory_guidance_is_a_compact_self_contained_section() {
         "guidance is appended to every turn's prompt and must stay compact; {lines} lines"
     );
 }
+
+/// Reading a path that holds no document is a domain answer, not a malformed
+/// request. Classifying it as `Input` renders as "the tool input could not be
+/// encoded", which tells the model to re-encode a request that was already
+/// correct.
+#[tokio::test]
+async fn reading_a_missing_document_is_an_operation_failure_not_an_input_error() {
+    let service = NativeMemoryService::from_filesystem(Arc::new(InMemoryBackend::new()), None);
+
+    let error = service
+        .read(
+            invocation(),
+            MemoryServiceReadRequest {
+                path: "projects/commitments/README.md".to_string(),
+            },
+        )
+        .await
+        .expect_err("a document that was never written cannot be read");
+
+    assert_eq!(
+        error.kind(),
+        MemoryServiceErrorKind::Operation,
+        "absence is a domain failure; `Input` would tell the model its arguments were wrong"
+    );
+    assert!(
+        error.message().contains("no memory document"),
+        "the model needs the cause, not a generic failure: {}",
+        error.message()
+    );
+}
+
+/// The same condition reached through `patch`, which took the correct kind
+/// already but reported it with the generic operation message.
+#[tokio::test]
+async fn patching_a_missing_document_names_the_absence() {
+    let service = NativeMemoryService::from_filesystem(Arc::new(InMemoryBackend::new()), None);
+
+    let error = service
+        .write(
+            invocation(),
+            MemoryServiceWriteRequest {
+                target: "notes/never-written.md".to_string(),
+                content: String::new(),
+                append: false,
+                old_string: Some("a".to_string()),
+                new_string: Some("b".to_string()),
+                replace_all: false,
+                metadata: None,
+                timezone: None,
+                expected_content_hash: None,
+            },
+        )
+        .await
+        .expect_err("patching a document that does not exist cannot succeed");
+
+    assert_eq!(error.kind(), MemoryServiceErrorKind::Operation);
+    assert!(
+        error.message().contains("no memory document"),
+        "unexpected message: {}",
+        error.message()
+    );
+}
+
+/// Negative control for the two tests above: a genuinely malformed path is
+/// still an `Input` error. Absence became `Operation`, and this pins that the
+/// change did not drag real input validation along with it.
+#[tokio::test]
+async fn a_malformed_path_is_still_an_input_error() {
+    let service = NativeMemoryService::from_filesystem(Arc::new(InMemoryBackend::new()), None);
+
+    for bad in ["../escape.md", "/absolute.md", "  "] {
+        let error = service
+            .read(
+                invocation(),
+                MemoryServiceReadRequest {
+                    path: bad.to_string(),
+                },
+            )
+            .await
+            .expect_err("a malformed path must be rejected");
+        assert_eq!(
+            error.kind(),
+            MemoryServiceErrorKind::Input,
+            "`{bad}` is a bad request, not a missing document"
+        );
+    }
+}

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/memory.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/memory.rs
@@ -535,19 +535,68 @@ pub fn map_memory_service_error(error: MemoryServiceError) -> FirstPartyCapabili
     match error.kind() {
         MemoryServiceErrorKind::Input => input_error(),
         MemoryServiceErrorKind::Operation | MemoryServiceErrorKind::Unavailable => {
-            // Log only the sanitized error kind — the `Display`/`source` chain
+            // Log only the sanitized error kind: the `Display`/`source` chain
             // can carry backend details or host paths.
             tracing::debug!(
                 error_kind = ?error.kind(),
                 "memory service operation failed"
             );
-            operation_error()
+            // Carry the sanitized message. Without it every domain failure
+            // arrives as the same opaque sentence, so "the document is not
+            // there" is indistinguishable from "the backend is broken" and the
+            // model cannot tell which of the two it should act on.
+            FirstPartyCapabilityError::with_safe_summary(
+                RuntimeDispatchErrorKind::OperationFailed,
+                error.message(),
+            )
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::map_memory_service_error;
+    use crate::first_party::FirstPartyCapabilityError;
+    use ironclaw_host_api::dispatch::RuntimeDispatchErrorKind;
+    use ironclaw_memory::MemoryServiceError;
+
+    /// The service classifying absence correctly is only half of it. This is
+    /// the seam where that classification becomes the sentence the model reads,
+    /// and a `Dispatch { safe_summary: None }` here would put every domain
+    /// failure back behind one opaque message.
+    #[test]
+    fn a_not_found_error_reaches_the_model_as_a_named_operation_failure() {
+        let mapped = map_memory_service_error(MemoryServiceError::not_found());
+
+        let FirstPartyCapabilityError::Dispatch {
+            kind, safe_summary, ..
+        } = mapped
+        else {
+            panic!("a memory service failure must map to a dispatch failure");
+        };
+        assert_eq!(
+            kind,
+            RuntimeDispatchErrorKind::OperationFailed,
+            "absence is a domain failure, not an encoding failure"
+        );
+        assert_eq!(
+            safe_summary.as_deref(),
+            Some("no memory document at that path"),
+            "the cause must survive to the model, not collapse into a generic summary"
+        );
+    }
+
+    /// The other side of the same seam: an input error must keep saying so.
+    #[test]
+    fn an_input_error_still_maps_to_input_encode() {
+        let mapped = map_memory_service_error(MemoryServiceError::input());
+
+        let FirstPartyCapabilityError::Dispatch { kind, .. } = mapped else {
+            panic!("a memory service failure must map to a dispatch failure");
+        };
+        assert_eq!(kind, RuntimeDispatchErrorKind::InputEncode);
+    }
+
     use std::sync::Arc;
 
     use ironclaw_filesystem::InMemoryBackend;

--- a/crates/kernel/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -3502,10 +3502,14 @@ async fn memory_write_treats_null_target_as_omitted() {
     );
 }
 
+/// Reading a path that holds no document reports a domain failure. It used to
+/// report `InputEncode`, which told the model its arguments were malformed
+/// when they were correct, so the model would re-encode a request that could
+/// never succeed instead of concluding the document is absent.
 #[tokio::test]
-async fn memory_read_returns_input_error_for_missing_document() {
+async fn memory_read_returns_operation_failure_for_missing_document() {
     let runtime = runtime_with_filesystem(InMemoryBackend::new());
-    let failure = invoke_with_context(
+    let failure = invoke_failure_with_context(
         &runtime,
         MEMORY_READ_CAPABILITY_ID,
         json!({"path": "projects/alpha/missing.md"}),
@@ -3514,9 +3518,17 @@ async fn memory_read_returns_input_error_for_missing_document() {
             memory_mounts(MountPermissions::read_write_list_delete()),
         ),
     )
-    .await
-    .unwrap_err();
-    assert_eq!(failure, FailureKind::InputEncode);
+    .await;
+    assert_eq!(failure.kind, FailureKind::OperationFailed);
+    // The sentence matters as much as the kind here. Asserting the kind alone
+    // would still pass if the mapper dropped the message, which would put every
+    // domain failure back behind one opaque sentinel and undo the point of the
+    // change: absence has to be distinguishable from a broken backend.
+    assert_eq!(
+        failure.message.as_deref(),
+        Some("no memory document at that path"),
+        "the mapper must carry the service's sentence, not a generic sentinel"
+    );
 }
 
 #[tokio::test]
@@ -3748,7 +3760,9 @@ async fn memory_write_rejects_protected_prompt_write_through_runtime() {
     );
 
     // The protected document must not exist — the rejected write must not
-    // persist, so the subsequent read returns the missing-document input error.
+    // persist, so the subsequent read reports the document as absent. That read
+    // used to have to assert `InputEncode` to mean "not there", because the
+    // memory service had no way to say a document is missing.
     let read_failure = invoke_with_context(
         &runtime,
         MEMORY_READ_CAPABILITY_ID,
@@ -3759,7 +3773,7 @@ async fn memory_write_rejects_protected_prompt_write_through_runtime() {
     .unwrap_err();
     assert_eq!(
         read_failure,
-        FailureKind::InputEncode,
+        FailureKind::OperationFailed,
         "rejected protected-prompt write must not persist the document"
     );
 }


### PR DESCRIPTION
## Summary

- `NativeMemoryService::read` reported a missing document as `MemoryServiceError::input()`, which the host runtime maps to `FailureKind::InputEncode`. That tells the model its tool input could not be encoded.
- The input was fine. The document was absent. The model responds to the wrong signal by rewriting arguments and searching for the document by other means, instead of reporting a one sentence answer.
- Absence is now `MemoryServiceError::not_found()`, projecting to `FailureKind::OperationFailed` with the summary `no memory document at that path`. Patch reports the same way.
- A malformed path stays an input error, because that one really is the caller's fault.
- Measured on a fresh IronClaw home, same prompt, same model: 17 tool calls before, 2 after.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #8041 (one of four instances of the same defect class).

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `reading_a_missing_document_is_an_operation_failure_not_an_input_error`, `patching_a_missing_document_names_the_absence`, `a_malformed_path_is_still_an_input_error`, `memory_read_returns_operation_failure_for_missing_document`
- [ ] `cargo test -p <owning-crate> --features integration`: not applicable, no database-backed or runtime-integration behavior changed. The backend is exercised through the in-memory backend.
- [x] Manual testing: end to end agent runs against a fresh IronClaw home, described under Test Strategy.
- [ ] `pr-shepherd`: not run.

Local gate is the pre-push hook (fmt, clippy, test), which ran on every push to this branch. CI is green.

## Test Strategy

User behavior: a user asks the assistant to read a memory document that does not exist. The correct behavior is one sentence saying so. The observed behavior was a long, expensive search followed by a speculative answer.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [x] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `crates/extensions/packages/memory-native/tests/memory_service_contract.rs`, three cases pinning read absence, patch absence, and the preserved input error for a malformed path.
- Reborn integration: `crates/kernel/ironclaw_host_runtime/tests/first_party_builtin_tools.rs`, `memory_read_returns_operation_failure_for_missing_document` dispatches `MEMORY_READ_CAPABILITY_ID` through `NativeMemoryToolHandler::dispatch` against an empty `InMemoryBackend`, so it exercises `dispatch` then `read` then the mapper rather than calling the mapper directly.
- Recorded fixture: not applicable.
- Browser E2E: not applicable.
- Backend or runtime: covered by the runtime test above.
- Live canary: the before and after agent runs below, on `inclusionai/ling-3.0-flash-fin:free`.

What the tests prove: that absence reaches the model as `OperationFailed` carrying `no memory document at that path`, and not as an input error. The runtime test asserts both the kind and the message, because the kind alone would still pass if the mapper dropped the message, which is the failure mode worth guarding.

Commands run:

```
cargo test -p ironclaw_memory_native
cargo test -p ironclaw_host_runtime --lib
```

### Measured effect

Fresh IronClaw home each run, identical prompt, identical model (`inclusionai/ling-3.0-flash-fin:free`). The only difference is one line in `NativeMemoryService::read`.

Prompt: `Read the memory document at projects/commitments/README.md and tell me what it says.`

The document does not exist. The correct answer is one sentence.

| | tool calls | messages |
|---|---|---|
| before, absence reported as `Input` | 17 | 36 |
| after, absence reported as `Operation` | 2 | 6 |

Before, the model called `memory.read`, then `read_file`, then `glob`, then `memory.tree`, then `list_dir`, and kept widening: `**/commitments/**`, `**/commitment*`, `**/README.md`, `**/projects/**`. It ended by offering the user two unrelated skill files as possible matches.

After, it called `memory.read`, then `memory.tree` once to check the store was empty, and answered:

> The memory document at `projects/commitments/README.md` doesn't exist. The memory store currently contains no documents at all. There's nothing to read at that path.

## Security Impact

None. No change to permissions, network, secrets, file access, tool execution, or sandbox policy. The message sent to the model is a fixed string and carries no path, no backend detail, and no host information. `with_safe_summary` still governs what the model sees.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: no new ones. `not_found()` is a constructor over the existing `MemoryServiceErrorKind::Operation`, not a new variant.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: unchanged. The summary is a fixed literal, not caller-supplied.
- [x] Hashes: not applicable, none added or changed.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. No new enum variant was added, so no match site gained an arm. Audited via `rg 'MemoryServiceErrorKind::' crates/`; every existing site keeps its behavior, and the read and patch paths move between two arms that both already existed.
- [x] Security/durability `serde(default)` fields: none added or changed.
- [x] Queues/maps/buffers/counters: none added or changed.
- [x] Driver/operator-visible errors have stable class semantics: this is the point of the change. Absence moves from `InputEncode`, whose fate is "correct the arguments and retry", to `OperationFailed`, whose fate is "the operation genuinely failed".
- [x] Sandbox/native/host names accurately describe trust boundary: unchanged.

## Database Impact

None. No migrations, no schema change, and no PostgreSQL or libSQL specific behavior. Absence is determined the same way it was before.

## Blast Radius

Three crates: `ironclaw_memory` (the error contract), `memory-native` (the classification), `ironclaw_host_runtime` (the mapping to `FailureKind`).

What could break: any caller that treated a memory read failure as an input error and branched on that. `curated_standing_snippets` was the one to check, and it reads the backend directly and handles `Ok(None)` itself, so it never went through `read`. Callers that only propagate are unaffected. A caller that retried on `InputEncode` will now see `OperationFailed` and stop retrying, which is the intended change.

## Rollback Plan

Revert the two commits. There is no persisted state, no migration, and no wire format involved, so a revert restores the previous behavior exactly.

## Review Follow-Through

CodeRabbit raised three points. Two are addressed in `6718e9d`: the caller-level regression test, and a stale comment that described the old contract and was wrong in both directions.

The third I have deliberately not done, and would value a maintainer's view. It asks that the backend cause be retained or host-logged before mapping. The `debug!` that logs only `error.kind()` predates this PR, along with the comment giving its rationale, that the `Display` and `source` chain can carry backend details or host paths. This PR only changed the line below it. There is a real tension between that and the error handling guideline, but resolving it means deciding what a host-only detail channel should look like for backend causes. That is wider than a failure kind fix and belongs in its own PR. Happy to raise it separately if you would like it pursued.

Rebased onto current `main` on 2 September, so the commit SHAs referenced in earlier review threads have moved. The content is unchanged by the rebase.

---

**Review track**: C (runtime error semantics)
