### PR TITLE
fix(llm): preserve flattened schema constraints

### DIFF
--- a/crates/domains/ironclaw_llm/src/tool_schema.rs
+++ b/crates/domains/ironclaw_llm/src/tool_schema.rs
@@ -276,7 +276,7 @@ fn flatten_top_level(
         serde_json::Map::new()
     };
     for keyword in FORBIDDEN_TOP_LEVEL {
-        flattened.remove(*keyword);
+        drop(flattened.remove(*keyword));
     }
     flattened.insert("type".to_string(), JsonValue::String("object".to_string()));
     flattened.insert(
@@ -519,6 +519,7 @@ mod tests {
                 "mode": ["name"]
             },
             "minProperties": 2,
+            "additionalProperties": false,
             "allOf": [
                 {
                     "properties": {
@@ -550,7 +551,7 @@ mod tests {
         assert_eq!(result["$defs"]["identifier"]["minLength"], 1);
         assert_eq!(result["properties"]["limit"]["type"], "integer");
         assert_eq!(result["required"], serde_json::json!(["mode"]));
-        assert_eq!(result["additionalProperties"], true);
+        assert_eq!(result["additionalProperties"], false);
         assert!(description.contains("Upstream JSON schema"));
     }
 
@@ -564,12 +565,15 @@ mod tests {
             &mut description,
         );
 
+        let mut keys = result
+            .as_object()
+            .expect("strict schema")
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        keys.sort_unstable();
         assert_eq!(
-            result
-                .as_object()
-                .expect("strict schema")
-                .keys()
-                .collect::<Vec<_>>(),
+            keys,
             vec!["additionalProperties", "properties", "required", "type"]
         );
         assert_eq!(result["properties"]["mode"]["type"], "string");

--- a/crates/domains/ironclaw_llm/src/tool_schema.rs
+++ b/crates/domains/ironclaw_llm/src/tool_schema.rs
@@ -47,7 +47,7 @@ fn normalize_schema(
     let mut schema = schema.clone();
 
     if needs_top_level_flatten(&schema) {
-        flatten_top_level(&mut schema, description);
+        flatten_top_level(&mut schema, description, !strict_objects);
         if let Some(props) = schema.get_mut("properties").and_then(|v| v.as_object_mut()) {
             for (_key, prop_schema) in props.iter_mut() {
                 normalize_schema_recursive(prop_schema, strict_objects);
@@ -247,7 +247,11 @@ pub(crate) fn serialize_json_capped(value: &JsonValue, max_bytes: usize) -> Resu
     })
 }
 
-fn flatten_top_level(parameters: &mut JsonValue, description: &mut String) {
+fn flatten_top_level(
+    parameters: &mut JsonValue,
+    description: &mut String,
+    preserve_non_forbidden: bool,
+) {
     const SCHEMA_HINT_MAX_BYTES: usize = 1500;
 
     let detected = detect_forbidden_top_level(parameters);
@@ -266,12 +270,24 @@ fn flatten_top_level(parameters: &mut JsonValue, description: &mut String) {
         description.push_str(&hint);
     }
 
-    *parameters = serde_json::json!({
-        "type": "object",
-        "properties": JsonValue::Object(merged_properties),
-        "additionalProperties": true,
-        "required": required
-    });
+    let mut flattened = if preserve_non_forbidden {
+        parameters.as_object().cloned().unwrap_or_default()
+    } else {
+        serde_json::Map::new()
+    };
+    for keyword in FORBIDDEN_TOP_LEVEL {
+        flattened.remove(*keyword);
+    }
+    flattened.insert("type".to_string(), JsonValue::String("object".to_string()));
+    flattened.insert(
+        "properties".to_string(),
+        JsonValue::Object(merged_properties),
+    );
+    flattened.insert("required".to_string(), JsonValue::Array(required));
+    flattened
+        .entry("additionalProperties".to_string())
+        .or_insert(JsonValue::Bool(true));
+    *parameters = JsonValue::Object(flattened);
 }
 
 fn normalize_schema_recursive(schema: &mut JsonValue, strict_objects: bool) {
@@ -484,6 +500,82 @@ mod tests {
         assert_eq!(result["properties"]["mode"]["const"], "by_name");
         assert_eq!(result["properties"]["name"]["type"], "string");
         assert_eq!(result["properties"]["id"]["type"], "string");
+        assert!(description.contains("Upstream JSON schema"));
+    }
+
+    fn schema_with_top_level_constraints() -> JsonValue {
+        serde_json::json!({
+            "type": "object",
+            "title": "Conditional lookup",
+            "$defs": {
+                "identifier": { "type": "string", "minLength": 1 }
+            },
+            "properties": {
+                "mode": { "type": "string" },
+                "name": { "$ref": "#/$defs/identifier" }
+            },
+            "required": ["mode"],
+            "dependentRequired": {
+                "mode": ["name"]
+            },
+            "minProperties": 2,
+            "allOf": [
+                {
+                    "properties": {
+                        "limit": { "type": "integer", "minimum": 1 }
+                    }
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn test_flatten_only_preserves_non_forbidden_top_level_constraints() {
+        let mut description = "Conditional lookup tool".to_string();
+
+        let result = shape_tool_schema(
+            ToolSchemaPolicy::FlattenOnly,
+            &schema_with_top_level_constraints(),
+            &mut description,
+        );
+
+        assert!(result.get("allOf").is_none());
+        assert_eq!(result["type"], "object");
+        assert_eq!(result["title"], "Conditional lookup");
+        assert_eq!(
+            result["dependentRequired"],
+            serde_json::json!({"mode": ["name"]})
+        );
+        assert_eq!(result["minProperties"], 2);
+        assert_eq!(result["$defs"]["identifier"]["minLength"], 1);
+        assert_eq!(result["properties"]["limit"]["type"], "integer");
+        assert_eq!(result["required"], serde_json::json!(["mode"]));
+        assert_eq!(result["additionalProperties"], true);
+        assert!(description.contains("Upstream JSON schema"));
+    }
+
+    #[test]
+    fn test_strict_openai_drops_unsupported_top_level_constraints() {
+        let mut description = "Conditional lookup tool".to_string();
+
+        let result = shape_tool_schema(
+            ToolSchemaPolicy::StrictOpenAi,
+            &schema_with_top_level_constraints(),
+            &mut description,
+        );
+
+        assert_eq!(
+            result
+                .as_object()
+                .expect("strict schema")
+                .keys()
+                .collect::<Vec<_>>(),
+            vec!["additionalProperties", "properties", "required", "type"]
+        );
+        assert_eq!(result["properties"]["mode"]["type"], "string");
+        assert_eq!(result["properties"]["limit"]["type"], "integer");
+        assert_eq!(result["required"], serde_json::json!(["mode"]));
+        assert_eq!(result["additionalProperties"], true);
         assert!(description.contains("Upstream JSON schema"));
     }
 


### PR DESCRIPTION
## Summary

- make `FlattenOnly` remove only the five forbidden top-level schema keywords instead of rebuilding from a whitelist
- preserve legal root constraints such as `dependentRequired`, `$defs`, `minProperties`, and `title` while overwriting the flattened object fields
- keep the existing conservative `StrictOpenAi` whitelist unchanged and add post-`shape_tool_schema` policy tests

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #7987

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` with `SKIP_FRONTEND_BUILD=1`
- [x] `cargo build` with `SKIP_FRONTEND_BUILD=1`
- [x] Relevant tests pass: all `ironclaw_llm` tests (990 unit tests and 2 module-charter tests)
- [ ] `cargo test -p <owning-crate> --features integration`: Not applicable; no database or runtime-integration behavior changed
- [x] Manual testing: reproduced the lost root constraint before the implementation and verified both policies at the final provider-visible shaping boundary
- [ ] `pr-shepherd`: Not available in this environment

## Test Strategy

User behavior:

Providers using `FlattenOnly` receive the original legal top-level constraints after union/intersection flattening, while StrictOpenAi providers continue receiving only the supported conservative key set.

Risk areas:
- [x] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: a shared schema fixture combines `allOf` with `dependentRequired`, `$defs`, `minProperties`, and `title`; tests assert the final `shape_tool_schema` output separately for FlattenOnly and StrictOpenAi.
- Reborn integration: Not applicable.
- Recorded fixture: Not applicable; no model request/response fixture changes.
- Browser E2E: Not applicable.
- Backend or runtime: covered at the owning `ironclaw_llm` provider-boundary function.
- Live canary: Not applicable; this is a deterministic schema transformation.

What the tests prove:

The regression test fails on the previous implementation because `title` and all other non-whitelisted constraints are absent after shaping. It passes when FlattenOnly subtracts forbidden keys, and the companion test proves StrictOpenAi still emits exactly `additionalProperties`, `properties`, `required`, and `type`.

Commands run:

- `cargo test -p ironclaw_llm`
- `cargo clippy -p ironclaw_llm --all-targets --all-features -- -D warnings`
- `SKIP_FRONTEND_BUILD=1 cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- `SKIP_FRONTEND_BUILD=1 cargo build`

## Security Impact

None. Provider selection, request transport, and tool execution are unchanged; only deterministic schema shaping changes.

## Reborn Trust-Boundary Checklist

N/A: no policy/evidence type, persistence field, queue, sandbox boundary, or error class changed.

## Database Impact

None.

## Blast Radius

Limited to top-level schemas that already trigger flattening. FlattenOnly preserves legal root metadata and constraints; StrictOpenAi remains byte-for-byte equivalent in its top-level key policy. Nested normalization and the existing advisory description remain unchanged.

## Rollback Plan

Revert this commit to restore whitelist reconstruction for both policies.

## Review Follow-Through

Provider support for individual preserved JSON Schema keywords remains owned by each non-strict adapter; this PR does not claim that models validate tool arguments against the schema.

## AI Assistance Disclosure

TRAE assisted with issue analysis, implementation, tests, and command execution. The contributor reviewed the diff, policy split, regression evidence, and validation results.

---

**Review track**: B