### PR TITLE
fix(cli,ci): keep serve alive when stderr closes, bind before the banner, and judge only named mutants in the critical gate

### DIFF
--- a/crates/app/ironclaw_cli/src/commands/serve.rs
+++ b/crates/app/ironclaw_cli/src/commands/serve.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -17,10 +18,10 @@ use ironclaw_config::{IdentitySection, seed_default_config_file_if_missing};
 use ironclaw_extension_host::channel_identity_binding::channel_identity_binding_hook_factory;
 use ironclaw_extension_host::extension_ingress::extension_ingress_route_mount;
 use ironclaw_webui::{
-    DeferredWebuiRouterHandle, EnvBearerAuthenticator, ProductAuthRouteState,
+    BoundWebuiListener, DeferredWebuiRouterHandle, EnvBearerAuthenticator, ProductAuthRouteState,
     RebornWebuiServeError, RebornWebuiServeOptions, WebuiAuthenticator, WebuiServeConfig,
-    deferred_webui_v2_startup_router, product_auth_route_mount, serve_webui_v2,
-    webui_v2_app_with_lifecycle,
+    bind_webui_v2, deferred_webui_v2_startup_router, product_auth_route_mount,
+    serve_bound_webui_v2, serve_webui_v2, webui_v2_app_with_lifecycle,
 };
 use secrecy::SecretString;
 
@@ -257,22 +258,21 @@ impl ServeCommand {
                 anyhow!("DEFAULT_SERVE_HOST `{DEFAULT_SERVE_HOST}` invalid: {err}")
             })?
         };
-        // `port = 0` would tell the OS to pick a free port — useful
-        // when invoked from a test harness with `--port 0`, but in a
-        // config file it produces a running server whose real bound
-        // port is never reported back to the operator (the banner
-        // prints `:0`). Allow `--port 0` from the CLI flag, reject
-        // `0` from `[webui].listen_port`.
+        // `port = 0` tells the OS to pick a free port — useful when a
+        // test harness passes `--port 0` and reads the port the banner
+        // reports, but wrong in a config file, where a fixed, documented
+        // port is what an operator and every client of it need. Allow
+        // `--port 0` from the CLI flag, reject `0` from
+        // `[webui].listen_port`.
         let port: u16 = if let Some(value) = self.port {
             value
         } else if let Some(value) = webui_section.and_then(|s| s.listen_port) {
             if value == 0 {
                 anyhow::bail!(
                     "[webui].listen_port = 0 from config is not supported: the OS would pick \
-                     an ephemeral port and the startup banner cannot report it. Set a fixed \
+                     an ephemeral port that no client of this config can know. Set a fixed \
                      port in config, or pass `--port 0` on the CLI when you genuinely want \
-                     an ephemeral port (the banner output is still :0 in that case — the \
-                     bound address is only useful when consumed through a test harness)."
+                     an ephemeral port (the startup banner then reports the port the OS chose)."
                 );
             }
             value
@@ -550,8 +550,21 @@ impl ServeCommand {
                 ))
             };
 
