### PR TITLE
fix(tool-disclosure): an unresolvable tool name is not an encoding error

### DIFF
--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -1203,7 +1203,19 @@ impl ToolDisclosureCapabilityPort {
                     "tool_call arguments must be a JSON object encoded as a string",
                 ))
             }
-            BridgeKind::Call => Ok(failed_invalid_input(
+            // A `tool_call` with no `name` really is malformed input, and it
+            // reaches the same fallback as an unresolvable name. Split it out so
+            // the kind below can be about resolution only.
+            BridgeKind::Call
+                if bridge
+                    .arguments
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .is_none() =>
+            {
+                Ok(failed_invalid_input("tool_call requires name"))
+            }
+            BridgeKind::Call => Ok(failed_unknown_target(
                 "tool_call target is not a known tool; use tool_search to find the correct tool name",
             )),
         }
@@ -1302,12 +1314,13 @@ impl ToolDisclosureCapabilityPort {
                 return Ok(failed_invalid_input("tool catalog is unavailable"));
             };
             let Some(result) = state.catalog.search_result(name) else {
-                return Ok(failed_invalid_input("tool_describe target is unknown"));
+                return Ok(failed_unknown_target("tool_describe target is unknown"));
             };
             // #5712: same message as a truly unknown name — a narrowed profile
-            // must not learn that a non-allowlisted tool exists.
+            // must not learn that a non-allowlisted tool exists. The kind has to
+            // match for the same reason, so these two move together.
             if !self.policy.permits_capability_id(&result.capability_id) {
-                return Ok(failed_invalid_input("tool_describe target is unknown"));
+                return Ok(failed_unknown_target("tool_describe target is unknown"));
             }
             if let Some(selected_rank) = state.search_ranks.get(&result.name).copied() {
                 debug!(
@@ -1350,7 +1363,7 @@ impl ToolDisclosureCapabilityPort {
                 return Ok(failed_invalid_input("tool catalog is unavailable"));
             };
             let Some(result) = state.catalog.search_result(name) else {
-                return Ok(failed_invalid_input("auto-schema target is unknown"));
+                return Ok(failed_unknown_target("auto-schema target is unknown"));
             };
             state.disclosed_names.insert(result.name.clone());
             json!({
@@ -1649,6 +1662,21 @@ fn decode_tool_call_arguments(bridge_arguments: &Value) -> Option<Value> {
 fn failed_invalid_input(summary: &'static str) -> Resolution {
     resolution::failed(
         ironclaw_host_api::result_meta::FailureKind::InputEncode,
+        summary.to_string(),
+        CapabilityFailureDetail::Diagnostic {
+            text: summary.to_string(),
+        },
+    )
+}
+
+/// The model named a tool the catalog cannot resolve. The arguments encoded
+/// fine, so this is not `InputEncode`: its recovery hint is
+/// `CorrectArgumentsBeforeRetry`, which tells the model to rewrite arguments it
+/// did not get wrong. `UnknownCapability` carries `UseDifferentCapability`,
+/// which is the move that can actually succeed.
+fn failed_unknown_target(summary: &'static str) -> Resolution {
+    resolution::failed(
+        ironclaw_host_api::result_meta::FailureKind::UnknownCapability,
         summary.to_string(),
         CapabilityFailureDetail::Diagnostic {
             text: summary.to_string(),
@@ -3681,12 +3709,12 @@ mod tests {
                     if matches!(
                         o.verdict,
                         ToolVerdict::RecoverableFailure {
-                            error_kind: FailureKind::InputEncode,
+                            error_kind: FailureKind::UnknownCapability,
                             ..
                         }
                     )
             ),
-            "fallback must be a recoverable InvalidInput failure, not run death"
+            "fallback must be a recoverable unknown-target failure, not run death"
         );
     }
 
@@ -3745,12 +3773,12 @@ mod tests {
                     if matches!(
                         o.verdict,
                         ToolVerdict::RecoverableFailure {
-                            error_kind: FailureKind::InputEncode,
+                            error_kind: FailureKind::UnknownCapability,
                             ..
                         }
                     )
             ),
-            "recursive tool_call must be a recoverable InvalidInput failure, not run death"
+            "recursive tool_call must be a recoverable unknown-target failure, not run death"
         );
         assert!(
             inner
@@ -3908,12 +3936,12 @@ mod tests {
                     if matches!(
                         o.verdict,
                         ToolVerdict::RecoverableFailure {
-                            error_kind: FailureKind::InputEncode,
+                            error_kind: FailureKind::UnknownCapability,
                             ..
                         }
                     )
             ),
-            "unknown-target tool_call must be a recoverable InvalidInput failure"
+            "unknown-target tool_call must be a recoverable unknown-capability failure"
         );
         assert!(
             inner
@@ -3931,6 +3959,83 @@ mod tests {
                 .is_empty(),
             "unknown target must not dispatch to the inner port"
         );
+    }
+
+    /// The kind has to separate "your arguments are wrong" from "no such tool".
+    ///
+    /// Observed in production with progressive disclosure on: the model called
+    /// `tool_call {"name": "commitment-digest", "arguments": "{}"}`, naming a
+    /// skill rather than a tool. The arguments encoded fine — the name simply
+    /// did not resolve — but the failure came back as `input_encode`, whose
+    /// recovery hint is `CorrectArgumentsBeforeRetry`. The model was told to
+    /// rewrite arguments that were already correct.
+    ///
+    /// `UnknownCapability` carries `UseDifferentCapability`, which is the move
+    /// that can actually succeed. A `tool_call` with no `name` at all is still
+    /// malformed input and must keep `InputEncode`; both halves are pinned here
+    /// so neither can drift onto the other.
+    #[tokio::test]
+    async fn tool_call_separates_an_unresolvable_name_from_malformed_arguments() {
+        let inner = Arc::new(SpyPort {
+            definitions: vec![provider_definition(
+                "fixture.read_file",
+                "read_file",
+                "Read a file",
+            )],
+            surface_version: CapabilitySurfaceVersion::new("surface:test")
+                .expect("valid surface version"),
+            registered_calls: Mutex::new(Vec::new()),
+            invocations: Mutex::new(Vec::new()),
+        });
+        let port = disclosure_port(
+            Arc::clone(&inner) as Arc<dyn LoopCapabilityPort>,
+            run_context(TurnId::new()).await,
+            Arc::new(Mutex::new(HashMap::new())),
+        );
+        port.visible_capabilities(VisibleCapabilityRequest)
+            .await
+            .expect("surface builds turn state");
+
+        for (arguments, expected, case) in [
+            (
+                json!({"name": "commitment-digest", "arguments": "{}"}),
+                FailureKind::UnknownCapability,
+                "a well-formed call naming a tool that does not exist",
+            ),
+            (
+                json!({"arguments": "{}"}),
+                FailureKind::InputEncode,
+                "a call with no name at all",
+            ),
+        ] {
+            let candidate =
+                port.register_provider_tool_call(RegisterProviderToolCallRequest::new(
+                    provider_call(TOOL_CALL_NAME, arguments),
+                ))
+                .await
+                .expect("tool_call registers on the bridge path");
+            let outcome = port
+                .invoke_capability(LoopRequest {
+                    activity_id: candidate.activity_id,
+                    surface_version: candidate.surface_version,
+                    capability_id: candidate.capability_id,
+                    input_ref: candidate.input_ref,
+                    approval_resume: None,
+                    auth_resume: None,
+                })
+                .await
+                .expect("bridge resolves the call");
+            let Resolution::Done(outcome) = outcome else {
+                panic!("{case} must resolve, got {outcome:?}");
+            };
+            let ToolVerdict::RecoverableFailure { error_kind, .. } = outcome.verdict else {
+                panic!(
+                    "{case} must be a recoverable failure, got {:?}",
+                    outcome.verdict
+                );
+            };
+            assert_eq!(error_kind, expected, "{case}");
+        }
     }
 
     #[tokio::test]

--- a/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/tool_disclosure_port.rs
@@ -174,11 +174,15 @@ enum BridgeKind {
     /// Internal auto-schema (describe-first): return a deferred tool's schema
     /// after a blind call to it failed pre-dispatch validation.
     DescribeFirst,
-    /// `tool_call` — invoke a tool by name. Reaching invoke with this kind means
-    /// the target could not be resolved (a resolvable target is dispatched
-    /// directly and never stored as a bridge invocation), so it always errors
-    /// recoverably.
+    /// `tool_call` — invoke a tool by name that the catalog could not resolve,
+    /// or that policy hides. A resolvable, registrable target is dispatched
+    /// directly and never stored as a bridge invocation.
     Call,
+    /// `tool_call` — the target DID resolve and was allowed, but the inner port
+    /// refused to register it (typically malformed arguments for a deferred
+    /// tool). Distinct from [`BridgeKind::Call`] because the tool exists: the
+    /// model should fix its arguments, not go looking for another tool.
+    CallUnregistrable,
 }
 
 struct BoundedCountingWriter {
@@ -558,11 +562,12 @@ impl LoopCapabilityPort for ToolDisclosureCapabilityPort {
                         error_kind = ?error.kind,
                         "tool_call target registration failed; falling back to recoverable bridge failure"
                     );
-                    return self.register_bridge_call(tool_call);
+                    return self
+                        .register_bridge_call(tool_call, Some(BridgeKind::CallUnregistrable));
                 }
             }
         }
-        self.register_bridge_call(tool_call)
+        self.register_bridge_call(tool_call, None)
     }
 
     async fn visible_capabilities(
@@ -1038,6 +1043,7 @@ impl ToolDisclosureCapabilityPort {
     fn register_bridge_call(
         &self,
         tool_call: ProviderToolCall,
+        kind_override: Option<BridgeKind>,
     ) -> Result<CapabilityCallCandidate, AgentLoopHostError> {
         let Some(definition) = bridge_tool_definitions()
             .into_iter()
@@ -1061,9 +1067,13 @@ impl ToolDisclosureCapabilityPort {
             .insert(
                 input_ref.as_str().to_string(),
                 BridgeInvocation {
-                    kind: BridgeKind::from_provider_name(tool_call.name.as_str()).ok_or_else(
-                        || invalid_invocation("bridge tool definition is unavailable"),
-                    )?,
+                    kind: match kind_override {
+                        Some(kind) => kind,
+                        None => BridgeKind::from_provider_name(tool_call.name.as_str())
+                            .ok_or_else(|| {
+                                invalid_invocation("bridge tool definition is unavailable")
+                            })?,
+                    },
                     arguments: tool_call.arguments.clone(),
                 },
             );
@@ -1215,6 +1225,11 @@ impl ToolDisclosureCapabilityPort {
             {
                 Ok(failed_invalid_input("tool_call requires name"))
             }
+            // The target resolved and was allowed; only registration failed, so
+            // the tool exists and the arguments are the thing to fix.
+            BridgeKind::CallUnregistrable => Ok(failed_invalid_input(
+                "tool_call arguments were rejected by the target tool; check its schema with tool_describe and retry",
+            )),
             BridgeKind::Call => Ok(failed_unknown_target(
                 "tool_call target is not a known tool; use tool_search to find the correct tool name",
             )),
@@ -3709,12 +3724,30 @@ mod tests {
                     if matches!(
                         o.verdict,
                         ToolVerdict::RecoverableFailure {
-                            error_kind: FailureKind::UnknownCapability,
+                            error_kind: FailureKind::InputEncode,
                             ..
                         }
                     )
             ),
-            "fallback must be a recoverable unknown-target failure, not run death"
+            "a resolved target that failed registration is an input error, not an unknown tool"
+        );
+        // And it must not be described as an unknown tool either: the summary is
+        // the other half of the signal, and sending the model tool_search here
+        // would be a wild goose chase for a tool that exists.
+        let Resolution::Done(done) = outcome else {
+            panic!("registration failure must resolve");
+        };
+        let ToolVerdict::RecoverableFailure { diagnostic, .. } = done.verdict else {
+            panic!("registration failure must be recoverable");
+        };
+        let summary = format!("{diagnostic:?}");
+        assert!(
+            !summary.contains("not a known tool"),
+            "a registrable-but-rejected target must not read as unknown: {summary}"
+        );
+        assert!(
+            summary.contains("arguments"),
+            "the summary should point at the arguments, which are the fixable thing: {summary}"
         );
     }
 


### PR DESCRIPTION
## The bug

The tool-disclosure bridge mints every recoverable failure through one helper, `failed_invalid_input`, which stamps `FailureKind::InputEncode` on all of them. Two unrelated situations end up sharing that kind.

The first is genuinely malformed input, where it is the right answer: a `tool_search` whose query is missing, non-string, blank or oversized; a `tool_call` whose `arguments` are not a JSON object encoded as a string; a `tool_describe` with no `name`.

The second is a name that does not resolve. `allowed_tool_call_target` returns `None` when the catalog has no such tool, and the caller falls through to the same arm. Here the input encoded perfectly well. The JSON was valid, the field was present, the value was a string — it simply does not name anything callable.

That distinction is already load-bearing in the failure vocabulary. `InputEncode` maps to the recovery hint `CorrectArgumentsBeforeRetry`; `UnknownCapability` maps to `UseDifferentCapability`. The two ask for opposite things. A model told to correct its arguments, when the arguments were never the problem, has nothing it can usefully change, so the obvious move is to send the call again.

## Observed

A 1.2.0 deployment with `REBORN_TOOL_DISCLOSURE=Namespaces`:

```
ironclaw.tool_call  {"name": "commitment-digest", "arguments": "{}"}
→ failure_kind: input_encode
   summary:      Capability failed with input_encode.
```

`commitment-digest` is a skill, not a tool. Nothing about the arguments was wrong.

## The change

The three name-resolution sites return `UnknownCapability` through a new sibling helper: the `tool_call` target, the `tool_describe` target, and the auto-schema target. Summaries are deliberately untouched — the integration suite asserts on that text in six places, and the text was never the part that was wrong.

Both `tool_describe` returns move together on purpose. #5712 gives a policy-hidden tool the identical message to a nonexistent one, so a narrowed profile cannot use the bridge as an existence oracle. The failure kind is exactly as visible as the message, so changing one and not the other would reopen that hole through a different field.

One genuine input error was reaching the same arm and needed separating first: a `tool_call` with no `name` at all. `allowed_tool_call_target` returns `None` for that case just as it does for an unresolvable name, so both landed together. It is split out and keeps `InputEncode`, which leaves the arm below about resolution only.

Both kinds are survivable under `FailureFate` and dispositioned `ModelVisibleToolError`, so nothing here changes whether a run continues. Only the guidance the model receives changes.

## Not in this PR

Three further sites return `InputEncode` for `tool catalog is unavailable`. That is neither malformed input nor a failed resolution — it is missing turn state, an internal fault the model cannot act on at all. It wants a different kind and arguably a different audience, and none of the three is reachable from the case observed here.

## Tests

`tool_call_separates_an_unresolvable_name_from_malformed_arguments` drives both halves through the real port and asserts the kinds differ.

Reverting only the production hunks and keeping the tests:

```
running 1 test
test tool_disclosure_port::tests::tool_call_separates_an_unresolvable_name_from_malformed_arguments ... FAILED

---- tool_call_separates_an_unresolvable_name_from_malformed_arguments stdout ----
assertion `left == right` failed: a well-formed call naming a tool that does not exist
  left: InputEncode
 right: UnknownCapability

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 717 filtered out
```

Restored:

```
running 1 test
test tool_disclosure_port::tests::tool_call_separates_an_unresolvable_name_from_malformed_arguments ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 717 filtered out
```

Three existing tests pinned the old kind on this arm. Two are repointed: the unknown-target guard and the recursion guard, both genuinely unresolvable names.

The third, the registration-failure fallback, is not, and the first revision of this PR got it wrong. That path is reached when a target resolved, passed the allowlist, and was then refused by the inner port, which the fallback's own comment describes as malformed arguments for a deferred tool. Calling that `UnknownCapability` sends the model hunting for a tool that exists. It keeps `InputEncode` and gains a summary naming the arguments, replacing one that read "not a known tool" about a known tool.

`BridgeKind::Call`'s doc comment claimed this case could not occur, which stopped being true when the registration fallback was added. That is corrected, and a `CallUnregistrable` variant now distinguishes the two ways the arm is reached.

| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo test -p ironclaw_loop_host --lib` | 718 passed, 0 failed |
| `cargo test --workspace --no-fail-fast` | 497 suites passed, 1 failed |

The one failing suite is `docker_reborn_entrypoint_uses_railway_volume_mount_for_home`: a macOS `/var/folders` symlink resolution problem in a Railway containment check, unrelated to this change and failing the same way on an unmodified tree.

