### PR TITLE
feat(llm): preserve NEAR AI model capabilities through discovery

### DIFF
--- a/crates/app/ironclaw_composition/src/runtime/tests/core.rs
+++ b/crates/app/ironclaw_composition/src/runtime/tests/core.rs
@@ -1034,6 +1034,7 @@ async fn standalone_cli_send_uses_saved_user_model_preference() {
                     "workspace-default".to_string(),
                     "preferred-model".to_string(),
                 ],
+                model_entries: Vec::new(),
             },
         )
         .await

--- a/crates/app/ironclaw_composition/src/runtime/tests/core.rs
+++ b/crates/app/ironclaw_composition/src/runtime/tests/core.rs
@@ -1034,7 +1034,7 @@ async fn standalone_cli_send_uses_saved_user_model_preference() {
                     "workspace-default".to_string(),
                     "preferred-model".to_string(),
                 ],
-                model_entries: Vec::new(),
+                model_entries: Some(Vec::new()),
             },
         )
         .await

--- a/crates/contracts/ironclaw_product_contracts/src/operator_llm.rs
+++ b/crates/contracts/ironclaw_product_contracts/src/operator_llm.rs
@@ -539,6 +539,9 @@ pub struct LlmModelCatalogEntry {
     pub output_modalities: Vec<LlmModelModality>,
 }
 
+/// Maximum serialized size accepted for a persisted model-selection policy.
+pub const MODEL_SELECTION_POLICY_MAX_BYTES: usize = 64 * 1024;
+
 /// Result of a model-listing probe.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LlmModelsResult {
@@ -588,8 +591,10 @@ impl UserModelCatalog {
 pub struct SetUserModelPolicyRequest {
     pub workspace_default: String,
     pub allowed_models: Vec<String>,
-    #[serde(default)]
-    pub model_entries: Vec<LlmModelCatalogEntry>,
+    /// `None` preserves metadata supplied by an earlier detailed-catalog client.
+    /// An explicit empty list clears it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_entries: Option<Vec<LlmModelCatalogEntry>>,
 }
 
 /// Caller-scoped model preference. `None` follows the workspace default.

--- a/crates/contracts/ironclaw_product_contracts/src/operator_llm.rs
+++ b/crates/contracts/ironclaw_product_contracts/src/operator_llm.rs
@@ -515,12 +515,38 @@ pub struct LlmProbeResult {
     pub message: String,
 }
 
+/// Stable, display-only model modality exposed through product surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmModelModality {
+    Text,
+    Image,
+    Audio,
+    Video,
+    Embedding,
+}
+
+/// A model identifier and the directional capabilities reported by its provider.
+///
+/// These fields are presentation metadata and must not influence routing,
+/// authorization, or model-policy enforcement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LlmModelCatalogEntry {
+    pub id: String,
+    #[serde(default)]
+    pub input_modalities: Vec<LlmModelModality>,
+    #[serde(default)]
+    pub output_modalities: Vec<LlmModelModality>,
+}
+
 /// Result of a model-listing probe.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LlmModelsResult {
     pub ok: bool,
     #[serde(default)]
     pub models: Vec<String>,
+    #[serde(default)]
+    pub model_entries: Vec<LlmModelCatalogEntry>,
     pub message: String,
 }
 
@@ -530,6 +556,8 @@ pub struct ModelSelectionPolicy {
     pub provider_id: String,
     pub workspace_default: String,
     pub allowed_models: Vec<String>,
+    #[serde(default)]
+    pub model_entries: Vec<LlmModelCatalogEntry>,
 }
 
 /// User-safe projection of the effective policy for the active provider.
@@ -540,6 +568,8 @@ pub struct UserModelCatalog {
     pub workspace_default: Option<String>,
     #[serde(default)]
     pub models: Vec<String>,
+    #[serde(default)]
+    pub model_entries: Vec<LlmModelCatalogEntry>,
 }
 
 impl UserModelCatalog {
@@ -548,6 +578,7 @@ impl UserModelCatalog {
             selection_enabled: false,
             workspace_default: None,
             models: Vec::new(),
+            model_entries: Vec::new(),
         }
     }
 }
@@ -557,6 +588,8 @@ impl UserModelCatalog {
 pub struct SetUserModelPolicyRequest {
     pub workspace_default: String,
     pub allowed_models: Vec<String>,
+    #[serde(default)]
+    pub model_entries: Vec<LlmModelCatalogEntry>,
 }
 
 /// Caller-scoped model preference. `None` follows the workspace default.
@@ -837,6 +870,7 @@ mod tests {
             Ok(LlmModelsResult {
                 ok: true,
                 models: vec![request.adapter],
+                model_entries: Vec::new(),
                 message: request.provider_id,
             })
         }
@@ -1213,6 +1247,36 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&NearAiAuthProvider::Github).expect("serializes"),
             "\"github\""
+        );
+    }
+
+    #[test]
+    fn legacy_model_policy_defaults_capabilities_to_empty() {
+        let policy: ModelSelectionPolicy = serde_json::from_value(serde_json::json!({
+            "provider_id": "nearai",
+            "workspace_default": "model-a",
+            "allowed_models": ["model-a"]
+        }))
+        .expect("legacy policy");
+
+        assert!(policy.model_entries.is_empty());
+    }
+
+    #[test]
+    fn model_catalog_entry_serializes_directional_modalities() {
+        let entry = LlmModelCatalogEntry {
+            id: "vision-model".to_string(),
+            input_modalities: vec![LlmModelModality::Text, LlmModelModality::Image],
+            output_modalities: vec![LlmModelModality::Text],
+        };
+
+        assert_eq!(
+            serde_json::to_value(entry).expect("catalog entry"),
+            serde_json::json!({
+                "id": "vision-model",
+                "input_modalities": ["text", "image"],
+                "output_modalities": ["text"]
+            })
         );
     }
 }

--- a/crates/contracts/ironclaw_product_contracts/src/operator_llm.rs
+++ b/crates/contracts/ironclaw_product_contracts/src/operator_llm.rs
@@ -623,11 +623,26 @@ pub trait ModelSelectionPolicyStore: Send + Sync {
         caller: &ProductSurfaceCaller,
     ) -> Result<Option<ModelSelectionPolicy>, ModelSelectionPolicyStoreError>;
 
-    async fn write(
+    /// Atomically replace the policy, optionally carrying forward capability
+    /// metadata from the latest same-provider record.
+    ///
+    /// Implementations must apply the update against a versioned snapshot and
+    /// retry bounded CAS conflicts. `PreserveExistingModelEntries` exists for
+    /// legacy clients that omit the metadata field; it must never be
+    /// implemented as a separate read followed by a blind write.
+    async fn update(
         &self,
         caller: &ProductSurfaceCaller,
         policy: &ModelSelectionPolicy,
-    ) -> Result<(), ModelSelectionPolicyStoreError>;
+        mode: ModelSelectionPolicyUpdateMode,
+    ) -> Result<ModelSelectionPolicy, ModelSelectionPolicyStoreError>;
+}
+
+/// Capability-metadata behavior for an atomic model-policy update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelSelectionPolicyUpdateMode {
+    Replace,
+    PreserveExistingModelEntries,
 }
 
 /// Opaque store failure; backend details remain on the implementing side.

--- a/crates/domains/ironclaw_llm/CONTRACT.md
+++ b/crates/domains/ironclaw_llm/CONTRACT.md
@@ -43,7 +43,7 @@ Multi-provider LLM integration with circuit breaker, retry, failover, and respon
 | `image_models.rs` | Image-generation model metadata table |
 | `vision_models.rs` | Vision-capable model registry for attachment routing |
 | `reasoning_models.rs` | Reasoning-capable model registry (Codex, R1, o-series, etc.) used for thinking-mode dispatch |
-| `models.rs` | Top-level model-name catalog and helpers |
+| `models.rs` | Provider-neutral discovered-model capabilities plus the top-level model-name catalog and helpers |
 | `testing/` | `StubLlm`, `StubErrorKind`, `fault_injection` — gated behind the `test-support` cargo feature for downstream test harnesses |
 
 ## Sub-owner map