+            // Bind before announcing: the banner's `listener` line is the
+            // readiness signal operators and the smoke harness wait on, so it
+            // prints only once connections are accepted — and with `--port 0`
+            // it can then name the port the OS chose. The hosted profile bound
+            // its listener at startup, ahead of the runtime build.
+            let listener = match startup_serve {
+                Some(startup) => ListenerPlan::Hosted(startup),
+                None => ListenerPlan::Bound(
+                    bind_webui_v2(listen_addr)
+                        .await
+                        .context("failed to bind WebChat v2 listener")?,
+                ),
+            };
             print_serve_banner(
-                listen_addr,
+                listener.announced_addr(listen_addr),
                 env_token_var,
                 env_user_id_var,
                 &allowed_origins_raw,
@@ -649,23 +662,19 @@ impl ServeCommand {
                 .context("failed to compose v2 Router")?;
             let (router, public_route_drains) = webui_app.into_parts();
 
-            let serve_result = if let Some(startup_serve) = startup_serve {
-                startup_serve
-                    .ready_handle
-                    .publish_ready_router(router)
-                    .context("failed to publish ready WebChat v2 router")?;
-                startup_serve
-                    .serve_task
-                    .await
-                    .context("hosted single-tenant startup WebChat v2 serve task failed to join")?
-            } else {
-                serve_webui_v2(RebornWebuiServeOptions {
-                    addr: listen_addr,
-                    router,
-                    shutdown: webui_shutdown_signal(),
-                    bound_addr_tx: None,
-                })
-                .await
+            let serve_result = match listener {
+                ListenerPlan::Hosted(startup_serve) => {
+                    startup_serve
+                        .ready_handle
+                        .publish_ready_router(router)
+                        .context("failed to publish ready WebChat v2 router")?;
+                    startup_serve.serve_task.await.context(
+                        "hosted single-tenant startup WebChat v2 serve task failed to join",
+                    )?
+                }
+                ListenerPlan::Bound(bound) => {
+                    serve_bound_webui_v2(bound, router, webui_shutdown_signal()).await
+                }
             };
 
             // Always drain public route mounts before shutting down the
@@ -684,6 +693,26 @@ impl ServeCommand {
         })?;
 
         Ok(())
+    }
+}
+
+/// Who holds the WebChat v2 listener when the banner prints: the hosted
+/// profile's startup task (bound ahead of the runtime build) or a listener
+/// this command bound itself immediately before announcing it.
+enum ListenerPlan {
+    Hosted(StartupServe),
+    Bound(BoundWebuiListener),
+}
+
+impl ListenerPlan {
+    /// The address the banner names: the bound address when this command
+    /// bound it (the real port for `--port 0`), else the address the hosted
+    /// startup listener was asked for.
+    fn announced_addr(&self, requested: SocketAddr) -> SocketAddr {
+        match self {
+            ListenerPlan::Hosted(_) => requested,
+            ListenerPlan::Bound(bound) => bound.local_addr(),
+        }
     }
 }
 
