### PR TITLE
fix(coding): list_dir names the path it could not find

### DIFF
--- a/crates/extensions/ironclaw_extension_support/src/coding/file.rs
+++ b/crates/extensions/ironclaw_extension_support/src/coding/file.rs
@@ -17,7 +17,7 @@ use super::{
     diff_preview::{file_diff_preview, will_use_large_diff_path},
     input_error,
     inputs::{optional_usize, required_str},
-    operation_error, operation_error_with_summary,
+    operation_error_with_summary,
     patch::{parse_apply_patch_input, replacement_error},
     paths::{
         create_parent_dir_unless_sensitive, filesystem_error, filesystem_error_with_summary,
@@ -637,7 +637,14 @@ pub(super) async fn list_dir(
             return Err(
                 match super::paths::unactivated_skill_hint(resolved.scoped_path.as_str()) {
                     Some(hint) => operation_error_with_summary(hint),
-                    None => operation_error(),
+                    // Name the path, as every other coding tool does through
+                    // `filesystem_error_with_summary`. Without it the failure carries only the
+                    // kind's fixed sentence and the loop has no cause to pass on, so the model
+                    // cannot tell a missing directory from a broken filesystem.
+                    None => operation_error_with_summary(format!(
+                        "list_dir failed for {}: path not found",
+                        safe_summary_path(resolved.scoped_path.as_str())
+                    )),
                 },
             );
         }

--- a/crates/kernel/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -281,6 +281,40 @@ async fn builtin_coding_grep_failure_reports_missing_root_path() {
     );
 }
 
+/// `list_dir` on a path that does not exist must name the path, like every sibling tool does.
+///
+/// Observed in production: `list_dir {"path": "commitments", "recursive": true}` against a
+/// directory that was never created. The failure carried no message at all, so the loop fell back
+/// to the shared `MODEL_DIAGNOSTIC_UNAVAILABLE` constant and the model was told only "the tool
+/// operation failed" with "the capability runtime did not provide additional diagnostic detail".
+/// It cannot tell a missing directory from a broken filesystem from that, and `operation_failed`
+/// permits retrying the same call.
+///
+/// `grep`, `read_file`, `apply_patch` and `document_edit` all route their misses through
+/// `filesystem_error_with_summary` and name the path. `list_dir` resolves its own miss from a
+/// `stat` that returns `None`, and that branch was the one place the path was dropped.
+#[tokio::test]
+async fn builtin_coding_list_dir_failure_reports_missing_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
+    let runtime = runtime_with_filesystem(filesystem);
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let failure = invoke_failure_with_context(
+        &runtime,
+        LIST_DIR_CAPABILITY_ID,
+        json!({"path": "/workspace/commitments", "recursive": true}),
+        context,
+    )
+    .await;
+
+    assert_eq!(failure.kind, FailureKind::OperationFailed);
+    assert_eq!(
+        failure.message.as_deref(),
+        Some("list_dir failed for path workspace commitments: path not found")
+    );
+}
+
 #[tokio::test]
 async fn builtin_coding_grep_failure_reports_file_disappeared_before_read() {
     let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- `list_dir` on a path that does not exist returned the bare summary `list_dir failed`, with no path in it.
- The model cannot tell which of its several in-flight paths failed, so it re-lists parents and siblings to work out what happened.
- The failure now names the path it could not find, through the same `safe_summary_path` used by the sibling `grep` failures, so scoping is unchanged.
- This is the smallest of a set of four, all the same class: a tool failure that does not carry the information the model needs to recover.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #8041 (one of four instances of the same defect class).

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `builtin_coding_list_dir_failure_reports_missing_path`, alongside the existing `builtin_coding_grep_failure_reports_missing_root_path` and `builtin_coding_grep_failure_reports_file_disappeared_before_read`
- [ ] `cargo test -p <owning-crate> --features integration`: not applicable, no database-backed or runtime-integration behavior changed.
- [x] Manual testing: confirmed the message reaching the model names the path.
- [ ] `pr-shepherd`: not run.

Local gate is the pre-push hook (fmt, clippy, test), which ran on every push to this branch. CI is green.

## Test Strategy

User behavior: the assistant lists a directory that is not there. It should be able to say which path was missing and move on, rather than probing the filesystem to find out what its own error referred to.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Security or permissions is ticked because the change puts a path into a model-visible string. That is the one thing worth reviewing here, and it is handled by reusing `safe_summary_path`, the same scoping the neighbouring `grep` failures already use. The path is the scoped path, not a host path.

Tests added or updated:
- Unit or contract: not applicable, the behavior is only observable through the runtime.
- Reborn integration: `crates/kernel/ironclaw_host_runtime/tests/first_party_coding_tools.rs`, `builtin_coding_list_dir_failure_reports_missing_path`, which dispatches the real capability against a missing path and asserts the summary contains it.
- Recorded fixture: not applicable.
- Browser E2E: not applicable.
- Backend or runtime: covered by the runtime test above.
- Live canary: not applicable, the change is a message string.

What the tests prove: that the path reaches the model in the failure summary, and that it is the scoped path rather than a host path. The test sits directly beside the two `grep` equivalents, so the three failure messages are pinned as a set and cannot drift apart again.

Commands run:

```
cargo test -p ironclaw_host_runtime --test first_party_coding_tools
```

## Security Impact

The change adds a path to a model-visible error summary. It goes through `safe_summary_path`, which is what the adjacent `grep` failures already use, so the exposed value is the scoped path and not a host path. No change to permissions, network, secrets, file access, tool execution, or sandbox policy.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: none added or changed.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive: the path is scoped through `safe_summary_path` before it reaches the summary, which is the primitive the sibling failures use.
- [x] Hashes: not applicable.
- [x] New/changed status, exit, policy, runtime, or error variants: none. The failure kind is unchanged, only the summary text. No match site is affected.
- [x] Security/durability `serde(default)` fields: none.
- [x] Queues/maps/buffers/counters: none.
- [x] Driver/operator-visible errors have stable class semantics: unchanged here. The kind was already right. This PR fixes the other half of the signal, the summary.
- [x] Sandbox/native/host names accurately describe trust boundary: unchanged, and `safe_summary_path` is the boundary primitive.

## Database Impact

None. No migrations, no schema change, no PostgreSQL or libSQL specific behavior.

## Blast Radius

One function in `crates/extensions/ironclaw_extension_support/src/coding/file.rs`, plus a test.

What could break: anything asserting on the exact previous string `list_dir failed`. I checked and nothing did apart from the test added here. The failure kind is untouched, so no control flow changes.

## Rollback Plan

Revert the single commit. The change is a message string and a test, with no persisted state, migration, or wire format.

## Review Follow-Through

Nothing outstanding. No review comments have been raised on this PR.

The one judgment call worth a reviewer's eye is the choice to reuse `safe_summary_path` rather than introduce separate scoping. That keeps `list_dir` consistent with the `grep` failures beside it, which seems better than a second convention, but I am happy to change it if you would rather these were scoped differently.

---

**Review track**: C (runtime, model-visible error surface)
