### PR TITLE
feat(subagent): a child's approval/auth gate reaches the owner's inbox (R3 slice 3a)

### DIFF
--- a/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
@@ -246,6 +246,35 @@ impl RunOutcomeProcessCommitObserver {
         Ok(suspension.gate_ref)
     }
 
+    /// The gate a run is currently suspended on, as the notification kind that
+    /// announces it. One authoritative read: reconciliation asks about several
+    /// kinds at once and every kind would otherwise re-read the same snapshot.
+    async fn current_gate(
+        source: &dyn ProcessJournalSource<Error = ironclaw_turns::TurnError>,
+        snapshot: &JournaledProcessSnapshot,
+    ) -> Result<Option<(NotificationKind, ironclaw_host_api::turn::TurnGateRef)>, String> {
+        let current = source
+            .get_process_snapshot(GetProcessSnapshotRequest {
+                scope: snapshot.scope.clone(),
+                process_id: snapshot.process_id,
+            })
+            .await
+            .map_err(|error| format!("read current gate process state failed: {error}"))?;
+        if current.status != ProcessLifecycleStatus::Suspended {
+            return Ok(None);
+        }
+        let Some(suspension) = current.suspension else {
+            return Ok(None);
+        };
+        let Some(kind) = gate_notification_kind(suspension.kind) else {
+            return Ok(None);
+        };
+        let Some(gate_ref) = suspension.gate_ref else {
+            return Ok(None);
+        };
+        Ok(Some((kind, gate_ref)))
+    }
+
     async fn resolve_gate_required(
         inbox: &dyn NotificationInboxStorePort,
         snapshot: &JournaledProcessSnapshot,
@@ -295,17 +324,23 @@ impl RunOutcomeProcessCommitObserver {
         // A later gate of a given kind can already be current by the time an
         // older Resumed commit arrives; preservation applies per kind, to
         // every kind requested here, not only auth. On a terminal commit the
-        // process is no longer Suspended, so `current_gate_ref` returns None
-        // for every kind and reconciliation still closes every open gate for
-        // the run, exactly as before.
-        let mut current_gate_refs = Vec::with_capacity(kinds.len());
-        for &kind in kinds {
-            let current_gate_ref = match self.process_journal_source.as_deref() {
-                Some(source) => Self::current_gate_ref(source, snapshot, kind).await?,
-                None => None,
-            };
-            current_gate_refs.push((kind, current_gate_ref));
-        }
+        // process is no longer Suspended, so `current_gate` returns None and
+        // reconciliation still closes every open gate for the run, exactly as
+        // before. A run is suspended on at most one gate at a time, so one
+        // read of the snapshot is enough to answer every requested kind.
+        let current_gate = match self.process_journal_source.as_deref() {
+            Some(source) => Self::current_gate(source, snapshot).await?,
+            None => None,
+        };
+        let current_gate_refs: Vec<_> = kinds
+            .iter()
+            .map(|&kind| {
+                let gate_ref = current_gate.as_ref().and_then(|(current_kind, gate_ref)| {
+                    (*current_kind == kind).then(|| gate_ref.clone())
+                });
+                (kind, gate_ref)
+            })
+            .collect();
         let mut cursor = None;
         loop {
             let page = self

--- a/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
@@ -527,6 +527,9 @@ impl ProcessJournalCommitObserver for RunOutcomeProcessCommitObserver {
     }
 
     async fn observe_process_commit(&self, commit: ProcessJournalCommit) -> Result<(), String> {
+        if let Some(metadata) = child_gate_run(&commit.state) {
+            return self.observe_child_gate_commit(&commit, &metadata).await;
+        }
         let Some(metadata) = eligible_user_run(&commit.state) else {
             return Ok(());
         };
@@ -631,6 +634,72 @@ impl ProcessJournalCommitObserver for RunOutcomeProcessCommitObserver {
                 .await?;
             }
             _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl RunOutcomeProcessCommitObserver {
+    /// The child-run half of `observe_process_commit`: publish the child's
+    /// approval/auth gate to the owner's inbox on `Suspended`; retire it when
+    /// the child resumes or ends. Terminal outcomes of a child are never
+    /// published — R2 delivers them into the parent thread.
+    async fn observe_child_gate_commit(
+        &self,
+        commit: &ProcessJournalCommit,
+        metadata: &OutcomeMetadata,
+    ) -> Result<(), String> {
+        let run_id = TurnRunId::from_uuid(commit.state.process_id.as_uuid());
+        let occurred_at = commit.occurred_at.unwrap_or(commit.state.created_at);
+        if commit.kind == ProcessJournalKind::Suspended
+            && commit.state.status == ProcessLifecycleStatus::Suspended
+        {
+            let Some(kind) = commit
+                .state
+                .suspension
+                .as_ref()
+                .and_then(|suspension| gate_notification_kind(suspension.kind))
+            else {
+                return Ok(());
+            };
+            return Self::publish_gate_required(
+                self.inbox.as_ref(),
+                self.process_journal_source.as_deref(),
+                &commit.state,
+                run_id,
+                kind,
+                occurred_at,
+            )
+            .await;
+        }
+        let resumed = commit.kind == ProcessJournalKind::Resumed;
+        if !resumed && !commit.state.status.is_terminal() {
+            return Ok(());
+        }
+        // ponytail: two inbox scans per child resume/terminal (the root-run
+        // path pays one per Resumed today). Ceiling: a parent with hundreds of
+        // children scans a large inbox hundreds of times. Upgrade path:
+        // resolve by deterministic id (`run_notification_inbox_id`) once the
+        // terminal snapshot carries the gate_ref it settled, or an inbox index
+        // by run id.
+        // An approval is decided either way once the child resumes; a denied
+        // auth resume keeps the auth item actionable until a verified recovery,
+        // exactly as the root-run path does.
+        self.resolve_open_run_notifications(
+            &commit.state,
+            run_id,
+            NotificationKind::ApprovalRequired,
+            occurred_at,
+        )
+        .await?;
+        if !resumed || metadata.resume_disposition != Some(GateResumeDisposition::Denied) {
+            self.resolve_open_run_notifications(
+                &commit.state,
+                run_id,
+                NotificationKind::AuthenticationRequired,
+                occurred_at,
+            )
+            .await?;
         }
         Ok(())
     }
@@ -877,6 +946,31 @@ fn eligible_user_run(snapshot: &JournaledProcessSnapshot) -> Option<OutcomeMetad
     Some(metadata)
 }
 
+/// A subagent child run (`parent_process_id` set, or journaled at depth > 0)
+/// with an owner and a thread. Children are screened out of every outcome
+/// notification by `eligible_user_run` — their results reach the parent thread
+/// through the await edge, never the inbox. A child's own approval or auth
+/// gate is the one outcome that path cannot carry: nothing resumes the child
+/// until a human decides, so it is the one child event that reaches the
+/// owner's inbox (subagent README §9, R3 slice 3a).
+fn child_gate_run(snapshot: &JournaledProcessSnapshot) -> Option<OutcomeMetadata> {
+    if snapshot.process_kind != ProcessKind::AgentTurn
+        || snapshot.owner_user_id.is_none()
+        || snapshot.scope.thread_id.is_none()
+        || snapshot.scope.agent_id.is_none()
+    {
+        return None;
+    }
+    let metadata = parse_outcome_metadata(snapshot)?;
+    if snapshot.parent_process_id.is_none() && metadata.subagent_depth == 0 {
+        return None;
+    }
+    if metadata.ownerless_thread {
+        return None;
+    }
+    Some(metadata)
+}
+
 fn is_background_run(metadata: &OutcomeMetadata) -> bool {
     metadata
         .product_context
@@ -983,11 +1077,11 @@ mod tests {
     };
     use ironclaw_notifications::{
         LifecycleRef, ListNotificationsRequest, MarkAllNotificationsReadRequest,
-        NotificationAction, NotificationInboxError, NotificationInboxStore,
-        NotificationInboxStorePort, NotificationInitialState, NotificationKind,
-        NotificationMutationOutcome, NotificationMutationRequest, NotificationPage,
-        NotificationRecipient, NotificationRecord, NotificationSeverity, NotificationSource,
-        PublishNotificationRequest,
+        NOTIFICATION_PAGE_LIMIT_MAX, NotificationAction, NotificationInboxError,
+        NotificationInboxStore, NotificationInboxStorePort, NotificationInitialState,
+        NotificationKind, NotificationMutationOutcome, NotificationMutationRequest,
+        NotificationPage, NotificationRecipient, NotificationRecord, NotificationSeverity,
+        NotificationSource, PublishNotificationRequest,
     };
     use ironclaw_processes::{
         ClaimProcessesRequest, GetProcessSnapshotRequest, JournaledProcessSnapshot,
@@ -2852,6 +2946,241 @@ mod tests {
         assert!(
             records(inbox.as_ref()).await.is_empty(),
             "neither a child run nor an ownerless thread reaches a user's inbox"
+        );
+    }
+
+    fn child_commit(
+        run_id: TurnRunId,
+        status: ProcessLifecycleStatus,
+        kind: ProcessJournalKind,
+        suspension: Option<ProcessSuspension>,
+    ) -> ProcessJournalCommit {
+        let mut commit = commit(run_id, status, kind, "web_ui");
+        commit.state.parent_process_id = Some(ProcessId::from_uuid(TurnRunId::new().as_uuid()));
+        commit.state.scope.thread_id = Some(child_thread());
+        commit.state.suspension = suspension;
+        commit.state.metadata = json!({
+            "agent_turn": {
+                "product_context": { "origin": "web_ui" },
+                "execution_outcome": "result_available",
+                "subagent_depth": 1,
+            }
+        });
+        commit
+    }
+
+    fn child_thread() -> ThreadId {
+        ThreadId::new("child-thread").expect("child thread id")
+    }
+
+    fn gate_suspension(kind: ProcessSuspensionKind, gate_ref: &str) -> ProcessSuspension {
+        ProcessSuspension {
+            kind,
+            gate_ref: Some(TurnGateRef::new(gate_ref).expect("gate ref")),
+            activity_id: None,
+            credential_requirements: Vec::new(),
+            detail: None,
+        }
+    }
+
+    async fn list_all(inbox: &dyn NotificationInboxStorePort) -> Vec<NotificationRecord> {
+        inbox
+            .list(ListNotificationsRequest {
+                recipient: NotificationRecipient {
+                    tenant_id: tenant(),
+                    user_id: user(),
+                },
+                limit: NOTIFICATION_PAGE_LIMIT_MAX,
+                cursor: None,
+                include_archived: true,
+            })
+            .await
+            .expect("list inbox")
+            .notifications
+    }
+
+    #[tokio::test]
+    async fn a_child_approval_gate_publishes_an_actionable_item_that_opens_the_child_thread() {
+        let inbox = inbox();
+        let observer = RunOutcomeProcessCommitObserver::new(
+            Arc::clone(&inbox) as Arc<dyn NotificationInboxStorePort>,
+            Arc::new(InMemorySessionThreadService::default()) as Arc<dyn SessionThreadService>,
+        );
+        let child_run = TurnRunId::new();
+
+        observer
+            .observe_process_commit(child_commit(
+                child_run,
+                ProcessLifecycleStatus::Suspended,
+                ProcessJournalKind::Suspended,
+                Some(gate_suspension(
+                    ProcessSuspensionKind::Approval,
+                    "gate:approval-1",
+                )),
+            ))
+            .await
+            .expect("child approval suspension");
+
+        let page = list_all(inbox.as_ref()).await;
+        assert_eq!(page.len(), 1, "exactly one item for one child gate");
+        let item = &page[0];
+        assert_eq!(item.kind, NotificationKind::ApprovalRequired);
+        assert_eq!(item.source.turn_run_id, Some(child_run));
+        assert_eq!(item.source.thread_id, Some(child_thread()));
+        assert_eq!(
+            item.action,
+            NotificationAction::OpenThread {
+                thread_id: child_thread()
+            }
+        );
+        assert!(item.resolved_at.is_none(), "a pending gate is actionable");
+        assert_eq!(
+            item.source.lifecycle_ref.as_ref().map(|r| r.as_str()),
+            Some("gate:approval-1"),
+            "the gate ref rides on the item so a later gate can be told apart"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_child_auth_gate_publishes_authentication_required() {
+        let inbox = inbox();
+        let observer = RunOutcomeProcessCommitObserver::new(
+            Arc::clone(&inbox) as Arc<dyn NotificationInboxStorePort>,
+            Arc::new(InMemorySessionThreadService::default()) as Arc<dyn SessionThreadService>,
+        );
+
+        observer
+            .observe_process_commit(child_commit(
+                TurnRunId::new(),
+                ProcessLifecycleStatus::Suspended,
+                ProcessJournalKind::Suspended,
+                Some(gate_suspension(
+                    ProcessSuspensionKind::Authorization,
+                    "gate:auth-1",
+                )),
+            ))
+            .await
+            .expect("child auth suspension");
+
+        assert_eq!(
+            records(inbox.as_ref()).await,
+            vec![NotificationKind::AuthenticationRequired]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_child_suspended_on_anything_but_a_gate_publishes_nothing() {
+        let inbox = inbox();
+        let observer = RunOutcomeProcessCommitObserver::new(
+            Arc::clone(&inbox) as Arc<dyn NotificationInboxStorePort>,
+            Arc::new(InMemorySessionThreadService::default()) as Arc<dyn SessionThreadService>,
+        );
+
+        for kind in [
+            ProcessSuspensionKind::Resource,
+            ProcessSuspensionKind::AwaitingChildProcess,
+            ProcessSuspensionKind::ExternalTool,
+        ] {
+            observer
+                .observe_process_commit(child_commit(
+                    TurnRunId::new(),
+                    ProcessLifecycleStatus::Suspended,
+                    ProcessJournalKind::Suspended,
+                    Some(gate_suspension(kind, "gate:other")),
+                ))
+                .await
+                .expect("non-gate child suspension is screened, not an error");
+        }
+        observer
+            .observe_process_commit(child_commit(
+                TurnRunId::new(),
+                ProcessLifecycleStatus::Completed,
+                ProcessJournalKind::Completed,
+                None,
+            ))
+            .await
+            .expect("child completion is delivered by the await edge, not the inbox");
+
+        assert!(records(inbox.as_ref()).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_child_gate_item_resolves_when_the_child_resumes_or_ends() {
+        let inbox = inbox();
+        let observer = RunOutcomeProcessCommitObserver::new(
+            Arc::clone(&inbox) as Arc<dyn NotificationInboxStorePort>,
+            Arc::new(InMemorySessionThreadService::default()) as Arc<dyn SessionThreadService>,
+        );
+        let resumed_child = TurnRunId::new();
+        let cancelled_child = TurnRunId::new();
+
+        for run in [resumed_child, cancelled_child] {
+            observer
+                .observe_process_commit(child_commit(
+                    run,
+                    ProcessLifecycleStatus::Suspended,
+                    ProcessJournalKind::Suspended,
+                    Some(gate_suspension(
+                        ProcessSuspensionKind::Approval,
+                        "gate:approval-1",
+                    )),
+                ))
+                .await
+                .expect("child approval suspension");
+        }
+        observer
+            .observe_process_commit(child_commit(
+                resumed_child,
+                ProcessLifecycleStatus::Running,
+                ProcessJournalKind::Resumed,
+                None,
+            ))
+            .await
+            .expect("child resumed after the decision");
+        observer
+            .observe_process_commit(child_commit(
+                cancelled_child,
+                ProcessLifecycleStatus::Cancelled,
+                ProcessJournalKind::Cancelled,
+                None,
+            ))
+            .await
+            .expect("child cancelled while gated");
+
+        let page = list_all(inbox.as_ref()).await;
+        assert_eq!(page.len(), 2);
+        assert!(
+            page.iter().all(|item| item.resolved_at.is_some()),
+            "a decided or dead child gate must not stay actionable: {page:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_root_approval_gate_still_publishes_nothing_durable() {
+        let inbox = inbox();
+        let observer = RunOutcomeProcessCommitObserver::new(
+            Arc::clone(&inbox) as Arc<dyn NotificationInboxStorePort>,
+            Arc::new(InMemorySessionThreadService::default()) as Arc<dyn SessionThreadService>,
+        );
+        let mut root = commit(
+            TurnRunId::new(),
+            ProcessLifecycleStatus::Suspended,
+            ProcessJournalKind::Suspended,
+            "web_ui",
+        );
+        root.state.suspension = Some(gate_suspension(
+            ProcessSuspensionKind::Approval,
+            "gate:root",
+        ));
+
+        observer
+            .observe_process_commit(root)
+            .await
+            .expect("root approval suspension");
+
+        assert!(
+            records(inbox.as_ref()).await.is_empty(),
+            "root approval prompts stay with the live projection; this slice only widens child gates"
         );
     }
 }

--- a/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
@@ -163,11 +163,19 @@ impl RunOutcomeProcessCommitObserver {
                     thread_id: Some(thread_id.clone()),
                     turn_run_id: Some(run_id),
                     lifecycle_ref: Some(lifecycle_ref),
-                    credential_providers: suspension
-                        .credential_requirements
-                        .iter()
-                        .map(|requirement| requirement.provider.clone())
-                        .collect(),
+                    // `NotificationSource::credential_providers` is contracted
+                    // (`ironclaw_notifications::types`) to stay empty for
+                    // non-auth notifications and legacy records; populate it
+                    // only for the auth-gate kind.
+                    credential_providers: if kind == NotificationKind::AuthenticationRequired {
+                        suspension
+                            .credential_requirements
+                            .iter()
+                            .map(|requirement| requirement.provider.clone())
+                            .collect()
+                    } else {
+                        Vec::new()
+                    },
                 },
                 action: NotificationAction::OpenThread { thread_id },
                 initial_state: NotificationInitialState::Open,
@@ -272,7 +280,7 @@ impl RunOutcomeProcessCommitObserver {
         &self,
         snapshot: &JournaledProcessSnapshot,
         run_id: TurnRunId,
-        kind: NotificationKind,
+        kinds: &[NotificationKind],
         occurred_at: Timestamp,
     ) -> Result<(), String> {
         // Reconcile by the notification's stable run identity; paging preserves
@@ -284,15 +292,20 @@ impl RunOutcomeProcessCommitObserver {
             tenant_id: snapshot.scope.tenant_id.clone(),
             user_id: owner_user_id,
         };
-        // A later auth gate can already be current by the time an older
-        // Resumed commit arrives. Only auth reconciliation preserves it;
-        // terminal approval reconciliation closes every open gate for the run.
-        let current_auth_gate_ref = match (kind, self.process_journal_source.as_deref()) {
-            (NotificationKind::AuthenticationRequired, Some(source)) => {
-                Self::current_gate_ref(source, snapshot, kind).await?
-            }
-            _ => None,
-        };
+        // A later gate of a given kind can already be current by the time an
+        // older Resumed commit arrives; preservation applies per kind, to
+        // every kind requested here, not only auth. On a terminal commit the
+        // process is no longer Suspended, so `current_gate_ref` returns None
+        // for every kind and reconciliation still closes every open gate for
+        // the run, exactly as before.
+        let mut current_gate_refs = Vec::with_capacity(kinds.len());
+        for &kind in kinds {
+            let current_gate_ref = match self.process_journal_source.as_deref() {
+                Some(source) => Self::current_gate_ref(source, snapshot, kind).await?,
+                None => None,
+            };
+            current_gate_refs.push((kind, current_gate_ref));
+        }
         let mut cursor = None;
         loop {
             let page = self
@@ -304,19 +317,20 @@ impl RunOutcomeProcessCommitObserver {
                     include_archived: true,
                 })
                 .await
-                .map_err(|error| format!("list {kind:?} notifications for run failed: {error}"))?;
+                .map_err(|error| format!("list {kinds:?} notifications for run failed: {error}"))?;
             for notification in page.notifications {
-                let is_current_auth_gate = current_auth_gate_ref.as_ref().is_some_and(|gate_ref| {
-                    notification
-                        .source
-                        .lifecycle_ref
-                        .as_ref()
-                        .is_some_and(|lifecycle_ref| lifecycle_ref.as_str() == gate_ref.as_str())
+                let is_current_gate = current_gate_refs.iter().any(|(kind, gate_ref)| {
+                    *kind == notification.kind
+                        && gate_ref.as_ref().is_some_and(|gate_ref| {
+                            notification.source.lifecycle_ref.as_ref().is_some_and(
+                                |lifecycle_ref| lifecycle_ref.as_str() == gate_ref.as_str(),
+                            )
+                        })
                 });
-                if notification.kind == kind
+                if kinds.contains(&notification.kind)
                     && notification.source.turn_run_id == Some(run_id)
                     && notification.resolved_at.is_none()
-                    && !is_current_auth_gate
+                    && !is_current_gate
                 {
                     match self
                         .inbox
@@ -330,7 +344,7 @@ impl RunOutcomeProcessCommitObserver {
                         Ok(_) | Err(NotificationInboxError::NotificationNotFound) => {}
                         Err(error) => {
                             return Err(format!(
-                                "resolve {kind:?} notification for run failed: {error}"
+                                "resolve {kinds:?} notification for run failed: {error}"
                             ));
                         }
                     }
@@ -341,7 +355,7 @@ impl RunOutcomeProcessCommitObserver {
             };
             if cursor.as_ref() == Some(&next_cursor) {
                 return Err(format!(
-                    "{kind:?} notification pagination cursor did not advance"
+                    "{kinds:?} notification pagination cursor did not advance"
                 ));
             }
             cursor = Some(next_cursor);
@@ -541,7 +555,7 @@ impl ProcessJournalCommitObserver for RunOutcomeProcessCommitObserver {
             self.resolve_open_run_notifications(
                 &commit.state,
                 run_id,
-                NotificationKind::AuthenticationRequired,
+                &[NotificationKind::AuthenticationRequired],
                 occurred_at,
             )
             .await?;
@@ -676,31 +690,27 @@ impl RunOutcomeProcessCommitObserver {
         if !resumed && !commit.state.status.is_terminal() {
             return Ok(());
         }
-        // ponytail: two inbox scans per child resume/terminal (the root-run
-        // path pays one per Resumed today). Ceiling: a parent with hundreds of
-        // children scans a large inbox hundreds of times. Upgrade path:
+        // ponytail: one inbox scan per child resume/terminal today (down from
+        // two). Ceiling: reconciliation still pages the recipient's whole
+        // inbox on every child resume/terminal, so a parent with hundreds of
+        // children still scans a large inbox hundreds of times. Upgrade path:
         // resolve by deterministic id (`run_notification_inbox_id`) once the
         // terminal snapshot carries the gate_ref it settled, or an inbox index
         // by run id.
         // An approval is decided either way once the child resumes; a denied
         // auth resume keeps the auth item actionable until a verified recovery,
         // exactly as the root-run path does.
-        self.resolve_open_run_notifications(
-            &commit.state,
-            run_id,
-            NotificationKind::ApprovalRequired,
-            occurred_at,
-        )
-        .await?;
-        if !resumed || metadata.resume_disposition != Some(GateResumeDisposition::Denied) {
-            self.resolve_open_run_notifications(
-                &commit.state,
-                run_id,
-                NotificationKind::AuthenticationRequired,
-                occurred_at,
-            )
+        let kinds: &[NotificationKind] =
+            if resumed && metadata.resume_disposition == Some(GateResumeDisposition::Denied) {
+                &[NotificationKind::ApprovalRequired]
+            } else {
+                &[
+                    NotificationKind::ApprovalRequired,
+                    NotificationKind::AuthenticationRequired,
+                ]
+            };
+        self.resolve_open_run_notifications(&commit.state, run_id, kinds, occurred_at)
             .await?;
-        }
         Ok(())
     }
 }
@@ -743,7 +753,7 @@ impl ProcessJournalCommitObserver for ApprovalNotificationBackfillProcessCommitO
             .resolve_open_run_notifications(
                 &commit.state,
                 run_id,
-                NotificationKind::ApprovalRequired,
+                &[NotificationKind::ApprovalRequired],
                 occurred_at,
             )
             .await
@@ -1069,7 +1079,9 @@ mod tests {
         Fault, FaultInjecting, FilesystemOperation, InMemoryBackend, ScopedFilesystem,
     };
     use ironclaw_host_api::{
-        ids::{AgentId, ProcessId, TenantId, ThreadId, UserId},
+        capability::RuntimeCredentialAccountSetup,
+        decision::RuntimeCredentialAuthRequirement,
+        ids::{AgentId, ExtensionId, ProcessId, TenantId, ThreadId, UserId, VendorId},
         mount::{MountGrant, MountPermissions, MountView},
         path::{MountAlias, VirtualPath},
         resource::ResourceScope,
@@ -3181,6 +3193,202 @@ mod tests {
         assert!(
             records(inbox.as_ref()).await.is_empty(),
             "root approval prompts stay with the live projection; this slice only widens child gates"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_denied_child_auth_resume_keeps_the_item_actionable_until_recovery() {
+        let inbox = inbox();
+        let observer = RunOutcomeProcessCommitObserver::new(
+            Arc::clone(&inbox) as Arc<dyn NotificationInboxStorePort>,
+            Arc::new(InMemorySessionThreadService::default()) as Arc<dyn SessionThreadService>,
+        );
+        let child_run = TurnRunId::new();
+
+        observer
+            .observe_process_commit(child_commit(
+                child_run,
+                ProcessLifecycleStatus::Suspended,
+                ProcessJournalKind::Suspended,
+                Some(gate_suspension(
+                    ProcessSuspensionKind::Authorization,
+                    "gate:child-auth-denied-then-authorized",
+                )),
+            ))
+            .await
+            .expect("publish child auth notification");
+
+        let mut denied = child_commit(
+            child_run,
+            ProcessLifecycleStatus::Queued,
+            ProcessJournalKind::Resumed,
+            None,
+        );
+        denied.state.metadata["agent_turn"]["auth_resume_disposition"] = json!("denied");
+        observer
+            .observe_process_commit(denied)
+            .await
+            .expect("observe denied child auth resume");
+
+        let denied_page = list_all(inbox.as_ref()).await;
+        let denied_item = denied_page
+            .iter()
+            .find(|item| item.kind == NotificationKind::AuthenticationRequired)
+            .expect("auth item present after denial");
+        assert!(
+            denied_item.resolved_at.is_none(),
+            "denial does not prove credential recovery"
+        );
+
+        observer
+            .observe_process_commit(child_commit(
+                child_run,
+                ProcessLifecycleStatus::Queued,
+                ProcessJournalKind::Resumed,
+                None,
+            ))
+            .await
+            .expect("observe verified child auth resume");
+
+        let recovered_page = list_all(inbox.as_ref()).await;
+        let recovered_item = recovered_page
+            .iter()
+            .find(|item| item.kind == NotificationKind::AuthenticationRequired)
+            .expect("auth item present after recovery");
+        assert!(
+            recovered_item.resolved_at.is_some(),
+            "verified recovery closes the notification"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stale_child_resume_replay_keeps_the_current_approval_gate_actionable() {
+        let inbox = inbox();
+        let child_run = TurnRunId::new();
+        let gate_a = "gate:child-approval-a";
+        let gate_b = "gate:child-approval-b";
+
+        let suspended_a = child_commit(
+            child_run,
+            ProcessLifecycleStatus::Suspended,
+            ProcessJournalKind::Suspended,
+            Some(gate_suspension(ProcessSuspensionKind::Approval, gate_a)),
+        );
+        let mut suspended_b = suspended_a.clone();
+        suspended_b.state.suspension =
+            Some(gate_suspension(ProcessSuspensionKind::Approval, gate_b));
+
+        let publisher = RunOutcomeProcessCommitObserver::new(
+            Arc::clone(&inbox) as Arc<dyn NotificationInboxStorePort>,
+            Arc::new(InMemorySessionThreadService::default()) as Arc<dyn SessionThreadService>,
+        );
+        publisher
+            .observe_process_commit(suspended_a.clone())
+            .await
+            .expect("publish gate A");
+        publisher
+            .observe_process_commit(suspended_b.clone())
+            .await
+            .expect("publish gate B before the stale resume for gate A is delivered");
+
+        let observer = RunOutcomeProcessCommitObserver::new(
+            Arc::clone(&inbox) as Arc<dyn NotificationInboxStorePort>,
+            Arc::new(InMemorySessionThreadService::default()) as Arc<dyn SessionThreadService>,
+        )
+        .with_process_journal_source(Arc::new(CurrentProcessSource::new(suspended_b.state)));
+
+        let mut resumed_stale = suspended_a;
+        resumed_stale.kind = ProcessJournalKind::Resumed;
+        resumed_stale.state.status = ProcessLifecycleStatus::Queued;
+        resumed_stale.state.suspension = None;
+        observer
+            .observe_process_commit(resumed_stale)
+            .await
+            .expect("reconcile the stale resume for gate A");
+
+        let page = list_all(inbox.as_ref()).await;
+        let mut gate_a_resolved = false;
+        let mut gate_b_open = false;
+        for notification in page {
+            let lifecycle_ref = notification
+                .source
+                .lifecycle_ref
+                .as_ref()
+                .map(LifecycleRef::as_str);
+            if lifecycle_ref == Some(gate_a) {
+                gate_a_resolved = notification.resolved_at.is_some();
+            }
+            if lifecycle_ref == Some(gate_b) {
+                gate_b_open = notification.resolved_at.is_none();
+            }
+        }
+        assert!(gate_a_resolved, "the stale resumed gate must be closed");
+        assert!(
+            gate_b_open,
+            "a stale resume replay must not close the run's current approval gate"
+        );
+    }
+
+    fn credential_requirement() -> RuntimeCredentialAuthRequirement {
+        RuntimeCredentialAuthRequirement {
+            provider: VendorId::new("slack").expect("provider id"),
+            setup: RuntimeCredentialAccountSetup::OAuth { scopes: Vec::new() },
+            requester_extension: ExtensionId::new("slack").expect("extension id"),
+            provider_scopes: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn an_approval_gate_notification_carries_no_credential_providers() {
+        let inbox = inbox();
+        let observer = RunOutcomeProcessCommitObserver::new(
+            Arc::clone(&inbox) as Arc<dyn NotificationInboxStorePort>,
+            Arc::new(InMemorySessionThreadService::default()) as Arc<dyn SessionThreadService>,
+        );
+
+        let mut approval_suspension =
+            gate_suspension(ProcessSuspensionKind::Approval, "gate:approval-creds");
+        approval_suspension.credential_requirements = vec![credential_requirement()];
+        observer
+            .observe_process_commit(child_commit(
+                TurnRunId::new(),
+                ProcessLifecycleStatus::Suspended,
+                ProcessJournalKind::Suspended,
+                Some(approval_suspension),
+            ))
+            .await
+            .expect("child approval suspension with credential requirements");
+
+        let mut auth_suspension =
+            gate_suspension(ProcessSuspensionKind::Authorization, "gate:auth-creds");
+        auth_suspension.credential_requirements = vec![credential_requirement()];
+        observer
+            .observe_process_commit(child_commit(
+                TurnRunId::new(),
+                ProcessLifecycleStatus::Suspended,
+                ProcessJournalKind::Suspended,
+                Some(auth_suspension),
+            ))
+            .await
+            .expect("child auth suspension with credential requirements");
+
+        let page = list_all(inbox.as_ref()).await;
+        let approval_item = page
+            .iter()
+            .find(|item| item.kind == NotificationKind::ApprovalRequired)
+            .expect("approval item present");
+        assert!(
+            approval_item.source.credential_providers.is_empty(),
+            "approval notifications must not carry credential providers"
+        );
+        let auth_item = page
+            .iter()
+            .find(|item| item.kind == NotificationKind::AuthenticationRequired)
+            .expect("auth item present");
+        assert_eq!(
+            auth_item.source.credential_providers.len(),
+            1,
+            "auth notifications still carry credential providers"
         );
     }
 }

--- a/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
@@ -101,32 +101,34 @@ impl RunOutcomeProcessCommitObserver {
         Ok(())
     }
 
-    async fn publish_authentication_required(
+    async fn publish_gate_required(
         inbox: &dyn NotificationInboxStorePort,
         process_journal_source: Option<
             &dyn ProcessJournalSource<Error = ironclaw_turns::TurnError>,
         >,
         snapshot: &JournaledProcessSnapshot,
         run_id: TurnRunId,
+        kind: NotificationKind,
         occurred_at: Timestamp,
     ) -> Result<(), String> {
         let Some(suspension) = snapshot.suspension.as_ref() else {
             return Ok(());
         };
-        if suspension.kind != ProcessSuspensionKind::Authorization {
+        if gate_notification_kind(suspension.kind) != Some(kind) {
             return Ok(());
         }
         let Some(gate_ref) = suspension.gate_ref.as_ref() else {
-            // A gate-less auth suspension cannot be resumed from the product
+            // A gate-less suspension cannot be resumed from the product
             // surface, so publishing an actionable notification would strand
             // an item the user cannot complete.
             return Ok(());
         };
-        if !Self::auth_gate_is_current(process_journal_source, snapshot, gate_ref).await? {
-            return Self::resolve_authentication_required(
+        if !Self::gate_is_current(process_journal_source, snapshot, kind, gate_ref).await? {
+            return Self::resolve_gate_required(
                 inbox,
                 snapshot,
                 run_id,
+                kind,
                 gate_ref,
                 occurred_at,
             )
@@ -136,19 +138,16 @@ impl RunOutcomeProcessCommitObserver {
             .scope
             .thread_id
             .clone()
-            .ok_or_else(|| "eligible auth suspension has no thread id".to_string())?;
+            .ok_or_else(|| "eligible gate suspension has no thread id".to_string())?;
         let owner_user_id = snapshot
             .owner_user_id
             .clone()
-            .ok_or_else(|| "eligible auth suspension has no owner".to_string())?;
+            .ok_or_else(|| "eligible gate suspension has no owner".to_string())?;
         let lifecycle_ref = LifecycleRef::new(gate_ref.as_str())
-            .map_err(|error| format!("build auth lifecycle reference failed: {error}"))?;
-        let notification_id = crate::run_delivery::run_notification_inbox_id(
-            run_id,
-            NotificationKind::AuthenticationRequired,
-            Some(gate_ref.as_str()),
-        )
-        .map_err(|error| format!("build auth notification id failed: {error}"))?;
+            .map_err(|error| format!("build gate lifecycle reference failed: {error}"))?;
+        let notification_id =
+            crate::run_delivery::run_notification_inbox_id(run_id, kind, Some(gate_ref.as_str()))
+                .map_err(|error| format!("build gate notification id failed: {error}"))?;
         let notification_id_for_reopen = notification_id.clone();
         let recipient = NotificationRecipient {
             tenant_id: snapshot.scope.tenant_id.clone(),
@@ -158,7 +157,7 @@ impl RunOutcomeProcessCommitObserver {
             .publish(PublishNotificationRequest {
                 id: notification_id,
                 recipient: recipient.clone(),
-                kind: NotificationKind::AuthenticationRequired,
+                kind,
                 severity: NotificationSeverity::Warning,
                 source: NotificationSource {
                     thread_id: Some(thread_id.clone()),
@@ -175,7 +174,7 @@ impl RunOutcomeProcessCommitObserver {
                 occurred_at,
             })
             .await
-            .map_err(|error| format!("publish auth notification failed: {error}"))?;
+            .map_err(|error| format!("publish gate notification failed: {error}"))?;
         // A verified resume may be followed by the same deterministic gate
         // becoming current again. Publication must remain a no-op for ordinary
         // retries, so the authoritative Suspended transition explicitly
@@ -187,36 +186,38 @@ impl RunOutcomeProcessCommitObserver {
                 occurred_at,
             })
             .await
-            .map_err(|error| format!("reopen auth notification failed: {error}"))?;
+            .map_err(|error| format!("reopen gate notification failed: {error}"))?;
         // The continuation can settle the gate between the pre-publication
         // state read and the Inbox CAS. Re-read after the write and retire the
         // just-published record if recovery won that race.
-        if !Self::auth_gate_is_current(process_journal_source, snapshot, gate_ref).await? {
-            Self::resolve_authentication_required(inbox, snapshot, run_id, gate_ref, occurred_at)
+        if !Self::gate_is_current(process_journal_source, snapshot, kind, gate_ref).await? {
+            Self::resolve_gate_required(inbox, snapshot, run_id, kind, gate_ref, occurred_at)
                 .await?;
         }
         Ok(())
     }
 
-    async fn auth_gate_is_current(
+    async fn gate_is_current(
         process_journal_source: Option<
             &dyn ProcessJournalSource<Error = ironclaw_turns::TurnError>,
         >,
         snapshot: &JournaledProcessSnapshot,
+        kind: NotificationKind,
         gate_ref: &ironclaw_host_api::turn::TurnGateRef,
     ) -> Result<bool, String> {
         let Some(source) = process_journal_source else {
             return Ok(true);
         };
-        Ok(Self::current_auth_gate_ref(source, snapshot)
+        Ok(Self::current_gate_ref(source, snapshot, kind)
             .await?
             .as_ref()
             == Some(gate_ref))
     }
 
-    async fn current_auth_gate_ref(
+    async fn current_gate_ref(
         source: &dyn ProcessJournalSource<Error = ironclaw_turns::TurnError>,
         snapshot: &JournaledProcessSnapshot,
+        kind: NotificationKind,
     ) -> Result<Option<ironclaw_host_api::turn::TurnGateRef>, String> {
         let current = source
             .get_process_snapshot(GetProcessSnapshotRequest {
@@ -224,35 +225,33 @@ impl RunOutcomeProcessCommitObserver {
                 process_id: snapshot.process_id,
             })
             .await
-            .map_err(|error| format!("read current auth process state failed: {error}"))?;
+            .map_err(|error| format!("read current gate process state failed: {error}"))?;
         if current.status != ProcessLifecycleStatus::Suspended {
             return Ok(None);
         }
         let Some(suspension) = current.suspension else {
             return Ok(None);
         };
-        if suspension.kind != ProcessSuspensionKind::Authorization {
+        if gate_notification_kind(suspension.kind) != Some(kind) {
             return Ok(None);
         }
         Ok(suspension.gate_ref)
     }
 
-    async fn resolve_authentication_required(
+    async fn resolve_gate_required(
         inbox: &dyn NotificationInboxStorePort,
         snapshot: &JournaledProcessSnapshot,
         run_id: TurnRunId,
+        kind: NotificationKind,
         gate_ref: &ironclaw_host_api::turn::TurnGateRef,
         occurred_at: Timestamp,
     ) -> Result<(), String> {
         let Some(owner_user_id) = snapshot.owner_user_id.clone() else {
             return Ok(());
         };
-        let notification_id = crate::run_delivery::run_notification_inbox_id(
-            run_id,
-            NotificationKind::AuthenticationRequired,
-            Some(gate_ref.as_str()),
-        )
-        .map_err(|error| format!("build auth notification id failed: {error}"))?;
+        let notification_id =
+            crate::run_delivery::run_notification_inbox_id(run_id, kind, Some(gate_ref.as_str()))
+                .map_err(|error| format!("build gate notification id failed: {error}"))?;
         match inbox
             .resolve(NotificationMutationRequest {
                 recipient: NotificationRecipient {
@@ -265,7 +264,7 @@ impl RunOutcomeProcessCommitObserver {
             .await
         {
             Ok(_) | Err(NotificationInboxError::NotificationNotFound) => Ok(()),
-            Err(error) => Err(format!("resolve auth notification failed: {error}")),
+            Err(error) => Err(format!("resolve gate notification failed: {error}")),
         }
     }
 
@@ -290,7 +289,7 @@ impl RunOutcomeProcessCommitObserver {
         // terminal approval reconciliation closes every open gate for the run.
         let current_auth_gate_ref = match (kind, self.process_journal_source.as_deref()) {
             (NotificationKind::AuthenticationRequired, Some(source)) => {
-                Self::current_auth_gate_ref(source, snapshot).await?
+                Self::current_gate_ref(source, snapshot, kind).await?
             }
             _ => None,
         };
@@ -547,11 +546,12 @@ impl ProcessJournalCommitObserver for RunOutcomeProcessCommitObserver {
         if commit.kind == ProcessJournalKind::Suspended
             && commit.state.status == ProcessLifecycleStatus::Suspended
         {
-            Self::publish_authentication_required(
+            Self::publish_gate_required(
                 self.inbox.as_ref(),
                 self.process_journal_source.as_deref(),
                 &commit.state,
                 run_id,
+                NotificationKind::AuthenticationRequired,
                 occurred_at,
             )
             .await?;
@@ -717,11 +717,12 @@ impl ProcessJournalCommitObserver for AuthNotificationBackfillProcessCommitObser
         }
         let run_id = TurnRunId::from_uuid(commit.state.process_id.as_uuid());
         let occurred_at = commit.occurred_at.unwrap_or(commit.state.created_at);
-        RunOutcomeProcessCommitObserver::publish_authentication_required(
+        RunOutcomeProcessCommitObserver::publish_gate_required(
             self.inbox.as_ref(),
             Some(self.process_journal_source.as_ref()),
             &commit.state,
             run_id,
+            NotificationKind::AuthenticationRequired,
             occurred_at,
         )
         .await
@@ -843,19 +844,11 @@ struct OutcomeProductContext {
     execution_policy: Option<TurnExecutionPolicy>,
 }
 
-fn eligible_user_run(snapshot: &JournaledProcessSnapshot) -> Option<OutcomeMetadata> {
-    if snapshot.process_kind != ProcessKind::AgentTurn
-        || snapshot.parent_process_id.is_some()
-        || snapshot.owner_user_id.is_none()
-        || snapshot.scope.thread_id.is_none()
-        || snapshot.scope.agent_id.is_none()
-    {
-        return None;
-    }
+fn parse_outcome_metadata(snapshot: &JournaledProcessSnapshot) -> Option<OutcomeMetadata> {
     // silent-ok: eligibility screening. Journal metadata this observer cannot
     // read describes a process it does not own, so the absence of a notification
     // is the correct outcome rather than a failure to report; the cause is
-    // recorded above before it is dropped.
+    // recorded before it is dropped.
     let envelope = serde_json::from_value::<OutcomeMetadataEnvelope>(snapshot.metadata.clone())
         .map_err(|error| {
             tracing::debug!(
@@ -865,7 +858,19 @@ fn eligible_user_run(snapshot: &JournaledProcessSnapshot) -> Option<OutcomeMetad
             );
         })
         .ok()?;
-    let metadata = envelope.agent_turn;
+    Some(envelope.agent_turn)
+}
+
+fn eligible_user_run(snapshot: &JournaledProcessSnapshot) -> Option<OutcomeMetadata> {
+    if snapshot.process_kind != ProcessKind::AgentTurn
+        || snapshot.parent_process_id.is_some()
+        || snapshot.owner_user_id.is_none()
+        || snapshot.scope.thread_id.is_none()
+        || snapshot.scope.agent_id.is_none()
+    {
+        return None;
+    }
+    let metadata = parse_outcome_metadata(snapshot)?;
     if metadata.subagent_depth != 0 || metadata.ownerless_thread {
         return None;
     }
@@ -939,6 +944,20 @@ fn outcome_notification_id(
     let kind = kind.stable_key();
     NotificationId::new(format!("run:{run_id}:{kind}"))
         .map_err(|error| format!("build run outcome notification id failed: {error}"))
+}
+
+/// Maps a gate suspension to the inbox kind that announces it. `None` for
+/// suspensions no inbox item can act on (resource, dependent-run, external).
+fn gate_notification_kind(kind: ProcessSuspensionKind) -> Option<NotificationKind> {
+    match kind {
+        ProcessSuspensionKind::Approval => Some(NotificationKind::ApprovalRequired),
+        ProcessSuspensionKind::Authorization => Some(NotificationKind::AuthenticationRequired),
+        ProcessSuspensionKind::Resource
+        | ProcessSuspensionKind::AwaitingChildProcess
+        | ProcessSuspensionKind::ExternalTool
+        | ProcessSuspensionKind::ExternalProcess
+        | ProcessSuspensionKind::ExtensionDefined => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
+++ b/crates/product/ironclaw_assistant/src/run_outcome_observer.rs
@@ -328,6 +328,20 @@ impl RunOutcomeProcessCommitObserver {
         // reconciliation still closes every open gate for the run, exactly as
         // before. A run is suspended on at most one gate at a time, so one
         // read of the snapshot is enough to answer every requested kind.
+        //
+        // ponytail: this sample is taken before the listing loop, and
+        // `NotificationInboxStorePort::resolve` takes no precondition, so a
+        // gate that becomes current *after* the sample can still be resolved
+        // by the scan below — the child stays suspended with no actionable
+        // item. Ceiling: a duplicate or delayed `Resumed` delivery racing a
+        // re-suspension, which the journal store permits (its observer
+        // documents that entries "may be delivered twice"). The window is
+        // pre-existing — it predates per-kind preservation, which only
+        // widened an auth-only sample — and re-reading here would trade it
+        // for a reopen that can resurrect a legitimately decided gate.
+        // Upgrade path: a conditional (compare-and-set on lifecycle state)
+        // resolve on the inbox port, which fixes every caller at once
+        // instead of teaching this one to re-check.
         let current_gate = match self.process_journal_source.as_deref() {
             Some(source) => Self::current_gate(source, snapshot).await?,
             None => None,

--- a/crates/product/ironclaw_assistant/tests/child_gate_notification_registry.rs
+++ b/crates/product/ironclaw_assistant/tests/child_gate_notification_registry.rs
@@ -1,0 +1,267 @@
+//! Proves that a child agent-turn's approval suspension reaches the owner's
+//! inbox through the *real* process journal observer registry, not through a
+//! direct call into `RunOutcomeProcessCommitObserver::observe_process_commit`.
+//!
+//! What this test proves: a real `ProcessJournalStore` subscribes a real
+//! `RunOutcomeProcessCommitObserver` via `ProcessJournalObserverRegistry`,
+//! then a child-shaped `AgentTurn` process (`parent_process_id` set,
+//! `subagent_depth: 1`) is driven, through the store's own claim/suspend
+//! transitions, to a `ProcessJournalKind::Suspended` commit carrying a
+//! `ProcessSuspension { kind: Approval, .. }`. Delivery goes through the
+//! store's cursor-based fan-out to every subscribed observer — the same path
+//! a production journal store uses for every commit, not a synthetic
+//! `ProcessJournalCommit` handed to the observer directly. The resulting
+//! inbox item is then read back through a real `NotificationInboxStore`
+//! rather than an in-memory `Vec` a test controls.
+//!
+//! What this test deliberately does not prove: that production composition
+//! wires this observer onto a store that a *real spawned subagent* writes
+//! to. `spawn_subagent` is deny-filtered by default
+//! (`default_disabled_capability_ids`,
+//! `crates/loop/ironclaw_turn_runner/src/runtime.rs:294-299`), and
+//! `ironclaw_composition::build_runtime` reads that deny list internally with
+//! no input seam to override it
+//! (`crates/app/ironclaw_composition/src/runtime.rs:4055`), so no
+//! composition-tier test can spawn a real child process today. That
+//! end-to-end proof — a live `spawn_subagent` call landing a suspension in
+//! this same store under production wiring — waits on the R9 enable slice /
+//! R4 harness enablement work tracked alongside subagent rollout.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use ironclaw_assistant::RunOutcomeProcessCommitObserver;
+use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+use ironclaw_host_api::{
+    ids::{AgentId, ProcessId, TenantId, ThreadId, UserId},
+    mount::{MountGrant, MountPermissions, MountView},
+    path::{MountAlias, VirtualPath},
+    resource::ResourceScope,
+    turn::TurnGateRef,
+};
+use ironclaw_notifications::{
+    ListNotificationsRequest, NOTIFICATION_INBOX_MAX_RECORDS, NotificationAction,
+    NotificationInboxStore, NotificationInboxStorePort, NotificationKind, NotificationRecipient,
+};
+use ironclaw_processes::{
+    ClaimProcessesRequest, ProcessCheckpointRef, ProcessJournalObserverRegistry,
+    ProcessJournalStore, ProcessKind, ProcessSubmissionPort, ProcessSuspension,
+    ProcessSuspensionKind, ProcessTransitionPort, ProcessWorkerId, SubmitProcessRequest,
+    SuspendProcessRequest,
+};
+use ironclaw_threads::InMemorySessionThreadService;
+use serde_json::json;
+
+fn scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant-child-gate").expect("tenant"),
+        user_id: UserId::new("owner-child-gate").expect("user"),
+        agent_id: Some(AgentId::new("agent-child-gate").expect("agent")),
+        project_id: None,
+        mission_id: None,
+        thread_id: Some(ThreadId::new("child-thread-child-gate").expect("child thread")),
+        invocation_id: ironclaw_host_api::ids::InvocationId::new(),
+    }
+}
+
+fn process_journal_store() -> ProcessJournalStore<InMemoryBackend> {
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/processes").expect("process mount alias"),
+        VirtualPath::new("/engine/test/child-gate-processes").expect("process mount target"),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .expect("process mount view");
+    ProcessJournalStore::new(Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::new(InMemoryBackend::new()),
+        mounts,
+    )))
+}
+
+fn notification_inbox() -> Arc<NotificationInboxStore<InMemoryBackend>> {
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/notifications").expect("notification mount alias"),
+        VirtualPath::new("/engine/test/child-gate-notifications")
+            .expect("notification mount target"),
+        MountPermissions::read_write_list_delete(),
+    )])
+    .expect("notification mount view");
+    Arc::new(NotificationInboxStore::new(
+        Arc::new(ScopedFilesystem::with_fixed_view(
+            Arc::new(InMemoryBackend::new()),
+            mounts,
+        )),
+        NOTIFICATION_INBOX_MAX_RECORDS,
+    ))
+}
+
+#[tokio::test]
+async fn a_child_approval_suspension_reaches_the_owner_inbox_through_the_observer_registry() {
+    let store = process_journal_store();
+    let inbox = notification_inbox();
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let observer = Arc::new(RunOutcomeProcessCommitObserver::new(
+        Arc::clone(&inbox) as Arc<dyn NotificationInboxStorePort>,
+        thread_service as Arc<dyn ironclaw_threads::SessionThreadService>,
+    ));
+    // Subscribe through the real registry trait — the exact seam the finding
+    // says no test exercises.
+    ProcessJournalObserverRegistry::subscribe_process_observer(&store, observer)
+        .expect("subscribe run-outcome observer on the real registry");
+
+    let scope = scope();
+    let parent_process_id = ProcessId::new();
+    let child_process_id = ProcessId::new();
+
+    // A child's `parent_process_id` must reference a process the store
+    // already knows (`apply_submit`,
+    // crates/kernel/ironclaw_processes/src/journal_store/state.rs:334-339),
+    // so the parent is submitted first, as a standalone internal bookkeeping
+    // process in the same lineage scope.
+    store
+        .submit_process(SubmitProcessRequest {
+            process_id: parent_process_id,
+            process_kind: ProcessKind::Internal,
+            scope: scope.clone(),
+            exclusive_within_scope: false,
+            operation_id: None,
+            owner_user_id: Some(scope.user_id.clone()),
+            concurrency_class: None,
+            parent_process_id: None,
+            root_process_id: None,
+            spawn_tree_descendant_cap: None,
+            dependency: None,
+            checkpoint_ref: None,
+            input: None,
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        })
+        .await
+        .expect("submit parent process");
+
+    let metadata = json!({
+        "agent_turn": {
+            "product_context": { "origin": "web_ui" },
+            "execution_outcome": "result_available",
+            // Both signals the observer's `child_gate_run` predicate accepts
+            // are set so this fixture is unambiguously "a child".
+            "subagent_depth": 1,
+        }
+    });
+
+    // Submitting a fresh AgentTurn process (child-shaped: parent_process_id
+    // set, owner + thread + agent present) durably commits a `Submitted`
+    // journal row and is fanned out to the subscribed observer, which
+    // screens it out (no suspension yet) without publishing anything.
+    store
+        .submit_process(SubmitProcessRequest {
+            process_id: child_process_id,
+            process_kind: ProcessKind::AgentTurn,
+            scope: scope.clone(),
+            exclusive_within_scope: false,
+            operation_id: None,
+            owner_user_id: Some(scope.user_id.clone()),
+            concurrency_class: None,
+            parent_process_id: Some(parent_process_id),
+            root_process_id: Some(parent_process_id),
+            spawn_tree_descendant_cap: Some(1),
+            dependency: None,
+            checkpoint_ref: None,
+            input: None,
+            created_at: Utc::now(),
+            metadata: metadata.clone(),
+        })
+        .await
+        .expect("submit child agent-turn process");
+
+    // Claim-then-suspend is the route that is guaranteed to emit a
+    // `ProcessJournalKind::Suspended` journal row. `submit_process_at_edge`
+    // was considered and ruled out: it is hard-restricted to standalone
+    // `CapabilityInvocationState` bookkeeping processes and rejects any
+    // submission with `parent_process_id` set
+    // (`apply_submit_at_edge`, crates/kernel/ironclaw_processes/src/journal_store/state.rs:495-506),
+    // so it cannot represent a child `AgentTurn` at all, let alone drive one
+    // to `Suspended`.
+    let worker_id = ProcessWorkerId::from_trusted("child-gate-worker");
+    let claimed = store
+        .claim_next_processes(ClaimProcessesRequest {
+            worker_id: worker_id.clone(),
+            scope_filter: Some(scope.clone()),
+            process_id_filter: Some(child_process_id),
+            process_kind_filter: Some(ProcessKind::AgentTurn),
+            max_processes: 1,
+        })
+        .await
+        .expect("claim the child agent-turn process")
+        .pop()
+        .expect("child process is claimable");
+    assert_eq!(claimed.state.process_id, child_process_id);
+
+    let gate_ref = TurnGateRef::new("gate:child-approval-1").expect("gate ref");
+    let suspended = store
+        .suspend_process(SuspendProcessRequest {
+            process_id: child_process_id,
+            worker_id,
+            lease_token: claimed.lease_token,
+            checkpoint_ref: ProcessCheckpointRef::from_trusted("child-gate-checkpoint"),
+            suspension: ProcessSuspension {
+                kind: ProcessSuspensionKind::Approval,
+                gate_ref: Some(gate_ref.clone()),
+                activity_id: None,
+                credential_requirements: Vec::new(),
+                detail: None,
+            },
+            metadata: Some(metadata),
+        })
+        .await
+        .expect("suspend the child agent-turn process on an approval gate");
+    assert_eq!(
+        suspended.status,
+        ironclaw_processes::ProcessLifecycleStatus::Suspended
+    );
+
+    // Read the inbox back through its own store API — not a test-owned
+    // `Vec` the observer was handed a reference to.
+    let recipient = NotificationRecipient {
+        tenant_id: scope.tenant_id.clone(),
+        user_id: scope.user_id.clone(),
+    };
+    let page = inbox
+        .list(ListNotificationsRequest {
+            recipient,
+            limit: 16,
+            cursor: None,
+            include_archived: true,
+        })
+        .await
+        .expect("list owner inbox");
+
+    assert_eq!(
+        page.notifications.len(),
+        1,
+        "exactly one notification for the one child approval gate, got {:?}",
+        page.notifications
+    );
+    let item = &page.notifications[0];
+    assert_eq!(item.kind, NotificationKind::ApprovalRequired);
+    assert_eq!(
+        item.source.turn_run_id,
+        Some(ironclaw_host_api::turn::TurnRunId::from_uuid(
+            child_process_id.as_uuid()
+        ))
+    );
+    assert_eq!(item.source.thread_id, scope.thread_id.clone());
+    assert_eq!(
+        item.action,
+        NotificationAction::OpenThread {
+            thread_id: scope.thread_id.clone().expect("child thread id")
+        }
+    );
+    assert!(
+        item.resolved_at.is_none(),
+        "a pending child approval gate stays actionable in the owner's inbox"
+    );
+    assert!(
+        item.source.credential_providers.is_empty(),
+        "an approval gate is not an auth gate; it must not carry credential providers"
+    );
+}

--- a/docs/internal/reborn/subagent-spawn/README.md
+++ b/docs/internal/reborn/subagent-spawn/README.md
@@ -360,7 +360,7 @@ substitute for it.
    later run touches — the result row is already in the transcript, only the
    autonomous wake is lost. A cross-scope re-drive needs a partition-leading
    dependency query the kernel charter does not have today; it is R4 work
-   alongside boot-recovery fairness. restart re-drives every non-closed background edge
+   alongside boot-recovery fairness. The design intent, once built: restart re-drives every non-closed background edge
    (`Settled`, `ResultAppended`, `AttentionScheduled`) through the same
    recovery logic as the run-start sweep — `Settled`/`ResultAppended`
    re-enter the deliver path, **including activation of parked parents**

--- a/docs/internal/reborn/subagent-spawn/README.md
+++ b/docs/internal/reborn/subagent-spawn/README.md
@@ -651,7 +651,7 @@ work, in order — names map to the retired shape doc's slices for continuity:
 
 | # | Work | Contents | Was |
 | --- | --- | --- | --- |
-| R2 | **Background core** | Everything in §4.3 + integration tests: per-child beat, three-trigger healing, `ThreadBusy` heal, crash-replay idempotency, the failure-injection matrix. Plus a **concurrent-running-children cap** at spawn admission (same path as the descendant cap) — Claude Code's changelog shows this cap removed and re-added under production pressure; it is D10's "active children per parent" line made real — **shipped 2026-08 except the concurrent-running-children cap (open debt, own slice) and the boot pass (moved to R4, §4.2)** | slice 2 (reshaped: append model replaces wake-only Tasks 8–9) |
+| R2 | **Background core** | Everything in §4.3 + integration tests: per-child beat, three-trigger healing, `ThreadBusy` heal (sweep-based), crash-replay idempotency, the failure-injection matrix. Plus a **concurrent-running-children cap** at spawn admission (same path as the descendant cap) — Claude Code's changelog shows this cap removed and re-added under production pressure; it is D10's "active children per parent" line made real — **shipped 2026-08 except the concurrent-running-children cap (open debt, own slice) and the boot pass (moved to R4, §4.2)** | slice 2 (reshaped: append model replaces wake-only Tasks 8–9) |
 | R3 | **Gate escalation walk** | 3a: a blocked child's approval/auth gate reaches the parent's owner as an actionable inbox item opening the child thread (shipped 2026-09); 3b: verify/land the WebUI gate card on a hidden child thread opened by URL; R3 is a prerequisite of the R9 enable, not the enable itself | slice 4 |
 | R4 | **Counters, operator command, e2e revival** | `ResolveReport` counters; `ironclaw subagent edges`; un-ignore the five e2e tests via harness-side enablement; boot-recovery fairness | slice 5 |
 | R5 | **`subagent_inspect` + per-kind config** | Model-facing status/gate/byte-count metadata (never raw transcript); per-kind budget + model override. Plus the **degraded-result taxonomy**: `child_terminal_output` distinguishes clean success / partial-on-forced-cutoff / provider error — Claude Code shipped three separate fixes for children returning empty on rate-limit cutoff or fabricating success on API error; D10's lifecycle-taxonomy line; the parent model learns of a blocked child here | slice 6 |
@@ -754,9 +754,12 @@ change.
 
 ## 9. Part II — pending work
 
-R3 slice 3a shipped (2026-09; PR number recorded at merge). Next: 3b (WebUI
+R3 slice 3a shipped 2026-09, PR #8046. Next: 3b (WebUI
 gate card on a hidden child thread opened by URL — verify first, it may
 already render), then the two R2 debts as their own slices
-(concurrent-running-children cap at spawn admission; `ThreadBusy` re-enqueue
-in `activate_parked_parent`). Plans are written here, spec-first against
+(concurrent-running-children cap at spawn admission; the `ThreadBusy`
+immediate-re-enqueue optimization in `activate_parked_parent` — R2 already
+ships the sweep-based heal that parks and re-attends the edge; this debt is
+re-enqueueing into the now-live parent's queue right away instead of waiting
+for the next sweep). Plans are written here, spec-first against
 Part I, when a slice starts.

--- a/docs/internal/reborn/subagent-spawn/README.md
+++ b/docs/internal/reborn/subagent-spawn/README.md
@@ -183,6 +183,7 @@ scope nothing else touches stays blocked until some later spawn happens to
 touch that scope. A true startup/boot pass for background edges (which need
 one regardless, since they have no gate to block on) is new work owned by
 Part II Task 7; blocking-mode recovery remains lazy as described here.
+(status, 2026-09-02: the boot pass did not ship with R2 — see §4.2 trigger 3.)
 
 ### 2.6 Parallel children
 
@@ -352,7 +353,14 @@ substitute for it.
    `group_ref = "bg:{parent_thread_id}"` (§4.3), so the existing
    group-ref dependency query serves it; the batch is capped at
    `MAX_QUEUED_INPUTS_PER_RUN`.
-3. **Boot pass**: restart re-drives every non-closed background edge
+3. **Boot pass**: **Not shipped (2026-09-02).** R2 landed
+   triggers 1 and 2 only; a restart re-drives nothing by itself. The stranding
+   window is a refusal after a successful observer pass (`ThreadBusy` or a
+   transient activation error leaves the edge `ResultAppended`) on a thread no
+   later run touches — the result row is already in the transcript, only the
+   autonomous wake is lost. A cross-scope re-drive needs a partition-leading
+   dependency query the kernel charter does not have today; it is R4 work
+   alongside boot-recovery fairness. restart re-drives every non-closed background edge
    (`Settled`, `ResultAppended`, `AttentionScheduled`) through the same
    recovery logic as the run-start sweep — `Settled`/`ResultAppended`
    re-enter the deliver path, **including activation of parked parents**
@@ -482,9 +490,12 @@ auth gate.
 And the child-side gates: a child blocked on **its own** approval or auth
 gate has produced no terminal event, so its edge stays `Open` and nothing
 delivers — a blocking parent keeps waiting, a background parent keeps
-working. Today that block is silent from the parent's side; surfacing and
-escalating it to the parent is exactly R3 (the gate-escalation walk), and
-child gate state becomes inspectable at R5.
+working. Today that block is silent from the parent's side; R3 slice 3a
+(2026-09-02) surfaces a child's approval/auth gate to the parent's
+**human owner** as an actionable inbox item that opens the child thread
+(`run_outcome_observer.rs`, `observe_child_gate_commit`); the parent
+*model* learns of a blocked child at R5 (`subagent_inspect`), since it
+cannot act on it before R6/R8.
 
 ## 5. Decision log
 
@@ -563,7 +574,9 @@ the append-model design review.
   (authoring UX; `SubagentKindId` is already the primitive), and
   fleet-wide cross-session messaging (R6 covers the in-scope
   parent→child case). Evidence is changelog-grade — shipped-behavior
-  descriptions, not source.
+  descriptions, not source. (status, 2026-09-02: the cap did not ship with
+  R2 and is open R2 debt for its own follow-up slice — the descendant cap
+  is the only admission bound today.)
 - **D9 ◇ Not in scope**: `TurnOwner` vs `TurnThreadOwner` stay separate
   types (ownership shape vs resolution disposition); no stored counters;
   never append to `completion_observer.rs`; new files < 800 lines;
@@ -638,10 +651,10 @@ work, in order — names map to the retired shape doc's slices for continuity:
 
 | # | Work | Contents | Was |
 | --- | --- | --- | --- |
-| R2 | **Background core** | Everything in §4.3 + integration tests: per-child beat, three-trigger healing, `ThreadBusy` heal, crash-replay idempotency, the failure-injection matrix. Plus a **concurrent-running-children cap** at spawn admission (same path as the descendant cap) — Claude Code's changelog shows this cap removed and re-added under production pressure; it is D10's "active children per parent" line made real | slice 2 (reshaped: append model replaces wake-only Tasks 8–9) |
-| R3 | **Gate escalation walk** | A blocked child (approval/auth) escalates to its parent; prod-enable gate | slice 4 |
+| R2 | **Background core** | Everything in §4.3 + integration tests: per-child beat, three-trigger healing, `ThreadBusy` heal, crash-replay idempotency, the failure-injection matrix. Plus a **concurrent-running-children cap** at spawn admission (same path as the descendant cap) — Claude Code's changelog shows this cap removed and re-added under production pressure; it is D10's "active children per parent" line made real — **shipped 2026-08 except the concurrent-running-children cap (open debt, own slice) and the boot pass (moved to R4, §4.2)** | slice 2 (reshaped: append model replaces wake-only Tasks 8–9) |
+| R3 | **Gate escalation walk** | 3a: a blocked child's approval/auth gate reaches the parent's owner as an actionable inbox item opening the child thread (shipped 2026-09); 3b: verify/land the WebUI gate card on a hidden child thread opened by URL; R3 is a prerequisite of the R9 enable, not the enable itself | slice 4 |
 | R4 | **Counters, operator command, e2e revival** | `ResolveReport` counters; `ironclaw subagent edges`; un-ignore the five e2e tests via harness-side enablement; boot-recovery fairness | slice 5 |
-| R5 | **`subagent_inspect` + per-kind config** | Model-facing status/gate/byte-count metadata (never raw transcript); per-kind budget + model override. Plus the **degraded-result taxonomy**: `child_terminal_output` distinguishes clean success / partial-on-forced-cutoff / provider error — Claude Code shipped three separate fixes for children returning empty on rate-limit cutoff or fabricating success on API error; D10's lifecycle-taxonomy line | slice 6 |
+| R5 | **`subagent_inspect` + per-kind config** | Model-facing status/gate/byte-count metadata (never raw transcript); per-kind budget + model override. Plus the **degraded-result taxonomy**: `child_terminal_output` distinguishes clean success / partial-on-forced-cutoff / provider error — Claude Code shipped three separate fixes for children returning empty on rate-limit cutoff or fabricating success on API error; D10's lifecycle-taxonomy line; the parent model learns of a blocked child here | slice 6 |
 | R6 | **`subagent_extend` + human priority** | `activate(child, …, ParentAgent)` with consent-to-wake + budget window; `human_waiting` reservation marker | slice 7 |
 | R7 | **WebUI child tree** | `GET …/threads/{id}/children` lineage projection; `ThreadTree` sidebar; raw-vs-framed display rule; interrupt & take over | slice 8 |
 | R8 | **`subagent_cancel`** (security review) + **scan checkpoint** | Model-facing cancel with clean tree teardown; **budget breach halts running children through this same teardown path** (Claude Code's `--max-budget-usd` fix: denying new spawns is not enough); **re-decide D7** (drain-site scan) here, before enable | slice 9 (+ deferred slice 3) |
@@ -729,6 +742,7 @@ Things no slice may break; each is enforced or pinned today.
 | Integration scenarios (edges) | `tests/integration/subagent_await_edge.rs` (`reborn_integration_subagent_await_edge`) |
 | Disabled-capability pins | `tests/integration/tool_call.rs` |
 | E2E suite (ignored until R4) | `tests/reborn_subagent_spawn_e2e.rs` |
+| Child gate → owner inbox (R3 3a) | `crates/product/ironclaw_assistant/src/run_outcome_observer.rs` (`child_gate_run`, `observe_child_gate_commit`) |
 
 Family rules: `crates/loop/AGENTS.md` and per-crate `AGENTS.md`/`README.md`
 files govern placement; `tests/integration/AGENTS.md` governs scenario
@@ -738,27 +752,11 @@ change.
 ---
 
 
-## 9. Part II — pending work: R3 gate escalation walk
+## 9. Part II — pending work
 
-**R2 (background core) shipped as three slices (D13): the inert surface in
-PR #7788 (slice 2a); slice 2b, which makes background spawn return a receipt
-and deliver to a live parent; and slice 2c, which adds parked-parent
-activation, streak-cap deferral, the healing sweeps, and the
-failure-injection matrix — 2b and 2c both land in the slices-2b/2c PR that
-landed this paragraph.** Its implementation plan —
-receipt semantics, the durable delivery-chain state machine, the resolver's
-background tail, the run-start sweep, and the five integration scenarios
-pinning them (`tests/integration/subagent_await_edge.rs`) — is retired from
-this document; the shipped mechanism is Part I (§2, §4) and the code itself.
-
-**R3 (§6): a blocked child's own approval/auth gate escalates to its
-parent, plus the prod-enable gate that clears `builtin.spawn_subagent`'s
-deny-filter (§7's first invariant).** Today a child blocked on its own gate
-is silent from the parent's side (§4.6's closing paragraph): the edge stays
-`Open`, a blocking parent keeps waiting on its dependent-run gate, and a
-background parent keeps working with no visibility at all. R3's plan is not
-yet written — start from the §6 roadmap row, the §4.6 child-gate paragraph,
-and this document's own maintenance rule (§ "Replaces", top of file) when
-drafting it: task-by-task under `superpowers:subagent-driven-development` or
-`superpowers:executing-plans`, spec-first against Part I, pruned in turn when
-R3 ships.
+R3 slice 3a shipped (2026-09; PR number recorded at merge). Next: 3b (WebUI
+gate card on a hidden child thread opened by URL — verify first, it may
+already render), then the two R2 debts as their own slices
+(concurrent-running-children cap at spawn admission; `ThreadBusy` re-enqueue
+in `activate_parked_parent`). Plans are written here, spec-first against
+Part I, when a slice starts.


### PR DESCRIPTION
## Summary

- A subagent child run blocked on its own approval or credential gate was invisible: the durable inbox observer (`RunOutcomeProcessCommitObserver`) screens out every child run, child threads are hidden from listings, and the parent only hears about children when they finish. Nothing told anyone.
- The observer now has one child-only branch: `Suspended{Approval|Authorization}` on a child publishes the matching actionable `ApprovalRequired` / `AuthenticationRequired` inbox item for the owner, with `OpenThread` pointing at the child thread (readable by id under the owner's scope; the existing gate route resolves it there). `Resumed` or a terminal commit retires it. Child terminal outcomes stay off the inbox — R2 delivers them into the parent thread.
- Structural prep in its own commit: the auth-only publisher and its current-gate/resolve helpers take a `NotificationKind`; the agent-turn metadata parse is extracted. Both existing callers still pass the auth kind; behavior unchanged.
- Root-run behavior is unchanged and pinned (`a_root_approval_gate_still_publishes_nothing_durable`). `eligible_user_run` (four callers, including the backfill observers) is not widened. The observer id is unchanged, so no cursor replay on rolling upgrade.
- Design doc: R2's two unshipped promises are recorded honestly (boot pass → R4 work; concurrent-running-children cap → open R2 debt), §9 no longer claims R3 clears the deny filter, R3 is split into 3a (this PR) and 3b (verify the WebUI gate card on a hidden child thread opened by URL), parent-model awareness of a blocked child moves to R5.

Shape and audit record: recon found no test harness composes the product observers (`RebornIntegrationHarness` and `RebornBinaryE2EHarness` both assemble runtime parts without `ironclaw_composition::build_runtime`, the only place the observer is subscribed), so this slice pins at crate tier. The child-scope gate resolution the notification hands off to is already pinned by the ignored e2e `blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes`.

## Change Type

- [x] New feature
- [x] Refactor
- [x] Documentation

## Linked Issue

Related #4474 (background subagent umbrella). The R3 gate-escalation row of `docs/internal/reborn/subagent-spawn/README.md` §6 is the approved scope.

## Validation

- [x] `cargo fmt --all -- --check` (crate-scoped `cargo fmt --check` run per commit)
- [x] `cargo clippy -p ironclaw_assistant --tests -- -D warnings` (clean per commit)
- [x] `cargo build` (crate builds as part of the test runs)
- [x] Relevant tests pass: `cargo test -p ironclaw_assistant run_outcome_observer` — 26/26 (21 existing + 5 new); `cargo test -p ironclaw_assistant backfill` — green
- [ ] `--features integration`: Not applicable — no database-backed or runtime-integration behavior changed
- [x] Manual testing: none beyond the test module; `python3 scripts/ci/check-guidance.py` exit 0
- [ ] `pr-shepherd`: to run after CI

Full crate run `cargo test -p ironclaw_assistant`: every suite green except `reborn_services_contract::trace_reads_are_available_as_product_views`, which fails on this dev machine because `~/.ironclaw/trace_contributions/policy.json` enrolls the caller and the view then performs a network fetch — unrelated to this diff (the policy file has `enabled: true` and an ingestion endpoint; the view never touches this diff's code).

## Test Strategy

User behavior: a human who owns a parent conversation whose subagent child hits an approval or credential gate sees an actionable inbox item; opening it lands on the child thread where the existing gate card and resolve route work; the item retires when the child resumes or ends.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect (inbox publish/resolve)
- [ ] Persistence
- [x] Security or permissions (notification opens a hidden prepared-context thread by id — listing-only hiding, owner-scoped read; no new resolve path)
- [ ] External provider
- [x] Cross-component behavior (kernel process journal → product observer → notifications inbox)

Tests added or updated:
- Unit or contract: `crates/product/ironclaw_assistant/src/run_outcome_observer.rs` tests — `a_child_approval_gate_publishes_an_actionable_item_that_opens_the_child_thread`, `a_child_auth_gate_publishes_authentication_required`, `a_child_suspended_on_anything_but_a_gate_publishes_nothing`, `a_child_gate_item_resolves_when_the_child_resumes_or_ends`, `a_root_approval_gate_still_publishes_nothing_durable`
- Reborn integration: Not applicable — neither integration harness composes the product observers (they bypass `build_runtime`); wiring a harness seam is R4's e2e-revival work
- Recorded fixture: Not applicable — no model behavior
- Browser E2E: Not applicable here — the WebUI gate card on a hidden child thread is slice 3b and is explicitly marked unverified in the design doc
- Backend or runtime: Not applicable
- Live canary: Not applicable

What the tests prove: driven through `observe_process_commit` (the production entry point) against the real in-memory inbox store, a child gate commit yields exactly one open item with the child's thread id, run id, gate ref and the right kind; non-gate child suspensions and child completions yield nothing; resume and cancellation retire the item; a root approval suspension still publishes nothing durable; the existing 21 observer tests (root auth publish/reopen/resolve races, backfill) are unchanged and green.

Commands run: `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=4 cargo test -p ironclaw_assistant run_outcome_observer`; `… cargo test -p ironclaw_assistant backfill`; `… cargo clippy -p ironclaw_assistant --tests -- -D warnings`; `cargo fmt --check`; `python3 scripts/ci/check-guidance.py`; `cargo test -p ironclaw_assistant` (full crate, one environmental failure noted above).

## Security Impact

The notification carries references only (child thread id, child run id, gate ref) — no child text. Approving happens through the existing `resolve_gate` route on the child scope, authorized by the existing owner-scoped thread read; no second gate-resolution path. Child threads stay hidden from listings (`record_is_prepared_context_hidden` has two call sites, both listing filters). No authority flows through child content (subagent README §7).

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: none added.
- [x] Untrusted content enters prompts: none — no prompt or content path touched.
- [x] Hashes: none added.
- [x] New/changed variants: none; `gate_notification_kind` is a total match over `ProcessSuspensionKind`.
- [x] `serde(default)` fields: none added.
- [x] Bounds: the child branch reuses `resolve_open_run_notifications`' paged scan (`NOTIFICATION_PAGE_LIMIT_MAX`); the two-scans-per-child-event cost is marked with a `ponytail:` comment naming the ceiling and upgrade path.
- [x] Error classes: unchanged (`Result<(), String>` observer contract).
- [x] Names: unchanged trust boundary.

## Database Impact

None.

## Blast Radius

`crates/product/ironclaw_assistant/src/run_outcome_observer.rs` only (plus the design doc). Every commit on the process journal now runs one extra predicate (`child_gate_run`) before the existing screen; root commits parse agent-turn metadata twice (cheap, accepted). Children's `Resumed`/terminal commits now scan the owner's inbox twice (marked debt).

## Rollback Plan

Revert the branch; the observer id is unchanged so cursors are unaffected, and any child gate items already published simply stop being produced/retired (they can be resolved by hand from the inbox).

## Review Follow-Through

- Slice 3b: verify the WebUI chat page renders the gate card on a hidden child thread opened by URL (design doc §9).
- Open R2 debt, own slices: concurrent-running-children cap at spawn admission; `ThreadBusy` re-enqueue in `activate_parked_parent`; boot pass is R4.
- Deferred minors from review: no test pins an ownerless child gate commit specifically; two-scan cost per child event (ponytail).

---

**Review track**: B

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AF1ViBFqzwK3qAsi533h5x