@@ -1034,22 +1063,33 @@ fn print_serve_banner(
     allowed_origins: &[String],
     readiness: &RebornReadiness,
 ) {
-    eprintln!("ironclaw: WebChat v2 listener");
-    eprintln!("  binary    : ironclaw");
-    eprintln!("  version   : {}", env!("CARGO_PKG_VERSION"));
-    eprintln!("  listen    : http://{listen_addr}");
-    eprintln!("  auth      : env-bearer (token ${env_token_var}, user ${env_user_id_var})");
+    // The banner is informational: a consumer that closed our stderr (a
+    // harness that stopped reading, a detached terminal) must not take the
+    // listener down with a broken-pipe panic, so every write is best effort.
+    let mut stderr = std::io::stderr().lock();
+    let _ = writeln!(stderr, "ironclaw: WebChat v2 listener");
+    let _ = writeln!(stderr, "  binary    : ironclaw");
+    let _ = writeln!(stderr, "  version   : {}", env!("CARGO_PKG_VERSION"));
+    let _ = writeln!(stderr, "  listen    : http://{listen_addr}");
+    let _ = writeln!(
+        stderr,
+        "  auth      : env-bearer (token ${env_token_var}, user ${env_user_id_var})"
+    );
     if allowed_origins.is_empty() {
-        eprintln!("  cors      : fail-closed (no allowed origins configured)");
+        let _ = writeln!(
+            stderr,
+            "  cors      : fail-closed (no allowed origins configured)"
+        );
     } else {
-        eprintln!(
+        let _ = writeln!(
+            stderr,
             "  cors      : {} origin(s) ({})",
             allowed_origins.len(),
             allowed_origins.join(", "),
         );
     }
-    eprintln!("  readiness : {readiness:?}");
-    eprintln!();
+    let _ = writeln!(stderr, "  readiness : {readiness:?}");
+    let _ = writeln!(stderr);
 }
 
 /// Parse `IRONCLAW_REBORN_DEV_SECRET__<handle>=<value>` pairs from an

--- a/crates/app/ironclaw_cli/tests/smoke.rs
+++ b/crates/app/ironclaw_cli/tests/smoke.rs
@@ -3056,6 +3056,139 @@ fn serve_does_not_mount_cli_login_route_when_token_is_env_sourced() {
 /// for why an unmounted `/login` is a 200 SPA-shell fallthrough rather than a
 /// 404 under root-path serving, not this route's own redirect) while
 /// `/auth/providers` stays up.
+/// The banner's `listener` line is the readiness signal an operator and this
+/// harness wait on, so it prints only once the listener is bound — and with
+/// `--port 0` it reports the port the OS chose. One connect attempt, with no
+/// retry, must therefore reach the port the banner names.
+#[test]
+fn serve_banner_reports_the_bound_port_and_prints_only_once_it_accepts_connections() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).expect("home dir");
+    let _serve_port_guard = SERVE_PORT_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let mut child = reborn_command()
+        .args(["serve", "--host", "127.0.0.1", "--port", "0"])
+        .env("HOME", &home)
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env(
+            "IRONCLAW_REBORN_WEBUI_TOKEN",
+            "reborn-smoke-test-token-0123456789abcdef",
+        )
+        .env("IRONCLAW_REBORN_WEBUI_USER_ID", "test-user")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("ironclaw-reborn serve should start");
+    let stderr = wait_for_serve_banner_with_capture(&mut child, "ephemeral-port serve");
+
+    // The `listen` line follows the banner header.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let listen_line = loop {
+        let text = stderr
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        if let Some(line) = text
+            .lines()
+            .find(|line| line.trim_start().starts_with("listen"))
+        {
+            break line.to_string();
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("the banner never printed its listen line; stderr: {text}");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    };
+    let port: u16 = listen_line
+        .rsplit(':')
+        .next()
+        .and_then(|port| port.trim().parse().ok())
+        .unwrap_or(0);
+    let connect = std::net::TcpStream::connect_timeout(
+        &std::net::SocketAddr::from(([127, 0, 0, 1], port)),
+        std::time::Duration::from_secs(2),
+    );
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert_ne!(
+        port, 0,
+        "the banner reports the port the OS chose, not the requested :0 — {listen_line}"
+    );
+    connect.expect("a single connect right after the banner must reach the listener");
+}
+
+/// A server must not depend on whoever reads its stderr. The harness once
+/// closed the pipe after the banner's first line, and `serve` died on the
+/// next line ("failed printing to stderr"): close it the same way and the
+/// listener must still answer.
+#[test]
+fn serve_keeps_serving_after_its_stderr_consumer_goes_away() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).expect("home dir");
+    let _serve_port_guard = SERVE_PORT_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let port = unused_local_port();
+
+    let mut child = reborn_command()
+        .args(["serve", "--host", "127.0.0.1", "--port"])
+        .arg(port.to_string())
+        .env("HOME", &home)
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env(
+            "IRONCLAW_REBORN_WEBUI_TOKEN",
+            "reborn-smoke-test-token-0123456789abcdef",
+        )
+        .env("IRONCLAW_REBORN_WEBUI_USER_ID", "test-user")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("ironclaw-reborn serve should start");
+
+    // Read only the banner's first line, then drop the pipe's read end.
+    let stderr = child.stderr.take().expect("stderr should be piped");
+    let mut reader = std::io::BufReader::new(stderr);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        let mut line = String::new();
+        let read = reader.read_line(&mut line).expect("read serve stderr");
+        if line.contains("ironclaw: WebChat v2 listener") {
+            break;
+        }
+        if read == 0 || std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("serve did not reach its listener banner");
+        }
+    }
+    drop(reader);
+
+    let response = http_response(
+        port,
+        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        "probe after stderr closed",
+    );
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let exited = child.try_wait().expect("serve child status");
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        exited.is_none(),
+        "serve must not exit because its stderr consumer went away, got {exited:?}"
+    );
+    response.expect("the listener answers although stderr is closed");
+}
+
 #[test]
 fn serve_with_sso_does_not_double_mount_session_exchange() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -3154,44 +3287,20 @@ fn strip_ansi(text: &str) -> String {
 /// Blocks until `child`'s stderr carries the ready banner. Returns
 /// everything captured up to and including the banner line, so callers can
 /// also assert on pre-banner diagnostics without their own drain thread.
+/// Wait for the serve banner while draining `child`'s stderr for the rest of
+/// its life. The drain must outlive this call: closing the pipe's read end
+/// after the banner's first line made the child's next `eprintln!` — the rest
+/// of the banner — fail with a broken pipe, which is a panic, and killed the
+/// server the test was about to probe. That was the "connection refused"
+/// flake in every serve smoke test.
 fn wait_for_serve_banner(child: &mut std::process::Child) -> String {
-    let stderr = child.stderr.take().expect("stderr should be piped");
-    let (stderr_tx, stderr_rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        for line in std::io::BufReader::new(stderr).lines() {
-            if stderr_tx.send(line).is_err() {
-                break;
-            }
-        }
-    });
-
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
-    let mut stderr_text = String::new();
-    loop {
-        if let Some(status) = child.try_wait().expect("serve child status") {
-            panic!("serve exited before binding with {status}; stderr: {stderr_text}");
-        }
-        if std::time::Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            panic!("serve did not reach listener banner; stderr: {stderr_text}");
-        }
-        match stderr_rx.recv_timeout(std::time::Duration::from_millis(100)) {
-            Ok(Ok(line)) => {
-                stderr_text.push_str(&line);
-                stderr_text.push('\n');
-                if stderr_text.contains("ironclaw: WebChat v2 listener") {
-                    break;
-                }
-            }
-            Ok(Err(error)) => panic!("failed to read serve stderr: {error}"),
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                panic!("serve stderr closed before banner; stderr: {stderr_text}");
-            }
-        }
-    }
-    stderr_text
+    let stderr_all = wait_for_serve_banner_with_capture(child, "serve");
+    let banner = stderr_all
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    drop(stderr_all);
+    banner
 }
 
 /// Like [`wait_for_serve_banner`], but keeps capturing `child`'s stderr for

