### PR TITLE
ci: parallelize affected crate tests with nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -31,7 +31,10 @@ slow-timeout = { period = "60s", terminate-after = 3 }
 [test-groups.ironclaw-smoke-process-local]
 max-threads = 1
 
-[test-groups.composition-budget-process-local]
+[test-groups.composition-runtime-process-local]
+max-threads = 1
+
+[test-groups.ironclaw-cli-global-policy]
 max-threads = 1
 
 [[profile.ci.overrides]]
@@ -39,8 +42,12 @@ filter = "package(ironclaw) & binary(smoke)"
 test-group = "ironclaw-smoke-process-local"
 
 [[profile.ci.overrides]]
-filter = "package(ironclaw_composition) & binary(budget_e2e)"
-test-group = "composition-budget-process-local"
+filter = "package(ironclaw_composition) & (binary(budget_e2e) | binary(runtime))"
+test-group = "composition-runtime-process-local"
+
+[[profile.ci.overrides]]
+filter = "package(ironclaw) & binary(ironclaw) & test(~commands::traces::tests::)"
+test-group = "ironclaw-cli-global-policy"
 
 # Per-test windows for the handful of scenarios that genuinely need more
 # than 60s (live-recorded fixtures + heavy integration).

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,6 +25,23 @@ success-output = "never"
 # against the workflow-level 25-minute cap.
 slow-timeout = { period = "60s", terminate-after = 3 }
 
+# These binaries currently use process-local locks to protect shared ports or
+# full-runtime state. Nextest launches each test in its own process, so the
+# runner owns their cross-process serialization explicitly.
+[test-groups.ironclaw-smoke-process-local]
+max-threads = 1
+
+[test-groups.composition-budget-process-local]
+max-threads = 1
+
+[[profile.ci.overrides]]
+filter = "package(ironclaw) & binary(smoke)"
+test-group = "ironclaw-smoke-process-local"
+
+[[profile.ci.overrides]]
+filter = "package(ironclaw_composition) & binary(budget_e2e)"
+test-group = "composition-budget-process-local"
+
 # Per-test windows for the handful of scenarios that genuinely need more
 # than 60s (live-recorded fixtures + heavy integration).
 [[profile.default.overrides]]

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -78,8 +78,10 @@ packages declaring `harness = false` or an unknown test-target kind retain
 Cargo's runner. The planner derives that split from Cargo metadata and each
 selected manifest after bucket coalescing, failing closed when classification
 is impossible. Exact changed targets keep their existing direct `cargo test`
-path. Nextest groups serialize runtime binaries whose existing locks are
-process-local and CLI trace-policy tests that share an on-disk global policy.
+path, and Cargo-only or exact-target buckets skip installing nextest. Nextest
+groups serialize runtime binaries whose existing locks are process-local and
+CLI trace-policy tests that share an on-disk global policy; the workflow checks
+representative tests against nextest's compiled inventory before execution.
 Zero-test package selections preserve Cargo's successful no-op.
 
 `Tests (Reborn)` owns Rust crate, root, architecture, runtime, and coverage

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -78,7 +78,9 @@ packages declaring `harness = false` or an unknown test-target kind retain
 Cargo's runner. The planner derives that split from Cargo metadata and each
 selected manifest after bucket coalescing, failing closed when classification
 is impossible. Exact changed targets keep their existing direct `cargo test`
-path. Nextest groups serialize binaries whose existing locks are process-local.
+path. Nextest groups serialize runtime binaries whose existing locks are
+process-local and CLI trace-policy tests that share an on-disk global policy.
+Zero-test package selections preserve Cargo's successful no-op.
 
 `Tests (Reborn)` owns Rust crate, root, architecture, runtime, and coverage
 contracts. Code Style owns WebUI lint, Vitest, and the production build on all

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -73,6 +73,12 @@ main retains exhaustive per-lane fan-out for instrumented coverage.
 Full-coverage crate buckets run one multi-package `cargo llvm-cov` invocation
 per bucket, preserving every package test and the bucket LCOV artifact while
 sharing dependency compilation across packages in the same job.
+Uninstrumented whole-package buckets run ordinary libtest targets with nextest;
+packages declaring `harness = false` or an unknown test-target kind retain
+Cargo's runner. The planner derives that split from Cargo metadata and each
+selected manifest after bucket coalescing, failing closed when classification
+is impossible. Exact changed targets keep their existing direct `cargo test`
+path. Nextest groups serialize binaries whose existing locks are process-local.
 
 `Tests (Reborn)` owns Rust crate, root, architecture, runtime, and coverage
 contracts. Code Style owns WebUI lint, Vitest, and the production build on all

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -385,10 +385,17 @@ jobs:
         if: needs.changes.outputs.run_coverage == 'true'
         uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # cargo-llvm-cov
 
+      - name: Install cargo-nextest
+        if: needs.changes.outputs.run_coverage != 'true'
+        uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # v2
+        with:
+          tool: cargo-nextest@0.9.143
+
       - name: Run crate tests
         env:
           BUCKET_NAME: ${{ matrix.bucket.name }}
           BUCKET_PACKAGES: ${{ toJSON(matrix.bucket.packages) }}
+          CARGO_PACKAGES: ${{ toJSON(matrix.bucket.cargo_packages || fromJSON('[]')) }}
           EXACT_TARGETS: ${{ toJSON(matrix.bucket.exact_targets || fromJSON('[]')) }}
           COLLECT_COVERAGE: ${{ needs.changes.outputs.run_coverage }}
         run: |
@@ -399,15 +406,37 @@ jobs:
           export IRONCLAW_HERMETIC_SUITE_SKIP_PREPARE=1
           package_args=()
           feature_args=()
+          nextest_package_args=()
+          nextest_feature_args=()
+          cargo_package_args=()
+          cargo_feature_args=()
           incremental_env=()
+          if ! jq -e --argjson packages "${BUCKET_PACKAGES}" '
+            type == "array" and length == (unique | length) and
+            all(.[]; $packages | index(.) != null)
+          ' <<< "${CARGO_PACKAGES}" >/dev/null; then
+            echo "cargo_packages must be a unique subset of bucket packages" >&2
+            exit 1
+          fi
           while IFS= read -r package; do
             package_args+=(-p "$package")
