### PR TITLE
refactor(webui): migrate Automations notices to InlineNotice

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/automations/automations-page.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/automations/automations-page.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { InlineNotice } from "../../design-system/inline-notice";
 import { SkeletonList } from "../../design-system/skeleton";
 import { PageScroll, PageStack } from "../../layout/page-shell";
 import { useT } from "../../lib/i18n";
@@ -63,20 +64,15 @@ export function AutomationsPage() {
       <PageStack>
           {automationsState.error &&
           (
-            <div
-              className="rounded-xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-200"
-            >
+            <InlineNotice tone="danger" role="alert">
               {t("automations.error.loadFailed")}
-            </div>
+            </InlineNotice>
           )}
           {!automationsState.error && automationsState.summaryError &&
           (
-            <div
-              role="status"
-              className="rounded-xl border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200"
-            >
+            <InlineNotice tone="warning" role="status">
               {t("automations.error.loadFailed")}
-            </div>
+            </InlineNotice>
           )}
           {showErrorOnly
             ? null
@@ -85,17 +81,14 @@ export function AutomationsPage() {
                 {!automationsState.isLoading &&
                 !automationsState.schedulerEnabled &&
                 (
-                  <div
-                    role="status"
-                    className="rounded-xl border border-amber-400/30 bg-amber-500/10 px-4 py-3"
-                  >
-                    <div className="text-sm font-semibold text-amber-200">
+                  <InlineNotice tone="warning" role="status">
+                    <div className="font-semibold">
                       {t("automations.schedulerOff.title")}
                     </div>
-                    <div className="mt-0.5 text-xs leading-5 text-amber-200/80">
+                    <div className="mt-0.5 text-xs leading-5 opacity-80">
                       {t("automations.schedulerOff.description")}
                     </div>
-                  </div>
+                  </InlineNotice>
                 )}
                 <AutomationsSummaryStrip
                   summary={automationsState.summary}

--- a/crates/product/ironclaw_webui/frontend/src/pages/automations/components/notification-channels-panel.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/automations/components/notification-channels-panel.test.ts
@@ -184,6 +184,7 @@ function createHarness({ saveNotificationChannels = async () => {}, isLoading = 
   function Badge() {}
   function Button() {}
   function Icon() {}
+  function InlineNotice() {}
   function Panel() {}
 
   const React = {
@@ -243,6 +244,7 @@ function createHarness({ saveNotificationChannels = async () => {}, isLoading = 
     Badge,
     Button,
     Icon,
+    InlineNotice,
     Panel,
     React,
     TextEncoder,
@@ -268,6 +270,7 @@ function createHarness({ saveNotificationChannels = async () => {}, isLoading = 
   const exports = context.globalThis.__testExports;
   return {
     Button,
+    InlineNotice,
     exports,
     render({ targets = [], channels = [] } = {}) {
       const { rows, selected } = mergeRows(targets, channels);
@@ -290,11 +293,32 @@ function createHarness({ saveNotificationChannels = async () => {}, isLoading = 
 test("NotificationChannelsPanel shows a load error instead of claiming there are no channels", () => {
   const harness = createHarness({ error: new Error("catalog unavailable") });
   const rendered = harness.render();
+  const [notice] = componentProps(rendered, harness.InlineNotice);
   const scalars = collectScalars(rendered);
+  assert.equal(notice.tone, "danger");
+  assert.equal(notice.role, "alert");
   assert.ok(scalars.includes("Unable to load automations"));
   assert.ok(
     !scalars.includes("No connected channels yet."),
     "a backend outage must not look like a truthful empty catalog"
+  );
+});
+
+test("NotificationChannelsPanel renders save failures through a danger alert notice", () => {
+  const harness = createHarness({ saveError: new Error("save failed") });
+  const rendered = harness.render({
+    targets: [target("slack-alpha")],
+    channels: [channel("slack-alpha")],
+  });
+  const [notice] = componentProps(rendered, harness.InlineNotice);
+
+  assert.ok(notice, "expected save failures to render InlineNotice");
+  assert.equal(notice.tone, "danger");
+  assert.equal(notice.role, "alert");
+  assert.ok(
+    collectScalars(rendered).includes(
+      "Couldn't save your notification channels. Please try again.",
+    ),
   );
 });
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/automations/components/notification-channels-panel.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/automations/components/notification-channels-panel.tsx
@@ -1,5 +1,6 @@
 import { Button } from "../../../design-system/button";
 import { Icon } from "../../../design-system/icons";
+import { InlineNotice } from "../../../design-system/inline-notice";
 import { Badge, Panel } from "../../../design-system/primitives";
 import React from "react";
 import { useT } from "../../../lib/i18n";
@@ -335,15 +336,12 @@ export function NotificationChannelsPanel({ channelsState }) {
         <div className="flex flex-col gap-3">
           {hasLoadError &&
           (
-            <div
-              role="alert"
-              className="rounded-xl border border-red-400/30 bg-red-500/10 px-4 py-3.5 text-sm text-red-200"
-            >
+            <InlineNotice tone="danger" role="alert">
               <div>{t("automations.error.loadFailed")}</div>
-              <div className="mt-1 text-xs leading-5 text-red-200/80">
+              <div className="mt-1 text-xs leading-5 opacity-80">
                 {t("automations.notificationChannels.loadFailedEditingDisabled")}
               </div>
-            </div>
+            </InlineNotice>
           )}
           {rows.map((row) => {
             const isSelected = draftIds.has(row.target_id);
@@ -407,24 +405,16 @@ export function NotificationChannelsPanel({ channelsState }) {
           </Button>
           {showSaved &&
           (
-            <span
-              role="status"
-              className="flex items-center gap-1.5 text-xs font-semibold text-[var(--v2-positive-text)]"
-            >
-              <Icon name="check" className="h-3 w-3" />
+            <InlineNotice tone="success" role="status">
               {t("automations.notificationChannels.saved")}
-            </span>
+            </InlineNotice>
           )}
           {channelsState.saveError &&
           !showSaved &&
           (
-            <span
-              role="alert"
-              className="flex items-center gap-1.5 text-xs font-semibold text-red-300"
-            >
-              <Icon name="close" className="h-3 w-3" />
+            <InlineNotice tone="danger" role="alert">
               {t("automations.notificationChannels.saveFailed")}
-            </span>
+            </InlineNotice>
           )}
         </div>
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/page-inline-notice.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/page-inline-notice.test.ts
@@ -13,7 +13,9 @@ const PAGE_FILES = [
   "./extensions/extensions-page.tsx",
 ] as const;
 
-const SETTINGS_ADMIN_NOTICE_CONSUMERS = [
+const NOTICE_CONSUMERS = [
+  ["./automations/automations-page.tsx", 3],
+  ["./automations/components/notification-channels-panel.tsx", 3],
   ["./settings/settings-page.tsx", 1],
   ["./settings/components/settings-toolbar.tsx", 1],
   ["./settings/components/restart-banner.tsx", 3],
@@ -24,6 +26,25 @@ const SETTINGS_ADMIN_NOTICE_CONSUMERS = [
   ["./admin/components/configuration-tab.tsx", 3],
   ["./admin/components/users-tab.tsx", 2],
   ["./admin/components/user-detail.tsx", 2],
+] as const;
+
+const AUTOMATIONS_NOTICE_CONSUMERS = [
+  [
+    "./automations/automations-page.tsx",
+    [
+      { roles: ["alert"], tones: ["danger"] },
+      { roles: ["status"], tones: ["warning"] },
+      { roles: ["status"], tones: ["warning"] },
+    ],
+  ],
+  [
+    "./automations/components/notification-channels-panel.tsx",
+    [
+      { roles: ["alert"], tones: ["danger"] },
+      { roles: ["status"], tones: ["success"] },
+      { roles: ["alert"], tones: ["danger"] },
+    ],
+  ],
 ] as const;
 
 function expressionValues(expression: ts.Expression): string[] | null {
@@ -91,7 +112,7 @@ for (const pageFile of PAGE_FILES) {
   });
 }
 
-for (const [consumerFile, minimumNoticeCount] of SETTINGS_ADMIN_NOTICE_CONSUMERS) {
+for (const [consumerFile, minimumNoticeCount] of NOTICE_CONSUMERS) {
   test(`${consumerFile} routes page feedback through InlineNotice`, () => {
     const source = readFileSync(new URL(consumerFile, import.meta.url), "utf8");
     const notices = inlineNoticeAttributes(source, consumerFile);
@@ -117,6 +138,15 @@ for (const [consumerFile, minimumNoticeCount] of SETTINGS_ADMIN_NOTICE_CONSUMERS
         );
       }
     }
+  });
+}
+
+for (const [consumerFile, expectedNotices] of AUTOMATIONS_NOTICE_CONSUMERS) {
+  test(`${consumerFile} assigns semantic roles and tones to every standard notice`, () => {
+    const source = readFileSync(new URL(consumerFile, import.meta.url), "utf8");
+
+    assert.deepEqual(inlineNoticeAttributes(source, consumerFile), expectedNotices);
+    assert.doesNotMatch(source, /bg-(?:red|amber|emerald)-500\/10/);
   });
 }
 


### PR DESCRIPTION
## Summary

- Migrates Automations loading failures, summary warnings, and the scheduler-disabled notice to the shared `InlineNotice` component.
- Migrates Notification Channels loading failures and save success/error feedback to `InlineNotice`.
- Preserves the existing loading, saving, mutation, and timed success-message behavior while assigning semantic tones and ARIA roles.
- Adds regression coverage for notice adoption, exact tone/role mappings, and removal of duplicated banner styles.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/4355019d-57f6-4b2b-a55b-e4159eadf393" />
<img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/68ca293a-c3b2-45b3-bdb5-56d2be42310a" />



## Linked Issue

Closes #8019

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `cargo test -p ironclaw_webui --all-features`
- `cargo clippy -p ironclaw_webui --all-features --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_webui -- -D warnings`
- `scripts/pre-commit-safety.sh`
- `git diff --check`

## Security Impact

No security behavior changes.

## Database Impact

No schema or migration changes.

## Blast Radius

Limited to Automations page status notices and Notification Channels feedback rendering.

## Rollback Plan

Revert this PR to restore the previous locally styled banners.