@@ -221,6 +221,7 @@ pub trait LlmProvider: Send + Sync {
 
     // Optional (have defaults)
     async fn list_models(&self) -> Result<Vec<String>, LlmError> { Ok(vec![]) }
+    async fn list_model_catalog(&self) -> Result<Vec<DiscoveredModel>, LlmError> { /* IDs with optional directional modalities */ }
     async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> { /* name only */ }
     fn effective_model_name(&self, requested_model: Option<&str>) -> String { /* uses active */ }
     fn active_model_name(&self) -> String { self.model_name().to_string() }
@@ -231,6 +232,7 @@ pub trait LlmProvider: Send + Sync {
 
 Key notes:
 - `model_name()` returns the configured model name; `active_model_name()` returns the currently active model (may differ if `set_model()` was called — only `NearAiChatProvider` supports this).
+- `list_model_catalog()` is additive to `list_models()`: its default projects legacy model IDs with empty capability metadata. Provider decorators must delegate the detailed method so metadata survives the production chain. NEAR AI preserves recognized top-level or `architecture` input/output modalities from `/models`; unknown or absent modality values are ignored rather than failing discovery. Capabilities are display metadata only and never participate in routing or authorization.
 - `cost_per_token()` returns `(Decimal, Decimal)` using `rust_decimal`. Look up via `costs::model_cost()` in your constructor; fall back to `costs::default_cost()` for unknowns.
 - `RigAdapter` forwards per-request model overrides through rig-core's typed request model field. Do not put `model` in flattened `additional_params`, which would serialize a duplicate top-level JSON key.
 - `complete_with_tools()` is never cached (tool calls can have side effects) — `CachedProvider` always passes them through.

--- a/crates/domains/ironclaw_llm/src/circuit_breaker.rs
+++ b/crates/domains/ironclaw_llm/src/circuit_breaker.rs
@@ -390,6 +390,10 @@ impl LlmProvider for CircuitBreakerProvider {
         self.inner.list_models().await
     }
 
+    async fn list_model_catalog(&self) -> Result<Vec<crate::models::DiscoveredModel>, LlmError> {
+        self.inner.list_model_catalog().await
+    }
+
     async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> {
         self.inner.model_metadata().await
     }

--- a/crates/domains/ironclaw_llm/src/failover.rs
+++ b/crates/domains/ironclaw_llm/src/failover.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, detailed model-catalog delegation stays with the existing failover decorator pending provider-adapter decomposition, plan #6175
 //! Multi-provider LLM failover.
 //!
 //! Wraps multiple LlmProvider instances and tries each in sequence

--- a/crates/domains/ironclaw_llm/src/failover.rs
+++ b/crates/domains/ironclaw_llm/src/failover.rs
@@ -548,10 +548,19 @@ impl LlmProvider for FailoverProvider {
     }
 
     async fn list_models(&self) -> Result<Vec<String>, LlmError> {
+        Ok(self
+            .list_model_catalog()
+            .await?
+            .into_iter()
+            .map(|model| model.id)
+            .collect())
+    }
+
+    async fn list_model_catalog(&self) -> Result<Vec<crate::models::DiscoveredModel>, LlmError> {
         let mut all_models = Vec::new();
 
         for provider in &self.providers {
-            match provider.list_models().await {
+            match provider.list_model_catalog().await {
                 Ok(models) => all_models.extend(models),
                 Err(err) => {
                     tracing::warn!(
@@ -563,8 +572,8 @@ impl LlmProvider for FailoverProvider {
             }
         }
 
-        all_models.sort();
-        all_models.dedup();
+        all_models.sort_by(|left, right| left.id.cmp(&right.id));
+        all_models.dedup_by(|left, right| left.id == right.id);
         Ok(all_models)
     }
 

--- a/crates/domains/ironclaw_llm/src/lib.rs
+++ b/crates/domains/ironclaw_llm/src/lib.rs
@@ -1392,6 +1392,19 @@ mod tests {
                 reasoning_details: None,
             })
         }
+
+        async fn list_model_catalog(
+            &self,
+        ) -> Result<Vec<crate::models::DiscoveredModel>, LlmError> {
+            Ok(vec![crate::models::DiscoveredModel {
+                id: "vision-model".to_string(),
+                input_modalities: vec![
+                    crate::models::ModelModality::Text,
+                    crate::models::ModelModality::Image,
+                ],
+                output_modalities: vec![crate::models::ModelModality::Text],
+            }])
+        }
     }
 
     struct RecordingSink(tokio::sync::mpsc::UnboundedSender<String>);
@@ -1572,6 +1585,38 @@ mod tests {
             .expect("tool streaming response");
         assert_eq!(response.content.as_deref(), Some("tool-live"));
         assert_eq!(raw.streaming_calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn configured_decorator_chain_preserves_model_capabilities() {
+        let raw: Arc<dyn LlmProvider> = Arc::new(StreamingProbe {
+            streaming_calls: AtomicUsize::new(0),
+            completion_gate: None,
+        });
+        let fallback: Arc<dyn LlmProvider> = Arc::new(StreamingProbe {
+            streaming_calls: AtomicUsize::new(0),
+            completion_gate: None,
+        });
+        let mut config = test_llm_config();
+        config.nearai.fallback_model = Some("fallback-probe".to_string());
+        config.circuit_breaker_threshold = Some(2);
+        config.response_cache_enabled = true;
+        let session = Arc::new(SessionManager::new(SessionConfig::default()));
+        let provider = apply_decorator_chain_with_fallback(raw, Some(fallback), &config, session)
+            .await
+            .expect("decorator chain");
+
+        let models = provider.list_model_catalog().await.expect("model catalog");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "vision-model");
+        assert_eq!(
+            models[0].input_modalities,
+            [
+                crate::models::ModelModality::Text,
+                crate::models::ModelModality::Image,
+            ]
+        );
     }
 
     #[tokio::test]

--- a/crates/domains/ironclaw_llm/src/models.rs
+++ b/crates/domains/ironclaw_llm/src/models.rs
@@ -5,6 +5,51 @@
 //! fetcher functions below are `pub(crate)` and not part of the public
 //! surface of `ironclaw_llm`.
 
+/// Provider-neutral model input/output modality discovered from a model catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelModality {
+    Text,
+    Image,
+    Audio,
+    Video,
+    Embedding,
+}
+
+impl ModelModality {
+    /// Normalize a provider-supplied modality while ignoring unknown future
+    /// values. Unknown values must not make model discovery fail.
+    pub(crate) fn from_provider_value(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "text" => Some(Self::Text),
+            "image" => Some(Self::Image),
+            "audio" => Some(Self::Audio),
+            "video" => Some(Self::Video),
+            "embedding" | "embeddings" => Some(Self::Embedding),
+            _ => None,
+        }
+    }
+}
+
+/// Provider-neutral entry returned by detailed model discovery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredModel {
+    pub id: String,
+    pub input_modalities: Vec<ModelModality>,
+    pub output_modalities: Vec<ModelModality>,
+}
+
+impl DiscoveredModel {
+    /// Preserve compatibility for providers that only expose model IDs.
+    pub fn from_id(id: String) -> Self {
+        Self {
+            id,
+            input_modalities: Vec::new(),
+            output_modalities: Vec::new(),
+        }
+    }
+}
+
 /// Options for [`fetch_models_for`].
 #[derive(Debug, Default)]
 pub struct ModelFetchOptions<'a> {

--- a/crates/domains/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/domains/ironclaw_llm/src/nearai_chat.rs
@@ -54,6 +54,20 @@ pub struct ModelInfo {
 /// tolerates the various field names different deployments emit. Returns an
 /// empty vec when no recognizable entries are found.
 fn parse_nearai_models(response_text: &str) -> Vec<DiscoveredModel> {
+    fn deserialize_modalities_lossy<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        Ok(match value {
+            serde_json::Value::Array(values) => values
+                .into_iter()
+                .filter_map(|value| value.as_str().map(str::to_owned))
+                .collect(),
+            _ => Vec::new(),
+        })
+    }
+
     #[derive(Deserialize)]
     struct ModelMetadataInner {
         #[serde(default)]
@@ -64,10 +78,30 @@ fn parse_nearai_models(response_text: &str) -> Vec<DiscoveredModel> {
 
     #[derive(Default, Deserialize)]
     struct ModelArchitecture {
-        #[serde(default, alias = "inputModalities")]
+        #[serde(
+            default,
+            alias = "inputModalities",
+            deserialize_with = "deserialize_modalities_lossy"
+        )]
         input_modalities: Vec<String>,
-        #[serde(default, alias = "outputModalities")]
+        #[serde(
+            default,
+            alias = "outputModalities",
+            deserialize_with = "deserialize_modalities_lossy"
+        )]
         output_modalities: Vec<String>,
+    }
+
+    fn deserialize_architecture_lossy<'de, D>(
+        deserializer: D,
+    ) -> Result<ModelArchitecture, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        // Capability metadata is optional display data. A malformed provider
+        // value must not hide otherwise-routable model IDs.
+        Ok(serde_json::from_value(value).unwrap_or_default())
     }
 
     #[derive(Deserialize)]
@@ -84,11 +118,19 @@ fn parse_nearai_models(response_text: &str) -> Vec<DiscoveredModel> {
         model_id: Option<String>,
         #[serde(default)]
         metadata: Option<ModelMetadataInner>,
-        #[serde(default, alias = "inputModalities")]
+        #[serde(
+            default,
+            alias = "inputModalities",
+            deserialize_with = "deserialize_modalities_lossy"
+        )]
         input_modalities: Vec<String>,
-        #[serde(default, alias = "outputModalities")]
+        #[serde(
+            default,
+            alias = "outputModalities",
+            deserialize_with = "deserialize_modalities_lossy"
+        )]
         output_modalities: Vec<String>,
-        #[serde(default)]
+        #[serde(default, deserialize_with = "deserialize_architecture_lossy")]
         architecture: ModelArchitecture,
     }
 