+            if jq -e --arg package "$package" 'index($package) != null' \
+              <<< "${CARGO_PACKAGES}" >/dev/null; then
+              cargo_package_args+=(-p "$package")
+              subset_feature_args_name=cargo_feature_args
+            else
+              nextest_package_args+=(-p "$package")
+              subset_feature_args_name=nextest_feature_args
+            fi
             feature_flags="$(scripts/ci/package-feature-flags.sh "$package")"
             if [[ -n "${feature_flags}" ]]; then
               features="${feature_flags#--features }"
               IFS=, read -ra package_features <<< "${features}"
               for feature in "${package_features[@]}"; do
                 feature_args+=(--features "${package}/${feature}")
+                declare -n subset_feature_args="${subset_feature_args_name}"
+                subset_feature_args+=(--features "${package}/${feature}")
+                unset -n subset_feature_args
               done
             fi
             if [[ "$package" == "ironclaw_composition" ]]; then
@@ -427,6 +456,10 @@ jobs:
           else
             echo "::group::cargo test affected bucket ${BUCKET_NAME}"
             if [[ "$(jq 'length' <<< "${EXACT_TARGETS}")" -gt 0 ]]; then
+              if [[ "$(jq 'length' <<< "${CARGO_PACKAGES}")" -gt 0 ]]; then
+                echo "exact_targets and cargo_packages are mutually exclusive" >&2
+                exit 1
+              fi
               while IFS=$'\t' read -r package kind name; do
                 target_feature_args=()
                 feature_flags="$(scripts/ci/package-feature-flags.sh "${package}")"
@@ -443,10 +476,20 @@ jobs:
                   <<< "${EXACT_TARGETS}"
               )
             else
-              scripts/ci/run-hermetic-deterministic-suite.sh command \
-                timeout --signal=INT --kill-after=30s 28m \
-                "${incremental_env[@]}" cargo test "${package_args[@]}" \
-                  "${feature_args[@]}" --ignore-rust-version --all-targets -- --nocapture
+              if [[ "${#nextest_package_args[@]}" -gt 0 ]]; then
+                scripts/ci/run-hermetic-deterministic-suite.sh command \
+                  timeout --signal=INT --kill-after=30s 28m \
+                  "${incremental_env[@]}" cargo nextest run --profile ci \
+                    "${nextest_package_args[@]}" "${nextest_feature_args[@]}" \
+                    --test-threads 4 --all-targets --ignore-rust-version
+              fi
+              if [[ "${#cargo_package_args[@]}" -gt 0 ]]; then
+                scripts/ci/run-hermetic-deterministic-suite.sh command \
+                  timeout --signal=INT --kill-after=30s 28m \
+                  "${incremental_env[@]}" cargo test "${cargo_package_args[@]}" \
+                    "${cargo_feature_args[@]}" --ignore-rust-version \
+                    --all-targets -- --nocapture
+              fi
             fi
             echo "::endgroup::"
           fi

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -279,10 +279,23 @@ jobs:
         id: bucket-settings
         env:
           BUCKET_PACKAGES: ${{ toJSON(matrix.bucket.packages) }}
+          CARGO_PACKAGES: ${{ toJSON(matrix.bucket.cargo_packages || fromJSON('[]')) }}
+          EXACT_TARGETS: ${{ toJSON(matrix.bucket.exact_targets || fromJSON('[]')) }}
         run: |
           needs_webui_node=false
           needs_postgres_image=false
+          needs_nextest=false
           sccache_dist_enabled=true
+
+          if jq -e -n \
+            --argjson packages "${BUCKET_PACKAGES}" \
+            --argjson cargo_packages "${CARGO_PACKAGES}" \
+            --argjson exact_targets "${EXACT_TARGETS}" '
+              ($exact_targets | length) == 0 and
+              (($packages - $cargo_packages) | length) > 0
+            ' >/dev/null; then
+            needs_nextest=true
+          fi
 
           while IFS= read -r package; do
             feature_flags="$(scripts/ci/package-feature-flags.sh "$package")"
@@ -309,6 +322,7 @@ jobs:
 
           echo "needs_webui_node=${needs_webui_node}" >> "${GITHUB_OUTPUT}"
           echo "needs_postgres_image=${needs_postgres_image}" >> "${GITHUB_OUTPUT}"
+          echo "needs_nextest=${needs_nextest}" >> "${GITHUB_OUTPUT}"
           echo "sccache_dist_enabled=${sccache_dist_enabled}" >> "${GITHUB_OUTPUT}"
 
       - name: Pre-pull Postgres test image
@@ -386,7 +400,9 @@ jobs:
         uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # cargo-llvm-cov
 
       - name: Install cargo-nextest
-        if: needs.changes.outputs.run_coverage != 'true'
+        if: >-
+          needs.changes.outputs.run_coverage != 'true' &&
+          steps.bucket-settings.outputs.needs_nextest == 'true'
         uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # v2
         with:
           tool: cargo-nextest@0.9.143
@@ -406,6 +422,7 @@ jobs:
           export IRONCLAW_HERMETIC_SUITE_SKIP_PREPARE=1
           package_args=()
           feature_args=()
+          nextest_packages=()
           nextest_package_args=()
           nextest_feature_args=()
           cargo_package_args=()
@@ -425,6 +442,7 @@ jobs:
               cargo_package_args+=(-p "$package")
               subset_feature_args_name=cargo_feature_args
             else
+              nextest_packages+=("$package")
               nextest_package_args+=(-p "$package")
               subset_feature_args_name=nextest_feature_args
             fi
@@ -477,6 +495,38 @@ jobs:
               )
             else
               if [[ "${#nextest_package_args[@]}" -gt 0 ]]; then
