### PR TITLE
fix(slack): preserve explicit mentions across callback dedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5183,6 +5183,7 @@ dependencies = [
  "ironclaw_attachments",
  "ironclaw_extension_contracts",
  "ironclaw_host_api",
+ "ironclaw_product_contracts",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
+++ b/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
@@ -2806,7 +2806,7 @@ async fn slack_explicit_mention_remains_single_when_authoritative_twin_arrives_f
 }
 
 #[tokio::test]
-async fn slack_text_only_mention_runs_while_ordinary_thread_reply_remains_noop() {
+async fn slack_text_only_mentions_run_for_supported_ids_while_ordinary_reply_remains_noop() {
     let harness = build_harness(TurnMode::Complete {
         assistant_text: "text mention reply".into(),
     })
@@ -2844,6 +2844,22 @@ async fn slack_text_only_mention_runs_while_ordinary_thread_reply_remains_noop()
         1,
         "ordinary thread chatter must not produce another bot reply"
     );
+
+    let mut w_options = HarnessOptions::new(TurnMode::Complete {
+        assistant_text: "W mention reply".into(),
+    });
+    w_options.slack_bot_user_id = "W012ABC";
+    let w_harness = build_harness_with_options(w_options).await;
+
+    let response = w_harness.post_event(W_PREFIXED_TEXT_ONLY_MENTION).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    w_harness.drain().await;
+    assert_eq!(
+        w_harness.coordinator.submitted_scopes().len(),
+        1,
+        "a W-prefixed configured bot ID must reach signed ingress admission"
+    );
+    assert_eq!(w_harness.slack_messages().len(), 1);
 }
 
 /// Ephemeral-per-ping: pairing mid-thread. Unpaired carol is nudged in place
@@ -4942,6 +4958,13 @@ const TEXT_ONLY_THREAD_MENTION: &str = r#"{
   "event":{"type":"message","user":"U123","channel":"C894",
            "text":"<@UBOT> investigate","thread_ts":"1710000010.000001",
            "ts":"1710000010.000002"}
+}"#;
+
+const W_PREFIXED_TEXT_ONLY_MENTION: &str = r#"{
+  "type":"event_callback","team_id":"T-A","event_id":"Ev-w-text-only-mention",
+  "event":{"type":"message","user":"U123","channel":"C894",
+           "text":"<@W012ABC> investigate","thread_ts":"1710000010.000001",
+           "ts":"1710000010.000005"}
 }"#;
 
 const ORDINARY_THREAD_REPLY: &str = r#"{

--- a/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
+++ b/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
@@ -447,6 +447,9 @@ struct HarnessOptions {
     /// `IRONCLAW_REBORN_WEBUI_BASE_URL`. `None` (the default) keeps the
     /// connect notice link-free.
     connect_link_base_url: Option<String>,
+    /// A stale value exercises a legacy installation whose saved bot user ID
+    /// no longer matches the callback's addressed member.
+    slack_bot_user_id: &'static str,
 }
 
 impl HarnessOptions {
@@ -460,6 +463,7 @@ impl HarnessOptions {
             actor_role: AdminUserRole::Member,
             connection_strategy: None,
             connect_link_base_url: None,
+            slack_bot_user_id: "UBOT",
         }
     }
 }
@@ -622,7 +626,7 @@ async fn build_harness_with_options(options: HarnessOptions) -> Harness {
     ]));
     let dm_targets = generic_dm_target_store();
 
