### PR TITLE
fix(ci): the pre-push gate cannot run on macOS

### DIFF
--- a/crates/app/ironclaw_cli/tests/smoke.rs
+++ b/crates/app/ironclaw_cli/tests/smoke.rs
@@ -754,7 +754,15 @@ fn docker_reborn_production_config_uses_postgres_storage() {
     assert_eq!(policy.default_profile.as_deref(), Some("secure_default"));
 }
 
-#[cfg(unix)]
+// Linux, not just unix: this is the one entrypoint test that reaches the
+// canonicalized containment check, and that check runs `readlink -m`. `-m` is a
+// GNU coreutils extension, so on a BSD `readlink` the entrypoint fails closed
+// with "Failed to resolve ..." and the test fails on every macOS checkout. The
+// entrypoint is a Linux container's, so this asserts container behaviour and
+// belongs where the container runs. The sibling `rejects_*` tests stay `unix`:
+// they trip the lexical `IRONCLAW_REBORN_HOME` check and exit before any
+// canonicalization, so they pass on macOS for the right reason.
+#[cfg(target_os = "linux")]
 #[test]
 fn docker_reborn_entrypoint_uses_railway_volume_mount_for_home() {
     let temp = tempfile::tempdir().expect("tempdir");

--- a/scripts/ci/reborn-local-coverage-ratchet.sh
+++ b/scripts/ci/reborn-local-coverage-ratchet.sh
@@ -72,8 +72,12 @@ while IFS= read -r bucket; do
             incremental_env=(env CARGO_INCREMENTAL=0)
         fi
 
+        # `${incremental_env[@]}` is empty for every package but composition, and
+        # bash 3.2 -- still the /bin/bash macOS ships -- treats expanding an empty
+        # array as an unbound variable under `set -u`. bash 4.4 fixed that; the
+        # `[@]+` guard works on both.
         # shellcheck disable=SC2086 # feature_flags intentionally expands to zero or more Cargo args.
-        run_cargo_cov_env "${incremental_env[@]}" cargo llvm-cov -p "${package}" ${feature_flags} --all-targets \
+        run_cargo_cov_env "${incremental_env[@]+"${incremental_env[@]}"}" cargo llvm-cov -p "${package}" ${feature_flags} --all-targets \
             --lcov --output-path "${package_lcov}" \
             test -- --nocapture
     done < <(jq -r '.packages[]' <<<"${bucket}")


### PR DESCRIPTION
## Summary

- The pre-push hook cannot complete on a macOS checkout. Two independent causes, one in a test and one in a CI script, each fatal on its own.
- `readlink -m` is a GNU extension, so the one entrypoint test that reaches the canonicalized Railway containment check fails on BSD `readlink`. That test is now gated to Linux, where the container it asserts about actually runs.
- `reborn-local-coverage-ratchet.sh` expands an empty array under `set -u`, which is an unbound variable error on bash 3.2, still the `/bin/bash` macOS ships. Guarded with `[@]+`.
- Neither affects CI or production. Both affect anyone developing on a Mac, and the practical result is that the hook gets bypassed with environment switches, which is worse than either bug.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. This is a local developer environment fix, not a behavior change.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `docker_reborn_entrypoint_uses_railway_volume_mount_for_home` now compiles out on macOS and continues to run on Linux. The seven sibling entrypoint tests are unchanged and still pass on both.
- [ ] `cargo test -p <owning-crate> --features integration`: not applicable.
- [x] Manual testing: the shell guard was verified directly on bash 3.2.57, output below.
- [ ] `pr-shepherd`: not run.

## Test Strategy

User behavior: a contributor on macOS runs `git push` and the pre-push hook completes, rather than failing on two environment differences that have nothing to do with their change.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated: no new tests. One existing test is narrowed in platform scope, and the coverage it provides is unchanged on the platform that matters.
- Unit or contract: not applicable.
- Reborn integration: `docker_reborn_entrypoint_uses_railway_volume_mount_for_home` gated to `#[cfg(target_os = "linux")]`.
- Recorded fixture: not applicable.
- Browser E2E: not applicable.
- Backend or runtime: not applicable.
- Live canary: not applicable.

What the tests prove: that CI keeps the Railway containment coverage, because CI runs Linux. The entrypoint under test is a Linux container's entrypoint, and the test asserts container behavior, so it belongs where the container runs.

I checked whether the seven sibling entrypoint tests were passing vacuously on macOS, and they are not. The `rejects_*` cases trip the earlier lexical `IRONCLAW_REBORN_HOME` check and exit before any canonicalization, so they never reach `readlink` and pass for the right reason. They stay `#[cfg(unix)]` deliberately.

Commands run:

```
cargo test -p ironclaw --test smoke
bash scripts/ci/reborn-local-coverage-ratchet.sh
```

### 1. `readlink -m` is GNU only

The test hands the script `PATH=<fake bin>:/usr/bin:/bin`, so on macOS it gets BSD `readlink`, which has no `-m`:

```
/usr/bin/readlink: illegal option -- m
usage: readlink [-fn] [file ...]
```

The entrypoint does the right thing and fails closed:

```
Failed to resolve IRONCLAW_REBORN_WORKSPACE_ROOT=/var/folders/.../railway-volume/ironclaw-reborn/workspace
for the Railway containment check.
```

so the test fails, and takes `cargo test` and the hook with it. The guard itself is untouched.

### 2. Empty array expansion under `set -u` on bash 3.2

`incremental_env=()` is populated only for `ironclaw_composition`. Expanding an empty array with `[@]` under `set -u` is an unbound variable error on bash 3.2. bash 4.4 changed this, so CI never sees it.

```
==> cargo llvm-cov -p ironclaw_host_runtime --features test-support test
scripts/ci/reborn-local-coverage-ratchet.sh: line 76: incremental_env[@]: unbound variable
```

Verified on bash 3.2.57:

```
unguarded empty : arraytest.sh: line 3: a[@]: unbound variable
guarded empty   : []
guarded nonempty: [env][CARGO_INCREMENTAL=0]
```

The non-empty case still expands to two separate words, which is what the `env CARGO_INCREMENTAL=0` prefix needs.

I checked the other arrays in `scripts/ci/*.sh` for the same pattern. Every other `[@]` expansion is either guarded by a `${#x[@]} -gt 0` test first, or provably non-empty at the expansion point (`CANDIDATES` in `check-hermetic-env.sh` always receives six entries before it is read). This is the only instance.

## Security Impact

None. No change to permissions, network, secrets, file access, tool execution, or sandbox policy. The Railway containment guard in the entrypoint is not modified, only the platform scope of the test that exercises it.

## Reborn Trust-Boundary Checklist

N/A with reason: this changes a test's platform gate and a shell array expansion in a local coverage script. No runtime, security, or DB code is touched, and the containment guard the test covers is unmodified.

The one item that does apply:
- [x] Sandbox/native/host names accurately describe trust boundary: unchanged. The containment check still fails closed when it cannot canonicalize a path, which is the behavior the gated test asserts on Linux.

## Database Impact

None. No migrations, no schema change, no PostgreSQL or libSQL specific behavior.

## Blast Radius

Two files: `crates/app/ironclaw_cli/tests/smoke.rs` and `scripts/ci/reborn-local-coverage-ratchet.sh`.

What could break: the Railway containment case no longer runs on non-Linux developer machines. That is the intent, and it was not passing there anyway. On Linux, including all of CI, coverage is identical. The shell guard is behavior-preserving on both bash versions, verified above.

## Rollback Plan

Revert the two commits. No persisted state, no migration, no wire format. Reverting restores the previous behavior, including the macOS failure.

## Review Follow-Through

Three checks are currently red on this PR, and none of them are this diff:

- `Fast deterministic checks` fails on `cargo-deny check advisories`, against `wasmtime 47.0.3` in the lockfile (RUSTSEC-2026-0268 and RUSTSEC-2026-0269). Pre-existing on the base branch, and a lockfile bump is outside this PR's scope. Happy to include it here if you would prefer that to a separate PR.
- `Code Style (fmt + clippy)` fails only because it gates on the job above (`fast-checks failed: failure`). No fmt or clippy lint fired.
- `Regression test enforcement` denies the reasoned commit marker, because the exemption needs a non-author approving review or the `skip-regression-check` label, and there is neither. This one resolves itself on review, but it is worth flagging that a two-line shell guard and a platform gate cannot carry a behavioral regression test in the usual sense, which is why the marker is there.

---

**Review track**: C (CI)