+                if [[ " ${nextest_packages[*]} " == *" ironclaw "* ||
+                      " ${nextest_packages[*]} " == *" ironclaw_composition "* ]]; then
+                nextest_group_report="$(
+                  scripts/ci/run-hermetic-deterministic-suite.sh command \
+                    timeout --signal=INT --kill-after=30s 28m \
+                    "${incremental_env[@]}" cargo nextest show-config \
+                      test-groups --profile ci \
+                      "${nextest_package_args[@]}" "${nextest_feature_args[@]}" \
+                      --all-targets --ignore-rust-version \
+                      --no-pager --color never
+                )"
+                while IFS='|' read -r package group test_name; do
+                  if [[ " ${nextest_packages[*]} " != *" ${package} "* ]]; then
+                    continue
+                  fi
+                  if ! awk -v header="group: ${group} (max threads = 1)" \
+                    -v test_name="${test_name}" '
+                      $0 == header { in_group = 1; found_group = 1; next }
+                      /^group: / { in_group = 0 }
+                      in_group && index($0, test_name) { found_test = 1 }
+                      END { exit !(found_group && found_test) }
+                    ' <<< "${nextest_group_report}"; then
+                    echo "nextest group ${group} did not contain ${test_name}" >&2
+                    exit 1
+                  fi
+                done <<'GROUP_TESTS'
+                ironclaw|ironclaw-smoke-process-local|onboard_login_link_then_bearer_authorizes_a_protected_request
+                ironclaw|ironclaw-cli-global-policy|commands::traces::tests::opt_in_writes_runtime_owner_policy
+                ironclaw_composition|composition-runtime-process-local|f1_happy_path_records_actual_usd_on_receipt
+                ironclaw_composition|composition-runtime-process-local|runtime_rejects_disabled_profile_before_local_substrate_lookup
+                GROUP_TESTS
+                fi
                 scripts/ci/run-hermetic-deterministic-suite.sh command \
                   timeout --signal=INT --kill-after=30s 28m \
                   "${incremental_env[@]}" cargo nextest run --profile ci \

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -481,7 +481,8 @@ jobs:
                   timeout --signal=INT --kill-after=30s 28m \
                   "${incremental_env[@]}" cargo nextest run --profile ci \
                     "${nextest_package_args[@]}" "${nextest_feature_args[@]}" \
-                    --test-threads 4 --all-targets --ignore-rust-version
+                    --test-threads 4 --all-targets --ignore-rust-version \
+                    --no-tests pass
               fi
               if [[ "${#cargo_package_args[@]}" -gt 0 ]]; then
                 scripts/ci/run-hermetic-deterministic-suite.sh command \

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -413,7 +413,7 @@ jobs:
           incremental_env=()
           if ! jq -e --argjson packages "${BUCKET_PACKAGES}" '
             type == "array" and length == (unique | length) and
-            all(.[]; $packages | index(.) != null)
+            all(.[]; . as $package | $packages | index($package) != null)
           ' <<< "${CARGO_PACKAGES}" >/dev/null; then
             echo "cargo_packages must be a unique subset of bucket packages" >&2
             exit 1

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -506,7 +506,14 @@ jobs:
                       --all-targets --ignore-rust-version \
                       --no-pager --color never
                 )"
-                while IFS='|' read -r package group test_name; do
+                group_test_specs=(
+                  'ironclaw|ironclaw-smoke-process-local|onboard_login_link_then_bearer_authorizes_a_protected_request'
+                  'ironclaw|ironclaw-cli-global-policy|commands::traces::tests::opt_in_writes_runtime_owner_policy'
+                  'ironclaw_composition|composition-runtime-process-local|f1_happy_path_records_actual_usd_on_receipt'
+                  'ironclaw_composition|composition-runtime-process-local|runtime_rejects_disabled_profile_before_local_substrate_lookup'
+                )
+                for group_test_spec in "${group_test_specs[@]}"; do
+                  IFS='|' read -r package group test_name <<< "${group_test_spec}"
                   if [[ " ${nextest_packages[*]} " != *" ${package} "* ]]; then
                     continue
                   fi
@@ -520,12 +527,7 @@ jobs:
                     echo "nextest group ${group} did not contain ${test_name}" >&2
                     exit 1
                   fi
-                done <<'GROUP_TESTS'
-                ironclaw|ironclaw-smoke-process-local|onboard_login_link_then_bearer_authorizes_a_protected_request
-                ironclaw|ironclaw-cli-global-policy|commands::traces::tests::opt_in_writes_runtime_owner_policy
-                ironclaw_composition|composition-runtime-process-local|f1_happy_path_records_actual_usd_on_receipt
-                ironclaw_composition|composition-runtime-process-local|runtime_rejects_disabled_profile_before_local_substrate_lookup
-                GROUP_TESTS
+                done
                 fi
                 scripts/ci/run-hermetic-deterministic-suite.sh command \
                   timeout --signal=INT --kill-after=30s 28m \

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -1290,6 +1290,7 @@ def build_plan(
                 event=event,
                 reason=f"unmapped Reborn test path: {path}",
                 canonical_packages=canonical_packages,
+                metadata=metadata,
             )
         if path.startswith("tests/e2e/"):
             # E2E scenarios and support live in the dedicated

--- a/scripts/ci/reborn_pr_test_plan.py
+++ b/scripts/ci/reborn_pr_test_plan.py
@@ -79,6 +79,14 @@ DIFF_EVENTS = {"pull_request", "merge_group"}
 FULL_EVENTS = {"push", "workflow_call", "workflow_dispatch", "schedule"}
 ALL_ROOT_PARTITIONS = (0, 1, 2, 3)
 ALL_INTEGRATION_LANES = (*range(INTEGRATION_PARTITION_COUNT), "groups")
+NEXTEST_LIBTEST_TARGET_KINDS = {
+    "lib",
+    "bin",
+    "test",
+    "bench",
+    "example",
+    "proc-macro",
+}
 # Doc-fact contract tests (#7378) read `docs/` pages from inside owning
 # crates, so a published-page edit can fail a cargo test. Route those edits
 # to exactly the doc-fact test binaries (no reverse-dependency widening —