-    let channel_config = configured_channel_config().await;
+    let channel_config = configured_channel_config(options.slack_bot_user_id).await;
     let identity = ChannelHostIdentity {
         tenant_id: TenantId::new(TENANT).expect("tenant"), // safety: static test tenant id is valid.
         agent_id: AgentId::new(AGENT).expect("agent"),     // safety: static test agent id is valid.
@@ -743,7 +747,7 @@ async fn build_harness_with_options(options: HarnessOptions) -> Harness {
 /// `[channel.config]` configured through the production configure service:
 /// the REAL slack manifest is installed into a durable installation store
 /// and the ingress verification secret is saved under its manifest handle.
-async fn configured_channel_config() -> Arc<ChannelConfigService> {
+async fn configured_channel_config(bot_user_id: &str) -> Arc<ChannelConfigService> {
     let installation_store = Arc::new(crate::filesystem_installation_store_for_test().await);
     let record = ExtensionManifestRecord::from_toml(
         slack_manifest_from_bundled_inventory(),
@@ -821,13 +825,10 @@ async fn configured_channel_config() -> Arc<ChannelConfigService> {
                 ("slack_api_app_id".to_string(), "A-E2E".to_string()),
                 ("slack_installation_id".to_string(), "I-E2E".to_string()),
                 // Must match the `<@…>` id every fixture's `text` mentions
-                // (`UBOT`, not e.g. "U-BOT-E2E"): the adapter's
-                // `strip_leading_bot_mention` now strips a leading mention
-                // only when it names THIS configured bot, so a mismatch here
-                // silently leaves the mention in the normalized text instead
-                // of failing loudly — re-check every `<@UBOT>` fixture below
-                // if this value ever changes.
-                ("slack_bot_user_id".to_string(), "UBOT".to_string()),
+                // (`UBOT`, not e.g. "U-BOT-E2E"). A mismatch leaves the
+                // mention in normalized text; a stale value intentionally
+                // exercises the legacy fallback.
+                ("slack_bot_user_id".to_string(), bot_user_id.to_string()),
                 (
                     "slack_oauth_client_id".to_string(),
                     "e2e-slack-client".to_string(),
@@ -5293,6 +5294,35 @@ async fn slack_thread_auth_deny_with_bot_mention_cancels_auth_gate_without_agent
     assert_eq!(messages[1]["channel"], "C123");
     assert_eq!(messages[1]["thread_ts"], "1710000000.000009");
     assert_eq!(messages[1]["text"], "Authentication canceled.");
+}
+
+#[tokio::test]
+async fn stale_slack_bot_id_thread_auth_deny_survives_unresolved_mention_filter() {
+    let mut options = HarnessOptions::new(TurnMode::BlockAuth);
+    options.slack_bot_user_id = "UOLD";
+    let harness = build_harness_with_options(options).await;
+
+    let first = harness
+        .post_event(app_mention_message("Ev-auth-cancel-start", "needs auth"))
+        .await;
+    assert_eq!(first.status(), StatusCode::OK); // safety: Slack E2E route assertion.
+    harness.drain().await;
+
+    let second = harness
+        .post_event(thread_message_event(
+            "Ev-auth-cancel",
+            "<@UBOT> auth deny gate:auth-slack",
+            "1710000000.000009",
+        ))
+        .await;
+    assert_eq!(second.status(), StatusCode::OK); // safety: Slack E2E route assertion.
+    harness.drain().await;
+
+    let auths = harness.auths.requests();
+    assert_eq!(auths.len(), 1); // safety: Slack E2E auth routing assertion.
+    assert_eq!(auths[0].decision, AuthInteractionDecision::Deny); // safety: length asserted above.
+    assert_eq!(auths[0].gate_ref.as_str(), AUTH_GATE); // safety: length asserted above.
+    assert_eq!(harness.coordinator.submitted_turn_count(), 1); // safety: no control reply agent turn.
 }
 
 #[tokio::test]

--- a/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
+++ b/crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs
@@ -2723,6 +2723,128 @@ async fn slack_in_thread_mentions_each_run_in_their_own_thread_replying_in_the_v
     }
 }
 
+/// Regression for the explicit-mention deduplication collision: Slack may
+/// describe one post with both a `message` callback and an authoritative
+/// `app_mention` callback. If the configured bot member id is stale, the
+/// `message` shape cannot prove which user was mentioned, so it must be ignored
+/// before durable admission rather than consume the identity the later
+/// `app_mention` needs to start the turn.
+#[tokio::test]
+async fn slack_explicit_mention_survives_reply_shaped_twin_arriving_first() {
+    let harness = build_harness(TurnMode::Complete {
+        assistant_text: "mention reply".into(),
+    })
+    .await;
+
+    let response = harness.post_event(STALE_ID_THREAD_MESSAGE_TWIN).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = harness.post_event(STALE_ID_THREAD_APP_MENTION_TWIN).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = harness
+        .post_retry_event(STALE_ID_THREAD_MESSAGE_TWIN, 1)
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = harness
+        .post_retry_event(STALE_ID_THREAD_APP_MENTION_TWIN, 1)
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    harness.drain().await;
+
+    assert_eq!(
+        harness.coordinator.submitted_scopes().len(),
+        1,
+        "the authoritative app_mention must start one turn even when its \
+         ambiguous message twin arrived first"
+    );
+    let messages = harness.slack_messages();
+    assert_eq!(messages.len(), 1, "the user must receive exactly one reply");
+    assert_eq!(messages[0]["channel"], "C891");
+    assert_eq!(messages[0]["text"], "mention reply");
+    assert_eq!(messages[0]["thread_ts"], "1710000007.000001");
+}
+
+#[tokio::test]
+async fn slack_explicit_mention_remains_single_when_authoritative_twin_arrives_first() {
+    let harness = build_harness(TurnMode::Complete {
+        assistant_text: "mention reply".into(),
+    })
+    .await;
+
+    let response = harness.post_event(STALE_ID_THREAD_APP_MENTION_TWIN).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    harness.drain().await;
+    assert_eq!(
+        harness.coordinator.submitted_scopes().len(),
+        1,
+        "an app_mention must start a turn without waiting for a message twin"
+    );
+    assert_eq!(harness.slack_messages().len(), 1);
+
+    let response = harness.post_event(STALE_ID_THREAD_MESSAGE_TWIN).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = harness
+        .post_retry_event(STALE_ID_THREAD_APP_MENTION_TWIN, 1)
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = harness
+        .post_retry_event(STALE_ID_THREAD_MESSAGE_TWIN, 1)
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    harness.drain().await;
+
+    assert_eq!(
+        harness.coordinator.submitted_scopes().len(),
+        1,
+        "the ambiguous message twin and callback retries must not add a turn"
+    );
+    assert_eq!(
+        harness.slack_messages().len(),
+        1,
+        "the user must receive exactly one threaded reply"
+    );
+}
+
+#[tokio::test]
+async fn slack_text_only_mention_runs_while_ordinary_thread_reply_remains_noop() {
+    let harness = build_harness(TurnMode::Complete {
+        assistant_text: "text mention reply".into(),
+    })
+    .await;
+
+    let response = harness.post_event(TEXT_ONLY_THREAD_MENTION).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    harness.drain().await;
+    assert_eq!(
+        harness.coordinator.submitted_scopes().len(),
+        1,
+        "a correctly configured message callback must not need an app_mention twin"
+    );
+    assert_eq!(harness.slack_messages().len(), 1);
+
+    let response = harness.post_event(ORDINARY_THREAD_REPLY).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = harness.post_retry_event(ORDINARY_THREAD_REPLY, 1).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = harness.post_event(THIRD_PARTY_THREAD_MENTION).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = harness
+        .post_retry_event(THIRD_PARTY_THREAD_MENTION, 1)
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    harness.drain().await;
+
+    assert_eq!(
+        harness.coordinator.submitted_scopes().len(),
+        1,
+        "ordinary thread chatter, including third-party mentions, must remain silent"
+    );
+    assert_eq!(
+        harness.slack_messages().len(),
+        1,
+        "ordinary thread chatter must not produce another bot reply"
+    );
+}
+
 /// Ephemeral-per-ping: pairing mid-thread. Unpaired carol is nudged in place
 /// while A's thread is ACTIVE (channel-level ephemeral connect notice, no run);
 /// carol pairs through the harness pairing seam; her next message is then served
@@ -4794,6 +4916,45 @@ const IN_THREAD_MENTION_BOB: &str = r#"{
   "api_app_id":"A-slack",
   "event_id":"Ev-inthread-bob",
   "event":{"type":"app_mention","user":"U456","channel":"C890","text":"<@UBOT> bob follows up here","ts":"1710000006.000003","thread_ts":"1710000006.000001"}
+}"#;
+
+// Both callbacks describe the same Slack post (`channel` + `ts`) but have
+// distinct envelope event ids. The configured bot id in this harness is
+// `UBOT`, while the text names `UACTUALBOT`, so only the authoritative
+// `app_mention` callback classifies as `BotMention` before the fix.
+const STALE_ID_THREAD_MESSAGE_TWIN: &str = r#"{
+  "type":"event_callback","team_id":"T-A","event_id":"Ev-stale-twin-message",
+  "event":{"type":"message","user":"U123","channel":"C891",
+           "text":"<@UACTUALBOT> investigate","thread_ts":"1710000007.000001",
+           "ts":"1710000007.000002"}
+}"#;
+
+const STALE_ID_THREAD_APP_MENTION_TWIN: &str = r#"{
+  "type":"event_callback","team_id":"T-A","event_id":"Ev-stale-twin-app-mention",
+  "event":{"type":"app_mention","user":"U123","channel":"C891",
+           "text":"<@UACTUALBOT> investigate","thread_ts":"1710000007.000001",
+           "ts":"1710000007.000002"}
+}"#;
+
+const TEXT_ONLY_THREAD_MENTION: &str = r#"{
+  "type":"event_callback","team_id":"T-A","event_id":"Ev-text-only-mention",
+  "event":{"type":"message","user":"U123","channel":"C894",
+           "text":"<@UBOT> investigate","thread_ts":"1710000010.000001",
+           "ts":"1710000010.000002"}
+}"#;
+
+const ORDINARY_THREAD_REPLY: &str = r#"{
+  "type":"event_callback","team_id":"T-A","event_id":"Ev-ordinary-thread-reply",
+  "event":{"type":"message","user":"U123","channel":"C894",
+           "text":"thanks everyone","thread_ts":"1710000010.000001",
+           "ts":"1710000010.000003"}
+}"#;
+
+const THIRD_PARTY_THREAD_MENTION: &str = r#"{
+  "type":"event_callback","team_id":"T-A","event_id":"Ev-third-party-thread-mention",
+  "event":{"type":"message","user":"U123","channel":"C894",
+           "text":"<@U456> thanks","thread_ts":"1710000010.000001",
+           "ts":"1710000010.000004"}
 }"#;
 
 // ── Pairing-mid-thread fixtures (#7377) ──────────────────────────────────────