--- a/crates/product/ironclaw_webui/CONTRACT.md
+++ b/crates/product/ironclaw_webui/CONTRACT.md
@@ -90,7 +90,9 @@ turning the `webui_v2_routes()` descriptors into tower layers.
 
 | Symbol | Role |
 |---|---|
-| `serve_webui_v2(opts)` | Bind a `TcpListener` + run `axum::serve` with graceful shutdown |
+| `serve_webui_v2(opts)` | Bind a `TcpListener` + run `axum::serve` with graceful shutdown (`bind_webui_v2` then `serve_bound_webui_v2`) |
+| `bind_webui_v2(addr)` | Bind only; returns a `BoundWebuiListener` whose `local_addr()` is the real port, and whose backlog holds connections until served |
+| `serve_bound_webui_v2(bound, router, shutdown)` | Run `axum::serve` on an already-bound listener with graceful shutdown |
 | `RebornWebuiServeOptions` | Owner-supplied input (addr, router, shutdown receiver) |
 | `EnvBearerAuthenticator` | Single-token `WebuiAuthenticator` for the standalone CLI; accepted tokens map to operator WebUI capabilities |
 | `SignedTokenSessionStore` | HMAC-signed bearer mint/lookup with a bounded process-local logout denylist |

--- a/crates/product/ironclaw_webui/README.md
+++ b/crates/product/ironclaw_webui/README.md
@@ -22,7 +22,10 @@ alone constructs authenticated-caller evidence.
 ## Public surface
 
 - `serve_webui_v2(RebornWebuiServeOptions)` — listener bind + `axum::serve` +
-  graceful shutdown (the one sanctioned socket bind in the product/API tier).
+  graceful shutdown (the one sanctioned socket bind in the product/API tier),
+  composed from `bind_webui_v2(addr) -> BoundWebuiListener` and
+  `serve_bound_webui_v2(bound, router, shutdown)` so a host can bind — and
+  announce the bound address — before its router exists.
 - `webui_v2_app(product_surface, config)` — the composed `axum::Router` with
   the fixed middleware order: ws-origin → body limit → bearer/session/OIDC
   auth → rate limit → handler.

--- a/crates/product/ironclaw_webui/src/lib.rs
+++ b/crates/product/ironclaw_webui/src/lib.rs
@@ -211,6 +211,40 @@ async fn deferred_webui_handler(
         .unwrap_or_else(|err: Infallible| match err {})
 }
 