@@ -829,16 +837,89 @@ def _affected_packages(changed: set[str], reverse: dict[str, set[str]]) -> set[s
     return affected
 
 
+def _manifest_requires_cargo(package: dict[str, Any]) -> bool:
+    """Whether a whole package needs Cargo's in-process test semantics."""
+    name = str(package.get("name", "<unknown>"))
+    manifest_path = Path(str(package.get("manifest_path", "")))
+    try:
+        manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(
+            f"cannot classify test runner for {name} at {manifest_path}: {error}"
+        ) from error
+
+    manifest_targets: list[dict[str, Any]] = []
+    for table in ("lib", "bin", "test", "bench", "example"):
+        value = manifest.get(table, [])
+        if isinstance(value, dict):
+            manifest_targets.append(value)
+        elif isinstance(value, list):
+            manifest_targets.extend(
+                target for target in value if isinstance(target, dict)
+            )
+    if any(target.get("harness") is False for target in manifest_targets):
+        return True
+
+    for target in package.get("targets", []):
+        if not target.get("test", False):
+            continue
+        kinds = set(target.get("kind", []))
+        if not kinds or not kinds <= NEXTEST_LIBTEST_TARGET_KINDS:
+            return True
+    return False
+
+
+def _cargo_required_packages(
+    metadata: dict[str, Any], packages: set[str]
+) -> set[str]:
+    by_name = {str(package["name"]): package for package in metadata["packages"]}
+    missing = sorted(packages - by_name.keys())
+    if missing:
+        raise ValueError(
+            "selected packages are missing from Cargo metadata: " + ", ".join(missing)
+        )
+    return {
+        package
+        for package in packages
+        if _manifest_requires_cargo(by_name[package])
+    }
+
+
+def _annotate_cargo_packages(
+    buckets: list[dict[str, Any]], metadata: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Add the Cargo-only subset after every bucket's package list is final."""
+    full_package_names = {
+        str(package)
+        for bucket in buckets
+        if not bucket.get("exact_targets")
+        for package in bucket.get("packages", [])
+    }
+    cargo_required = _cargo_required_packages(metadata, full_package_names)
+    annotated: list[dict[str, Any]] = []
+    for bucket in buckets:
+        candidate = dict(bucket)
+        if not candidate.get("exact_targets"):
+            cargo_packages = sorted(set(candidate["packages"]) & cargo_required)
+            if cargo_packages:
+                candidate["cargo_packages"] = cargo_packages
+        annotated.append(candidate)
+    return annotated
+
+
 def _full_plan(
     reason: str,
     canonical_packages: list[str],
+    metadata: dict[str, Any],
 ) -> dict[str, Any]:
     return {
         "mode": "full",
         "reasons": [reason],
         "changed_packages": [],
         "affected_packages": canonical_packages,
-        "crate_buckets": _bucket_packages(canonical_packages),
+        "crate_buckets": _annotate_cargo_packages(
+            _bucket_packages(canonical_packages), metadata
+        ),
         "root_partitions": list(ALL_ROOT_PARTITIONS),
         "integration_lanes": list(ALL_INTEGRATION_LANES),
         "run_qa_replay": True,
@@ -866,6 +947,7 @@ def _unclassified_path_plan(
     event: str,
     reason: str,
     canonical_packages: list[str],
+    metadata: dict[str, Any],
 ) -> dict[str, Any]:
     """Fail PR feedback loudly; widen an otherwise valid queue diff."""
     if event == "merge_group":
@@ -873,6 +955,7 @@ def _unclassified_path_plan(
             f"merge-group scope could not classify {reason}; running the "
             "exhaustive plan",
             canonical_packages,
+            metadata,
         )
     raise ValueError(reason)
 
@@ -887,9 +970,11 @@ def build_plan(
 ) -> dict[str, Any]:
     """Build a deterministic test plan, rejecting or widening unknown inputs."""
     if event in FULL_EVENTS:
-        return _full_plan(f"{event} requires exhaustive coverage", canonical_packages)
+        return _full_plan(
+            f"{event} requires exhaustive coverage", canonical_packages, metadata
+        )
     if event not in DIFF_EVENTS:
-        return _full_plan(f"unknown event {event!r}", canonical_packages)
+        return _full_plan(f"unknown event {event!r}", canonical_packages, metadata)
 
     paths = {path.strip().replace("\\", "/") for path in changed_paths if path.strip()}
     if not paths:
@@ -906,6 +991,7 @@ def build_plan(
                 f"merge-group global or topology input changed: {global_risk}; "
                 "running the exhaustive plan",
                 canonical_packages,
+                metadata,
             )
 
     package_directories, reverse = _workspace_packages(metadata)
@@ -923,6 +1009,7 @@ def build_plan(
                 "merge-group workspace topology input changed: "
                 f"{changed_manifest}; running the exhaustive plan",
                 canonical_packages,
+                metadata,
             )
     production_packages: set[str] = set()
     direct_test_packages: set[str] = set()
@@ -1305,6 +1392,7 @@ def build_plan(
                     "a crate path maps to no workspace package (deletion or "
                     f"rename): {path}; this PR runs the exhaustive plan",
                     canonical_packages,
+                    metadata,
                 )
             directory = next(
                 directory
@@ -1336,6 +1424,7 @@ def build_plan(
                 event=event,
                 reason=f"unmapped Reborn test path: {path}",
                 canonical_packages=canonical_packages,
+                metadata=metadata,
             )
         if path.startswith("tests/e2e/"):
             # The browser/E2E suite has its own workflow (`reborn-e2e.yml`,
@@ -1350,22 +1439,26 @@ def build_plan(
                 event=event,
                 reason=f"unmapped test or CI path: {path}",
                 canonical_packages=canonical_packages,
+                metadata=metadata,
             )
         return _unclassified_path_plan(
             event=event,
             reason=f"unclassified pull-request path: {path}",
             canonical_packages=canonical_packages,
+            metadata=metadata,
         )
 
     if nextest_config_changed:
         return _full_plan(
             "nextest runner config changed; this PR runs the exhaustive plan",
             canonical_packages,
+            metadata,
         )
     if shared_reborn_action_changed:
         return _full_plan(
             "shared reborn action changed; this PR runs the exhaustive plan",
             canonical_packages,
+            metadata,
         )
 
     canonical_set = set(canonical_packages)
@@ -1404,6 +1497,7 @@ def build_plan(
             f"coalesced {original_bucket_count} affected crate buckets into "
             f"{len(buckets)} PR jobs without omitting packages"
         )
+    buckets = _annotate_cargo_packages(buckets, metadata)
     active = bool(
         buckets
         or root_partitions

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -330,6 +330,15 @@ class RebornPrTestPlanTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "empty merge-group diff"):
             self.plan("merge_group", [])
 
+    def test_unmapped_reborn_test_path_preserves_fail_closed_behavior(self) -> None:
+        path = "tests/reborn_unmapped_contract.rs"
+        with self.assertRaisesRegex(ValueError, "unmapped Reborn test path"):
+            self.plan("pull_request", [path])
+
+        merge_group = self.plan("merge_group", [path])
+        self.assertEqual(merge_group["mode"], "full")
+        self.assertEqual(merge_group["root_partitions"], [0, 1, 2, 3])
+
     def test_changed_package_includes_transitive_reverse_dependents(self) -> None:
         plan = self.plan("pull_request", ["crates/alpha/src/lib.rs"])
         self.assertEqual(plan["mode"], "selected")
@@ -2523,6 +2532,7 @@ class RebornPrTestPlanTests(unittest.TestCase):
         )
         self.assertIn("cargo nextest run --profile ci", crate_job)
         self.assertIn("--test-threads 4 --all-targets", crate_job)
+        self.assertIn("--no-tests pass", crate_job)
         self.assertIn('if [[ "$(jq \'length\' <<< "${EXACT_TARGETS}")" -gt 0 ]]', crate_job)
         self.assertIn("run-hermetic-deterministic-suite.sh command", crate_job)
         self.assertNotIn('coverage/${package}.lcov', workflow)
@@ -2634,9 +2644,13 @@ class RebornPrTestPlanTests(unittest.TestCase):
             1,
         )
         self.assertEqual(
-            config["test-groups"]["composition-budget-process-local"][
+            config["test-groups"]["composition-runtime-process-local"][
                 "max-threads"
             ],
+            1,
+        )
+        self.assertEqual(
+            config["test-groups"]["ironclaw-cli-global-policy"]["max-threads"],
             1,
         )
         ci_overrides = config["profile"]["ci"]["overrides"]
@@ -2651,9 +2665,23 @@ class RebornPrTestPlanTests(unittest.TestCase):
         self.assertTrue(
             any(
                 override.get("filter")
-                == 'package(ironclaw_composition) & binary(budget_e2e)'
+                == (
+                    "package(ironclaw_composition) & "
+                    "(binary(budget_e2e) | binary(runtime))"
+                )
                 and override.get("test-group")
-                == "composition-budget-process-local"
+                == "composition-runtime-process-local"
+                for override in ci_overrides
+            )
+        )
+        self.assertTrue(
+            any(
+                override.get("filter")
+                == (
+                    "package(ironclaw) & binary(ironclaw) & "
+                    "test(~commands::traces::tests::)"
+                )
+                and override.get("test-group") == "ironclaw-cli-global-policy"
                 for override in ci_overrides
             )
         )

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -239,13 +239,21 @@ class RebornPrTestPlanTests(unittest.TestCase):
     def setUp(self) -> None:
         planner._sandbox_crate_directory.cache_clear()
         self.original_bucket_packages = planner._bucket_packages
+        self.original_cargo_required_packages = getattr(
+            planner, "_cargo_required_packages", None
+        )
         planner._bucket_packages = lambda packages: (
             [{"name": "selected", "packages": packages}] if packages else []
         )
+        planner._cargo_required_packages = lambda metadata, packages: set()
         self.canonical = ["alpha", "beta", "gamma"]
 
     def tearDown(self) -> None:
         planner._bucket_packages = self.original_bucket_packages
+        if self.original_cargo_required_packages is None:
+            del planner._cargo_required_packages
+        else:
+            planner._cargo_required_packages = self.original_cargo_required_packages
         planner._sandbox_crate_directory.cache_clear()
 
     def plan(
@@ -357,6 +365,84 @@ class RebornPrTestPlanTests(unittest.TestCase):
         self.assertEqual(plan["affected_packages"], ["alpha"])
         self.assertNotIn("exact_targets", plan["crate_buckets"][0])
 
+    def test_full_package_buckets_partition_cargo_required_packages(self) -> None:
+        with mock.patch.object(
+            planner, "_cargo_required_packages", return_value={"beta"}
+        ):
+            selected = self.plan("pull_request", ["crates/alpha/src/lib.rs"])
+            exhaustive = self.plan("workflow_dispatch", [])
+
+        self.assertEqual(selected["crate_buckets"][0]["cargo_packages"], ["beta"])
+        self.assertEqual(exhaustive["crate_buckets"][0]["cargo_packages"], ["beta"])
+
+    def test_exact_target_bucket_keeps_the_existing_cargo_contract(self) -> None:
+        with mock.patch.object(
+            planner, "_cargo_required_packages", return_value={"alpha"}
+        ):
+            plan = self.plan("pull_request", ["crates/alpha/tests/contract.rs"])
+
+        bucket = plan["crate_buckets"][0]
+        self.assertEqual(
+            bucket["exact_targets"],
+            [{"package": "alpha", "kind": "test", "name": "contract"}],
+        )
+        self.assertNotIn("cargo_packages", bucket)
+
+    def test_manifest_harness_false_requires_whole_package_cargo(self) -> None:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        manifest = root / "Cargo.toml"
+        manifest.write_text(
+            '[[test]]\nname = "custom"\npath = "tests/custom.rs"\nharness = false\n',
+            encoding="utf-8",
+        )
+        package = {
+            "name": "alpha",
+            "manifest_path": str(manifest),
+            "targets": [{"kind": ["test"], "test": True}],
+        }
+
+        self.assertTrue(planner._manifest_requires_cargo(package))
+
+    def test_unknown_test_target_kind_requires_whole_package_cargo(self) -> None:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        manifest = root / "Cargo.toml"
+        manifest.write_text('[package]\nname = "alpha"\n', encoding="utf-8")
+        package = {
+            "name": "alpha",
+            "manifest_path": str(manifest),
+            "targets": [{"kind": ["future-test-kind"], "test": True}],
+        }
+
+        self.assertTrue(planner._manifest_requires_cargo(package))
+
+    def test_ordinary_libtest_package_is_nextest_compatible(self) -> None:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        manifest = root / "Cargo.toml"
+        manifest.write_text(
+            '[[test]]\nname = "ordinary"\npath = "tests/ordinary.rs"\n',
+            encoding="utf-8",
+        )
+        package = {
+            "name": "alpha",
+            "manifest_path": str(manifest),
+            "targets": [{"kind": ["test"], "test": True}],
+        }
+
+        self.assertFalse(planner._manifest_requires_cargo(package))
+
+    def test_malformed_selected_manifest_fails_with_package_context(self) -> None:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        manifest = root / "Cargo.toml"
+        manifest.write_text("[[test]\n", encoding="utf-8")
+        package = {
+            "name": "alpha",
+            "manifest_path": str(manifest),
+            "targets": [],
+        }
+
+        with self.assertRaisesRegex(ValueError, "alpha.*Cargo.toml"):
+            planner._manifest_requires_cargo(package)
+
     def test_high_fanout_package_keeps_consumers_in_bounded_jobs(self) -> None:
         wide = metadata()
         for index in range(5):
@@ -380,12 +466,15 @@ class RebornPrTestPlanTests(unittest.TestCase):
             {"name": package, "packages": [package]} for package in packages
         ]
 
-        plan = planner.build_plan(
-            event="pull_request",
-            changed_paths=["crates/alpha/src/lib.rs"],
-            metadata=wide,
-            canonical_packages=canonical,
-        )
+        with mock.patch.object(
+            planner, "_cargo_required_packages", return_value={"consumer_0"}
+        ):
+            plan = planner.build_plan(
+                event="pull_request",
+                changed_paths=["crates/alpha/src/lib.rs"],
+                metadata=wide,
+                canonical_packages=canonical,
+            )
 
         self.assertEqual(plan["affected_packages"], canonical)
         self.assertEqual(len(plan["crate_buckets"]), 3)
@@ -398,13 +487,30 @@ class RebornPrTestPlanTests(unittest.TestCase):
             canonical,
         )
         self.assertIn("without omitting packages", plan["reasons"][-1])
-
-        merge_group_plan = planner.build_plan(
-            event="merge_group",
-            changed_paths=["crates/alpha/src/lib.rs"],
-            metadata=wide,
-            canonical_packages=canonical,
+        self.assertEqual(
+            [
+                bucket["name"]
+                for bucket in plan["crate_buckets"]
+                if bucket.get("cargo_packages") == ["consumer_0"]
+            ],
+            [
+                next(
+                    bucket["name"]
+                    for bucket in plan["crate_buckets"]
+                    if "consumer_0" in bucket["packages"]
+                )
+            ],
         )
+
+        with mock.patch.object(
+            planner, "_cargo_required_packages", return_value={"consumer_0"}
+        ):
+            merge_group_plan = planner.build_plan(
+                event="merge_group",
+                changed_paths=["crates/alpha/src/lib.rs"],
+                metadata=wide,
+                canonical_packages=canonical,
+            )
         self.assertEqual(len(merge_group_plan["crate_buckets"]), len(canonical))
         self.assertEqual(
             sorted(
@@ -2395,7 +2501,7 @@ class RebornPrTestPlanTests(unittest.TestCase):
         )
         self.assertIn("--test reborn_integration_sandbox_shell_turn", workflow)
         self.assertIn(
-            '"${feature_args[@]}" --ignore-rust-version --all-targets',
+            'cargo test "${cargo_package_args[@]}"',
             workflow,
         )
         self.assertIn(
@@ -2403,6 +2509,22 @@ class RebornPrTestPlanTests(unittest.TestCase):
             '                "${package_args[@]}" "${feature_args[@]}"',
             workflow,
         )
+        crate_job = workflow.split("\n  crate-tests:\n", 1)[1].split(
+            "\n  reborn-root-tests:\n", 1
+        )[0]
+        integration_job = workflow.split(
+            "  reborn-integration-coverage:", 1
+        )[1].split("  coverage-report:", 1)[0]
+        self.assertIn("CARGO_PACKAGES:", crate_job)
+        self.assertIn("cargo-nextest@0.9.143", crate_job)
+        self.assertIn(
+            "taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20",
+            crate_job,
+        )
+        self.assertIn("cargo nextest run --profile ci", crate_job)
+        self.assertIn("--test-threads 4 --all-targets", crate_job)
+        self.assertIn('if [[ "$(jq \'length\' <<< "${EXACT_TARGETS}")" -gt 0 ]]', crate_job)
+        self.assertIn("run-hermetic-deterministic-suite.sh command", crate_job)
         self.assertNotIn('coverage/${package}.lcov', workflow)
         self.assertIn(
             "max-parallel: ${{ github.event_name == 'pull_request' && 3 || 14 }}",
@@ -2424,9 +2546,6 @@ class RebornPrTestPlanTests(unittest.TestCase):
             "max-parallel: ${{ github.event_name == 'pull_request' && 1 || 5 }}",
             workflow,
         )
-        integration_job = workflow.split("  reborn-integration-coverage:", 1)[1].split(
-            "  coverage-report:", 1
-        )[0]
         self.assertIn(
             "timeout-minutes: ${{ github.event_name == 'push' && 120 || 300 }}",
             integration_job,
@@ -2504,6 +2623,39 @@ class RebornPrTestPlanTests(unittest.TestCase):
             '"${incremental_env[@]}" cargo test \\\n'
             '                    -p "${package}" "--${kind}" "${name}"',
             workflow,
+        )
+
+    def test_nextest_process_local_tests_are_serialized_across_processes(self) -> None:
+        config = tomllib.loads(
+            (ROOT / ".config/nextest.toml").read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            config["test-groups"]["ironclaw-smoke-process-local"]["max-threads"],
+            1,
+        )
+        self.assertEqual(
+            config["test-groups"]["composition-budget-process-local"][
+                "max-threads"
+            ],
+            1,
+        )
+        ci_overrides = config["profile"]["ci"]["overrides"]
+        self.assertTrue(
+            any(
+                override.get("filter") == 'package(ironclaw) & binary(smoke)'
+                and override.get("test-group")
+                == "ironclaw-smoke-process-local"
+                for override in ci_overrides
+            )
+        )
+        self.assertTrue(
+            any(
+                override.get("filter")
+                == 'package(ironclaw_composition) & binary(budget_e2e)'
+                and override.get("test-group")
+                == "composition-budget-process-local"
+                for override in ci_overrides
+            )
         )
 
     def test_integration_batch_shape_matches_event(self) -> None:

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -2581,6 +2581,43 @@ class RebornPrTestPlanTests(unittest.TestCase):
             workflow,
         )
 
+    def test_workflow_rejects_cargo_packages_outside_bucket(self) -> None:
+        workflow = (ROOT / ".github/workflows/reborn-tests.yml").read_text(
+            encoding="utf-8"
+        )
+        crate_job = workflow.split("\n  crate-tests:\n", 1)[1].split(
+            "\n  reborn-root-tests:\n", 1
+        )[0]
+        match = re.search(
+            r'if ! jq -e --argjson packages "\$\{BUCKET_PACKAGES\}" \'\n'
+            r"(?P<expression>.*?)\n          ' <<< \"\$\{CARGO_PACKAGES\}\"",
+            crate_job,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match, "crate runner must validate cargo_packages")
+        expression = match.group("expression").strip()  # type: ignore[union-attr]
+
+        def validate(cargo_packages: list[str]) -> bool:
+            completed = subprocess.run(
+                [
+                    "jq",
+                    "-e",
+                    "--argjson",
+                    "packages",
+                    '["ironclaw", "ironclaw_host_ingress"]',
+                    expression,
+                ],
+                input=json.dumps(cargo_packages),
+                capture_output=True,
+                text=True,
+            )
+            return completed.returncode == 0
+
+        self.assertTrue(validate(["ironclaw_host_ingress"]))
+        self.assertTrue(validate([]))
+        self.assertFalse(validate(["not-in-the-bucket"]))
+        self.assertFalse(validate(["ironclaw", "ironclaw"]))
+
         code_style = (ROOT / ".github/workflows/code_style.yml").read_text(
             encoding="utf-8"
         )

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -2618,6 +2618,97 @@ class RebornPrTestPlanTests(unittest.TestCase):
         self.assertFalse(validate(["not-in-the-bucket"]))
         self.assertFalse(validate(["ironclaw", "ironclaw"]))
 
+    def test_workflow_installs_nextest_only_for_buckets_that_use_it(self) -> None:
+        workflow = (ROOT / ".github/workflows/reborn-tests.yml").read_text(
+            encoding="utf-8"
+        )
+        crate_job = workflow.split("\n  crate-tests:\n", 1)[1].split(
+            "\n  reborn-root-tests:\n", 1
+        )[0]
+        settings = crate_job.split("      - name: Resolve bucket settings", 1)[
+            1
+        ].split("      - name: Pre-pull Postgres test image", 1)[0]
+        install = crate_job.split("      - name: Install cargo-nextest", 1)[1].split(
+            "      - name: Run crate tests", 1
+        )[0]
+
+        self.assertIn("CARGO_PACKAGES:", settings)
+        self.assertIn("EXACT_TARGETS:", settings)
+        self.assertIn("needs_nextest=false", settings)
+        self.assertIn('echo "needs_nextest=${needs_nextest}"', settings)
+        self.assertIn(
+            "steps.bucket-settings.outputs.needs_nextest == 'true'", install
+        )
+        match = re.search(
+            r'--argjson exact_targets "\$\{EXACT_TARGETS\}" \'\n'
+            r"(?P<expression>.*?)\n            ' >/dev/null",
+            settings,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match, "bucket settings must derive nextest usage")
+        expression = match.group("expression").strip()  # type: ignore[union-attr]
+
+        def needs_nextest(
+            packages: list[str], cargo_packages: list[str], exact_targets: list[object]
+        ) -> bool:
+            completed = subprocess.run(
+                [
+                    "jq",
+                    "-e",
+                    "-n",
+                    "--argjson",
+                    "packages",
+                    json.dumps(packages),
+                    "--argjson",
+                    "cargo_packages",
+                    json.dumps(cargo_packages),
+                    "--argjson",
+                    "exact_targets",
+                    json.dumps(exact_targets),
+                    expression,
+                ],
+                capture_output=True,
+                text=True,
+            )
+            return completed.returncode == 0
+
+        self.assertTrue(needs_nextest(["alpha", "beta"], ["beta"], []))
+        self.assertFalse(needs_nextest(["alpha"], ["alpha"], []))
+        self.assertFalse(
+            needs_nextest(
+                ["alpha"], [], [{"package": "alpha", "kind": "test", "name": "x"}]
+            )
+        )
+
+    def test_workflow_validates_process_local_groups_against_inventory(self) -> None:
+        workflow = (ROOT / ".github/workflows/reborn-tests.yml").read_text(
+            encoding="utf-8"
+        )
+        crate_job = workflow.split("\n  crate-tests:\n", 1)[1].split(
+            "\n  reborn-root-tests:\n", 1
+        )[0]
+        self.assertIn("cargo nextest show-config", crate_job)
+        self.assertIn("test-groups --profile ci", crate_job)
+        self.assertIn("ironclaw-smoke-process-local", crate_job)
+        self.assertIn(
+            "onboard_login_link_then_bearer_authorizes_a_protected_request",
+            crate_job,
+        )
+        self.assertIn("composition-runtime-process-local", crate_job)
+        self.assertIn(
+            "f1_happy_path_records_actual_usd_on_receipt",
+            crate_job,
+        )
+        self.assertIn(
+            "runtime_rejects_disabled_profile_before_local_substrate_lookup",
+            crate_job,
+        )
+        self.assertIn("ironclaw-cli-global-policy", crate_job)
+        self.assertIn(
+            "commands::traces::tests::opt_in_writes_runtime_owner_policy",
+            crate_job,
+        )
+
         code_style = (ROOT / ".github/workflows/code_style.yml").read_text(
             encoding="utf-8"
         )

--- a/scripts/ci/test_reborn_pr_test_plan.py
+++ b/scripts/ci/test_reborn_pr_test_plan.py
@@ -2689,6 +2689,8 @@ class RebornPrTestPlanTests(unittest.TestCase):
         )[0]
         self.assertIn("cargo nextest show-config", crate_job)
         self.assertIn("test-groups --profile ci", crate_job)
+        self.assertIn("group_test_specs=(", crate_job)
+        self.assertNotIn("done <<'GROUP_TESTS'", crate_job)
         self.assertIn("ironclaw-smoke-process-local", crate_job)
         self.assertIn(
             "onboard_login_link_then_bearer_authorizes_a_protected_request",
@@ -2708,6 +2710,23 @@ class RebornPrTestPlanTests(unittest.TestCase):
             "commands::traces::tests::opt_in_writes_runtime_owner_policy",
             crate_job,
         )
+
+    def test_crate_runner_shell_is_syntactically_valid(self) -> None:
+        workflow = (ROOT / ".github/workflows/reborn-tests.yml").read_text(
+            encoding="utf-8"
+        )
+        block = workflow.split("      - name: Run crate tests\n", 1)[1].split(
+            "      - name: Upload bucket lcov artifact\n", 1
+        )[0]
+        script = block.split("        run: |\n", 1)[1]
+        script = "\n".join(
+            line[10:] if line.startswith("          ") else line
+            for line in script.splitlines()
+        )
+        completed = subprocess.run(
+            ["bash", "-n"], input=script, capture_output=True, text=True
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
 
         code_style = (ROOT / ".github/workflows/code_style.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary

- run ordinary affected-package crate tests through nextest with four test processes instead of Cargo's cross-binary sequential scheduler
- derive a conservative Cargo-only subset from selected manifests and Cargo metadata; custom `harness = false` and unknown test target kinds remain on `cargo test`
- preserve exact-target and coverage execution paths, and add nextest groups for smoke and budget binaries whose existing locks are process-local
- document and regression-test the runner-selection contract, including post-coalescing classification and fail-closed manifest handling

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check` — not applicable: no Rust files changed
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings` — not applicable: no Rust files changed
- [ ] `cargo build` — not applicable: CI orchestration only
- [x] Relevant tests pass: planner, workflow, hermetic-runner, coverage-wiring, quality-gate, and scope-classifier contracts
- [ ] `cargo test -p <owning-crate> --features integration` — not applicable: no product or database behavior changed
- [x] Manual testing: parsed nextest configuration and workflow YAML; checked embedded crate-job Bash with `bash -n`; classified live workspace manifests from `cargo metadata --no-deps`
- [ ] If a coding agent was used and supports it, `pr-shepherd` was run before requesting review — will run after PR CI/review exists

## Test Strategy

User behavior: Contributors should receive the same affected-crate coverage with less crate-test scheduler idle time. This PR does not claim a measured wall-clock improvement until GitHub Actions runs provide evidence.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [x] External provider — GitHub Actions execution only
- [x] Cross-component behavior — planner output is consumed by the crate-test matrix

Tests added or updated:
- Unit or contract: planner classification, full/selected/coalesced buckets, exact-target precedence, workflow routing, and nextest serialization policy
- Reborn integration: Not applicable: production behavior is unchanged
- Recorded fixture: Not applicable: fixture behavior is unchanged
- Browser E2E: Not applicable: browser behavior is unchanged
- Backend or runtime: Not applicable: runtime implementation is unchanged
- Live canary: Not applicable: no live provider behavior changed

What the tests prove: ordinary full-package buckets reach nextest; Cargo-required packages remain on Cargo; exact targets and coverage retain their existing runners; invalid manifests fail closed; and process-local resource guards remain serialized under nextest.

Commands run:

```text
python3 scripts/ci/test_reborn_pr_test_plan.py                         # 109 passed
python3 scripts/ci/test_ws12_workflow_contracts.py                    # 158 passed
python3 scripts/ci/ws12_workflow_contracts.py                         # passed
bash scripts/ci/test-hermetic-test-process.sh                         # passed
bash scripts/ci/test-check-reborn-branch-coverage-flags.sh            # 20 passed
bash scripts/ci/test-quality-gate-runner.sh                           # passed
bash scripts/ci/test-classify-test-scope.sh                           # passed
cargo nextest show-config version --profile ci --no-pager            # passed
git diff --check                                                      # passed
```

The full compiled workspace nextest inventory was not run locally: the shared Cargo cache is read-only, and an isolated cache exceeded the environment disk quota. PR CI is the runtime/inventory proof.

## Security Impact

None. The existing hermetic test-process wrapper remains the boundary for both runners; this change does not add credentials, permissions, network access, or secret handling.

## Reborn Trust-Boundary Checklist

N/A: CI runner selection only; no product trust boundary or runtime contract changes.

## Database Impact

None.

## Blast Radius

Affected crate-test buckets in `.github/workflows/reborn-tests.yml`. Coverage stays on `cargo llvm-cov`; exact changed targets and custom-harness packages stay on Cargo. The main failure mode is a nextest scheduling incompatibility in an ordinary libtest package, which should surface in this PR's exhaustive workflow-triggered CI plan.

Compatibility: the planner schema only adds optional `cargo_packages`; existing `packages` and `exact_targets` semantics remain intact. Unknown or unreadable target shapes fail closed instead of silently moving to nextest.

Follow-up risk: GitHub Actions timings must confirm that added test concurrency improves critical-path duration without increasing flakes or runner contention.

## Rollback Plan

Revert this PR. That removes the nextest installation and package split from the crate job, returning every affected crate bucket to the previous multi-package `cargo test` command. No persisted data or migration is involved.

## Review Follow-Through

Please pay particular attention to the manifest compatibility classifier and the two nextest process-local serialization groups. Runtime value should be judged from PR and merge-queue timings rather than inferred from local tests.

---

**Review track**: C (CI)
