### PR TITLE
fix(live-qa): state Slack admission from the accepted outcome, not dispatch routing

### DIFF
--- a/scripts/reborn_webui_v2_live_qa/run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/run_live_qa.py
@@ -2991,20 +2991,34 @@ def _slack_event_run_id_for_message(reborn_home: Path, message_key: str) -> str 
         return None
     if not isinstance(payload, dict):
         return None
-    dispatch_kind = payload.get("dispatch_kind")
-    if isinstance(dispatch_kind, dict):
-        user_message_turn = dispatch_kind.get("user_message_turn")
-        if isinstance(user_message_turn, dict):
-            run_id = str(user_message_turn.get("run_id") or "").strip()
-            if run_id:
-                return run_id
-    outcome = payload.get("outcome")
-    if isinstance(outcome, dict):
-        accepted = outcome.get("accepted")
-        if isinstance(accepted, dict):
-            run_id = str(accepted.get("submitted_run_id") or "").strip()
-            if run_id:
-                return run_id
+    # ONLY `outcome.accepted` states that this event was admitted into a run.
+    #
+    # `dispatch_kind` is deliberately not consulted: `dispatch_kind_from_ack`
+    # (crates/product/ironclaw_assistant/src/workflow.rs) maps `DeferredBusy`
+    # and `RejectedBusy` to `UserMessageTurn { run_id: active_run_id }` -- the
+    # run that was already active and BLOCKED this event. Reading it would
+    # report success for a rejected event and hand the gate helper a run the
+    # injected message never started.
+    return _accepted_run_id(payload.get("outcome"))
+
+
+def _accepted_run_id(outcome: object, *, depth: int = 0) -> str | None:
+    """The submitted run id of an `Accepted` ack, unwrapping one `Duplicate`.
+
+    A retried delivery settles as `Duplicate { prior }`; the event was still
+    admitted, so an accepted `prior` is the right answer. Depth is bounded
+    because `prior` is itself an ack and could nest.
+    """
+    if not isinstance(outcome, dict) or depth > 4:
+        return None
+    accepted = outcome.get("accepted")
+    if isinstance(accepted, dict):
+        run_id = str(accepted.get("submitted_run_id") or "").strip()
+        if run_id:
+            return run_id
+    duplicate = outcome.get("duplicate")
+    if isinstance(duplicate, dict):
+        return _accepted_run_id(duplicate.get("prior"), depth=depth + 1)
     return None
 
 

--- a/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
+++ b/scripts/reborn_webui_v2_live_qa/test_run_live_qa.py
@@ -5716,6 +5716,9 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                                         "-T0AQMKHM7LK-D0QA5D-1788265537.085000"
                                     )
                                 },
+                                # Both fields are present on a real record; the
+                                # lookup must read the accepted outcome, never
+                                # the dispatch routing hint.
                                 "dispatch_kind": {
                                     "user_message_turn": {"run_id": "run-from-dispatch"}
                                 },
@@ -5739,9 +5742,9 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                                         "-T0AQMKHM7LK-D0QA7D-1788265904.338000"
                                     )
                                 },
-                                "dispatch_kind": {
-                                    "user_message_turn": {
-                                        "run_id": "run-from-generic-ingress"
+                                "outcome": {
+                                    "accepted": {
+                                        "submitted_run_id": "run-from-generic-ingress"
                                     }
                                 },
                             }
@@ -5755,7 +5758,7 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                     home,
                     run_live_qa._slack_message_key("D0QA5D", "1788265537.085000"),
                 ),
-                "run-from-dispatch",
+                "run-from-outcome",
             )
             self.assertEqual(
                 run_live_qa._slack_event_run_id_for_message(
@@ -5801,8 +5804,8 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                                         "-D0QA7D-1788265904.338000"
                                     )
                                 },
-                                "dispatch_kind": {
-                                    "user_message_turn": {"run_id": "run-admitted"}
+                                "outcome": {
+                                    "accepted": {"submitted_run_id": "run-admitted"}
                                 },
                             }
                         ),
@@ -5822,6 +5825,125 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                     home,
                     "EvREBORNQA7D1788265904338",
                 ),
