### PR TITLE
fix(live-qa): find the Slack run by message identity, not envelope event_id

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -2551,7 +2551,7 @@ async def _live_github_latest_release(owner: str, repo: str) -> dict[str, str]:
 async def _wait_for_google_sheet_marker_after_slack_event(
     ctx: LiveQaContext,
     *,
-    event_id: str,
+    message_key: str,
     access_token: str,
     spreadsheet_id: str,
     marker: str,
@@ -2566,7 +2566,7 @@ async def _wait_for_google_sheet_marker_after_slack_event(
     while time.monotonic() < deadline:
         approval = await _approve_slack_event_gates(
             ctx,
-            event_id=event_id,
+            message_key=message_key,
             approved_gate_refs=approved_gate_refs,
         )
         if approval.get("run_id"):
@@ -2948,9 +2948,26 @@ def _delivered_gate_routes_for_run(reborn_home: Path, run_id: str) -> list[dict[
     return routes
 
 
-def _slack_event_run_id_for_event(reborn_home: Path, event_id: str) -> str | None:
+def _slack_message_key(channel_id: str, ts: str) -> str:
+    """The message identity Slack ingress keys its admission record on.
+
+    Slack sends twins -- an `app_mention` and a `message` -- with DISTINCT
+    envelope `event_id`s for one post, so keying admission on the envelope id
+    would admit two runs and answer one mention twice. Ingress therefore builds
+    its `external_event_id` from the message itself:
+    `slack-{installation}-msg-{team}-{channel}-{ts}` (see
+    `build_message_event_id` in `crates/extensions/packages/slack/src/payload.rs`).
+
+    `(channel, ts)` is the trailing, installation- and team-independent part of
+    that id, which is what lets this match without resolving an installation id
+    the harness never sees.
+    """
+    return f"-{channel_id}-{ts}"
+
+
+def _slack_event_run_id_for_message(reborn_home: Path, message_key: str) -> str | None:
     db_path = reborn_home / "local-dev" / "reborn-local-dev.db"
-    if not db_path.exists() or not event_id:
+    if not db_path.exists() or not message_key:
         return None
     with closing(sqlite3.connect(db_path)) as db:
         row = db.execute(
@@ -2964,7 +2981,7 @@ def _slack_event_run_id_for_event(reborn_home: Path, event_id: str) -> str | Non
             ORDER BY updated_at DESC, path DESC
             LIMIT 1
             """,
-            (event_id,),
+            (message_key,),
         ).fetchone()
     if not row:
         return None
@@ -3017,10 +3034,10 @@ async def _approve_delivered_gate_routes_for_run(
 async def _approve_slack_event_gates(
     ctx: LiveQaContext,
     *,
-    event_id: str,
+    message_key: str,
     approved_gate_refs: set[str],
 ) -> dict[str, object]:
-    run_id = _slack_event_run_id_for_event(ctx.reborn_home, event_id)
+    run_id = _slack_event_run_id_for_message(ctx.reborn_home, message_key)
     if not run_id:
         return {"run_id": None, "approval_attempts": []}
     return {
@@ -3036,18 +3053,18 @@ async def _approve_slack_event_gates(
 async def _wait_for_slack_event_run_id(
     ctx: LiveQaContext,
     *,
-    event_id: str,
+    message_key: str,
     timeout: float = 180.0,
 ) -> str:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        run_id = _slack_event_run_id_for_event(ctx.reborn_home, event_id)
+        run_id = _slack_event_run_id_for_message(ctx.reborn_home, message_key)
         if run_id:
             return run_id
         await asyncio.sleep(1.0)
     raise AssertionError(
         "Slack event was not accepted into a Reborn run before timeout. "
-        f"event_id={event_id!r}"
+        f"message_key={message_key!r}"
     )
 
 
@@ -5295,7 +5312,7 @@ async def case_qa_5d_slack_strategy_doc_answer(ctx: LiveQaContext) -> ProbeResul
             event_id=f"EvREBORNQA5D{suffix}",
         )
         observed["signed_event"] = post_result
-        event_id = str(post_result.get("event_id") or f"EvREBORNQA5D{suffix}")
+        message_key = str(post_result["message_key"])
         deadline = time.monotonic() + 360.0
         last_history: dict[str, object] | None = None
         approved_gate_refs: set[str] = set()
@@ -5304,7 +5321,7 @@ async def case_qa_5d_slack_strategy_doc_answer(ctx: LiveQaContext) -> ProbeResul
         while time.monotonic() < deadline:
             approval = await _approve_slack_event_gates(
                 ctx,
-                event_id=event_id,
+                message_key=message_key,
                 approved_gate_refs=approved_gate_refs,
             )
             if approval.get("run_id"):
@@ -6147,20 +6164,25 @@ async def _post_signed_slack_dm_event(
         setup = slack.get("setup")
         if isinstance(setup, dict):
             api_app_id = setup.get("api_app_id")
+    # Minted here, not inline in the payload, because it is half of the message
+    # identity ingress dedups on -- the caller needs it to find the admitted run
+    # (see `_slack_message_key`).
+    now = time.time()
+    ts = f"{int(now)}.{int((now % 1) * 1_000_000):06d}"
     payload = {
         "token": "live-qa-local-signed-event",
         "team_id": str(team_id or ""),
         "api_app_id": str(api_app_id or ""),
         "type": "event_callback",
         "event_id": event_id,
-        "event_time": int(time.time()),
+        "event_time": int(now),
         "event": {
             "type": "message",
             "user": user_id,
             "text": text,
             "channel": channel_id,
             "channel_type": "im",
-            "ts": f"{int(time.time())}.{int((time.time() % 1) * 1_000_000):06d}",
+            "ts": ts,
         },
     }
     body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
@@ -6179,6 +6201,8 @@ async def _post_signed_slack_dm_event(
         "status_code": response.status_code,
         "body_excerpt": response_text,
         "event_id": event_id,
+        "ts": ts,
+        "message_key": _slack_message_key(channel_id, ts),
         "channel_id_present": bool(channel_id),
         "synthetic_user_id": user_id,
     }
@@ -6223,7 +6247,7 @@ async def case_qa_7d_slack_bug_message_trigger(ctx: LiveQaContext) -> ProbeResul
         observed["signed_event"] = post_result
         run_id = await _wait_for_slack_event_run_id(
             ctx,
-            event_id=event_id,
+            message_key=str(post_result["message_key"]),
             timeout=180.0,
         )
         observed["accepted_run_id"] = run_id
@@ -6323,7 +6347,7 @@ async def case_qa_7e_slack_bug_sheet_delivery(ctx: LiveQaContext) -> ProbeResult
         )
         marker_check = await _wait_for_google_sheet_marker_after_slack_event(
             ctx,
-            event_id=str(post_result.get("event_id") or event_id),
+            message_key=str(post_result["message_key"]),
             access_token=access_token,
             spreadsheet_id=spreadsheet_id,
             marker=row_marker,

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -4589,11 +4589,15 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             return {
                 "status_code": 200,
                 "event_id": kwargs["event_id"],
+                "ts": "1788265904.338000",
+                "message_key": run_live_qa._slack_message_key(
+                    kwargs["channel_id"], "1788265904.338000"
+                ),
                 "channel_id_present": True,
             }
 
         async def fake_wait_for_slack_event_run_id(_ctx, **kwargs):
-            return f"run-for-{kwargs['event_id']}"
+            return f"run-for-{kwargs['message_key']}"
 
         with (
             patch.object(
@@ -5127,7 +5131,12 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
 
         async def fake_post_signed_slack_dm_event(*_args, **kwargs):
             captured_slack_event_texts.append(kwargs["text"])
-            return {"ok": True}
+            return {
+                "ok": True,
+                "message_key": run_live_qa._slack_message_key(
+                    kwargs["channel_id"], "1788265537.085000"
+                ),
+            }
 
         async def fake_slack_history_contains_marker(*_args, **kwargs):
             captured_slack_required_text.extend(kwargs["required_text"])
@@ -5703,7 +5712,8 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                             {
                                 "fingerprint": {
                                     "external_event_id": (
-                                        "slack-local-dev-installation-EvREBORNQA5D123"
+                                        "slack-local-dev-installation-msg"
+                                        "-T0AQMKHM7LK-D0QA5D-1788265537.085000"
                                     )
                                 },
                                 "dispatch_kind": {
@@ -5725,7 +5735,8 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                             {
                                 "fingerprint": {
                                     "external_event_id": (
-                                        "slack-slack-EvREBORNQA7D456"
+                                        "slack-slack-msg"
+                                        "-T0AQMKHM7LK-D0QA7D-1788265904.338000"
                                     )
                                 },
                                 "dispatch_kind": {
@@ -5740,13 +5751,203 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                 db.commit()
 
             self.assertEqual(
-                run_live_qa._slack_event_run_id_for_event(home, "EvREBORNQA5D123"),
+                run_live_qa._slack_event_run_id_for_message(
+                    home,
+                    run_live_qa._slack_message_key("D0QA5D", "1788265537.085000"),
+                ),
                 "run-from-dispatch",
             )
             self.assertEqual(
-                run_live_qa._slack_event_run_id_for_event(home, "EvREBORNQA7D456"),
+                run_live_qa._slack_event_run_id_for_message(
+                    home,
+                    run_live_qa._slack_message_key("D0QA7D", "1788265904.338000"),
+                ),
                 "run-from-generic-ingress",
             )
+
+    def test_slack_event_run_id_does_not_match_the_envelope_event_id(self):
+        """Slack's envelope `event_id` must not resolve a run.
+
+        Slack sends twins (`app_mention` + `message`) with DISTINCT envelope
+        ids for one post, so ingress keys the durable admission record on the
+        message identity instead. A harness that still searches for the
+        envelope id silently matches nothing and burns its whole timeout --
+        which is exactly how qa_7d failed 33 runs straight.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "reborn-home"
+            db_path = home / "local-dev" / "reborn-local-dev.db"
+            db_path.parent.mkdir(parents=True)
+            with closing(sqlite3.connect(db_path)) as db:
+                db.execute(
+                    """
+                    CREATE TABLE root_filesystem_entries (
+                        path TEXT PRIMARY KEY,
+                        contents BLOB NOT NULL,
+                        updated_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z'
+                    )
+                    """
+                )
+                db.execute(
+                    "INSERT INTO root_filesystem_entries(path, contents) VALUES (?, ?)",
+                    (
+                        "/tenants/reborn-cli/shared/channel-extensions/slack/"
+                        "product-workflow/idempotency/actions/event.json",
+                        json.dumps(
+                            {
+                                "fingerprint": {
+                                    "external_event_id": (
+                                        "slack-reborn-cli-msg-T0AQMKHM7LK"
+                                        "-D0QA7D-1788265904.338000"
+                                    )
+                                },
+                                "dispatch_kind": {
+                                    "user_message_turn": {"run_id": "run-admitted"}
+                                },
+                            }
+                        ),
+                    ),
+                )
+                db.commit()
+
+            self.assertEqual(
+                run_live_qa._slack_event_run_id_for_message(
+                    home,
+                    run_live_qa._slack_message_key("D0QA7D", "1788265904.338000"),
+                ),
+                "run-admitted",
+            )
+            self.assertIsNone(
+                run_live_qa._slack_event_run_id_for_message(
+                    home,
+                    "EvREBORNQA7D1788265904338",
+                ),
+            )
+
+    def test_slack_event_run_id_distinguishes_two_posts_in_one_channel(self):
+        """The key must carry `ts`, not just the channel.
+
+        qa_5d, qa_7d and qa_7e all inject into the SAME DM channel inside one
+        lane run. A channel-only key resolves whichever record the ordering
+        happens to surface, so a case would silently read the previous case's
+        run id and pass on it.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "reborn-home"
+            db_path = home / "local-dev" / "reborn-local-dev.db"
+            db_path.parent.mkdir(parents=True)
+            with closing(sqlite3.connect(db_path)) as db:
+                db.execute(
+                    """
+                    CREATE TABLE root_filesystem_entries (
+                        path TEXT PRIMARY KEY,
+                        contents BLOB NOT NULL,
+                        updated_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z'
+                    )
+                    """
+                )
+                for ts, run_id in (
+                    ("1788265537.085000", "run-earlier-case"),
+                    ("1788266098.194000", "run-later-case"),
+                ):
+                    db.execute(
+                        "INSERT INTO root_filesystem_entries(path, contents)"
+                        " VALUES (?, ?)",
+                        (
+                            "/tenants/reborn-cli/shared/channel-extensions/slack/"
+                            f"product-workflow/idempotency/actions/{ts}.json",
+                            json.dumps(
+                                {
+                                    "fingerprint": {
+                                        "external_event_id": (
+                                            "slack-reborn-cli-msg-T0AQMKHM7LK"
+                                            f"-D0SHARED-{ts}"
+                                        )
+                                    },
+                                    "dispatch_kind": {
+                                        "user_message_turn": {"run_id": run_id}
+                                    },
+                                }
+                            ),
+                        ),
+                    )
+                db.commit()
+
+            self.assertEqual(
+                run_live_qa._slack_event_run_id_for_message(
+                    home,
+                    run_live_qa._slack_message_key("D0SHARED", "1788265537.085000"),
+                ),
+                "run-earlier-case",
+            )
+            self.assertEqual(
+                run_live_qa._slack_event_run_id_for_message(
+                    home,
+                    run_live_qa._slack_message_key("D0SHARED", "1788266098.194000"),
+                ),
+                "run-later-case",
+            )
+
+    def test_signed_slack_dm_event_returns_the_message_key_it_posted(self):
+        """The poster owns the `ts` it minted, so it must surface the key.
+
+        `ts` is generated inside the payload literal; without returning it the
+        caller cannot reconstruct the message identity ingress dedups on, and
+        has nothing to look the admitted run up by.
+        """
+        captured: dict[str, object] = {}
+
+        class FakeResponse:
+            status_code = 200
+            text = "ok"
+
+        class FakeAsyncClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, _exc_type, _exc, _tb):
+                return None
+
+            async def post(self, _url, **kwargs):
+                captured["body"] = json.loads(kwargs["content"].decode("utf-8"))
+                return FakeResponse()
+
+        fake_httpx = types.SimpleNamespace(AsyncClient=FakeAsyncClient)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            ctx = run_live_qa.LiveQaContext(
+                base_url="http://127.0.0.1:3000",
+                output_dir=root,
+                reborn_home=root / "reborn-home",
+                env={"IRONCLAW_REBORN_SLACK_SIGNING_SECRET": "signing-secret"},
+            )
+            with (
+                patch.dict(sys.modules, {"httpx": fake_httpx}),
+                patch.object(
+                    run_live_qa,
+                    "_slack_preflight",
+                    return_value={"auth_test": {"team_id": "T0AQMKHM7LK"}},
+                ),
+            ):
+                result = asyncio.run(
+                    run_live_qa._post_signed_slack_dm_event(
+                        ctx,
+                        channel_id="D0QA7D",
+                        user_id="U0QA",
+                        text="bug: smoke",
+                        event_id="EvREBORNQA7D1",
+                    )
+                )
+
+        posted_ts = captured["body"]["event"]["ts"]
+        self.assertEqual(result["ts"], posted_ts)
+        self.assertEqual(
+            result["message_key"],
+            run_live_qa._slack_message_key("D0QA7D", posted_ts),
+        )
 
     def test_wait_for_google_sheet_marker_after_slack_event_approves_gate(self):
         ctx = self._dummy_ctx()
@@ -5765,7 +5966,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
         with (
             patch.object(
                 run_live_qa,
-                "_slack_event_run_id_for_event",
+                "_slack_event_run_id_for_message",
                 return_value="run-123",
             ),
             patch.object(
@@ -5793,7 +5994,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
             result = asyncio.run(
                 run_live_qa._wait_for_google_sheet_marker_after_slack_event(
                     ctx,
-                    event_id="EvREBORNQA7E123",
+                    message_key="-D0QA7E-1788266098.194000",
                     access_token="access-token",
                     spreadsheet_id="spreadsheet-id",
                     marker="row-marker",


### PR DESCRIPTION
## Summary

- `qa_7d_slack_bug_message_trigger` has failed **every scheduled canary run since 2026-08-28 03:09Z — 33 consecutive runs** — always by burning its full 180s wait and raising `Slack event was not accepted into a Reborn run before timeout`.
- The event was always accepted. The harness could not see it. PR #7941 moved the ingress dedup key off Slack's envelope `event_id` onto the message identity, and the harness was never updated.
- Renames `_slack_event_run_id_for_event` → `_slack_event_run_id_for_message` and keys it on `(channel, ts)`; `_post_signed_slack_dm_event` now returns the `ts` it mints plus the derived `message_key`.
- Also un-breaks `_approve_slack_event_gates`, which shares the lookup and has been silently no-opping for every Slack-triggered run.
- Harness-only. No product code changes — ingress is healthy.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None — found while triaging the live canary. Full triage of the current canary board (this plus a separate timeout-margin class): https://claude.ai/code/artifact/50b32f05-e7a1-4927-ac4c-80a0f4e5858f

## What actually broke

Slack sends twins — an `app_mention` and a `message` — with **distinct envelope `event_id`s for one post**. Keying admission on the envelope id admits two runs and answers one mention twice, so #7941 moved the key onto the message itself:

```
slack-{installation}-msg-{team}-{channel}-{ts}
```
(`build_message_event_id`, `crates/extensions/packages/slack/src/payload.rs`)

`_slack_event_run_id_for_event` still ran `CAST(contents AS TEXT) LIKE '%' || event_id || '%'` over the persisted idempotency records, searching for a string that is no longer written anywhere. It returned `None` on every poll for 180s.

The fix keys on `(channel, ts)` — the trailing, installation- and team-independent part of that id, which the harness can reconstruct without resolving an installation id it never sees.

## Why no test caught it

`test_slack_event_run_id_reads_idempotency_record` seeded its fixture with the **pre-#7941** id shape (`slack-local-dev-installation-EvREBORNQA5D123`), so it kept passing against a contract production had stopped writing. Its fixtures now use the shape production actually writes, verified against a real canary database (run `33507434003`).

## Why this was invisible on the board

`qa_5d_slack_strategy_doc_answer` injects **the same signed DM event through the same ingress** and has passed **60/60** runs — because it asserts on the answer landing back in Slack rather than on the lookup. That contrast is what separates "Slack ingress is broken" from "the harness's key is stale". Ingress was never broken.

## Second-order fix

`_approve_slack_event_gates` uses the same lookup, so it has been returning `{"run_id": None, "approval_attempts": []}` instead of approving gates for every Slack-triggered run (visible as `approval_attempts=[]` in qa_7e failures). It is currently masked by `AGENT_AUTO_APPROVE_TOOLS=true` in `live-canary.yml`, so it was **untested rather than failing**. This restores it.

## Incidental defect fixed

`ts` was built from two separate `time.time()` calls:

```python
"ts": f"{int(time.time())}.{int((time.time() % 1) * 1_000_000):06d}"
```

which can straddle a second boundary and post a timestamp off by one second. Now minted once.

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust changed
- [ ] `cargo clippy ...` — Not applicable: no Rust changed
- [ ] `cargo build` — Not applicable: no Rust changed
- [x] Relevant tests pass: `python3 -m unittest scripts.reborn_webui_v2_live_qa.test_run_live_qa` → **234 tests, OK**
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no Rust changed
- [x] Manual testing: root-caused against the real persisted record in the canary artifact for run `33507434003` (`generated-reborn-home/local-dev/reborn-local-dev.db`), confirming both the ledger path (`/tenants/{t}/shared/channel-extensions/slack/product-workflow/idempotency/actions/...`) and the record shape (`fingerprint.external_event_id`, `dispatch_kind.user_message_turn.run_id`, `outcome.accepted.submitted_run_id`).
- [x] `bash scripts/pre-commit-safety.sh` — clean
- [x] `python3 scripts/ci/test_reborn_pr_test_plan.py` — 102 tests, OK

## Test Strategy

User behavior: a person sends a `bug:` DM to the bot in Slack; it becomes a Reborn run. The canary asserts that admission is observable.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `test_slack_event_run_id_reads_idempotency_record` (fixtures moved to the production id shape); `test_slack_event_run_id_does_not_match_the_envelope_event_id`; `test_slack_event_run_id_distinguishes_two_posts_in_one_channel`; `test_signed_slack_dm_event_returns_the_message_key_it_posted`
- Reborn integration: Not applicable: the change is in the live-QA harness, which has no Rust tier
- Recorded fixture: Not applicable
- Browser E2E: Not applicable
- Backend or runtime: Not applicable: no product code changed
- Live canary: this **is** the canary — `qa_7d` is the regression signal; `qa_5d`/`qa_7e` exercise the shared gate-approval path

What the tests prove:
1. A record keyed the way production keys it resolves its run.
2. The envelope `event_id` **does not** resolve a run — pins the actual regression.
3. Two posts in the **same DM channel** resolve to their own runs. qa_5d, qa_7d and qa_7e all inject into the same channel in one lane run, so a channel-only key would silently return a previous case's run id and pass on it.
4. The poster surfaces the `ts` it actually posted, so the caller can reconstruct the key.

Each was sabotage-verified, not just observed green:
- reverting `message_key` to the envelope `event_id` → `test_signed_slack_dm_event_returns_the_message_key_it_posted` fails
- dropping `ts` from the key → `test_slack_event_run_id_distinguishes_two_posts_in_one_channel` fails

(The first sabotage pass showed the same-channel case was **not** covered by the initial tests — that test was added in response.)

Commands run:
```
python3 -m unittest scripts.reborn_webui_v2_live_qa.test_run_live_qa   # 234 OK
bash scripts/pre-commit-safety.sh                                      # clean
python3 scripts/ci/test_reborn_pr_test_plan.py                         # 102 OK
```

## Security Impact

None. No change to authentication, signing, scopes, or the ingress trust boundary. The signed-event payload is byte-identical apart from `ts` now being minted once instead of twice; the envelope `event_id` is still sent, because the adapter still requires it (it just no longer decides identity).

## Reborn Trust-Boundary Checklist

N/A — test-harness-only change under `scripts/reborn_webui_v2_live_qa/`. No production types, prompts, hashes, status variants, `serde` fields, queues, or sandbox names are touched.

## Database Impact

None. Read-only `SELECT` against the local-dev libSQL/SQLite file the harness already reads; no schema, no migration.

## Blast Radius

`scripts/reborn_webui_v2_live_qa/` only. Affects the `reborn-webui-v2-live-qa` canary lanes that inject signed Slack events: qa_5d (QA 5), qa_7d + qa_7e (QA 7). If the key were wrong, those three cases fail exactly as they do today — no other lane, and no shipping code, can regress from this.

## Rollback Plan

`git revert` this commit. Single, self-contained, harness-only; reverting restores today's behaviour (qa_7d red).

## Review Follow-Through

Two things deliberately **not** in this PR:

1. **The other eight red cases are a different problem.** 2D, 2E, 3D, 6C, 6D, 7C, 9B, 9D are wall-clock timeouts, not breaks — each has passed *and* failed on an identical commit, fails cluster at ~337s against a 300s budget while passes sit at 78–176s. That needs budgeting the work rather than the seconds; raising the ceiling again just repeats #6270 (180s → 300s, same three cases). Not fixed here.
2. **`qa_9c_slack_digest_names_not_ids` is 0/60** — it has never passed in the observed window. It is `blocking=False`, so it reports as a warning. Worth deciding whether it is a canary or a tracked known-gap.

Both are written up in the triage linked above.

---

**Review track**: A (tests/chore — harness-only, no product code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VALcHTcTeaar6JRGuPnobL