@@ -2064,7 +2106,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn private_model_discovery_uses_session_authentication() {
+    async fn private_model_discovery_authenticates_and_tolerates_malformed_capabilities() {
         use tokio::net::TcpListener;
         use tokio::sync::oneshot;
 
@@ -2082,7 +2124,20 @@ mod tests {
                     }
                     write_http_json_response(
                         &mut socket,
-                        serde_json::json!({ "data": [{ "id": "nearai/test-model" }] }),
+                        serde_json::json!({
+                            "data": [
+                                {
+                                    "id": "nearai/malformed-capabilities",
+                                    "input_modalities": ["text", 7, null],
+                                    "output_modalities": null,
+                                    "architecture": null
+                                },
+                                {
+                                    "id": "nearai/valid",
+                                    "architecture": { "input_modalities": ["image"] }
+                                }
+                            ]
+                        }),
                     )
                     .await;
                     break;
@@ -2104,12 +2159,16 @@ mod tests {
         let provider = NearAiChatProvider::new(config, session).expect("provider");
 
         let models = provider
-            .list_models_full()
+            .list_model_catalog_full()
             .await
             .expect("private model discovery should use the session token");
 
-        assert_eq!(models.len(), 1);
-        assert_eq!(models[0].name, "nearai/test-model");
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "nearai/malformed-capabilities");
+        assert_eq!(models[0].input_modalities, [ModelModality::Text]);
+        assert!(models[0].output_modalities.is_empty());
+        assert_eq!(models[1].id, "nearai/valid");
+        assert_eq!(models[1].input_modalities, [ModelModality::Image]);
         let headers = headers_rx.await.expect("models request headers");
         assert!(
             headers

--- a/crates/domains/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/domains/ironclaw_llm/src/nearai_chat.rs
@@ -99,8 +99,7 @@ fn parse_nearai_models(response_text: &str) -> Vec<DiscoveredModel> {
         D: serde::Deserializer<'de>,
     {
         let value = serde_json::Value::deserialize(deserializer)?;
-        // Capability metadata is optional display data. A malformed provider
-        // value must not hide otherwise-routable model IDs.
+        // silent-ok: malformed optional display metadata must not hide routable model IDs.
         Ok(serde_json::from_value(value).unwrap_or_default())
     }
 

--- a/crates/domains/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/domains/ironclaw_llm/src/nearai_chat.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use self::nearai_tool_message_flattening::flatten_tool_messages;
 use crate::config::NearAiConfig;
 use crate::error::LlmError;
+use crate::models::{DiscoveredModel, ModelModality};
 use crate::provider::{
     ChatMessage, CompletionRequest, CompletionResponse, CompletionStreamSink, FinishReason,
     LlmProvider, Role, ToolCall, ToolCompletionRequest, ToolCompletionResponse,
@@ -47,18 +48,26 @@ pub struct ModelInfo {
     pub provider: Option<String>,
 }
 
-/// Parse a NEAR AI `/models` response body into [`ModelInfo`] entries.
+/// Parse a NEAR AI `/models` response body into provider-neutral catalog entries.
 ///
 /// Accepts `{models: [...]}`, `{data: [...]}`, or a bare `[...]` array, and
 /// tolerates the various field names different deployments emit. Returns an
 /// empty vec when no recognizable entries are found.
-fn parse_nearai_models(response_text: &str) -> Vec<ModelInfo> {
+fn parse_nearai_models(response_text: &str) -> Vec<DiscoveredModel> {
     #[derive(Deserialize)]
     struct ModelMetadataInner {
         #[serde(default)]
         name: Option<String>,
         #[serde(default, alias = "modelName", alias = "model_name")]
         model_name: Option<String>,
+    }
+
+    #[derive(Default, Deserialize)]
+    struct ModelArchitecture {
+        #[serde(default, alias = "inputModalities")]
+        input_modalities: Vec<String>,
+        #[serde(default, alias = "outputModalities")]
+        output_modalities: Vec<String>,
     }
 
     #[derive(Deserialize)]
@@ -75,6 +84,12 @@ fn parse_nearai_models(response_text: &str) -> Vec<ModelInfo> {
         model_id: Option<String>,
         #[serde(default)]
         metadata: Option<ModelMetadataInner>,
+        #[serde(default, alias = "inputModalities")]
+        input_modalities: Vec<String>,
+        #[serde(default, alias = "outputModalities")]
+        output_modalities: Vec<String>,
+        #[serde(default)]
+        architecture: ModelArchitecture,
     }
 
     impl ModelEntry {
@@ -104,6 +119,32 @@ fn parse_nearai_models(response_text: &str) -> Vec<ModelInfo> {
                 .or_else(|| self.metadata.as_ref().and_then(|m| clean(&m.model_name)))
                 .or_else(|| self.metadata.as_ref().and_then(|m| clean(&m.name)))
         }
+
+        fn modalities(&self) -> (Vec<ModelModality>, Vec<ModelModality>) {
+            fn normalize(values: &[String]) -> Vec<ModelModality> {
+                let mut modalities = Vec::new();
+                for value in values {
+                    if let Some(modality) = ModelModality::from_provider_value(value)
+                        && !modalities.contains(&modality)
+                    {
+                        modalities.push(modality);
+                    }
+                }
+                modalities
+            }
+
+            let input = if self.input_modalities.is_empty() {
+                &self.architecture.input_modalities
+            } else {
+                &self.input_modalities
+            };
+            let output = if self.output_modalities.is_empty() {
+                &self.architecture.output_modalities
+            } else {
+                &self.output_modalities
+            };
+            (normalize(input), normalize(output))
+        }
     }
 
     #[derive(Deserialize)]
@@ -125,9 +166,13 @@ fn parse_nearai_models(response_text: &str) -> Vec<ModelInfo> {
             entries
                 .into_iter()
                 .filter_map(|e| {
-                    e.resolve_id().map(|name| ModelInfo {
-                        name,
-                        provider: None,
+                    e.resolve_id().map(|id| {
+                        let (input_modalities, output_modalities) = e.modalities();
+                        DiscoveredModel {
+                            id,
+                            input_modalities,
+                            output_modalities,
+                        }
                     })
                 })
                 .collect()
@@ -703,20 +748,32 @@ impl NearAiChatProvider {
     /// Handles session renewal on 401 (same pattern as `send_request`).
     /// Supports multiple response formats: `{models: [...]}`, `{data: [...]}`, and plain array.
     pub async fn list_models_full(&self) -> Result<Vec<ModelInfo>, LlmError> {
-        match self.list_models_inner().await {
+        Ok(self
+            .list_model_catalog_full()
+            .await?
+            .into_iter()
+            .map(|model| ModelInfo {
+                name: model.id,
+                provider: None,
+            })
+            .collect())
+    }
+
+    async fn list_model_catalog_full(&self) -> Result<Vec<DiscoveredModel>, LlmError> {
+        match self.list_model_catalog_inner().await {
             Ok(models) => Ok(models),
             Err(LlmError::SessionExpired { .. })
                 if !is_public_nearai_model_catalog(&self.config.base_url)
                     && !self.uses_api_key() =>
             {
                 self.session.handle_auth_failure().await?;
-                self.list_models_inner().await
+                self.list_model_catalog_inner().await
             }
             Err(e) => Err(e),
         }
     }
 
-    async fn list_models_inner(&self) -> Result<Vec<ModelInfo>, LlmError> {
+    async fn list_model_catalog_inner(&self) -> Result<Vec<DiscoveredModel>, LlmError> {
         let url = self.api_url("models");
         let requires_auth = !is_public_nearai_model_catalog(&self.config.base_url);
 
@@ -1127,6 +1184,10 @@ impl LlmProvider for NearAiChatProvider {
     async fn list_models(&self) -> Result<Vec<String>, LlmError> {
         let models = self.list_models_full().await?;
         Ok(models.into_iter().map(|m| m.name).collect())
+    }
+
+    async fn list_model_catalog(&self) -> Result<Vec<DiscoveredModel>, LlmError> {
+        self.list_model_catalog_full().await
     }
 
     fn active_model_name(&self) -> String {
@@ -1805,9 +1866,73 @@ mod tests {
         ]}"#;
         let models: Vec<_> = parse_nearai_models(body)
             .into_iter()
-            .map(|m| m.name)
+            .map(|m| m.id)
             .collect();
         assert_eq!(models, ["deepseek-ai/DeepSeek-V4-Flash", "qwen/Qwen3-30B"]);
+    }
+
+    #[test]
+    fn parse_models_preserves_top_level_modalities() {
+        let body = r#"{"data":[{
+            "id":"openai/gpt-5-image",
+            "input_modalities":["text","image","unknown"],
+            "output_modalities":["text","image"]
+        }]}"#;
+
+        let models = parse_nearai_models(body);
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0].input_modalities,
+            [
+                crate::models::ModelModality::Text,
+                crate::models::ModelModality::Image,
+            ]
+        );
+        assert_eq!(
+            models[0].output_modalities,
+            [
+                crate::models::ModelModality::Text,
+                crate::models::ModelModality::Image,
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_models_preserves_nested_architecture_modalities() {
+        let body = r#"[{
+            "id":"google/gemini",
+            "architecture": {
+                "inputModalities":["text","image","audio","video"],
+                "outputModalities":["text"]
+            }
+        }]"#;
+
+        let models = parse_nearai_models(body);
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0].input_modalities,
+            [
+                crate::models::ModelModality::Text,
+                crate::models::ModelModality::Image,
+                crate::models::ModelModality::Audio,
+                crate::models::ModelModality::Video,
+            ]
+        );
+        assert_eq!(
+            models[0].output_modalities,
+            [crate::models::ModelModality::Text]
+        );
+    }
+
+    #[test]
+    fn parse_models_defaults_missing_modalities_to_empty() {
+        let models = parse_nearai_models(r#"[{"id":"legacy/model"}]"#);
+
+        assert_eq!(models.len(), 1);
+        assert!(models[0].input_modalities.is_empty());
+        assert!(models[0].output_modalities.is_empty());
     }
 
     #[test]
@@ -1817,7 +1942,7 @@ mod tests {
         let body = r#"[{"name":"gpt-4o"},{"model":"o3-mini"}]"#;
         let models: Vec<_> = parse_nearai_models(body)
             .into_iter()
-            .map(|m| m.name)
+            .map(|m| m.id)
             .collect();
         assert_eq!(models, ["gpt-4o", "o3-mini"]);
     }
@@ -1830,7 +1955,7 @@ mod tests {
         ]}"#;
         let models: Vec<_> = parse_nearai_models(body)
             .into_iter()
-            .map(|m| m.name)
+            .map(|m| m.id)
             .collect();
         // Blank `id` falls through to `name`; second entry uses `model`.
         assert_eq!(models, ["only-display", "meta/Llama-4"]);
@@ -1842,7 +1967,7 @@ mod tests {
         let body = r#"[{"model_id":"vendor/x"},{"modelId":"vendor/y"}]"#;
         let models: Vec<_> = parse_nearai_models(body)
             .into_iter()
-            .map(|m| m.name)
+            .map(|m| m.id)
             .collect();
         assert_eq!(models, ["vendor/x", "vendor/y"]);
     }
@@ -1854,7 +1979,7 @@ mod tests {
         let body = r#"[{"model_name":"qwen-turbo"},{"modelName":"glm-5"}]"#;
         let models: Vec<_> = parse_nearai_models(body)
             .into_iter()
-            .map(|m| m.name)
+            .map(|m| m.id)
             .collect();
         assert_eq!(models, ["qwen-turbo", "glm-5"]);
     }
@@ -1869,7 +1994,7 @@ mod tests {
         ]"#;
         let models: Vec<_> = parse_nearai_models(body)
             .into_iter()
-            .map(|m| m.name)
+            .map(|m| m.id)
             .collect();
         assert_eq!(models, ["meta-model", "meta-display"]);
     }

--- a/crates/domains/ironclaw_llm/src/provider.rs
+++ b/crates/domains/ironclaw_llm/src/provider.rs
@@ -998,6 +998,19 @@ pub trait LlmProvider: Send + Sync {
         Ok(Vec::new())
     }
 
+    /// List available models with optional provider-discovered capabilities.
+    ///
+    /// Providers that only expose IDs inherit an empty-capability projection,
+    /// keeping existing implementations source-compatible.
+    async fn list_model_catalog(&self) -> Result<Vec<crate::models::DiscoveredModel>, LlmError> {
+        Ok(self
+            .list_models()
+            .await?
+            .into_iter()
+            .map(crate::models::DiscoveredModel::from_id)
+            .collect())
+    }
+
     /// Fetch metadata for the current model (context length, etc.).
     /// Default returns the model name with no size info.
     async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> {

--- a/crates/domains/ironclaw_llm/src/recording.rs
+++ b/crates/domains/ironclaw_llm/src/recording.rs
@@ -1365,6 +1365,10 @@ impl LlmProvider for RecordingLlm {
         self.inner.list_models().await
     }
 
+    async fn list_model_catalog(&self) -> Result<Vec<crate::models::DiscoveredModel>, LlmError> {
+        self.inner.list_model_catalog().await
+    }
+
     async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> {
         self.inner.model_metadata().await
     }

--- a/crates/domains/ironclaw_llm/src/response_cache.rs
+++ b/crates/domains/ironclaw_llm/src/response_cache.rs
@@ -332,6 +332,10 @@ impl LlmProvider for CachedProvider {
         self.inner.list_models().await
     }
 
+    async fn list_model_catalog(&self) -> Result<Vec<crate::models::DiscoveredModel>, LlmError> {
+        self.inner.list_model_catalog().await
+    }
+
     async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> {
         self.inner.model_metadata().await
     }

--- a/crates/domains/ironclaw_llm/src/retry.rs
+++ b/crates/domains/ironclaw_llm/src/retry.rs
@@ -450,6 +450,10 @@ impl LlmProvider for RetryProvider {
         self.inner.list_models().await
     }
 
+    async fn list_model_catalog(&self) -> Result<Vec<crate::models::DiscoveredModel>, LlmError> {
+        self.inner.list_model_catalog().await
+    }
+
     async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> {
         self.inner.model_metadata().await
     }

--- a/crates/domains/ironclaw_llm/src/runtime.rs
+++ b/crates/domains/ironclaw_llm/src/runtime.rs
@@ -226,6 +226,10 @@ impl LlmProvider for SwappableLlmProvider {
         self.current().list_models().await
     }
 
+    async fn list_model_catalog(&self) -> Result<Vec<crate::models::DiscoveredModel>, LlmError> {
+        self.current().list_model_catalog().await
+    }
+
     async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> {
         self.current().model_metadata().await
     }

--- a/crates/domains/ironclaw_llm/src/smart_routing.rs
+++ b/crates/domains/ironclaw_llm/src/smart_routing.rs
@@ -1065,6 +1065,10 @@ impl LlmProvider for SmartRoutingProvider {
         self.primary.list_models().await
     }
 
+    async fn list_model_catalog(&self) -> Result<Vec<crate::models::DiscoveredModel>, LlmError> {
+        self.primary.list_model_catalog().await
+    }
+
     async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> {
         self.primary.model_metadata().await
     }

--- a/crates/domains/ironclaw_llm/src/token_refreshing.rs
+++ b/crates/domains/ironclaw_llm/src/token_refreshing.rs
@@ -241,6 +241,11 @@ impl LlmProvider for TokenRefreshingProvider {
         self.inner.list_models().await
     }
 
+    async fn list_model_catalog(&self) -> Result<Vec<crate::models::DiscoveredModel>, LlmError> {
+        self.ensure_fresh_token().await;
+        self.inner.list_model_catalog().await
+    }
+
     async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> {
         self.ensure_fresh_token().await;
         self.inner.model_metadata().await

--- a/crates/product/ironclaw_assistant/tests/reborn_services_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/reborn_services_contract.rs
@@ -11307,6 +11307,7 @@ impl Default for SetupRecordingLlmConfigService {
                 selection_enabled: true,
                 workspace_default: Some("model-a".to_string()),
                 models: vec!["model-a".to_string(), "model-b".to_string()],
+                model_entries: Vec::new(),
             }),
             user_model_preferences: Mutex::new(HashMap::new()),
             user_model_preference_updates: Mutex::new(Vec::new()),
@@ -11514,6 +11515,7 @@ impl LlmConfigService for SetupRecordingLlmConfigService {
         Ok(LlmModelsResult {
             ok: true,
             models: vec!["model-a".to_string()],
+            model_entries: Vec::new(),
             message: String::new(),
         })
     }
@@ -17935,6 +17937,7 @@ async fn member_model_status_marks_a_stale_preference_unavailable() {
         selection_enabled: true,
         workspace_default: Some("model-a".to_string()),
         models: vec!["model-a".to_string()],
+        model_entries: Vec::new(),
     });
 
     let view =

--- a/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
@@ -32,11 +32,11 @@ use ironclaw_llm::{
 use ironclaw_product_contracts::operator_llm::{
     CodexLoginStart, LlmActiveSelection, LlmConfigService, LlmConfigServiceError,
     LlmConfigSnapshot, LlmModelCatalogEntry, LlmModelModality, LlmModelsResult, LlmProbeRequest,
-    LlmProbeResult, LlmProviderView, ModelSelectionPolicy, ModelSelectionPolicyStore,
-    ModelSelectionPolicyStoreError, NearAiLoginRequest, NearAiLoginStart, NearAiWalletLoginRequest,
-    NearAiWalletLoginResult, SetActiveLlmRequest, SetUserModelPolicyRequest,
-    SetUserModelPreferenceRequest, UpsertLlmProviderRequest, UserModelCatalog, UserModelPreference,
-    UserModelPreferenceStore, UserModelPreferenceStoreError,
+    LlmProbeResult, LlmProviderView, MODEL_SELECTION_POLICY_MAX_BYTES, ModelSelectionPolicy,
+    ModelSelectionPolicyStore, ModelSelectionPolicyStoreError, NearAiLoginRequest,
+    NearAiLoginStart, NearAiWalletLoginRequest, NearAiWalletLoginResult, SetActiveLlmRequest,
+    SetUserModelPolicyRequest, SetUserModelPreferenceRequest, UpsertLlmProviderRequest,
+    UserModelCatalog, UserModelPreference, UserModelPreferenceStore, UserModelPreferenceStoreError,
 };
 use ironclaw_product_contracts::surface::ProductSurfaceCaller;
 use secrecy::{ExposeSecret as _, SecretString};
@@ -858,7 +858,18 @@ impl LlmConfigService for RebornLlmConfigService {
             .ok_or(LlmConfigServiceError::Unavailable)?;
         let snapshot = self.build_provider_snapshot().await?;
         let active = snapshot.active.ok_or(LlmConfigServiceError::Unavailable)?;
-        let policy = validated_model_policy(active.provider_id, request)?;
+        let preserved_entries = if request.model_entries.is_none() {
+            store
+                .read(&caller)
+                .await
+                .map_err(map_model_policy_store_error)?
+                .filter(|policy| policy.provider_id == active.provider_id)
+                .map(|policy| policy.model_entries)
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let policy = validated_model_policy(active.provider_id, request, preserved_entries)?;
         store
             .write(&caller, &policy)
             .await
@@ -1523,12 +1534,15 @@ fn validate_provider_id(id: &str) -> Result<String, LlmConfigServiceError> {
 fn validated_model_policy(
     provider_id: String,
     request: SetUserModelPolicyRequest,
+    preserved_entries: Vec<LlmModelCatalogEntry>,
 ) -> Result<ModelSelectionPolicy, LlmConfigServiceError> {
     let SetUserModelPolicyRequest {
         workspace_default,
         allowed_models: requested_models,
         model_entries: requested_entries,
     } = request;
+    let preserving_entries = requested_entries.is_none();
+    let requested_entries = requested_entries.unwrap_or(preserved_entries);
     if requested_models.is_empty() || requested_models.len() > USER_MODEL_POLICY_MAX_MODELS {
         return Err(invalid_policy_field(
             "allowed_models",
@@ -1566,6 +1580,9 @@ fn validated_model_policy(
     for mut entry in requested_entries {
         entry.id = validated_model_id("model_entries", &entry.id)?;
         if !seen.contains(&entry.id) {
+            if preserving_entries {
+                continue;
+            }
             return Err(invalid_policy_field(
                 "model_entries",
                 "model_entries may only describe allowed_models",
@@ -1578,12 +1595,22 @@ fn validated_model_policy(
         }
     }
 
-    Ok(ModelSelectionPolicy {
+    let policy = ModelSelectionPolicy {
         provider_id,
         workspace_default,
         allowed_models,
         model_entries,
-    })
+    };
+    let serialized_len = serde_json::to_vec(&policy)
+        .map_err(|_| invalid_policy_field("model_entries", "model policy is not serializable"))?
+        .len();
+    if serialized_len > MODEL_SELECTION_POLICY_MAX_BYTES {
+        return Err(invalid_policy_field(
+            "model_entries",
+            "model policy exceeds the 64 KiB storage limit",
+        ));
+    }
+    Ok(policy)
 }
 
 fn matching_active_model_policy(
@@ -1850,7 +1877,7 @@ mod tests {
         SetUserModelPolicyRequest {
             workspace_default: default.to_string(),
             allowed_models: models.iter().map(|model| (*model).to_string()).collect(),
-            model_entries: Vec::new(),
+            model_entries: Some(Vec::new()),
         }
     }
 
@@ -1944,7 +1971,7 @@ mod tests {
         let request = SetUserModelPolicyRequest {
             workspace_default: "model-a".to_string(),
             allowed_models: vec!["model-a".to_string(), "model-b".to_string()],
-            model_entries: vec![
+            model_entries: Some(vec![
                 LlmModelCatalogEntry {
                     id: "model-a".to_string(),
                     input_modalities: vec![
@@ -1959,7 +1986,7 @@ mod tests {
                     input_modalities: vec![LlmModelModality::Audio],
                     output_modalities: Vec::new(),
                 },
-            ],
+            ]),
         };
 
         let catalog = service
@@ -1978,17 +2005,129 @@ mod tests {
         let invalid = SetUserModelPolicyRequest {
             workspace_default: "model-a".to_string(),
             allowed_models: vec!["model-a".to_string()],
-            model_entries: vec![LlmModelCatalogEntry {
+            model_entries: Some(vec![LlmModelCatalogEntry {
                 id: "model-c".to_string(),
                 input_modalities: vec![LlmModelModality::Text],
                 output_modalities: Vec::new(),
-            }],
+            }]),
         };
         assert!(matches!(
             service
                 .set_user_model_policy(caller().with_operator_config(true), invalid)
                 .await,
             Err(LlmConfigServiceError::InvalidRequest { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn legacy_policy_update_preserves_capabilities_for_remaining_models() {
+        let (_temp, service) = service_with_active_provider("nearai", "provider-default");
+        let admin = caller().with_operator_config(true);
+        service
+            .set_user_model_policy(
+                admin.clone(),
+                SetUserModelPolicyRequest {
+                    workspace_default: "model-a".to_string(),
+                    allowed_models: vec!["model-a".to_string(), "model-b".to_string()],
+                    model_entries: Some(vec![
+                        LlmModelCatalogEntry {
+                            id: "model-a".to_string(),
+                            input_modalities: vec![LlmModelModality::Text],
+                            output_modalities: vec![LlmModelModality::Text],
+                        },
+                        LlmModelCatalogEntry {
+                            id: "model-b".to_string(),
+                            input_modalities: vec![LlmModelModality::Text, LlmModelModality::Image],
+                            output_modalities: vec![LlmModelModality::Text],
+                        },
+                    ]),
+                },
+            )
+            .await
+            .expect("seed policy with capabilities");
+
+        let legacy_request: SetUserModelPolicyRequest = serde_json::from_value(serde_json::json!({
+            "workspace_default": "model-b",
+            "allowed_models": ["model-b"]
+        }))
+        .expect("legacy request without model_entries");
+        let catalog = service
+            .set_user_model_policy(admin, legacy_request)
+            .await
+            .expect("legacy policy update");
+
+        assert_eq!(catalog.models, ["model-b"]);
+        assert_eq!(catalog.model_entries.len(), 1);
+        assert_eq!(catalog.model_entries[0].id, "model-b");
+        assert_eq!(
+            catalog.model_entries[0].input_modalities,
+            [LlmModelModality::Text, LlmModelModality::Image]
+        );
+
+        let cleared = service
+            .set_user_model_policy(
+                caller().with_operator_config(true),
+                SetUserModelPolicyRequest {
+                    workspace_default: "model-b".to_string(),
+                    allowed_models: vec!["model-b".to_string()],
+                    model_entries: Some(Vec::new()),
+                },
+            )
+            .await
+            .expect("explicitly clear capability metadata");
+        assert!(cleared.model_entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn oversized_model_policy_is_rejected_before_persistence() {
+        let (_temp, service) = service_with_active_provider("nearai", "provider-default");
+        let model_ids: Vec<_> = (0..USER_MODEL_POLICY_MAX_MODELS)
+            .map(|index| {
+                let prefix = format!("model-{index:03}-");
+                format!(
+                    "{prefix}{}",
+                    "x".repeat(USER_MODEL_ID_MAX_BYTES - prefix.len())
+                )
+            })
+            .collect();
+        let model_entries = model_ids
+            .iter()
+            .map(|id| LlmModelCatalogEntry {
+                id: id.clone(),
+                input_modalities: vec![
+                    LlmModelModality::Text,
+                    LlmModelModality::Image,
+                    LlmModelModality::Audio,
+                    LlmModelModality::Video,
+                    LlmModelModality::Embedding,
+                ],
+                output_modalities: vec![
+                    LlmModelModality::Text,
+                    LlmModelModality::Image,
+                    LlmModelModality::Audio,
+                    LlmModelModality::Video,
+                    LlmModelModality::Embedding,
+                ],
+            })
+            .collect();
+
+        let result = service
+            .set_user_model_policy(
+                caller().with_operator_config(true),
+                SetUserModelPolicyRequest {
+                    workspace_default: model_ids[0].clone(),
+                    allowed_models: model_ids,
+                    model_entries: Some(model_entries),
+                },
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(LlmConfigServiceError::InvalidRequest {
+                field: Some(field),
+                ..
+            }) if field == "model_entries"
         ));
     }
 

--- a/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
@@ -24,18 +24,19 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use ironclaw_config::{LlmSlotSelection, RebornBootConfig};
+use ironclaw_llm::models::{DiscoveredModel, ModelModality};
 use ironclaw_llm::registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};
 use ironclaw_llm::{
     NearWalletSignedMessage, OpenAiCodexConfig, OpenAiCodexSessionManager, default_nearai_base_url,
 };
 use ironclaw_product_contracts::operator_llm::{
     CodexLoginStart, LlmActiveSelection, LlmConfigService, LlmConfigServiceError,
-    LlmConfigSnapshot, LlmModelsResult, LlmProbeRequest, LlmProbeResult, LlmProviderView,
-    ModelSelectionPolicy, ModelSelectionPolicyStore, ModelSelectionPolicyStoreError,
-    NearAiLoginRequest, NearAiLoginStart, NearAiWalletLoginRequest, NearAiWalletLoginResult,
-    SetActiveLlmRequest, SetUserModelPolicyRequest, SetUserModelPreferenceRequest,
-    UpsertLlmProviderRequest, UserModelCatalog, UserModelPreference, UserModelPreferenceStore,
-    UserModelPreferenceStoreError,
+    LlmConfigSnapshot, LlmModelCatalogEntry, LlmModelModality, LlmModelsResult, LlmProbeRequest,
+    LlmProbeResult, LlmProviderView, ModelSelectionPolicy, ModelSelectionPolicyStore,
+    ModelSelectionPolicyStoreError, NearAiLoginRequest, NearAiLoginStart, NearAiWalletLoginRequest,
+    NearAiWalletLoginResult, SetActiveLlmRequest, SetUserModelPolicyRequest,
+    SetUserModelPreferenceRequest, UpsertLlmProviderRequest, UserModelCatalog, UserModelPreference,
+    UserModelPreferenceStore, UserModelPreferenceStoreError,
 };
 use ironclaw_product_contracts::surface::ProductSurfaceCaller;
 use secrecy::{ExposeSecret as _, SecretString};
@@ -800,12 +801,18 @@ impl LlmConfigService for RebornLlmConfigService {
         request: LlmProbeRequest,
     ) -> Result<LlmModelsResult, LlmConfigServiceError> {
         let provider = self.probe_provider(&request).await?;
-        match provider.list_models().await {
-            Ok(models) => Ok(LlmModelsResult {
-                ok: true,
-                models,
-                message: String::new(),
-            }),
+        match provider.list_model_catalog().await {
+            Ok(discovered) => {
+                let model_entries: Vec<_> =
+                    discovered.into_iter().map(product_model_entry).collect();
+                let models = model_entries.iter().map(|entry| entry.id.clone()).collect();
+                Ok(LlmModelsResult {
+                    ok: true,
+                    models,
+                    model_entries,
+                    message: String::new(),
+                })
+            }
             Err(error) => {
                 tracing::debug!(
                     provider_id = %request.provider_id,
@@ -816,6 +823,7 @@ impl LlmConfigService for RebornLlmConfigService {
                 Ok(LlmModelsResult {
                     ok: false,
                     models: Vec::new(),
+                    model_entries: Vec::new(),
                     message: "could not list models for this provider".to_string(),
                 })
             }
@@ -1516,9 +1524,12 @@ fn validated_model_policy(
     provider_id: String,
     request: SetUserModelPolicyRequest,
 ) -> Result<ModelSelectionPolicy, LlmConfigServiceError> {
-    if request.allowed_models.is_empty()
-        || request.allowed_models.len() > USER_MODEL_POLICY_MAX_MODELS
-    {
+    let SetUserModelPolicyRequest {
+        workspace_default,
+        allowed_models: requested_models,
+        model_entries: requested_entries,
+    } = request;
+    if requested_models.is_empty() || requested_models.len() > USER_MODEL_POLICY_MAX_MODELS {
         return Err(invalid_policy_field(
             "allowed_models",
             "allowed_models must contain between 1 and 128 models",
@@ -1526,14 +1537,14 @@ fn validated_model_policy(
     }
 
     let mut seen = HashSet::new();
-    let mut allowed_models = Vec::with_capacity(request.allowed_models.len());
-    for model in request.allowed_models {
+    let mut allowed_models = Vec::with_capacity(requested_models.len());
+    for model in requested_models {
         let model = validated_model_id("allowed_models", &model)?;
         if seen.insert(model.clone()) {
             allowed_models.push(model);
         }
     }
-    let workspace_default = validated_model_id("workspace_default", &request.workspace_default)?;
+    let workspace_default = validated_model_id("workspace_default", &workspace_default)?;
     if !allowed_models
         .iter()
         .any(|model| model == &workspace_default)
@@ -1544,10 +1555,34 @@ fn validated_model_policy(
         ));
     }
 
+    if requested_entries.len() > USER_MODEL_POLICY_MAX_MODELS {
+        return Err(invalid_policy_field(
+            "model_entries",
+            "model_entries must contain at most 128 models",
+        ));
+    }
+    let mut seen_entries = HashSet::new();
+    let mut model_entries = Vec::with_capacity(requested_entries.len());
+    for mut entry in requested_entries {
+        entry.id = validated_model_id("model_entries", &entry.id)?;
+        if !seen.contains(&entry.id) {
+            return Err(invalid_policy_field(
+                "model_entries",
+                "model_entries may only describe allowed_models",
+            ));
+        }
+        dedup_modalities(&mut entry.input_modalities);
+        dedup_modalities(&mut entry.output_modalities);
+        if seen_entries.insert(entry.id.clone()) {
+            model_entries.push(entry);
+        }
+    }
+
     Ok(ModelSelectionPolicy {
         provider_id,
         workspace_default,
         allowed_models,
+        model_entries,
     })
 }
 
@@ -1587,6 +1622,38 @@ fn catalog_from_policy(policy: ModelSelectionPolicy) -> UserModelCatalog {
         selection_enabled: true,
         workspace_default: Some(policy.workspace_default),
         models: policy.allowed_models,
+        model_entries: policy.model_entries,
+    }
+}
+
+fn dedup_modalities(modalities: &mut Vec<LlmModelModality>) {
+    let mut seen = HashSet::new();
+    modalities.retain(|modality| seen.insert(*modality));
+}
+
+fn product_model_entry(model: DiscoveredModel) -> LlmModelCatalogEntry {
+    LlmModelCatalogEntry {
+        id: model.id,
+        input_modalities: model
+            .input_modalities
+            .into_iter()
+            .map(product_model_modality)
+            .collect(),
+        output_modalities: model
+            .output_modalities
+            .into_iter()
+            .map(product_model_modality)
+            .collect(),
+    }
+}
+
+fn product_model_modality(modality: ModelModality) -> LlmModelModality {
+    match modality {
+        ModelModality::Text => LlmModelModality::Text,
+        ModelModality::Image => LlmModelModality::Image,
+        ModelModality::Audio => LlmModelModality::Audio,
+        ModelModality::Video => LlmModelModality::Video,
+        ModelModality::Embedding => LlmModelModality::Embedding,
     }
 }
 
@@ -1783,6 +1850,7 @@ mod tests {
         SetUserModelPolicyRequest {
             workspace_default: default.to_string(),
             allowed_models: models.iter().map(|model| (*model).to_string()).collect(),
+            model_entries: Vec::new(),
         }
     }
 
@@ -1845,6 +1913,7 @@ mod tests {
                 selection_enabled: true,
                 workspace_default: Some("model-a".to_string()),
                 models: vec!["model-a".to_string(), "model-b".to_string()],
+                model_entries: Vec::new(),
             },
         );
         assert_eq!(
@@ -1864,6 +1933,60 @@ mod tests {
         assert!(matches!(
             service
                 .resolve_user_model(caller(), Some("model-c".to_string()))
+                .await,
+            Err(LlmConfigServiceError::InvalidRequest { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn configured_policy_preserves_only_allowed_model_capabilities() {
+        let (_temp, service) = service_with_active_provider("nearai", "provider-default");
+        let request = SetUserModelPolicyRequest {
+            workspace_default: "model-a".to_string(),
+            allowed_models: vec!["model-a".to_string(), "model-b".to_string()],
+            model_entries: vec![
+                LlmModelCatalogEntry {
+                    id: "model-a".to_string(),
+                    input_modalities: vec![
+                        LlmModelModality::Text,
+                        LlmModelModality::Image,
+                        LlmModelModality::Image,
+                    ],
+                    output_modalities: vec![LlmModelModality::Text],
+                },
+                LlmModelCatalogEntry {
+                    id: "model-a".to_string(),
+                    input_modalities: vec![LlmModelModality::Audio],
+                    output_modalities: Vec::new(),
+                },
+            ],
+        };
+
+        let catalog = service
+            .set_user_model_policy(caller().with_operator_config(true), request)
+            .await
+            .expect("set policy with capabilities");
+
+        assert_eq!(catalog.model_entries.len(), 1);
+        assert_eq!(catalog.model_entries[0].id, "model-a");
+        assert_eq!(
+            catalog.model_entries[0].input_modalities,
+            [LlmModelModality::Text, LlmModelModality::Image]
+        );
+        assert!(catalog.models.contains(&"model-b".to_string()));
+
+        let invalid = SetUserModelPolicyRequest {
+            workspace_default: "model-a".to_string(),
+            allowed_models: vec!["model-a".to_string()],
+            model_entries: vec![LlmModelCatalogEntry {
+                id: "model-c".to_string(),
+                input_modalities: vec![LlmModelModality::Text],
+                output_modalities: Vec::new(),
+            }],
+        };
+        assert!(matches!(
+            service
+                .set_user_model_policy(caller().with_operator_config(true), invalid)
                 .await,
             Err(LlmConfigServiceError::InvalidRequest { .. })
         ));
@@ -2201,6 +2324,64 @@ mod tests {
             model: Some("acme-1".to_string()),
             api_key: api_key.map(SecretString::from),
         }
+    }
+
+    async fn spawn_model_catalog_server(body: &'static str) -> String {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind model catalog server");
+        let address = listener.local_addr().expect("server address");
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+            let mut request = vec![0_u8; 4096];
+            let _ = socket.read(&mut request).await.expect("read request");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+        format!("http://{address}/v1")
+    }
+
+    #[tokio::test]
+    async fn list_models_keeps_ids_and_capability_entries_consistent() {
+        let base_url = spawn_model_catalog_server(
+            r#"{"data":[{"id":"vision-model","input_modalities":["text","image"],"output_modalities":["text"]}]}"#,
+        )
+        .await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service = RebornLlmConfigService::new(
+            boot_for_home(&temp.path().join("reborn-home")),
+            key_store(),
+        );
+        let request = LlmProbeRequest {
+            provider_id: "nearai".to_string(),
+            adapter: "nearai".to_string(),
+            base_url: Some(base_url),
+            model: Some("vision-model".to_string()),
+            api_key: Some(SecretString::from("test-key".to_string())),
+        };
+
+        let result = service
+            .list_models(caller(), request)
+            .await
+            .expect("list models");
+
+        assert!(result.ok);
+        assert_eq!(result.models, ["vision-model"]);
+        assert_eq!(result.model_entries.len(), 1);
+        assert_eq!(result.model_entries[0].id, result.models[0]);
+        assert_eq!(
+            result.model_entries[0].input_modalities,
+            [LlmModelModality::Text, LlmModelModality::Image]
+        );
     }
 
     /// An unknown adapter (validated locally, not via the network) must

--- a/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/llm_config_service.rs
@@ -33,10 +33,11 @@ use ironclaw_product_contracts::operator_llm::{
     CodexLoginStart, LlmActiveSelection, LlmConfigService, LlmConfigServiceError,
     LlmConfigSnapshot, LlmModelCatalogEntry, LlmModelModality, LlmModelsResult, LlmProbeRequest,
     LlmProbeResult, LlmProviderView, MODEL_SELECTION_POLICY_MAX_BYTES, ModelSelectionPolicy,
-    ModelSelectionPolicyStore, ModelSelectionPolicyStoreError, NearAiLoginRequest,
-    NearAiLoginStart, NearAiWalletLoginRequest, NearAiWalletLoginResult, SetActiveLlmRequest,
-    SetUserModelPolicyRequest, SetUserModelPreferenceRequest, UpsertLlmProviderRequest,
-    UserModelCatalog, UserModelPreference, UserModelPreferenceStore, UserModelPreferenceStoreError,
+    ModelSelectionPolicyStore, ModelSelectionPolicyStoreError, ModelSelectionPolicyUpdateMode,
+    NearAiLoginRequest, NearAiLoginStart, NearAiWalletLoginRequest, NearAiWalletLoginResult,
+    SetActiveLlmRequest, SetUserModelPolicyRequest, SetUserModelPreferenceRequest,
+    UpsertLlmProviderRequest, UserModelCatalog, UserModelPreference, UserModelPreferenceStore,
+    UserModelPreferenceStoreError,
 };
 use ironclaw_product_contracts::surface::ProductSurfaceCaller;
 use secrecy::{ExposeSecret as _, SecretString};
@@ -858,20 +859,14 @@ impl LlmConfigService for RebornLlmConfigService {
             .ok_or(LlmConfigServiceError::Unavailable)?;
         let snapshot = self.build_provider_snapshot().await?;
         let active = snapshot.active.ok_or(LlmConfigServiceError::Unavailable)?;
-        let preserved_entries = if request.model_entries.is_none() {
-            store
-                .read(&caller)
-                .await
-                .map_err(map_model_policy_store_error)?
-                .filter(|policy| policy.provider_id == active.provider_id)
-                .map(|policy| policy.model_entries)
-                .unwrap_or_default()
+        let update_mode = if request.model_entries.is_none() {
+            ModelSelectionPolicyUpdateMode::PreserveExistingModelEntries
         } else {
-            Vec::new()
+            ModelSelectionPolicyUpdateMode::Replace
         };
-        let policy = validated_model_policy(active.provider_id, request, preserved_entries)?;
-        store
-            .write(&caller, &policy)
+        let policy = validated_model_policy(active.provider_id, request, Vec::new())?;
+        let policy = store
+            .update(&caller, &policy, update_mode)
             .await
             .map_err(map_model_policy_store_error)?;
         Ok(catalog_from_policy(policy))
@@ -1719,7 +1714,15 @@ fn map_admin_error(error: crate::RebornProviderAdminError) -> LlmConfigServiceEr
 mod tests {
     use super::*;
     use ironclaw_config::{RebornHome, RebornProfile};
-    use ironclaw_host_api::ids::{AgentId, ProjectId, TenantId, UserId};
+    use ironclaw_filesystem::{
+        BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemError,
+        InMemoryBackend, RecordVersion, RootFilesystem, ScopedFilesystem, VersionedEntry,
+    };
+    use ironclaw_host_api::{
+        ids::{AgentId, ProjectId, TenantId, UserId},
+        mount::{MountGrant, MountPermissions, MountView},
+        path::{MountAlias, VirtualPath},
+    };
     use ironclaw_llm::NEARAI_CLOUD_DEFAULT_BASE_URL;
     use ironclaw_product_contracts::operator_llm::{
         SetUserModelPreferenceRequest, UserModelPreference, UserModelPreferenceStore,
@@ -1813,6 +1816,74 @@ mod tests {
         preferences: std::sync::Mutex<HashMap<(String, String), UserModelPreference>>,
     }
 
+    struct FirstPolicyWriteBarrierBackend {
+        inner: Arc<InMemoryBackend>,
+        armed: std::sync::atomic::AtomicBool,
+        intercepted: std::sync::atomic::AtomicBool,
+        write_entered: tokio::sync::Notify,
+        release_write: tokio::sync::Notify,
+    }
+
+    impl FirstPolicyWriteBarrierBackend {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(InMemoryBackend::new()),
+                armed: std::sync::atomic::AtomicBool::new(false),
+                intercepted: std::sync::atomic::AtomicBool::new(false),
+                write_entered: tokio::sync::Notify::new(),
+                release_write: tokio::sync::Notify::new(),
+            }
+        }
+
+        fn arm(&self) {
+            self.armed.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        async fn wait_until_write_is_blocked(&self) {
+            self.write_entered.notified().await;
+        }
+
+        fn release(&self) {
+            self.release_write.notify_one();
+        }
+    }
+
+    #[async_trait]
+    impl RootFilesystem for FirstPolicyWriteBarrierBackend {
+        fn capabilities(&self) -> BackendCapabilities {
+            self.inner.capabilities()
+        }
+
+        async fn put(
+            &self,
+            path: &VirtualPath,
+            entry: Entry,
+            cas: CasExpectation,
+        ) -> Result<RecordVersion, FilesystemError> {
+            let should_block = self.armed.load(std::sync::atomic::Ordering::SeqCst)
+                && !self
+                    .intercepted
+                    .swap(true, std::sync::atomic::Ordering::SeqCst);
+            if should_block {
+                self.write_entered.notify_one();
+                self.release_write.notified().await;
+            }
+            self.inner.put(path, entry, cas).await
+        }
+
+        async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+            self.inner.get(path).await
+        }
+
+        async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+            self.inner.list_dir(path).await
+        }
+
+        async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+            self.inner.stat(path).await
+        }
+    }
+
     #[async_trait]
     impl UserModelPreferenceStore for InMemoryUserModelPreferenceStore {
         async fn read(
@@ -1860,16 +1931,30 @@ mod tests {
                 .cloned())
         }
 
-        async fn write(
+        async fn update(
             &self,
             caller: &ProductSurfaceCaller,
             policy: &ModelSelectionPolicy,
-        ) -> Result<(), ModelSelectionPolicyStoreError> {
-            self.policies
-                .lock()
-                .expect("policy lock")
-                .insert(caller.tenant_id.as_str().to_string(), policy.clone());
-            Ok(())
+            mode: ModelSelectionPolicyUpdateMode,
+        ) -> Result<ModelSelectionPolicy, ModelSelectionPolicyStoreError> {
+            let mut policies = self.policies.lock().expect("policy lock");
+            let mut next = policy.clone();
+            if mode == ModelSelectionPolicyUpdateMode::PreserveExistingModelEntries {
+                next.model_entries = policies
+                    .get(caller.tenant_id.as_str())
+                    .filter(|stored| stored.provider_id == next.provider_id)
+                    .map(|stored| {
+                        stored
+                            .model_entries
+                            .iter()
+                            .filter(|entry| next.allowed_models.contains(&entry.id))
+                            .cloned()
+                            .collect()
+                    })
+                    .unwrap_or_default();
+            }
+            policies.insert(caller.tenant_id.as_str().to_string(), next.clone());
+            Ok(next)
         }
     }
 
@@ -1885,13 +1970,25 @@ mod tests {
         provider_id: &str,
         model: &str,
     ) -> (tempfile::TempDir, RebornLlmConfigService) {
+        service_with_active_provider_and_policy_store(
+            provider_id,
+            model,
+            Arc::new(InMemoryModelPolicyStore::default()),
+        )
+    }
+
+    fn service_with_active_provider_and_policy_store(
+        provider_id: &str,
+        model: &str,
+        model_policy_store: Arc<dyn ModelSelectionPolicyStore>,
+    ) -> (tempfile::TempDir, RebornLlmConfigService) {
         let temp = tempfile::tempdir().expect("tempdir");
         let boot = boot_for_home(&temp.path().join("reborn-home"));
         RebornProviderAdmin::new(boot.clone())
             .set_provider(provider_id, Some(model))
             .expect("persist active provider");
         let service = RebornLlmConfigService::new(boot, key_store())
-            .with_model_policy_store(Arc::new(InMemoryModelPolicyStore::default()))
+            .with_model_policy_store(model_policy_store)
             .with_user_model_preference_store(
                 Arc::new(InMemoryUserModelPreferenceStore::default()),
             );
@@ -2076,6 +2173,92 @@ mod tests {
             .await
             .expect("explicitly clear capability metadata");
         assert!(cleared.model_entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn concurrent_legacy_update_preserves_the_latest_capability_metadata() {
+        let backend = Arc::new(FirstPolicyWriteBarrierBackend::new());
+        let filesystem = Arc::new(ScopedFilesystem::new(Arc::clone(&backend), |scope| {
+            MountView::new(vec![MountGrant::new(
+                MountAlias::new("/tenant-shared")?,
+                VirtualPath::new(format!("/tenants/{}/shared", scope.tenant_id.as_str()))?,
+                MountPermissions::read_write(),
+            )])
+        }));
+        let store = Arc::new(crate::llm_admin::FilesystemModelSelectionPolicyStore::new(
+            filesystem,
+        ));
+        let (_temp, service) =
+            service_with_active_provider_and_policy_store("nearai", "provider-default", store);
+        let service = Arc::new(service);
+        let admin = caller().with_operator_config(true);
+
+        service
+            .set_user_model_policy(
+                admin.clone(),
+                SetUserModelPolicyRequest {
+                    workspace_default: "model-a".to_string(),
+                    allowed_models: vec!["model-a".to_string(), "model-b".to_string()],
+                    model_entries: Some(vec![LlmModelCatalogEntry {
+                        id: "model-a".to_string(),
+                        input_modalities: vec![LlmModelModality::Text],
+                        output_modalities: vec![LlmModelModality::Text],
+                    }]),
+                },
+            )
+            .await
+            .expect("seed policy");
+
+        backend.arm();
+        let legacy_service = Arc::clone(&service);
+        let legacy_admin = admin.clone();
+        let legacy_update = tokio::spawn(async move {
+            let request = serde_json::from_value(serde_json::json!({
+                "workspace_default": "model-a",
+                "allowed_models": ["model-a"]
+            }))
+            .expect("legacy request");
+            legacy_service
+                .set_user_model_policy(legacy_admin, request)
+                .await
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            backend.wait_until_write_is_blocked(),
+        )
+        .await
+        .expect("legacy write reaches the barrier");
+        service
+            .set_user_model_policy(
+                admin,
+                SetUserModelPolicyRequest {
+                    workspace_default: "model-a".to_string(),
+                    allowed_models: vec!["model-a".to_string()],
+                    model_entries: Some(vec![LlmModelCatalogEntry {
+                        id: "model-a".to_string(),
+                        input_modalities: vec![LlmModelModality::Text, LlmModelModality::Image],
+                        output_modalities: vec![LlmModelModality::Text],
+                    }]),
+                },
+            )
+            .await
+            .expect("write current capabilities");
+        backend.release();
+
+        tokio::time::timeout(Duration::from_secs(5), legacy_update)
+            .await
+            .expect("legacy update completes after the CAS retry")
+            .expect("legacy task")
+            .expect("legacy update retries");
+        let catalog = service
+            .user_model_catalog(caller())
+            .await
+            .expect("read final catalog");
+        assert_eq!(
+            catalog.model_entries[0].input_modalities,
+            [LlmModelModality::Text, LlmModelModality::Image]
+        );
     }
 
     #[tokio::test]

--- a/crates/product/ironclaw_operator/src/llm_admin/model_selection_policy_store.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/model_selection_policy_store.rs
@@ -7,14 +7,13 @@ use ironclaw_filesystem::{FilesystemError, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{ids::InvocationId, path::ScopedPath, resource::ResourceScope};
 use ironclaw_product_contracts::{
     operator_llm::{
-        ModelSelectionPolicy, ModelSelectionPolicyStore, ModelSelectionPolicyStoreError,
+        MODEL_SELECTION_POLICY_MAX_BYTES, ModelSelectionPolicy, ModelSelectionPolicyStore,
+        ModelSelectionPolicyStoreError,
     },
     surface::ProductSurfaceCaller,
 };
 
 const POLICY_PATH: &str = "/tenant-shared/llm-user-model-policy.json";
-const POLICY_MAX_BYTES: usize = 64 * 1024;
-
 pub struct FilesystemModelSelectionPolicyStore<F: RootFilesystem + ?Sized> {
     filesystem: Arc<ScopedFilesystem<F>>,
 }
@@ -54,7 +53,7 @@ impl<F: RootFilesystem + ?Sized> ModelSelectionPolicyStore
         let scope = Self::scope(caller);
         let bytes = match self
             .filesystem
-            .read_bytes_bounded(&scope, &path, POLICY_MAX_BYTES)
+            .read_bytes_bounded(&scope, &path, MODEL_SELECTION_POLICY_MAX_BYTES)
             .await
         {
             Ok(Some(bytes)) => bytes,
@@ -78,7 +77,7 @@ impl<F: RootFilesystem + ?Sized> ModelSelectionPolicyStore
     ) -> Result<(), ModelSelectionPolicyStoreError> {
         let bytes =
             serde_json::to_vec(policy).map_err(|_| ModelSelectionPolicyStoreError::InvalidData)?;
-        if bytes.len() > POLICY_MAX_BYTES {
+        if bytes.len() > MODEL_SELECTION_POLICY_MAX_BYTES {
             return Err(ModelSelectionPolicyStoreError::InvalidData);
         }
         let path = Self::path()?;

--- a/crates/product/ironclaw_operator/src/llm_admin/model_selection_policy_store.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/model_selection_policy_store.rs
@@ -3,12 +3,15 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use ironclaw_filesystem::{FilesystemError, RootFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::{
+    CasApply, CasUpdateError, ContentType, Entry, FilesystemError, RootFilesystem,
+    ScopedFilesystem, cas_update,
+};
 use ironclaw_host_api::{ids::InvocationId, path::ScopedPath, resource::ResourceScope};
 use ironclaw_product_contracts::{
     operator_llm::{
         MODEL_SELECTION_POLICY_MAX_BYTES, ModelSelectionPolicy, ModelSelectionPolicyStore,
-        ModelSelectionPolicyStoreError,
+        ModelSelectionPolicyStoreError, ModelSelectionPolicyUpdateMode,
     },
     surface::ProductSurfaceCaller,
 };
@@ -39,6 +42,41 @@ impl<F: RootFilesystem + ?Sized> FilesystemModelSelectionPolicyStore<F> {
         }
         .tenant_shared_managed_scope()
     }
+
+    fn decode_policy(bytes: &[u8]) -> Result<ModelSelectionPolicy, ModelSelectionPolicyStoreError> {
+        if bytes.len() > MODEL_SELECTION_POLICY_MAX_BYTES {
+            return Err(ModelSelectionPolicyStoreError::InvalidData);
+        }
+        serde_json::from_slice(bytes).map_err(|error| {
+            tracing::error!(error = %error, "user model policy record is invalid");
+            ModelSelectionPolicyStoreError::InvalidData
+        })
+    }
+
+    fn encode_policy(
+        policy: &ModelSelectionPolicy,
+    ) -> Result<Entry, ModelSelectionPolicyStoreError> {
+        let bytes = serde_json::to_vec(policy).map_err(|error| {
+            tracing::error!(error = %error, "user model policy serialization failed");
+            ModelSelectionPolicyStoreError::InvalidData
+        })?;
+        if bytes.len() > MODEL_SELECTION_POLICY_MAX_BYTES {
+            return Err(ModelSelectionPolicyStoreError::InvalidData);
+        }
+        Ok(Entry::bytes(bytes).with_content_type(ContentType::json()))
+    }
+}
+
+fn map_cas_update_error(
+    error: CasUpdateError<ModelSelectionPolicyStoreError>,
+) -> ModelSelectionPolicyStoreError {
+    match error {
+        CasUpdateError::Apply(error) => error,
+        error => {
+            tracing::error!(error = ?error, "atomic user model policy update failed");
+            ModelSelectionPolicyStoreError::Unavailable
+        }
+    }
 }
 
 #[async_trait]
@@ -64,31 +102,45 @@ impl<F: RootFilesystem + ?Sized> ModelSelectionPolicyStore
                 return Err(ModelSelectionPolicyStoreError::Unavailable);
             }
         };
-        serde_json::from_slice(&bytes).map(Some).map_err(|error| {
-            tracing::error!(error = %error, "user model policy record is invalid");
-            ModelSelectionPolicyStoreError::InvalidData
-        })
+        Self::decode_policy(&bytes).map(Some)
     }
 
-    async fn write(
+    async fn update(
         &self,
         caller: &ProductSurfaceCaller,
         policy: &ModelSelectionPolicy,
-    ) -> Result<(), ModelSelectionPolicyStoreError> {
-        let bytes =
-            serde_json::to_vec(policy).map_err(|_| ModelSelectionPolicyStoreError::InvalidData)?;
-        if bytes.len() > MODEL_SELECTION_POLICY_MAX_BYTES {
-            return Err(ModelSelectionPolicyStoreError::InvalidData);
-        }
+        mode: ModelSelectionPolicyUpdateMode,
+    ) -> Result<ModelSelectionPolicy, ModelSelectionPolicyStoreError> {
         let path = Self::path()?;
         let scope = Self::scope(caller);
-        self.filesystem
-            .write_bytes(&scope, &path, bytes)
-            .await
-            .map_err(|error| {
-                tracing::error!(error = %error, "user model policy write failed");
-                ModelSelectionPolicyStoreError::Unavailable
-            })
+        let requested = policy.clone();
+        cas_update(
+            &self.filesystem,
+            &scope,
+            &path,
+            Self::decode_policy,
+            Self::encode_policy,
+            move |current| {
+                let mut next = requested.clone();
+                async move {
+                    if mode == ModelSelectionPolicyUpdateMode::PreserveExistingModelEntries {
+                        next.model_entries = current
+                            .filter(|stored| stored.provider_id == next.provider_id)
+                            .map(|stored| {
+                                stored
+                                    .model_entries
+                                    .into_iter()
+                                    .filter(|entry| next.allowed_models.contains(&entry.id))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                    }
+                    Ok(CasApply::new(next.clone(), next))
+                }
+            },
+        )
+        .await
+        .map_err(map_cas_update_error)
     }
 }
 
@@ -146,7 +198,11 @@ mod tests {
     async fn policy_is_shared_by_users_inside_one_tenant_and_isolated_across_tenants() {
         let store = store();
         store
-            .write(&caller("tenant-a", "admin"), &policy("provider-a"))
+            .update(
+                &caller("tenant-a", "admin"),
+                &policy("provider-a"),
+                ModelSelectionPolicyUpdateMode::Replace,
+            )
             .await
             .expect("write policy");
 

--- a/crates/product/ironclaw_operator/src/llm_admin/model_selection_policy_store.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/model_selection_policy_store.rs
@@ -248,4 +248,84 @@ mod tests {
 
         assert!(loaded.model_entries.is_empty());
     }
+
+    #[tokio::test]
+    async fn filesystem_cas_preserves_only_allowed_entries_for_the_same_provider() {
+        let filesystem = filesystem();
+        let policy_caller = caller("tenant-a", "admin");
+        let initial = ModelSelectionPolicy {
+            provider_id: "provider-a".to_string(),
+            workspace_default: "model-a".to_string(),
+            allowed_models: vec!["model-a".to_string(), "model-b".to_string()],
+            model_entries: vec![
+                LlmModelCatalogEntry {
+                    id: "model-a".to_string(),
+                    input_modalities: vec![LlmModelModality::Text, LlmModelModality::Image],
+                    output_modalities: vec![LlmModelModality::Text],
+                },
+                LlmModelCatalogEntry {
+                    id: "model-b".to_string(),
+                    input_modalities: vec![LlmModelModality::Text],
+                    output_modalities: vec![LlmModelModality::Text, LlmModelModality::Image],
+                },
+            ],
+        };
+        FilesystemModelSelectionPolicyStore::new(Arc::clone(&filesystem))
+            .update(
+                &policy_caller,
+                &initial,
+                ModelSelectionPolicyUpdateMode::Replace,
+            )
+            .await
+            .expect("seed policy");
+
+        let legacy_same_provider = ModelSelectionPolicy {
+            provider_id: "provider-a".to_string(),
+            workspace_default: "model-b".to_string(),
+            allowed_models: vec!["model-b".to_string()],
+            model_entries: Vec::new(),
+        };
+        let retained = FilesystemModelSelectionPolicyStore::new(Arc::clone(&filesystem))
+            .update(
+                &policy_caller,
+                &legacy_same_provider,
+                ModelSelectionPolicyUpdateMode::PreserveExistingModelEntries,
+            )
+            .await
+            .expect("preserve same-provider metadata");
+        assert_eq!(
+            retained.model_entries,
+            vec![initial.model_entries[1].clone()]
+        );
+        assert_eq!(
+            FilesystemModelSelectionPolicyStore::new(Arc::clone(&filesystem))
+                .read(&policy_caller)
+                .await
+                .expect("reopen same-provider policy"),
+            Some(retained),
+        );
+
+        let legacy_other_provider = ModelSelectionPolicy {
+            provider_id: "provider-b".to_string(),
+            workspace_default: "model-b".to_string(),
+            allowed_models: vec!["model-b".to_string()],
+            model_entries: Vec::new(),
+        };
+        let isolated = FilesystemModelSelectionPolicyStore::new(Arc::clone(&filesystem))
+            .update(
+                &policy_caller,
+                &legacy_other_provider,
+                ModelSelectionPolicyUpdateMode::PreserveExistingModelEntries,
+            )
+            .await
+            .expect("isolate provider metadata");
+        assert!(isolated.model_entries.is_empty());
+        assert_eq!(
+            FilesystemModelSelectionPolicyStore::new(filesystem)
+                .read(&policy_caller)
+                .await
+                .expect("reopen cross-provider policy"),
+            Some(isolated),
+        );
+    }
 }

--- a/crates/product/ironclaw_operator/src/llm_admin/model_selection_policy_store.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/model_selection_policy_store.rs
@@ -102,6 +102,7 @@ mod tests {
         mount::{MountGrant, MountPermissions, MountView},
         path::{MountAlias, VirtualPath},
     };
+    use ironclaw_product_contracts::operator_llm::{LlmModelCatalogEntry, LlmModelModality};
 
     fn caller(tenant: &str, user: &str) -> ProductSurfaceCaller {
         ProductSurfaceCaller::new(
@@ -112,15 +113,21 @@ mod tests {
         )
     }
 
+    fn filesystem() -> Arc<ScopedFilesystem<InMemoryBackend>> {
+        Arc::new(ScopedFilesystem::new(
+            Arc::new(InMemoryBackend::new()),
+            |scope| {
+                MountView::new(vec![MountGrant::new(
+                    MountAlias::new("/tenant-shared")?,
+                    VirtualPath::new(format!("/tenants/{}/shared", scope.tenant_id.as_str()))?,
+                    MountPermissions::read_write(),
+                )])
+            },
+        ))
+    }
+
     fn store() -> FilesystemModelSelectionPolicyStore<InMemoryBackend> {
-        let filesystem = ScopedFilesystem::new(Arc::new(InMemoryBackend::new()), |scope| {
-            MountView::new(vec![MountGrant::new(
-                MountAlias::new("/tenant-shared")?,
-                VirtualPath::new(format!("/tenants/{}/shared", scope.tenant_id.as_str()))?,
-                MountPermissions::read_write(),
-            )])
-        });
-        FilesystemModelSelectionPolicyStore::new(Arc::new(filesystem))
+        FilesystemModelSelectionPolicyStore::new(filesystem())
     }
 
     fn policy(provider: &str) -> ModelSelectionPolicy {
@@ -128,6 +135,11 @@ mod tests {
             provider_id: provider.to_string(),
             workspace_default: "model-a".to_string(),
             allowed_models: vec!["model-a".to_string(), "model-b".to_string()],
+            model_entries: vec![LlmModelCatalogEntry {
+                id: "model-a".to_string(),
+                input_modalities: vec![LlmModelModality::Text, LlmModelModality::Image],
+                output_modalities: vec![LlmModelModality::Text],
+            }],
         }
     }
 
@@ -153,5 +165,30 @@ mod tests {
                 .expect("read"),
             None,
         );
+    }
+
+    #[tokio::test]
+    async fn legacy_policy_record_loads_without_capability_metadata() {
+        let filesystem = filesystem();
+        let store = FilesystemModelSelectionPolicyStore::new(Arc::clone(&filesystem));
+        let policy_caller = caller("tenant-a", "admin");
+        filesystem
+            .write_bytes(
+                &FilesystemModelSelectionPolicyStore::<InMemoryBackend>::scope(&policy_caller),
+                &FilesystemModelSelectionPolicyStore::<InMemoryBackend>::path()
+                    .expect("policy path"),
+                br#"{"provider_id":"nearai","workspace_default":"model-a","allowed_models":["model-a"]}"#
+                    .to_vec(),
+            )
+            .await
+            .expect("write legacy policy");
+
+        let loaded = store
+            .read(&policy_caller)
+            .await
+            .expect("read legacy policy")
+            .expect("policy");
+
+        assert!(loaded.model_entries.is_empty());
     }
 }

--- a/crates/product/ironclaw_operator/src/llm_admin/model_selection_policy_store.rs
+++ b/crates/product/ironclaw_operator/src/llm_admin/model_selection_policy_store.rs
@@ -133,6 +133,8 @@ impl<F: RootFilesystem + ?Sized> ModelSelectionPolicyStore
                                     .filter(|entry| next.allowed_models.contains(&entry.id))
                                     .collect()
                             })
+                            // silent-ok: an absent policy has no model metadata to preserve;
+                            // CAS and decode failures propagate through `map_cas_update_error`.
                             .unwrap_or_default();
                     }
                     Ok(CasApply::new(next.clone(), next))

--- a/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
+++ b/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
@@ -7137,8 +7137,7 @@ async fn user_model_routes_expose_only_the_safe_catalog_and_replace_policy() {
         invoke_calls[0].1,
         serde_json::json!({
             "workspace_default": "model-b",
-            "allowed_models": ["model-a", "model-b"],
-            "model_entries": []
+            "allowed_models": ["model-a", "model-b"]
         })
     );
 }

--- a/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
+++ b/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
@@ -7087,7 +7087,8 @@ async fn user_model_routes_expose_only_the_safe_catalog_and_replace_policy() {
         serde_json::json!({
             "selection_enabled": true,
             "workspace_default": "model-a",
-            "models": ["model-a", "model-b"]
+            "models": ["model-a", "model-b"],
+            "model_entries": []
         })
     );
 
@@ -7136,7 +7137,8 @@ async fn user_model_routes_expose_only_the_safe_catalog_and_replace_policy() {
         invoke_calls[0].1,
         serde_json::json!({
             "workspace_default": "model-b",
-            "allowed_models": ["model-a", "model-b"]
+            "allowed_models": ["model-a", "model-b"],
+            "model_entries": []
         })
     );
 }

--- a/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
+++ b/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
@@ -1006,6 +1006,7 @@ impl StubServices {
                     selection_enabled: true,
                     workspace_default: Some("model-a".to_string()),
                     models: vec!["model-a".to_string(), "model-b".to_string()],
+                    model_entries: Vec::new(),
                 })
                 .expect("user model catalog payload"),
                 next_cursor: None,
@@ -1696,6 +1697,7 @@ impl StubServices {
         Ok(LlmModelsResult {
             ok: true,
             models: vec!["model-a".to_string()],
+            model_entries: Vec::new(),
             message: String::new(),
         })
     }


### PR DESCRIPTION
## Summary

- Add a provider-neutral model catalog entry containing model IDs and supported input/output modalities.
- Preserve the legacy `list_models()` API while introducing additive `list_model_catalog()` discovery.
- Parse NEAR AI model capabilities and propagate detailed model discovery through every LLM provider decorator.
- Carry optional capability metadata through the operator service, persisted model-selection policy, and WebUI API.
- Keep legacy policies and non-NEAR providers compatible by defaulting capability metadata to empty values.

## Linked Issue

Closes #7970

Part of #7969

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_llm -p ironclaw_product_contracts -p ironclaw_operator --all-targets --all-features -- -D warnings`
- [x] `cargo test -p ironclaw_llm -p ironclaw_product_contracts -p ironclaw_operator --all-features --no-fail-fast`
- [x] `cargo test -p ironclaw_webui --test webui_v2_handlers_contract`
- [x] `cargo test -p ironclaw_assistant --test reborn_services_contract`
- [x] `cargo test -p ironclaw_composition standalone_cli_send_uses_saved_user_model_preference`
- [x] `cargo test -p ironclaw_architecture_tests`
- [x] `bash scripts/pre-commit-safety.sh`
- [x] Verified the live NEAR AI catalog response with 47 models and typed capability metadata.

## Security Impact

None.

Provider-returned capability metadata is treated as untrusted display metadata. Only recognized modalities are retained, unknown values are ignored, and persisted entries remain validated and bounded.

Capability metadata does not affect model routing, authorization, tool access, credential handling, or sandbox policy.

## Database Impact

None. No database migrations or schema changes are included.

The filesystem-backed model-selection policy gains an optional `model_entries` field. Existing policy files remain compatible because the field defaults to an empty list.

## Blast Radius

This change affects provider-neutral model discovery, NEAR AI catalog parsing, LLM provider decorators, operator model-selection policy handling, and the WebUI model-selection API.

The legacy `list_models()` method remains available. Providers that do not supply detailed metadata continue returning their existing model IDs with empty capability metadata.

## Rollback Plan

Revert this PR.

No data migration is required. Older code will ignore the optional persisted capability metadata, and legacy `list_models()` behavior remains intact.

---

Review track: B