+/// A WebChat v2 listener that is bound but not yet served. Connections queue
+/// in the accept backlog until [`serve_bound_webui_v2`] runs, so a host may
+/// announce the address — and a probe may connect — before the router exists.
+pub struct BoundWebuiListener {
+    listener: TcpListener,
+    addr: SocketAddr,
+}
+
+impl BoundWebuiListener {
+    /// The address the OS bound: the real port when the request asked for `:0`.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.addr
+    }
+}
+
+/// Bind the WebChat v2 `TcpListener` at `addr` without serving yet.
+pub async fn bind_webui_v2(addr: SocketAddr) -> Result<BoundWebuiListener, RebornWebuiServeError> {
+    let listener = TcpListener::bind(addr)
+        .await
+        .map_err(|source| RebornWebuiServeError::Bind { addr, source })?;
+    let bound = listener
+        .local_addr()
+        .map_err(RebornWebuiServeError::LocalAddr)?;
+    tracing::info!(
+        target: "ironclaw::reborn::webui_ingress",
+        %bound,
+        "WebChat v2 listener bound",
+    );
+    Ok(BoundWebuiListener {
+        listener,
+        addr: bound,
+    })
+}
+
 /// Bind a `TcpListener` at `opts.addr`, run the axum serve loop with
 /// the composed `Router`, and wait for `opts.shutdown` to fire before
 /// returning. Graceful shutdown gives in-flight requests a chance to
@@ -222,27 +256,25 @@ pub async fn serve_webui_v2(opts: RebornWebuiServeOptions) -> Result<(), RebornW
         shutdown,
         bound_addr_tx,
     } = opts;
-
-    let listener = TcpListener::bind(addr)
-        .await
-        .map_err(|source| RebornWebuiServeError::Bind { addr, source })?;
-
-    let bound = listener
-        .local_addr()
-        .map_err(RebornWebuiServeError::LocalAddr)?;
-    tracing::info!(
-        target: "ironclaw::reborn::webui_ingress",
-        %bound,
-        "WebChat v2 listener bound",
-    );
+    let bound = bind_webui_v2(addr).await?;
     if let Some(tx) = bound_addr_tx {
         // Receiver may have been dropped (test exited early). Ignore
         // — that's a test bug, not a serve-loop concern.
-        let _ = tx.send(bound);
+        let _ = tx.send(bound.local_addr());
     }
+    serve_bound_webui_v2(bound, router, shutdown).await
+}
 