+            )
+
+    def test_slack_event_run_id_ignores_a_busy_rejected_record(self):
+        """A busy rejection must not read as an admitted run.
+
+        `dispatch_kind_from_ack` (crates/product/ironclaw_assistant/src/workflow.rs)
+        maps BOTH `DeferredBusy` and `RejectedBusy` to
+        `UserMessageTurn { run_id: active_run_id }` -- the id of the run that was
+        ALREADY active and blocked this one, not a run the injected event
+        started. Trusting `dispatch_kind` would turn qa_7d green with no
+        admitted run, and let the shared gate helper approve gates on somebody
+        else's run. Only `outcome.accepted` states admission.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "reborn-home"
+            db_path = home / "local-dev" / "reborn-local-dev.db"
+            db_path.parent.mkdir(parents=True)
+            with closing(sqlite3.connect(db_path)) as db:
+                db.execute(
+                    """
+                    CREATE TABLE root_filesystem_entries (
+                        path TEXT PRIMARY KEY,
+                        contents BLOB NOT NULL,
+                        updated_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z'
+                    )
+                    """
+                )
+                db.execute(
+                    "INSERT INTO root_filesystem_entries(path, contents) VALUES (?, ?)",
+                    (
+                        "/tenants/reborn-cli/shared/channel-extensions/slack/"
+                        "product-workflow/idempotency/actions/busy.json",
+                        json.dumps(
+                            {
+                                "fingerprint": {
+                                    "external_event_id": (
+                                        "slack-reborn-cli-msg-T0AQMKHM7LK"
+                                        "-D0QA7D-1788265904.338000"
+                                    )
+                                },
+                                "dispatch_kind": {
+                                    "user_message_turn": {
+                                        "run_id": "run-that-was-already-active"
+                                    }
+                                },
+                                "outcome": {
+                                    "rejected_busy": {
+                                        "accepted_message_ref": "msg:rejected",
+                                        "active_run_id": "run-that-was-already-active",
+                                    }
+                                },
+                            }
+                        ),
+                    ),
+                )
+                db.commit()
+
+            self.assertIsNone(
+                run_live_qa._slack_event_run_id_for_message(
+                    home,
+                    run_live_qa._slack_message_key("D0QA7D", "1788265904.338000"),
+                ),
+            )
+
+    def test_slack_event_run_id_accepts_a_duplicate_replay_of_an_accepted_event(self):
+        """A `Duplicate` settles wrapping the prior ack; an accepted prior counts.
+
+        Slack retries a delivery it thinks timed out, and the replay settles as
+        `Duplicate { prior }`. The event WAS admitted, so the run behind the
+        prior `Accepted` is the right answer.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "reborn-home"
+            db_path = home / "local-dev" / "reborn-local-dev.db"
+            db_path.parent.mkdir(parents=True)
+            with closing(sqlite3.connect(db_path)) as db:
+                db.execute(
+                    """
+                    CREATE TABLE root_filesystem_entries (
+                        path TEXT PRIMARY KEY,
+                        contents BLOB NOT NULL,
+                        updated_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z'
+                    )
+                    """
+                )
+                db.execute(
+                    "INSERT INTO root_filesystem_entries(path, contents) VALUES (?, ?)",
+                    (
+                        "/tenants/reborn-cli/shared/channel-extensions/slack/"
+                        "product-workflow/idempotency/actions/replay.json",
+                        json.dumps(
+                            {
+                                "fingerprint": {
+                                    "external_event_id": (
+                                        "slack-reborn-cli-msg-T0AQMKHM7LK"
+                                        "-D0QA7D-1788265904.338000"
+                                    )
+                                },
+                                "outcome": {
+                                    "duplicate": {
+                                        "prior": {
+                                            "accepted": {
+                                                "submitted_run_id": "run-admitted",
+                                            }
+                                        }
+                                    }
+                                },
+                            }
+                        ),
+                    ),
+                )
+                db.commit()
+
+            self.assertEqual(
+                run_live_qa._slack_event_run_id_for_message(
+                    home,
+                    run_live_qa._slack_message_key("D0QA7D", "1788265904.338000"),
+                ),
+                "run-admitted",
             )
 
     def test_slack_event_run_id_distinguishes_two_posts_in_one_channel(self):
@@ -5864,8 +5986,8 @@ class RebornWebUiV2LiveQaRunnerTests(unittest.TestCase):
                                             f"-D0SHARED-{ts}"
                                         )
                                     },
-                                    "dispatch_kind": {
-                                        "user_message_turn": {"run_id": run_id}
+                                    "outcome": {
+                                        "accepted": {"submitted_run_id": run_id}
                                     },
                                 }
                             ),


### PR DESCRIPTION
## Summary

- Follow-up to #8027, closing the one finding from its review. Agreed to land separately rather than dequeue #8027 from the merge queue.
- `_slack_event_run_id_for_message` read `dispatch_kind` before `outcome`. `dispatch_kind_from_ack` maps **both** `DeferredBusy` and `RejectedBusy` to `UserMessageTurn { run_id: active_run_id }` — the run that was already active and **blocked** the event — so a busy-rejected Slack event reported a run id.
- Effect: `qa_7d` could go green with **nothing admitted**, and `_approve_slack_event_gates` could approve gates on an unrelated pre-existing run.
- `dispatch_kind` is no longer consulted at all. Only `outcome.accepted` states admission, unwrapping a `Duplicate { prior }` with bounded depth.
- Harness-only, as #8027 was.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Follows up #8027 (review finding). Triage context: https://claude.ai/code/artifact/50b32f05-e7a1-4927-ac4c-80a0f4e5858f

## Why this is a real false-green, not a theoretical one

`crates/product/ironclaw_assistant/src/workflow.rs:1677`:

```rust
ProductInboundAck::DeferredBusy { active_run_id, .. } => {
    Ok(ActionDispatchKind::UserMessageTurn { run_id: *active_run_id })
}
ProductInboundAck::RejectedBusy { active_run_id, .. } => {
    if let Some(run_id) = active_run_id {
        Ok(ActionDispatchKind::UserMessageTurn { run_id: *run_id })
    } else { Ok(ActionDispatchKind::NoOp) }
}
```

`active_run_id` is the run that **blocked** the event, not one the event started. `qa_7c` runs immediately before `qa_7d` and creates a routine, so an event injected while that run is still active is exactly the shape that hits this — in the lane, not just in principle.

The precedence predates #8027, but was unreachable while the query never matched a row. #8027 made the query work, which makes it live. A case whose whole purpose is catching a false signal must not itself be able to pass on one.

## Correction to the review finding

The review also asked to avoid the `outcome` path. That half does not apply: busy acks serialize `active_run_id`, not `submitted_run_id` (`ProductInboundAck::{DeferredBusy,RejectedBusy}`, `crates/contracts/ironclaw_product_contracts/src/inbound.rs:1144`), and the outcome branch only ever read `outcome.accepted.submitted_run_id`. The false-positive path was solely `dispatch_kind`.

## Why `Duplicate` is unwrapped

`ProductInboundAck::Duplicate { prior }` is a durable outcome (`is_durable_outcome`). A retried delivery settles as a duplicate wrapping the prior ack — the event **was** admitted, so an accepted `prior` is the correct answer. Recursion is depth-bounded because `prior` is itself an ack.

## Fixtures now match production

The fixtures #8027 carried were `dispatch_kind`-only, which is not what a real record looks like. They now carry the `outcome.accepted` shape, verified against the canary database from run `33507434003`. The first one keeps a `dispatch_kind` pointing at a **different** run, so the assertion proves the accepted outcome wins rather than merely that some run id comes back.

## Validation

- [ ] `cargo fmt --all -- --check` — Not applicable: no Rust changed
- [ ] `cargo clippy --all ...` — Not applicable: no Rust changed
- [ ] `cargo build` — Not applicable: no Rust changed
- [x] Relevant tests pass: `python3 -m unittest scripts.reborn_webui_v2_live_qa.test_run_live_qa` → **236 tests, OK**
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no Rust changed
- [x] Manual testing: outcome shapes read off `ProductInboundAck` and `dispatch_kind_from_ack`; record shape confirmed against the canary DB from run `33507434003`
- [x] `bash scripts/pre-commit-safety.sh` — clean

## Test Strategy

User behavior: a person's Slack DM becomes a Reborn run. The canary must call that admitted **only** when it actually was — never when the message was rejected because another run held the conversation.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [x] Persistence
- [ ] Security or permissions
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `test_slack_event_run_id_ignores_a_busy_rejected_record` (the rejected-busy fixture the review asked for); `test_slack_event_run_id_accepts_a_duplicate_replay_of_an_accepted_event`; fixtures in `test_slack_event_run_id_reads_idempotency_record`, `..._does_not_match_the_envelope_event_id` and `..._distinguishes_two_posts_in_one_channel` moved to the production `outcome.accepted` shape
- Reborn integration: Not applicable: live-QA harness has no Rust tier
- Recorded fixture: Not applicable
- Browser E2E: Not applicable
- Backend or runtime: Not applicable: no product code changed
- Live canary: `qa_7d` is the signal; `qa_5d`/`qa_7e` exercise the shared gate-approval path

What the tests prove:
1. A `RejectedBusy` record resolves to **no** run, even though its `dispatch_kind` names one.
2. A `Duplicate` wrapping an `Accepted` still resolves the admitted run.
3. `outcome.accepted` wins over a `dispatch_kind` naming a different run.

Sabotage-verified: restoring the `dispatch_kind` branch fails `test_slack_event_run_id_ignores_a_busy_rejected_record` and `test_slack_event_run_id_reads_idempotency_record`.

Commands run:
```
python3 -m unittest scripts.reborn_webui_v2_live_qa.test_run_live_qa   # 236 OK
bash scripts/pre-commit-safety.sh                                      # clean
```

## Security Impact

None. Read-only lookup in the QA harness; no change to authentication, signing, scopes, or the ingress trust boundary.

## Database Impact

None. Read-only `SELECT` against the local-dev SQLite file the harness already reads.

## Blast Radius

`scripts/reborn_webui_v2_live_qa/` only — the canary cases that inject signed Slack events (qa_5d, qa_7d, qa_7e). Strictly narrows what counts as admission, so the failure mode of a mistake here is a case going red, never a false green.

## Rollback Plan

`git revert`. Single self-contained harness commit; reverting restores #8027's behaviour.

## Review Follow-Through

Unchanged from #8027: the other eight red canary cases are wall-clock timeouts rather than breaks and are not addressed here, and `qa_9c` is 0/60 as a non-blocking behavioral probe that should be either fixed or converted to a tracked known-gap.

---

**Review track**: A (tests/chore — harness-only, no product code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VALcHTcTeaar6JRGuPnobL