--- a/crates/extensions/packages/slack/Cargo.toml
+++ b/crates/extensions/packages/slack/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4", features = ["serde"] }
 ironclaw_attachments = { path = "../../../domains/ironclaw_attachments", version = "0.1.0" }
 ironclaw_host_api = { path = "../../../contracts/ironclaw_host_api", version = "0.1.0" }
 ironclaw_extension_contracts = { path = "../../../contracts/ironclaw_extension_contracts", version = "0.1.0" }
+ironclaw_product_contracts = { path = "../../../contracts/ironclaw_product_contracts", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Form-encoded Slack slash-command / ssl_check payloads (PR-3 native

--- a/crates/extensions/packages/slack/src/payload.rs
+++ b/crates/extensions/packages/slack/src/payload.rs
@@ -118,6 +118,12 @@ pub enum SlackIgnoreReason {
     /// A channel message that neither mentions the bot nor replies in a
     /// thread — bystander chatter.
     AmbientChannelMessage,
+    /// A threaded `message` callback that names a Slack user other than the
+    /// configured bot. It is ambiguous at this boundary: the token may name
+    /// the real bot while configuration is stale, in which case Slack's
+    /// authoritative `app_mention` callback must own admission. Ignoring this
+    /// shape also leaves ordinary third-party mentions silent, as before.
+    UnresolvedThreadMention,
     /// Authored by an integration, including this bot's own echo.
     BotAuthored,
     /// An `app_mention` whose `subtype` is `document_mention`: a person did
@@ -397,7 +403,29 @@ fn mentions_bot(text: &str, bot_user_id: Option<&str>) -> bool {
     let Some(bot) = bot_user_id.filter(|id| !id.is_empty()) else {
         return false;
     };
-    text.contains(&format!("<@{bot}>")) || text.contains(&format!("<@{bot}|"))
+    contains_slack_user_mention(text, Some(bot))
+}
+
+/// Match a complete Slack `<@user>` or `<@user|label>` token.
+fn contains_slack_user_mention(text: &str, expected_user_id: Option<&str>) -> bool {
+    text.split_inclusive('>').any(|segment| {
+        let Some(before_close) = segment.strip_suffix('>') else {
+            return false;
+        };
+        // Taking the last opener also lets a malformed `<@...` candidate
+        // precede a complete token without hiding it. Each `>`-terminated
+        // segment is scanned once, so hostile input remains linear.
+        let Some((_, inside)) = before_close.rsplit_once("<@") else {
+            return false;
+        };
+        let mention_id = inside.split_once('|').map_or(inside, |(id, _)| id);
+        let valid_user_id = (mention_id.starts_with('U') || mention_id.starts_with('W'))
+            && mention_id.len() > 1
+            && mention_id
+                .chars()
+                .all(|character| character.is_ascii_uppercase() || character.is_ascii_digit());
+        valid_user_id && expected_user_id.is_none_or(|expected| mention_id == expected)
+    })
 }
 
 /// The bot's own member id, from host-resolved, manifest-declared non-secret
@@ -497,9 +525,19 @@ fn normalize_user_message(
         });
     };
 
-    let event_id = build_message_event_id(installation_id, team_id, channel, ts)?;
-
     let raw_text = event.text.as_deref().unwrap_or_default();
+    // ponytail: Slack gives a `message` callback no target-user field, so a
+    // third-party mention is indistinguishable from the real bot under stale
+    // configuration. Both are non-turn-producing thread chatter here; if
+    // Slack adds a typed target identity, narrow this ignore without changing
+    // event keys. Keep this after the canonical authorship/subtype/shape gates
+    // above so ignored events retain their most precise diagnostic reason.
+    if matches!(kind, SlackMessageKind::ThreadReply) && contains_slack_user_mention(raw_text, None)
+    {
+        return Ok(SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::UnresolvedThreadMention,
+        });
+    }
     let (text, thread_ts, trigger) = match kind {
         SlackMessageKind::AppMention | SlackMessageKind::TextMention => (
             strip_leading_bot_mention(raw_text, bot_user_id),
@@ -517,6 +555,7 @@ fn normalize_user_message(
             ProductTriggerReason::ReplyToBot,
         ),
     };
+    let event_id = build_message_event_id(installation_id, team_id, channel, ts)?;
 
     let actor = build_actor_ref(user)?;
     let conversation = build_conversation_ref(team_id, channel, thread_ts, Some(ts))?;
@@ -563,12 +602,11 @@ fn require_well_formed_envelope(
 /// The dedup key for one Slack MESSAGE, not one Slack EVENT.
 ///
 /// Slack announces a single post as up to two events — `app_mention` and
-/// `message` — with DISTINCT `event_id`s, and both can now start a run. Keyed
-/// on `event_id` the durable admission gate cannot see they are the same
-/// message and would admit two runs, so one @mention would be answered twice.
+/// `message` — with DISTINCT `event_id`s, and both can start a run. Keyed on
+/// `event_id` the durable admission gate cannot see they are the same message
+/// and would admit two runs, so one @mention would be answered twice.
 /// `(team, channel, ts)` is the identity Slack itself gives the message, so
 /// the twins collapse to exactly one run whichever of them arrives first.
-/// (`openclaw` and `suna` key the same collapse on the same triple.)
 fn build_message_event_id(
     installation_id: &AdapterInstallationId,
     team_id: Option<&str>,

--- a/crates/extensions/packages/slack/src/payload.rs
+++ b/crates/extensions/packages/slack/src/payload.rs
@@ -13,6 +13,7 @@ use ironclaw_extension_contracts::external::{
     ProductAttachmentKind,
 };
 use ironclaw_host_api::product_adapter::AdapterInstallationId;
+use ironclaw_product_contracts::inbound::classify_channel_inbound_text;
 use serde::Deserialize;
 use thiserror::Error;
 
@@ -528,16 +529,32 @@ fn normalize_user_message(
     let raw_text = event.text.as_deref().unwrap_or_default();
     // ponytail: Slack gives a `message` callback no target-user field, so a
     // third-party mention is indistinguishable from the real bot under stale
-    // configuration. Both are non-turn-producing thread chatter here; if
-    // Slack adds a typed target identity, narrow this ignore without changing
-    // event keys. Keep this after the canonical authorship/subtype/shape gates
-    // above so ignored events retain their most precise diagnostic reason.
-    if matches!(kind, SlackMessageKind::ThreadReply) && contains_slack_user_mention(raw_text, None)
+    // configuration. Both are non-turn-producing thread chatter here, except
+    // for text the canonical product classifier recognizes as a control or
+    // command: those preserve the legacy thread-control path without copying
+    // its grammar into this adapter. If Slack adds a typed target identity,
+    // narrow this ignore without changing event keys. Keep this after the
+    // canonical authorship/subtype/shape gates above so ignored events retain
+    // their most precise diagnostic reason.
+    let unresolved_thread_control = if matches!(kind, SlackMessageKind::ThreadReply)
+        && contains_slack_user_mention(raw_text, None)
     {
-        return Ok(SlackInboundEvent::Ignore {
-            reason: SlackIgnoreReason::UnresolvedThreadMention,
-        });
-    }
+        let text_without_leading_mention = strip_leading_bot_mention(raw_text, None);
+        if classify_channel_inbound_text(
+            &text_without_leading_mention,
+            ProductTriggerReason::ReplyToBot,
+        )
+        .is_some()
+        {
+            Some(text_without_leading_mention)
+        } else {
+            return Ok(SlackInboundEvent::Ignore {
+                reason: SlackIgnoreReason::UnresolvedThreadMention,
+            });
+        }
+    } else {
+        None
+    };
     let (text, thread_ts, trigger) = match kind {
         SlackMessageKind::AppMention | SlackMessageKind::TextMention => (
             strip_leading_bot_mention(raw_text, bot_user_id),
@@ -550,7 +567,8 @@ fn normalize_user_message(
             ProductTriggerReason::DirectChat,
         ),
         SlackMessageKind::ThreadReply => (
-            strip_leading_bot_mention(raw_text, bot_user_id),
+            unresolved_thread_control
+                .unwrap_or_else(|| strip_leading_bot_mention(raw_text, bot_user_id)),
             event.thread_ts.as_deref(),
             ProductTriggerReason::ReplyToBot,
         ),

--- a/crates/extensions/packages/slack/src/tests/payload_normalized.rs
+++ b/crates/extensions/packages/slack/src/tests/payload_normalized.rs
@@ -71,6 +71,11 @@ fn dm_and_thread_messages_normalize_to_the_same_contract() {
     }));
     assert_eq!(thread.conversation.topic_id(), Some("1710000000.000010"));
     assert_eq!(thread.trigger, ProductTriggerReason::ReplyToBot);
+    assert_eq!(
+        thread.event_id.as_str(),
+        "slack-install-alpha-msg-T123-C123-1710000000.000011",
+        "ordinary replies, including command and gate text, retain the legacy key"
+    );
 }
 
 #[test]
@@ -93,6 +98,111 @@ fn app_mention_strips_only_the_provider_mention_and_self_roots_a_thread() {
 }
 
 #[test]
+fn slack_user_mention_token_boundaries_are_exact() {
+    let labeled = message(serde_json::json!({
+        "type": "event_callback", "team_id": "T123", "event_id": "EvLabeledMention",
+        "event": {
+            "type": "message", "user": "U1", "channel": "C1",
+            "text": "<@UBOT|ironclaw> ping", "thread_ts": "1.0", "ts": "1.1"
+        }
+    }));
+    assert_eq!(labeled.trigger, ProductTriggerReason::BotMention);
+
+    let after_malformed = message(serde_json::json!({
+        "type": "event_callback", "team_id": "T123", "event_id": "EvNestedMention",
+        "event": {
+            "type": "message", "user": "U1", "channel": "C1",
+            "text": "<@not-closed <@UBOT> ping", "thread_ts": "1.0", "ts": "1.2"
+        }
+    }));
+    assert_eq!(
+        after_malformed.trigger,
+        ProductTriggerReason::BotMention,
+        "a malformed candidate must not hide a later complete bot mention"
+    );
+
+    for text in ["<@UOTHER> ping", "<@UBOTX> ping"] {
+        let third_party = normalize(serde_json::json!({
+            "type": "event_callback", "team_id": "T123", "event_id": "EvThirdPartyMention",
+            "event": {
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": text, "thread_ts": "2.0", "ts": "2.1"
+            }
+        }));
+        assert!(matches!(
+            third_party,
+            SlackInboundEvent::Ignore {
+                reason: SlackIgnoreReason::UnresolvedThreadMention
+            }
+        ));
+    }
+
+    for (label, text) in [
+        ("unterminated token", "<@UBOT ping"),
+        ("wrong case", "<@ubot> ping"),
+    ] {
+        let reply = message(serde_json::json!({
+            "type": "event_callback", "team_id": "T123", "event_id": "EvNearMention",
+            "event": {
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": text, "thread_ts": "2.0", "ts": "2.1"
+            }
+        }));
+        assert_eq!(reply.trigger, ProductTriggerReason::ReplyToBot, "{label}");
+        assert_eq!(
+            reply.event_id.as_str(),
+            "slack-install-alpha-msg-T123-C1-2.1",
+            "{label} must retain the historical ordinary-reply identity"
+        );
+    }
+}
+
+#[test]
+fn legacy_configuration_uses_authoritative_app_mention_only() {
+    let message_twin = serde_json::json!({
+        "type": "event_callback", "team_id": "T123", "event_id": "EvLegacyMessage",
+        "event": {
+            "type": "message", "user": "U1", "channel": "C1",
+            "text": "<@UBOT> ping", "thread_ts": "3.0", "ts": "3.1"
+        }
+    });
+    let outcome = normalize_slack_event(
+        &serde_json::to_vec(&message_twin).expect("serializes"),
+        &installation_id(),
+        None,
+    )
+    .expect("normalizes");
+    assert!(matches!(
+        outcome,
+        SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::UnresolvedThreadMention
+        }
+    ));
+
+    let app_mention = serde_json::json!({
+        "type": "event_callback", "team_id": "T123", "event_id": "EvLegacyAppMention",
+        "event": {
+            "type": "app_mention", "user": "U1", "channel": "C1",
+            "text": "<@UBOT> ping", "thread_ts": "3.0", "ts": "3.1"
+        }
+    });
+    let outcome = normalize_slack_event(
+        &serde_json::to_vec(&app_mention).expect("serializes"),
+        &installation_id(),
+        None,
+    )
+    .expect("normalizes");
+    let SlackInboundEvent::Message(app_mention) = outcome else {
+        panic!("authoritative app_mention must remain admitted without bot configuration");
+    };
+    assert_eq!(app_mention.trigger, ProductTriggerReason::BotMention);
+    assert_eq!(
+        app_mention.event_id.as_str(),
+        "slack-install-alpha-msg-T123-C1-3.1"
+    );
+}
+
+#[test]
 fn bots_subtypes_and_ambient_channels_are_ignored() {
     for (event, expected_reason) in [
         (
@@ -106,6 +216,22 @@ fn bots_subtypes_and_ambient_channels_are_ignored() {
             serde_json::json!({
                 "type": "message", "user": "U1", "channel": "D1", "text": "changed",
                 "ts": "1.0", "subtype": "message_changed"
+            }),
+            SlackIgnoreReason::NonUserMessageSubtype("message_changed".to_string()),
+        ),
+        (
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": "<@UOTHER> loop", "thread_ts": "0.9", "ts": "1.0",
+                "bot_id": "B1"
+            }),
+            SlackIgnoreReason::BotAuthored,
+        ),
+        (
+            serde_json::json!({
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": "<@UOTHER> changed", "thread_ts": "0.9", "ts": "1.0",
+                "subtype": "message_changed"
             }),
             SlackIgnoreReason::NonUserMessageSubtype("message_changed".to_string()),
         ),
@@ -543,6 +669,56 @@ fn app_mention_and_message_twins_of_one_post_collapse_to_the_same_event_id() {
     );
     assert_eq!(app_mention_twin.trigger, ProductTriggerReason::BotMention);
     assert_eq!(message_twin.trigger, ProductTriggerReason::BotMention);
+
+    let mismatched_message_payload = serde_json::json!({
+        "type": "event_callback", "team_id": "T123",
+        "event_id": "EvMismatchedTwinMessage",
+        "event": {
+            "type": "message", "user": "U1", "channel": "C1",
+            "text": "<@UACTUALBOT> ping", "thread_ts": "1710000000.000039",
+            "ts": shared_ts
+        }
+    });
+    let mismatched_app_mention_payload = serde_json::json!({
+        "type": "event_callback", "team_id": "T123",
+        "event_id": "EvMismatchedTwinAppMention",
+        "event": {
+            "type": "app_mention", "user": "U1", "channel": "C1",
+            "text": "<@UACTUALBOT> ping", "thread_ts": "1710000000.000039",
+            "ts": shared_ts
+        }
+    });
+    let mismatched_message = normalize(mismatched_message_payload.clone());
+    let mismatched_app_mention = message(mismatched_app_mention_payload.clone());
+
+    assert!(matches!(
+        mismatched_message,
+        SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::UnresolvedThreadMention
+        }
+    ));
+    assert_eq!(
+        mismatched_app_mention.trigger,
+        ProductTriggerReason::BotMention,
+        "Slack's app_mention callback remains authoritative"
+    );
+    assert_eq!(
+        mismatched_app_mention.event_id.as_str(),
+        "slack-install-alpha-msg-T123-C1-1710000000.000040",
+        "the authoritative callback retains the historical message identity"
+    );
+
+    assert!(matches!(
+        normalize(mismatched_message_payload),
+        SlackInboundEvent::Ignore {
+            reason: SlackIgnoreReason::UnresolvedThreadMention
+        }
+    ));
+    assert_eq!(
+        mismatched_app_mention.event_id,
+        message(mismatched_app_mention_payload).event_id,
+        "an app_mention retry must reproduce its mention identity"
+    );
 }
 
 /// `strip_leading_bot_mention` strips ONLY a leading token that names the