+/// Run the axum serve loop on an already-bound listener and wait for
+/// `shutdown` to fire before returning. Graceful shutdown gives in-flight
+/// requests a chance to complete before the listener closes.
+pub async fn serve_bound_webui_v2(
+    bound: BoundWebuiListener,
+    router: Router,
+    shutdown: tokio::sync::oneshot::Receiver<()>,
+) -> Result<(), RebornWebuiServeError> {
     axum::serve(
-        listener,
+        bound.listener,
         router.into_make_service_with_connect_info::<SocketAddr>(),
     )
     .with_graceful_shutdown(async move {

--- a/crates/product/ironclaw_webui/tests/serve_loop.rs
+++ b/crates/product/ironclaw_webui/tests/serve_loop.rs
@@ -13,7 +13,10 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use axum::{Router, extract::ConnectInfo, routing::get};
-use ironclaw_webui::{RebornWebuiServeOptions, deferred_webui_v2_startup_router, serve_webui_v2};
+use ironclaw_webui::{
+    RebornWebuiServeOptions, bind_webui_v2, deferred_webui_v2_startup_router, serve_bound_webui_v2,
+    serve_webui_v2,
+};
 use tokio::sync::oneshot;
 
 async fn build_test_router() -> Router {
@@ -222,4 +225,48 @@ async fn deferred_startup_router_serves_health_then_delegates_when_ready() {
         .expect("serve loop must exit within 2s of shutdown signal")
         .expect("serve loop join handle must not panic")
         .expect("serve loop must return Ok after shutdown");
+}
+
+/// The bind is a separate step so a host can announce the listener before
+/// the router exists: a connection made after `bind_webui_v2` and before
+/// `serve_bound_webui_v2` waits in the accept backlog and is served once the
+/// loop runs, instead of being refused.
+#[tokio::test]
+async fn a_bound_listener_accepts_a_connection_made_before_the_serve_loop_runs() {
+    let bound = bind_webui_v2(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind on an ephemeral port");
+    let addr = bound.local_addr();
+    assert_ne!(
+        addr.port(),
+        0,
+        "the bound address carries the port the OS chose"
+    );
+
+    // Connect BEFORE anything serves: the kernel completes the handshake
+    // against the bound listener, so the connect does not fail.
+    let early = tokio::time::timeout(Duration::from_secs(2), tokio::net::TcpStream::connect(addr))
+        .await
+        .expect("connect must not hang")
+        .expect("a bound listener accepts a connection before it is served");
+    drop(early);
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let router = build_test_router().await;
+    let serve_handle =
+        tokio::spawn(async move { serve_bound_webui_v2(bound, router, shutdown_rx).await });
+    let body = test_client()
+        .get(format!("http://{addr}/ping"))
+        .send()
+        .await
+        .expect("request once serving")
+        .text()
+        .await
+        .expect("body");
+    assert_eq!(body, "pong");
+    shutdown_tx.send(()).expect("serve loop still running");
+    serve_handle
+        .await
+        .expect("serve task joins")
+        .expect("serve loop exits cleanly on shutdown");
 }

--- a/scripts/ci/critical_mutation_gate.py
+++ b/scripts/ci/critical_mutation_gate.py
@@ -378,12 +378,28 @@ def main() -> int:
                 if total == 0:
                     raise GateError(f"critical mutation run produced zero mutants for {path}")
                 reported_mutants = missed + caught + unviable + timed_out
-                if set(reported_mutants) != set(selected_mutants) or len(
-                    reported_mutants
-                ) != len(selected_mutants):
+                # cargo-mutants (27.1) examines struct-field-deletion mutants
+                # regardless of `--re`. Only the named functions' tests ran,
+                # so a mutant outside them carries no verdict here: report it
+                # and judge the named set exactly.
+                named = set(selected_mutants)
+                extras = [mutant for mutant in reported_mutants if mutant not in named]
+                if extras:
+                    print(
+                        "  NOTE: ignored mutants cargo-mutants examined outside the named "
+                        "functions (no verdict — only the named tests ran):\n  "
+                        + "\n  ".join(extras),
+                        flush=True,
+                    )
+                reported_named = [mutant for mutant in reported_mutants if mutant in named]
+                if set(reported_named) != named or len(reported_named) != len(selected_mutants):
                     raise GateError(
                         "cargo-mutants results did not match the exact named-mutant allowlist"
                     )
+                timed_out = [mutant for mutant in timed_out if mutant in named]
+                missed = [mutant for mutant in missed if mutant in named]
+                caught = [mutant for mutant in caught if mutant in named]
+                unviable = [mutant for mutant in unviable if mutant in named]
                 if timed_out:
                     raise GateError(
                         "critical mutants timed out (no passing verdict):\n  "

--- a/scripts/ci/test-critical-mutation-gate.sh
+++ b/scripts/ci/test-critical-mutation-gate.sh
@@ -120,6 +120,14 @@ case "${STUB_MODE:-caught}" in
       >"${out}/mutants.out/caught.txt"
     exit 0
     ;;
+  extra)
+    # cargo-mutants 27.1 examines struct-field-deletion mutants regardless of
+    # `--re`: the named mutant is caught, an unnamed one rides along missed.
+    echo "${mutant}" >"${out}/mutants.out/caught.txt"
+    echo 'crates/ironclaw_demo/src/lib.rs:2:1: delete field flag from struct Demo expression in Demo::authorize_helper' \
+      >"${out}/mutants.out/missed.txt"
+    exit 2
+    ;;
   zero) exit 0 ;;
 esac
 STUB
@@ -191,8 +199,12 @@ check_rc "a similarly named sibling does not satisfy discovery" 1
 check_text "substring discovery failure names the exact function" \
   "named critical function produced zero mutants: ${source_path}::authorize"
 capture unexpected
-check_rc "a result outside the named-mutant allowlist fails" 1
-check_text "unexpected result reports an allowlist mismatch" "exact named-mutant allowlist"
+check_rc "a missing named mutant fails even when another result appears" 1
+check_text "a missing named mutant reports an allowlist mismatch" "exact named-mutant allowlist"
+capture extra
+check_rc "an unnamed mutant the tool examined anyway carries no verdict" 0
+check_text "the unnamed mutant is reported as ignored" "outside the named functions"
+check_text "the named verdict still passes" "0 survived; 0 timed out"
 capture zero
 check_rc "an empty result is not a pass" 1
 check_text "empty result explains zero mutants" "produced zero mutants"


### PR DESCRIPTION
## Summary

Two merge-queue failures that ejected #8006 (run 33642416400) and hit its pull-request runs five times out of six. Each is fixed at its owning seam with a regression that failed before the change.

### The serve smoke flake was the harness killing the server

Every serve smoke test waits for `serve`'s banner and then probes the port; the failures read `connect to serve listener failed: Connection refused`. The cause is not timing on the runner. The harness's `wait_for_serve_banner` reader thread stopped as soon as the banner's first line arrived and dropped the pipe's read end; `serve`'s next `eprintln!` — the rest of its own banner — then failed with a broken pipe, which is a panic, and the process died before it ever bound the port. Closing the pipe after the first banner line reproduces it deterministically: `serve` exits with status 101 and the port is refused (five of six runs on the old binary, six of six after the reorder below moved the bind ahead of the banner, where the symptom becomes a connection reset).

- **Harness (`crates/app/ironclaw_cli/tests/smoke.rs`):** `wait_for_serve_banner` now drains stderr for the child's whole life (it is the capturing helper), so no serve test can close the pipe on a live server.
- **Server (`crates/app/ironclaw_cli/src/commands/serve.rs`):** the banner writes through a locked stderr handle and ignores write errors — a consumer that stops reading, or a detached terminal, must not take the listener down.
- **Readiness (`serve.rs`, `crates/product/ironclaw_webui/src/lib.rs`):** the banner's `listener` line is the readiness signal operators and the harness wait on, yet it printed before the WebUI crate's serve entry bound anything. `ironclaw_webui` now exposes `bind_webui_v2(addr) -> BoundWebuiListener` and `serve_bound_webui_v2(bound, router, shutdown)` (`serve_webui_v2` is composed from them); `serve` binds first, prints the banner with the bound address, then composes the router and serves. The hosted single-tenant profile keeps its startup listener. `--port 0` now reports the port the OS chose instead of `:0`, and the config error for `[webui].listen_port = 0` says so.

### The critical-mutation gate failed on a cargo-mutants filter bypass

cargo-mutants 27.1.0 examines struct-field-deletion mutants regardless of `--re` (`--re '^zzz$'` still lists `delete field progressive from struct WorkingIndicator expression` in `run_delivery/observer.rs`). The gate runs only the named functions' tests, so such a mutant is "missed" by construction, and the exact-set comparison failed although the named mutants (`try_claim`: one caught, one unviable) were unchanged. The gate now judges the named set exactly — a missing or duplicated named mutant, a survivor, or a timeout still fails — and reports mutants examined outside the named functions as ignored, since no verdict exists for them.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Unblocks #8006 (merge-queue run 33642416400: reborn-core bucket + Critical named-function mutation gate).

## Layers in this diff

product (`ironclaw_webui` bind/serve split, README + CONTRACT rows) · app (`ironclaw_cli` serve: best-effort banner, bind before banner, `ListenerPlan`, `--port 0` banner) · CI (`scripts/ci/critical_mutation_gate.py` + self-test) · tests (WebUI serve-loop test, CLI smoke harness + two smoke tests).

## Compatibility & rollback

- `serve_webui_v2(RebornWebuiServeOptions)` keeps its signature and behavior; the two new functions are additive.
- The banner's `listen` line shows the bound address; for a fixed port that is the same text as before.
- The gate's fail-closed cases are unchanged; only mutants outside the named functions stop counting.
- Each commit reverts on its own.

## Test Strategy

- Caller path: `cargo test -p ironclaw --test smoke` — `serve_keeps_serving_after_its_stderr_consumer_goes_away` (reads the first banner line, drops the pipe, requires the listener to still answer and the process to still run; red before: exit status 101) and `serve_banner_reports_the_bound_port_and_prints_only_once_it_accepts_connections` (`--port 0`; parses the banner's port; one connect with no retry; red before: the banner said `:0`). The two previously flaky serve tests and the full smoke suite pass in repeated runs.
- Unit/contract: `cargo test -p ironclaw_webui` — `a_bound_listener_accepts_a_connection_made_before_the_serve_loop_runs` plus the existing serve-loop suite.
- Gate: `bash scripts/ci/test-critical-mutation-gate.sh` — new stub mode `extra` (named mutant caught, unnamed one missed → passes with an ignored notice; red before) and the renamed `unexpected` case (named mutant missing → still fails); 63 self-tests pass. The real gate, run locally against #8006's observer file, fails before and passes after (`1 caught; 1 unviable`, one ignored).
- Not applicable: integration tier (bind ordering and stderr handling only); browser E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