--- a/crates/extensions/packages/slack/src/tests/payload_normalized.rs
+++ b/crates/extensions/packages/slack/src/tests/payload_normalized.rs
@@ -108,6 +108,24 @@ fn slack_user_mention_token_boundaries_are_exact() {
     }));
     assert_eq!(labeled.trigger, ProductTriggerReason::BotMention);
 
+    let w_prefixed = normalize_slack_event(
+        &serde_json::to_vec(&serde_json::json!({
+            "type": "event_callback", "team_id": "T123", "event_id": "EvWPrefixedMention",
+            "event": {
+                "type": "message", "user": "U1", "channel": "C1",
+                "text": "<@W012ABC|ironclaw> ping", "thread_ts": "1.0", "ts": "1.15"
+            }
+        }))
+        .expect("payload"),
+        &installation_id(),
+        Some("W012ABC"),
+    )
+    .expect("normalizes");
+    let SlackInboundEvent::Message(w_prefixed) = w_prefixed else {
+        panic!("expected W-prefixed bot mention")
+    };
+    assert_eq!(w_prefixed.trigger, ProductTriggerReason::BotMention);
+
     let after_malformed = message(serde_json::json!({
         "type": "event_callback", "team_id": "T123", "event_id": "EvNestedMention",
         "event": {


### PR DESCRIPTION
## Summary

- Preserve explicit Slack mentions when Slack delivers the same threaded post as both `message` and `app_mention` callbacks.
- Ignore only the ambiguous reply-shaped callback before durable admission, allowing the authoritative `app_mention` callback to start the turn with the existing canonical `msg` identity.
- Keep correctly configured message-only mentions working, retain retry/idempotency behavior, and parse Slack mention tokens in bounded linear time.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None. The regression was reproduced directly against current `origin/main` (`3864e9e5f4e44d35ca889838af3c46b939f3cd12`), and no matching open issue was found.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: Slack package suite, channel conformance, and signed-ingress callback-order regressions
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (not applicable: no database or runtime-integration behavior changed)
- [ ] Manual testing: not applicable; regression is deterministically exercised through signed Slack ingress
- [ ] If a coding agent was used and supports it, `pr-shepherd` was run before requesting review

Targeted clippy passed with warnings denied:

```text
cargo clippy -p ironclaw_slack_extension -p ironclaw_extension_host --all-targets --all-features -- -D warnings
```

The new signed-ingress regression was first run against current main and failed for the expected reason: the `message` callback consumed the shared `msg` event identity, so the later `app_mention` produced 0 submitted turns instead of 1.

## Test Strategy

User behavior: A user explicitly mentions IronClaw in an existing Slack thread. Whether Slack sends `message` or `app_mention` first, IronClaw starts exactly one turn and posts exactly one reply. A message-only explicit mention still works when the bot user ID is configured.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: Slack normalization covers callback twins, legacy configuration, token boundaries, malformed input, unchanged event IDs, and diagnostic gates.
- Reborn integration: Not applicable; the existing extension-host signed-ingress E2E harness reaches the production adapter, durable admission, turn submitter, and reply path.
- Recorded fixture: Not applicable; the Slack callbacks are deterministic signed JSON payloads built by the existing harness.
- Browser E2E: Not applicable; no browser surface changed.
- Backend or runtime: Two extension-host E2E regressions cover both callback orders, retries, turn cardinality, and reply cardinality.
- Live canary: Not applicable before merge; no test workspace credentials are required for the deterministic ingress proof.

What the tests prove:

- A reply-shaped `message` twin cannot suppress the authoritative `app_mention`.
- Either callback order and repeated delivery still produce exactly one turn and one reply.
- Correctly configured message-only mentions remain admitted.
- Ordinary thread replies, bot-authored callbacks, unsupported subtypes, legacy configuration, and historical `msg` event identities retain their intended behavior.
- Malformed mention text cannot hide a later valid token or cause quadratic scanning.

Commands run:

```text
cargo fmt --check
git diff --check
cargo test -p ironclaw_slack_extension
cargo test -p ironclaw_extension_host explicit_mention
cargo test -p ironclaw_architecture_tests
cargo clippy -p ironclaw_slack_extension -p ironclaw_extension_host --all-targets --all-features -- -D warnings
```

## Security Impact

No permission, credential, network destination, or trust-boundary changes. Slack request verification remains unchanged. The mention parser is bounded by the existing payload limit and scans input linearly.

## Reborn Trust-Boundary Checklist

N/A: this changes classification inside the existing verified Slack ingress boundary; it does not add or weaken a trust-bearing type, policy, runtime lane, queue, or error contract.

## Database Impact

None. No schema, migration, or backend behavior changes.

## Blast Radius

Slack event normalization and the generic extension-host ingress path exercised by Slack. The main compatibility risks are callback ordering, event identity, and accidentally suppressing standalone bot mentions; all three are pinned by regression tests.

## Rollback Plan

Revert this commit. No data migration, configuration migration, or provider-side cleanup is required.

## Review Follow-Through

The final local multi-agent review covered correctness, security, performance/concurrency, design/maintainability, and coverage with no remaining findings. A separate strict maintainability review also returned no findings.

---

**Review track**: B
