### PR TITLE
fix(reply): the answer is the current model call's text; earlier calls are narration

### DIFF
--- a/crates/contracts/ironclaw_extension_contracts/src/reply.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/reply.rs
@@ -45,6 +45,9 @@ pub const REPLY_DISPLAY_TEXT_MAX_BYTES: usize = 2 * 1024;
 pub const REPLY_DISPLAY_PREVIEW_MAX_BYTES: usize = 4 * 1024;
 /// Bound on one product-approved reasoning summary segment.
 pub const REPLY_REASONING_SEGMENT_MAX_BYTES: usize = 8 * 1024;
+/// Bound on one narration entry (the text of a model call the loop went on
+/// past); longer text is kept up to this bound on a character boundary.
+pub const REPLY_NARRATION_ENTRY_MAX_BYTES: usize = 8 * 1024;
 /// Bound on a reply/item identifier.
 pub const REPLY_ITEM_ID_MAX_BYTES: usize = 128;
 /// Bound on activity rows retained per document (older rows stay; later
@@ -52,6 +55,8 @@ pub const REPLY_ITEM_ID_MAX_BYTES: usize = 128;
 pub const REPLY_MAX_ACTIVITIES: usize = 256;
 /// Bound on retained reasoning summary segments.
 pub const REPLY_MAX_REASONING_SEGMENTS: usize = 128;
+/// Bound on retained narration entries (later ones are dropped).
+pub const REPLY_MAX_NARRATION_ENTRIES: usize = 32;
 /// Bound on final attachments.
 pub const REPLY_MAX_ATTACHMENTS: usize = 16;
 /// Bound on the adapter-owned checkpoint the host persists between
@@ -364,12 +369,17 @@ impl ReplyPhase {
     }
 }
 
-/// The answer as it currently stands.
+/// The answer as it currently stands: the text of the current model call.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReplyAnswer {
-    /// Cumulative text (progressive appends, then the canonical finalized
-    /// transcript text once the run finalizes it).
+    /// Cumulative text of the current model call (progressive appends, then
+    /// the canonical finalized transcript text once the run finalizes it).
     pub text: ReplyAnswerText,
+    /// Which model call's text this is. Every call the loop goes on past
+    /// ([`ReplyDocument::reset_answer`]) starts the next phase, so a surface
+    /// can key what it shows per phase instead of per run.
+    #[serde(default = "first_answer_phase")]
+    pub phase: u64,
     /// True once [`ReplyDocument::finalize_answer`] replaced the progressive
     /// text with the canonical transcript row. Progressive appends after that
     /// are ignored.
@@ -384,10 +394,25 @@ impl Default for ReplyAnswer {
     fn default() -> Self {
         Self {
             text: ReplyAnswerText(String::new()),
+            phase: first_answer_phase(),
             finalized: false,
             truncated: false,
         }
     }
+}
+
+fn first_answer_phase() -> u64 {
+    1
+}
+
+/// The text of one model call the loop went on past — narration such as
+/// "Let me check the workspace.", never the answer — kept under the phase it
+/// streamed as, so a surface that showed it as the provisional answer can
+/// re-home it, and a surface that never shows narration can ignore it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplyNarration {
+    pub phase: u64,
+    pub text: ReplyAnswerText,
 }
 
 /// Lifecycle state of one capability/tool activity row. The projection folds
@@ -512,6 +537,12 @@ pub struct ReplyDocument {
     pub status_kind: Option<ReplyStatusKind>,
     #[serde(default)]
     pub answer: ReplyAnswer,
+    /// Text of the model calls the loop went on past, in phase order
+    /// ([`ReplyDocument::reset_answer`]). Progress, not the answer: a
+    /// surface with an activity panel shows it there; a stream surface
+    /// never shows it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub narration: Vec<ReplyNarration>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub reasoning: Vec<ReplyReasoningText>,
     /// True while the last reasoning segment is still being produced
@@ -542,6 +573,7 @@ impl Default for ReplyDocument {
             status: None,
             status_kind: None,
             answer: ReplyAnswer::default(),
+            narration: Vec::new(),
             reasoning: Vec::new(),
             reasoning_open: false,
             activities: Vec::new(),
@@ -616,6 +648,31 @@ impl ReplyDocument {
         self.answer.text = ReplyAnswerText(String::new());
         self.answer.truncated = false;
         self.push_answer_bounded(text);
+        true
+    }
+
+    /// The loop went on past the model call that produced the answer — a
+    /// capability ran, a gate blocked, another call started — so that text
+    /// was narration, not the answer: it moves to [`Self::narration`] under
+    /// its phase and the next phase starts empty. This is the transcript's
+    /// own rule (only the run's final assistant message is the answer)
+    /// applied progressively. Ignored once finalized or terminal; a no-op
+    /// while the answer is empty.
+    pub fn reset_answer(&mut self) -> bool {
+        if self.is_terminal() || self.answer.finalized || self.answer.text.0.is_empty() {
+            return false;
+        }
+        self.next_ordinal();
+        if self.narration.len() < REPLY_MAX_NARRATION_ENTRIES {
+            let text = char_boundary_prefix(&self.answer.text.0, REPLY_NARRATION_ENTRY_MAX_BYTES);
+            self.narration.push(ReplyNarration {
+                phase: self.answer.phase,
+                text: ReplyAnswerText(text.to_string()),
+            });
+        }
+        self.answer.text = ReplyAnswerText(String::new());
+        self.answer.truncated = false;
+        self.answer.phase = self.answer.phase.saturating_add(1);
         true
     }
 

--- a/crates/contracts/ironclaw_extension_contracts/src/reply.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/reply.rs
@@ -375,11 +375,13 @@ pub struct ReplyAnswer {
     /// Cumulative text of the current model call (progressive appends, then
     /// the canonical finalized transcript text once the run finalizes it).
     pub text: ReplyAnswerText,
-    /// Which model call's text this is. Every call the loop goes on past
-    /// ([`ReplyDocument::reset_answer`]) starts the next phase, so a surface
-    /// can key what it shows per phase instead of per run.
-    #[serde(default = "first_answer_phase")]
-    pub phase: u64,
+    /// Which model call's text this is, counting the calls that produced
+    /// text: a call the loop goes on past ([`ReplyDocument::reset_answer`])
+    /// starts the next one, a call that produced no text does not. A surface
+    /// keys what it shows per call instead of per run. Distinct from the
+    /// document's lifecycle [`ReplyDocument::phase`].
+    #[serde(default = "first_answer_call")]
+    pub call: u64,
     /// True once [`ReplyDocument::finalize_answer`] replaced the progressive
     /// text with the canonical transcript row. Progressive appends after that
     /// are ignored.
@@ -394,24 +396,24 @@ impl Default for ReplyAnswer {
     fn default() -> Self {
         Self {
             text: ReplyAnswerText(String::new()),
-            phase: first_answer_phase(),
+            call: first_answer_call(),
             finalized: false,
             truncated: false,
         }
     }
 }
 
-fn first_answer_phase() -> u64 {
+fn first_answer_call() -> u64 {
     1
 }
 
 /// The text of one model call the loop went on past — narration such as
-/// "Let me check the workspace.", never the answer — kept under the phase it
+/// "Let me check the workspace.", never the answer — kept under the call it
 /// streamed as, so a surface that showed it as the provisional answer can
 /// re-home it, and a surface that never shows narration can ignore it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReplyNarration {
-    pub phase: u64,
+    pub call: u64,
     pub text: ReplyAnswerText,
 }
 
@@ -537,7 +539,7 @@ pub struct ReplyDocument {
     pub status_kind: Option<ReplyStatusKind>,
     #[serde(default)]
     pub answer: ReplyAnswer,
-    /// Text of the model calls the loop went on past, in phase order
+    /// Text of the model calls the loop went on past, in call order
     /// ([`ReplyDocument::reset_answer`]). Progress, not the answer: a
     /// surface with an activity panel shows it there; a stream surface
     /// never shows it. Bounded like every facet of this display document
@@ -657,7 +659,7 @@ impl ReplyDocument {
     /// The loop went on past the model call that produced the answer — a
     /// capability ran, a gate blocked, another call started — so that text
     /// was narration, not the answer: it moves to [`Self::narration`] under
-    /// its phase and the next phase starts empty. This is the transcript's
+    /// its call and the next call's answer starts empty. This is the transcript's
     /// own rule (only the run's final assistant message is the answer)
     /// applied progressively. Ignored once finalized or terminal; a no-op
     /// while the answer is empty.
@@ -669,13 +671,13 @@ impl ReplyDocument {
         if self.narration.len() < REPLY_MAX_NARRATION_ENTRIES {
             let text = char_boundary_prefix(&self.answer.text.0, REPLY_NARRATION_ENTRY_MAX_BYTES);
             self.narration.push(ReplyNarration {
-                phase: self.answer.phase,
+                call: self.answer.call,
                 text: ReplyAnswerText(text.to_string()),
             });
         }
         self.answer.text = ReplyAnswerText(String::new());
         self.answer.truncated = false;
-        self.answer.phase = self.answer.phase.saturating_add(1);
+        self.answer.call = self.answer.call.saturating_add(1);
         true
     }
 

--- a/crates/contracts/ironclaw_extension_contracts/src/reply.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/reply.rs
@@ -540,7 +540,10 @@ pub struct ReplyDocument {
     /// Text of the model calls the loop went on past, in phase order
     /// ([`ReplyDocument::reset_answer`]). Progress, not the answer: a
     /// surface with an activity panel shows it there; a stream surface
-    /// never shows it.
+    /// never shows it. Bounded like every facet of this display document
+    /// ([`REPLY_MAX_NARRATION_ENTRIES`] entries of
+    /// [`REPLY_NARRATION_ENTRY_MAX_BYTES`]); the durable transcript keeps
+    /// every model call in full.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub narration: Vec<ReplyNarration>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/contracts/ironclaw_extension_contracts/tests/reply_contract.rs
+++ b/crates/contracts/ironclaw_extension_contracts/tests/reply_contract.rs
@@ -17,14 +17,14 @@ use ironclaw_extension_contracts::external::ExternalConversationRef;
 use ironclaw_extension_contracts::reply::{
     REPLY_ANSWER_MAX_BYTES, REPLY_CONTEXT_MAX_BYTES, REPLY_DISPLAY_PREVIEW_MAX_BYTES,
     REPLY_DISPLAY_TEXT_MAX_BYTES, REPLY_MAX_ACTIVITIES, REPLY_MAX_PROVIDER_REFS,
-    REPLY_OUTCOME_REASON_MAX_BYTES, REPLY_REASONING_SEGMENT_MAX_BYTES,
-    REPLY_SINK_CHECKPOINT_MAX_BYTES, REPLY_THREAD_ANCHOR_MAX_BYTES, ReplyActivityState,
-    ReplyAnswerText, ReplyAttention, ReplyAttentionKind, ReplyAudience, ReplyContextBytes,
-    ReplyContractError, ReplyDisplayPreview, ReplyDisplayText, ReplyDocument, ReplyItemId,
-    ReplyOutcome, ReplyOutcomeReason, ReplyPhase, ReplyProviderRef, ReplyProviderRefs,
-    ReplyReasoningText, ReplyReconcilePoint, ReplyReconcileRequest, ReplyRevision, ReplySink,
-    ReplySinkCheckpoint, ReplySinkEvidence, ReplySinkOutcome, ReplySinkReport, ReplyTarget,
-    ReplyThreadAnchor,
+    REPLY_NARRATION_ENTRY_MAX_BYTES, REPLY_OUTCOME_REASON_MAX_BYTES,
+    REPLY_REASONING_SEGMENT_MAX_BYTES, REPLY_SINK_CHECKPOINT_MAX_BYTES,
+    REPLY_THREAD_ANCHOR_MAX_BYTES, ReplyActivityState, ReplyAnswerText, ReplyAttention,
+    ReplyAttentionKind, ReplyAudience, ReplyContextBytes, ReplyContractError, ReplyDisplayPreview,
+    ReplyDisplayText, ReplyDocument, ReplyItemId, ReplyOutcome, ReplyOutcomeReason, ReplyPhase,
+    ReplyProviderRef, ReplyProviderRefs, ReplyReasoningText, ReplyReconcilePoint,
+    ReplyReconcileRequest, ReplyRevision, ReplySink, ReplySinkCheckpoint, ReplySinkEvidence,
+    ReplySinkOutcome, ReplySinkReport, ReplyTarget, ReplyThreadAnchor,
 };
 use ironclaw_extension_contracts::tool_adapter::{
     RestrictedEgress, RestrictedEgressError, RestrictedEgressRequest, RestrictedEgressResponse,
@@ -232,6 +232,50 @@ fn mutators_fold_the_documented_facets() {
         Some("50 messages")
     );
     assert!(!document.is_terminal());
+}
+
+/// `reset_answer` moves the current call's text into narration under its
+/// call and starts the next call empty; it is a no-op on an empty answer and
+/// ignored once the answer is finalized or the document is terminal. A
+/// truncated answer resets clean: the entry is cut to the narration bound
+/// and `truncated` clears, so the next call appends again.
+#[test]
+fn reset_answer_moves_the_answer_to_narration_and_is_ignored_once_finalized_or_terminal() {
+    let mut document = ReplyDocument::default();
+    assert!(!document.reset_answer(), "an empty answer is a no-op");
+    assert_eq!(document.answer.call, 1);
+
+    document.append_answer(&"a".repeat(REPLY_ANSWER_MAX_BYTES + 1));
+    assert!(document.answer.truncated);
+    assert!(document.reset_answer());
+    assert_eq!(document.narration.len(), 1);
+    assert_eq!(document.narration[0].call, 1);
+    assert_eq!(
+        document.narration[0].text.as_str().len(),
+        REPLY_NARRATION_ENTRY_MAX_BYTES,
+        "the entry is cut to the narration bound"
+    );
+    assert_eq!(document.answer.call, 2);
+    assert!(document.answer.text.as_str().is_empty());
+    assert!(!document.answer.truncated, "the next call appends again");
+
+    document.append_answer("final");
+    document.finalize_answer(answer("final"), Vec::new());
+    assert!(
+        !document.reset_answer(),
+        "the finalized row is never demoted"
+    );
+    assert_eq!(document.narration.len(), 1);
+    assert_eq!(document.answer.call, 2);
+
+    let mut terminal = ReplyDocument::default();
+    terminal.append_answer("late");
+    terminal.complete();
+    assert!(
+        !terminal.reset_answer(),
+        "terminal documents ignore the reset"
+    );
+    assert!(terminal.narration.is_empty());
 }
 
 #[test]

--- a/crates/contracts/ironclaw_product_contracts/src/outbound.rs
+++ b/crates/contracts/ironclaw_product_contracts/src/outbound.rs
@@ -1051,7 +1051,24 @@ pub enum ProductProjectionItem {
 impl ProductProjectionItem {
     fn validate(&self) -> Result<(), ProductAdapterError> {
         match self {
-            Self::Text { id, body, .. } | Self::Thinking { id, body, .. } => {
+            Self::Text {
+                id,
+                body,
+                finalized,
+                narration,
+                ..
+            } => {
+                validate_bounded_text("projection_item_id", id, PROJECTION_ITEM_ID_MAX_BYTES)?;
+                validate_bounded_text("projection_text", body, PROJECTION_TEXT_MAX_BYTES)?;
+                if *finalized && *narration {
+                    return Err(invalid(
+                        "projection_text",
+                        "a finalized transcript row is never narration",
+                    ));
+                }
+                Ok(())
+            }
+            Self::Thinking { id, body, .. } => {
                 validate_bounded_text("projection_item_id", id, PROJECTION_ITEM_ID_MAX_BYTES)?;
                 validate_bounded_text("projection_text", body, PROJECTION_TEXT_MAX_BYTES)
             }

--- a/crates/contracts/ironclaw_product_contracts/src/outbound.rs
+++ b/crates/contracts/ironclaw_product_contracts/src/outbound.rs
@@ -982,6 +982,12 @@ pub enum ProductProjectionItem {
         /// Live projection text leaves this false and cannot prove delivery.
         #[serde(default, skip_serializing_if = "is_false")]
         finalized: bool,
+        /// True once the loop went on past the model call that produced this
+        /// text ("Let me check the workspace." before a tool call): it is
+        /// progress narration that belongs with the run's activity, not the
+        /// answer. Live projection only; a finalized row is never narration.
+        #[serde(default, skip_serializing_if = "is_false")]
+        narration: bool,
     },
     Thinking {
         id: String,
@@ -1164,6 +1170,8 @@ impl<'de> Deserialize<'de> for ProductProjectionItem {
                 body: String,
                 #[serde(default)]
                 finalized: bool,
+                #[serde(default)]
+                narration: bool,
             },
             Thinking {
                 id: String,
@@ -1215,11 +1223,13 @@ impl<'de> Deserialize<'de> for ProductProjectionItem {
                 run_id,
                 body,
                 finalized,
+                narration,
             } => ProductProjectionItem::Text {
                 id,
                 run_id,
                 body,
                 finalized,
+                narration,
             },
             Wire::Thinking { id, run_id, body } => {
                 ProductProjectionItem::Thinking { id, run_id, body }

--- a/crates/contracts/ironclaw_product_contracts/tests/product_contract.rs
+++ b/crates/contracts/ironclaw_product_contracts/tests/product_contract.rs
@@ -34,6 +34,7 @@ fn projection_text_distinguishes_live_from_finalized_transcript_rows() {
             run_id: Some(run_id),
             body: "final".to_string(),
             finalized: true,
+            narration: false,
         }],
     )
     .expect("finalized text state");

--- a/crates/contracts/ironclaw_product_contracts/tests/product_contract.rs
+++ b/crates/contracts/ironclaw_product_contracts/tests/product_contract.rs
@@ -46,6 +46,58 @@ fn projection_text_distinguishes_live_from_finalized_transcript_rows() {
     );
 }
 
+/// Live text a run went on past is flagged `narration`; the durable
+/// finalized row never is, and the contract refuses the contradiction on
+/// construction and on the wire alike.
+#[test]
+fn projection_text_narration_is_live_only() {
+    let run_id = TurnRunId::new();
+    let narration = ProductProjectionState::new(
+        "thread-1",
+        vec![ProductProjectionItem::Text {
+            id: format!("text:{run_id}:1"),
+            run_id: Some(run_id),
+            body: "Let me look.".to_string(),
+            finalized: false,
+            narration: true,
+        }],
+    )
+    .expect("live narration state");
+    let value = serde_json::to_value(&narration).expect("serialize narration");
+    assert_eq!(value["items"][0]["text"]["narration"], true);
+    assert!(
+        value["items"][0]["text"].get("finalized").is_none(),
+        "a false flag is not serialized"
+    );
+    assert_eq!(
+        serde_json::from_value::<ProductProjectionState>(value).expect("round trip narration"),
+        narration
+    );
+
+    let contradiction = ProductProjectionState::new(
+        "thread-1",
+        vec![ProductProjectionItem::Text {
+            id: "message-1".to_string(),
+            run_id: Some(run_id),
+            body: "final".to_string(),
+            finalized: true,
+            narration: true,
+        }],
+    );
+    assert!(
+        contradiction.is_err(),
+        "a finalized row flagged as narration is refused on construction"
+    );
+    let wire = serde_json::from_value::<ProductProjectionState>(json!({
+        "thread_id": "thread-1",
+        "items": [{"text": {"id": "message-1", "run_id": run_id, "body": "final", "finalized": true, "narration": true}}]
+    }));
+    assert!(
+        wire.is_err(),
+        "a finalized row flagged as narration is refused on the wire"
+    );
+}
+
 #[test]
 fn product_stream_continuation_is_process_local_not_wire_state() {
     let (_sender, receiver) = tokio::sync::mpsc::channel(1);

--- a/crates/events/ironclaw_event_streams/src/types.rs
+++ b/crates/events/ironclaw_event_streams/src/types.rs
@@ -176,6 +176,11 @@ pub enum ThreadLiveProjectionItem {
         id: String,
         run_id: TurnRunId,
         body: String,
+        /// True once the loop went on past the model call that produced this
+        /// text: it is narration inside the run's activity, not the answer.
+        /// Additive; absent for pre-existing producers.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        narration: bool,
     },
     Thinking {
         id: String,

--- a/crates/events/ironclaw_event_streams/tests/event_stream_manager_contract/redaction_live.rs
+++ b/crates/events/ironclaw_event_streams/tests/event_stream_manager_contract/redaction_live.rs
@@ -11,6 +11,7 @@ async fn fresh_subscription_hydrates_latest_live_state_then_tails_new_updates() 
         id: "text:active-run".to_string(),
         run_id,
         body: body.to_string(),
+        narration: false,
     };
     let thinking_item = ThreadLiveProjectionItem::Thinking {
         id: "thinking:active-run".to_string(),

--- a/crates/extensions/packages/slack/src/reply_sink/agent_api.rs
+++ b/crates/extensions/packages/slack/src/reply_sink/agent_api.rs
@@ -224,8 +224,12 @@ pub(super) fn outcome_for_failure(
 ) -> ReplySinkOutcome {
     match failure {
         SlackApiFailure::Ambiguous { reason } => {
-            // Session status is idempotent: a lost answer is safe to retry.
-            if method == SlackWebApiMethod::AgentsSessionsSetStatus {
+            // Session status is idempotent, and so is deleting a message the
+            // sink tolerates finding gone: a lost answer is safe to retry.
+            if matches!(
+                method,
+                SlackWebApiMethod::AgentsSessionsSetStatus | SlackWebApiMethod::ChatDelete
+            ) {
                 ReplySinkOutcome::Retryable {
                     reason: ReplyOutcomeReason::new(reason),
                     retry_after: None,

--- a/crates/extensions/packages/slack/src/reply_sink/mod.rs
+++ b/crates/extensions/packages/slack/src/reply_sink/mod.rs
@@ -543,8 +543,10 @@ impl Reconciler<'_> {
     }
 
     /// The answer was rewritten under the stream (the prefix Slack shows no
-    /// longer matches the document). Close the stale stream and forget the
-    /// presentation; the caller opens a fresh one with the full text.
+    /// longer matches the document — a call the loop went on past had its
+    /// paragraph streamed, or the canonical text differs). Close the stale
+    /// stream, retract its message, and forget the presentation; the caller
+    /// opens a fresh one with what the document shows now.
     async fn re_present(
         &mut self,
         route: &SlackReplyRoute,
@@ -575,8 +577,39 @@ impl Reconciler<'_> {
                 ));
             }
         }
+        self.retract_message(stream).await?;
         self.checkpoint.forget_presentation();
         Ok(())
+    }
+
+    /// `chat.delete` the stale stream's message so the fresh presentation
+    /// never stands beside text the document no longer shows. A message
+    /// already gone is the retraction this wanted, which also makes a lost
+    /// answer plainly retryable rather than ambiguous: the retry finds the
+    /// message deleted or deletes it. A Slack refusal (a workspace that
+    /// forbids the delete) leaves the stale message and is logged, because
+    /// the fresh stream still carries the answer and failing the reply over
+    /// it would be worse.
+    async fn retract_message(&mut self, stream: &SlackStreamState) -> Result<(), ReplySinkOutcome> {
+        let body = json!({ "channel": stream.channel, "ts": stream.ts });
+        match self.api.post(SlackWebApiMethod::ChatDelete, body).await {
+            Ok(_) => Ok(()),
+            Err(SlackApiFailure::Rejected { error, .. }) if error == "message_not_found" => Ok(()),
+            Err(SlackApiFailure::Rejected { error, .. }) => {
+                tracing::debug!(
+                    channel = %stream.channel,
+                    ts = %stream.ts,
+                    error = %error,
+                    "slack refused to retract the stale stream's message; leaving it"
+                );
+                Ok(())
+            }
+            Err(SlackApiFailure::Ambiguous { reason }) => Err(ReplySinkOutcome::Retryable {
+                reason: ReplyOutcomeReason::new(reason),
+                retry_after: None,
+            }),
+            Err(failure) => Err(outcome_for_failure(SlackWebApiMethod::ChatDelete, failure)),
+        }
     }
 
     /// Reconcile the session status to what the document implies (attention
@@ -758,11 +791,11 @@ impl Reconciler<'_> {
             Err(AnswerRewritten) => {
                 // The canonical answer is not an extension of what was
                 // streamed (a genuine rewrite — the in-place terminal fold
-                // upstream absorbs the ordinary multi-phase case): close the
-                // stale stream as it stands and re-present the canonical
-                // text on ONE fresh native stream, opened and closed in this
-                // reconcile. Never as a conventional message beside the
-                // stream — that is the duplicate-answer shape.
+                // upstream absorbs the ordinary case): close the stale
+                // stream as it stands, retract its message, and re-present
+                // the canonical text on ONE fresh native stream, opened and
+                // closed in this reconcile. Never as a conventional message
+                // beside the stream — that is the duplicate-answer shape.
                 self.stop_stream(
                     route,
                     document,
@@ -771,6 +804,7 @@ impl Reconciler<'_> {
                     &SlackAppliedState::default(),
                 )
                 .await?;
+                self.retract_message(stream).await?;
                 self.checkpoint.forget_presentation();
                 return self.open_and_close_terminal_stream(route, document).await;
             }
@@ -1141,6 +1175,40 @@ mod tests {
         assert!(
             text_chunks(&plan).is_empty(),
             "no complete paragraph yet: nothing goes out"
+        );
+        assert_eq!(plan.applied.to_chars, 0);
+    }
+
+    #[test]
+    fn held_text_is_not_flushed_ahead_of_an_attention_block() {
+        // A gate is raised for a tool call the same model call produced, so
+        // text ahead of it is narration by construction: it stays held (and
+        // the document resets it once the loop goes on). Only the block
+        // itself goes out.
+        let mut document = ReplyDocument::default();
+        document.append_answer("Let me send the summary.");
+        document.require_attention(ironclaw_extension_contracts::reply::ReplyAttention {
+            kind: ironclaw_extension_contracts::reply::ReplyAttentionKind::Approval,
+            headline: title("Approve sending the summary"),
+            body: None,
+            action_url: None,
+            gate_ref: Some(title("gate:approval-1")),
+        });
+
+        let plan = plan_for(&document);
+
+        let chunks = text_chunks(&plan);
+        assert!(
+            chunks
+                .iter()
+                .all(|chunk| !chunk.contains("Let me send the summary.")),
+            "held narration does not flush ahead of the block: {chunks:?}"
+        );
+        assert!(
+            chunks
+                .iter()
+                .any(|chunk| chunk.contains("Approve sending the summary")),
+            "the block itself goes out: {chunks:?}"
         );
         assert_eq!(plan.applied.to_chars, 0);
     }

--- a/crates/extensions/packages/slack/src/reply_sink/mod.rs
+++ b/crates/extensions/packages/slack/src/reply_sink/mod.rs
@@ -546,7 +546,9 @@ impl Reconciler<'_> {
     /// longer matches the document — a call the loop went on past had its
     /// paragraph streamed, or the canonical text differs). Close the stale
     /// stream, retract its message, and forget the presentation; the caller
-    /// opens a fresh one with what the document shows now.
+    /// opens a fresh one with what the document shows now. A stale stream
+    /// already closed, or a message already gone (a retraction whose answer
+    /// was lost), is the state this wanted.
     async fn re_present(
         &mut self,
         route: &SlackReplyRoute,
@@ -564,7 +566,10 @@ impl Reconciler<'_> {
         match self.api.post(SlackWebApiMethod::ChatStopStream, body).await {
             Ok(_) => {}
             Err(SlackApiFailure::Rejected { error, .. })
-                if error == "message_not_in_streaming_state" => {}
+                if matches!(
+                    error.as_str(),
+                    "message_not_in_streaming_state" | "message_not_found"
+                ) => {}
             Err(SlackApiFailure::Ambiguous { reason }) => {
                 return Err(ReplySinkOutcome::Ambiguous {
                     reason: ReplyOutcomeReason::new(reason),
@@ -796,16 +801,7 @@ impl Reconciler<'_> {
                 // the canonical text on ONE fresh native stream, opened and
                 // closed in this reconcile. Never as a conventional message
                 // beside the stream — that is the duplicate-answer shape.
-                self.stop_stream(
-                    route,
-                    document,
-                    stream,
-                    Vec::new(),
-                    &SlackAppliedState::default(),
-                )
-                .await?;
-                self.retract_message(stream).await?;
-                self.checkpoint.forget_presentation();
+                self.re_present(route, stream).await?;
                 return self.open_and_close_terminal_stream(route, document).await;
             }
         };

--- a/crates/extensions/packages/slack/src/reply_sink/mod.rs
+++ b/crates/extensions/packages/slack/src/reply_sink/mod.rs
@@ -213,6 +213,21 @@ impl Reconciler<'_> {
         let document = &self.request.revision.document;
         let text = document.answer.text.as_str();
         let carried_text = pending.to_chars > stream.appended_chars;
+        if carried_text {
+            // The document no longer holds the text the pending carried (the
+            // loop went on and reset the answer): whether or not the append
+            // landed, this stream is stale, and read-back has nothing to
+            // verify against. Re-present — close, retract, forget — so the
+            // next call never lands beneath narration that may be showing.
+            let document_still_holds_it = char_prefix(text, pending.to_chars)
+                .is_some_and(|prefix| checkpoint::fingerprint(&[prefix]) == pending.to_hash);
+            if !document_still_holds_it {
+                tracing::debug!(
+                    "slack pending text append no longer matches the document; re-presenting"
+                );
+                return self.re_present(route, &stream).await;
+            }
+        }
         let message = match self.api.read_back(&route.channel, &stream.ts).await {
             Ok(message) => message,
             Err(failure) => {
@@ -597,23 +612,31 @@ impl Reconciler<'_> {
     /// it would be worse.
     async fn retract_message(&mut self, stream: &SlackStreamState) -> Result<(), ReplySinkOutcome> {
         let body = json!({ "channel": stream.channel, "ts": stream.ts });
-        match self.api.post(SlackWebApiMethod::ChatDelete, body).await {
-            Ok(_) => Ok(()),
-            Err(SlackApiFailure::Rejected { error, .. }) if error == "message_not_found" => Ok(()),
-            Err(SlackApiFailure::Rejected { error, .. }) => {
+        let failure = match self.api.post(SlackWebApiMethod::ChatDelete, body).await {
+            Ok(_) => return Ok(()),
+            Err(SlackApiFailure::Rejected { error, .. }) if error == "message_not_found" => {
+                return Ok(());
+            }
+            Err(failure) => failure,
+        };
+        // Rate limits, transport, and auth failures keep their usual
+        // outcomes (the retry deletes, or the reply stops); only a refusal
+        // Slack will never lift leaves the stale message behind.
+        match outcome_for_failure(SlackWebApiMethod::ChatDelete, failure) {
+            // silent-ok: a refusal Slack will never lift (`cant_delete_message`,
+            // a compliance export hold) leaves the stale message behind; the
+            // fresh stream still carries the answer, and failing the reply
+            // over a leftover message would be the greater harm.
+            ReplySinkOutcome::Permanent { reason } => {
                 tracing::debug!(
                     channel = %stream.channel,
                     ts = %stream.ts,
-                    error = %error,
+                    reason = %reason,
                     "slack refused to retract the stale stream's message; leaving it"
                 );
                 Ok(())
             }
-            Err(SlackApiFailure::Ambiguous { reason }) => Err(ReplySinkOutcome::Retryable {
-                reason: ReplyOutcomeReason::new(reason),
-                retry_after: None,
-            }),
-            Err(failure) => Err(outcome_for_failure(SlackWebApiMethod::ChatDelete, failure)),
+            outcome => Err(outcome),
         }
     }
 

--- a/crates/extensions/packages/slack/src/reply_sink/mod.rs
+++ b/crates/extensions/packages/slack/src/reply_sink/mod.rs
@@ -56,7 +56,9 @@ mod agent_api;
 mod checkpoint;
 mod plan;
 
-use agent_api::{SlackAgentApi, SlackApiFailure, outcome_for_failure, outcome_for_part};
+use agent_api::{
+    SlackAgentApi, SlackApiFailure, outcome_for_failure, outcome_for_part, outcome_for_slack_error,
+};
 use checkpoint::{
     SlackAppliedState, SlackReplyCheckpoint, SlackSessionStatus, SlackStreamState,
     SlackTerminalState, char_prefix, delta_landed_after, encode_checkpoint, load_checkpoint,
@@ -606,10 +608,13 @@ impl Reconciler<'_> {
     /// never stands beside text the document no longer shows. A message
     /// already gone is the retraction this wanted, which also makes a lost
     /// answer plainly retryable rather than ambiguous: the retry finds the
-    /// message deleted or deletes it. A Slack refusal (a workspace that
-    /// forbids the delete) leaves the stale message and is logged, because
-    /// the fresh stream still carries the answer and failing the reply over
-    /// it would be worse.
+    /// message deleted or deletes it. A refusal Slack itself answers and
+    /// will never lift (a workspace that forbids the delete) leaves the
+    /// stale message and is logged, because the fresh stream still carries
+    /// the answer and failing the reply over it would be worse. Everything
+    /// else — rate limits, transport loss, auth, and any failure that is not
+    /// Slack's own answer (a host egress denial, a request that could not be
+    /// built) — keeps its usual outcome.
     async fn retract_message(&mut self, stream: &SlackStreamState) -> Result<(), ReplySinkOutcome> {
         let body = json!({ "channel": stream.channel, "ts": stream.ts });
         let failure = match self.api.post(SlackWebApiMethod::ChatDelete, body).await {
@@ -617,27 +622,32 @@ impl Reconciler<'_> {
             Err(SlackApiFailure::Rejected { error, .. }) if error == "message_not_found" => {
                 return Ok(());
             }
+            Err(SlackApiFailure::Rejected { error, retry_after }) => {
+                return match outcome_for_slack_error(
+                    SlackWebApiMethod::ChatDelete,
+                    &error,
+                    retry_after,
+                ) {
+                    // silent-ok: a refusal Slack will never lift
+                    // (`cant_delete_message`, a compliance export hold) leaves
+                    // the stale message behind; the fresh stream still carries
+                    // the answer, and failing the reply over a leftover
+                    // message would be the greater harm.
+                    ReplySinkOutcome::Permanent { reason } => {
+                        tracing::debug!(
+                            channel = %stream.channel,
+                            ts = %stream.ts,
+                            reason = %reason,
+                            "slack refused to retract the stale stream's message; leaving it"
+                        );
+                        Ok(())
+                    }
+                    outcome => Err(outcome),
+                };
+            }
             Err(failure) => failure,
         };
-        // Rate limits, transport, and auth failures keep their usual
-        // outcomes (the retry deletes, or the reply stops); only a refusal
-        // Slack will never lift leaves the stale message behind.
-        match outcome_for_failure(SlackWebApiMethod::ChatDelete, failure) {
-            // silent-ok: a refusal Slack will never lift (`cant_delete_message`,
-            // a compliance export hold) leaves the stale message behind; the
-            // fresh stream still carries the answer, and failing the reply
-            // over a leftover message would be the greater harm.
-            ReplySinkOutcome::Permanent { reason } => {
-                tracing::debug!(
-                    channel = %stream.channel,
-                    ts = %stream.ts,
-                    reason = %reason,
-                    "slack refused to retract the stale stream's message; leaving it"
-                );
-                Ok(())
-            }
-            outcome => Err(outcome),
-        }
+        Err(outcome_for_failure(SlackWebApiMethod::ChatDelete, failure))
     }
 
     /// Reconcile the session status to what the document implies (attention

--- a/crates/extensions/packages/slack/src/reply_sink/plan.rs
+++ b/crates/extensions/packages/slack/src/reply_sink/plan.rs
@@ -86,13 +86,12 @@ pub(super) fn plan_chunks(
     }
     chunks.extend(task_chunks);
 
-    // Held text flushes when the answer is complete (terminal, or a canonical
-    // finalized text) and before an attention block, which belongs after
-    // whatever the run had already said.
-    let attention_is_new = document.attention.as_ref().is_some_and(|attention| {
-        checkpoint.attention_key.as_deref() != Some(attention_fingerprint(attention).as_str())
-    });
-    let publish = if document.is_terminal() || document.answer.finalized || attention_is_new {
+    // Held text flushes only when the answer is complete (terminal, or a
+    // canonical finalized text). Not ahead of an attention block: a gate is
+    // raised for a tool call the same model call produced, so text ahead of
+    // it is narration by construction — the document resets it once the
+    // loop goes on, and flushing it here would only force a retraction.
+    let publish = if document.is_terminal() || document.answer.finalized {
         delta
     } else {
         // `publishable_len` only ever returns a line end or a position past a

--- a/crates/extensions/packages/slack/tests/reply_sink_agent_api.rs
+++ b/crates/extensions/packages/slack/tests/reply_sink_agent_api.rs
@@ -1434,6 +1434,40 @@ async fn a_lost_narration_append_followed_by_a_reset_retracts_the_stale_stream()
     );
 }
 
+/// Only Slack's own refusal is tolerated. A retraction the host's egress
+/// policy denies before the network never reached Slack: that is a
+/// deployment fault to surface, so the reply fails loudly and no fresh
+/// stream opens beside a message that is still there.
+#[tokio::test]
+async fn an_egress_denied_retraction_fails_the_reply_instead_of_opening_a_fresh_stream() {
+    let mut harness = Harness::dm();
+    harness.append("Let me look at two things first.\n\n");
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Opened).await);
+
+    assert!(harness.document.reset_answer());
+    harness
+        .document
+        .activity_started(item("act-0"), text("Search Slack"), None);
+    harness.fake.inject(Fault::EgressDenied {
+        method: SlackWebApiMethod::ChatDelete,
+    });
+    let report = harness.reconcile(ReplyReconcilePoint::Progress).await;
+    assert!(
+        matches!(report.outcome, ReplySinkOutcome::Permanent { .. }),
+        "an egress denial is not a slack refusal, got {:?}",
+        report.outcome
+    );
+    assert!(harness.fake.deleted().is_empty());
+    assert_eq!(
+        harness
+            .fake
+            .bodies(SlackWebApiMethod::ChatStartStream)
+            .len(),
+        1,
+        "no fresh stream opens beside a message that is still there"
+    );
+}
+
 // ── No conventional fallback ─────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/extensions/packages/slack/tests/reply_sink_agent_api.rs
+++ b/crates/extensions/packages/slack/tests/reply_sink_agent_api.rs
@@ -1224,38 +1224,54 @@ async fn a_streamed_narration_paragraph_is_retracted_when_the_answer_resets() {
     );
 }
 
-/// A retraction whose `chat.delete` never gets an answer is retried: the
-/// next reconcile finds the stale stream already closed, deletes it, and
-/// opens the fresh stream exactly once.
+/// A retraction whose `chat.delete` never gets an answer is retried, in
+/// both shapes: the request never reached Slack (the retry deletes for the
+/// first time) and the request was applied before the transport failed
+/// (the retry finds the message gone — `message_not_found` on the close and
+/// on the delete — which is the state it wanted). Either way the fresh
+/// stream opens exactly once.
 #[tokio::test]
 async fn a_lost_retraction_answer_is_retried_without_a_second_fresh_stream() {
-    let mut harness = Harness::dm();
-    harness.append("Let me look at two things first.\n\n");
-    assert_applied(&harness.reconcile(ReplyReconcilePoint::Opened).await);
-    let stale = harness.stream_ts();
+    for fault in [
+        Fault::TransportBeforeAccept {
+            method: SlackWebApiMethod::ChatDelete,
+        },
+        Fault::TransportAfterAccept {
+            method: SlackWebApiMethod::ChatDelete,
+        },
+    ] {
+        let mut harness = Harness::dm();
+        harness.append("Let me look at two things first.\n\n");
+        assert_applied(&harness.reconcile(ReplyReconcilePoint::Opened).await);
+        let stale = harness.stream_ts();
 
-    assert!(harness.document.reset_answer());
-    harness
-        .document
-        .activity_started(item("act-0"), text("Search Slack"), None);
-    harness.fake.inject(Fault::TransportBeforeAccept {
-        method: SlackWebApiMethod::ChatDelete,
-    });
-    let report = harness.reconcile(ReplyReconcilePoint::Progress).await;
-    assert!(
-        matches!(report.outcome, ReplySinkOutcome::Retryable { .. }),
-        "a transport failure on the retraction is retried, got {:?}",
-        report.outcome
-    );
-    let before = harness.fake.calls().len();
-    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
-    assert_eq!(
-        harness.fake.calls()[before..],
-        ["chat.stopStream", "chat.delete", "chat.startStream"],
-        "the retry closes (already closed: tolerated), retracts, and opens once"
-    );
-    assert_eq!(harness.fake.deleted(), [stale]);
-    assert_eq!(harness.fake.streams().len(), 1);
+        assert!(harness.document.reset_answer());
+        harness
+            .document
+            .activity_started(item("act-0"), text("Search Slack"), None);
+        let applied_before_loss = matches!(fault, Fault::TransportAfterAccept { .. });
+        harness.fake.inject(fault);
+        let report = harness.reconcile(ReplyReconcilePoint::Progress).await;
+        assert!(
+            matches!(report.outcome, ReplySinkOutcome::Retryable { .. }),
+            "a transport failure on the retraction is retried, got {:?}",
+            report.outcome
+        );
+        assert_eq!(
+            harness.fake.deleted().len(),
+            usize::from(applied_before_loss),
+            "an applied-then-lost delete already removed the message"
+        );
+        let before = harness.fake.calls().len();
+        assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+        assert_eq!(
+            harness.fake.calls()[before..],
+            ["chat.stopStream", "chat.delete", "chat.startStream"],
+            "the retry closes (already closed or gone: tolerated), retracts (or finds it gone), and opens once"
+        );
+        assert_eq!(harness.fake.deleted(), [stale.as_str()]);
+        assert_eq!(harness.fake.streams().len(), 1);
+    }
 }
 
 // ── No conventional fallback ─────────────────────────────────────────────

--- a/crates/extensions/packages/slack/tests/reply_sink_agent_api.rs
+++ b/crates/extensions/packages/slack/tests/reply_sink_agent_api.rs
@@ -1274,6 +1274,166 @@ async fn a_lost_retraction_answer_is_retried_without_a_second_fresh_stream() {
     }
 }
 
+/// A workspace can forbid deleting messages (retention policies answer
+/// `chat.delete` with a refusal). The answer must still reach the user, so
+/// a refused retraction is logged and the fresh stream opens anyway: the
+/// stale narration message is the lesser harm, and it is a decision, not
+/// an accident. Only a missing message counts as retracted.
+#[tokio::test]
+async fn a_refused_retraction_leaves_the_stale_message_and_still_delivers_the_answer() {
+    let mut harness = Harness::dm();
+    harness.append("Let me look at two things first.\n\n");
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Opened).await);
+    let stale = harness.stream_ts();
+
+    assert!(harness.document.reset_answer());
+    harness
+        .document
+        .activity_started(item("act-0"), text("Search Slack"), None);
+    harness.fake.inject(Fault::SlackError {
+        method: SlackWebApiMethod::ChatDelete,
+        error: "cant_delete_message",
+    });
+    let before = harness.fake.calls().len();
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+    assert_eq!(
+        harness.fake.calls()[before..],
+        ["chat.stopStream", "chat.delete", "chat.startStream"],
+        "the refusal does not stop the fresh stream from opening"
+    );
+    assert!(
+        harness.fake.deleted().is_empty(),
+        "nothing was retracted: the workspace refused"
+    );
+    let streams = harness.fake.streams();
+    assert_eq!(
+        streams.len(),
+        2,
+        "the stale message stays beside the fresh stream"
+    );
+    let (fresh, fresh_stream) = streams
+        .iter()
+        .find(|(ts, _)| ts != &stale)
+        .expect("a fresh stream");
+    assert_eq!(
+        fresh_stream.text, "",
+        "the fresh stream carries no narration"
+    );
+
+    harness.append("Here is what I found.\n\n");
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+    assert_eq!(
+        harness.fake.stream(fresh).expect("fresh stream").text,
+        "Here is what I found.\n\n",
+        "the answer streams on the fresh stream regardless"
+    );
+}
+
+/// A rate-limited `chat.delete` is not a refusal: the retraction is retried
+/// with Slack's hint, no fresh stream opens until it lands, and the retry
+/// deletes the stale message and opens the fresh stream once.
+#[tokio::test]
+async fn a_rate_limited_retraction_is_retried_before_the_fresh_stream_opens() {
+    let mut harness = Harness::dm();
+    harness.append("Let me look at two things first.\n\n");
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Opened).await);
+    let stale = harness.stream_ts();
+
+    assert!(harness.document.reset_answer());
+    harness
+        .document
+        .activity_started(item("act-0"), text("Search Slack"), None);
+    harness.fake.inject(Fault::SlackError {
+        method: SlackWebApiMethod::ChatDelete,
+        error: "ratelimited",
+    });
+    let report = harness.reconcile(ReplyReconcilePoint::Progress).await;
+    assert!(
+        matches!(report.outcome, ReplySinkOutcome::Retryable { .. }),
+        "a rate limit on the retraction is retried, got {:?}",
+        report.outcome
+    );
+    assert!(harness.fake.deleted().is_empty());
+    assert_eq!(
+        harness.fake.streams().len(),
+        1,
+        "no fresh stream opens beside a message that is still there"
+    );
+
+    let before = harness.fake.calls().len();
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+    assert_eq!(
+        harness.fake.calls()[before..],
+        ["chat.stopStream", "chat.delete", "chat.startStream"]
+    );
+    assert_eq!(harness.fake.deleted(), [stale.as_str()]);
+    assert_eq!(
+        harness.fake.streams().len(),
+        1,
+        "only the fresh stream remains"
+    );
+}
+
+/// The append carrying a narration paragraph crosses transport unanswered,
+/// and before the next reconcile the tool call resets the answer. Read-back
+/// can no longer verify the pending against a document that dropped that
+/// text — and it does not matter whether the append landed: the stream is
+/// stale either way. The sink closes it, retracts its message, and opens
+/// the fresh stream, instead of appending the next call beneath narration
+/// that may be showing.
+#[tokio::test]
+async fn a_lost_narration_append_followed_by_a_reset_retracts_the_stale_stream() {
+    let mut harness = Harness::dm();
+    harness
+        .document
+        .activity_started(item("act-0"), text("Search Slack"), None);
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Opened).await);
+    let stale = harness.stream_ts();
+
+    harness.fake.inject(Fault::TransportAfterAccept {
+        method: SlackWebApiMethod::ChatAppendStream,
+    });
+    harness.append("Let me look at two things first.\n\n");
+    let report = harness.reconcile(ReplyReconcilePoint::Progress).await;
+    assert!(
+        matches!(report.outcome, ReplySinkOutcome::Ambiguous { .. }),
+        "the lost append is pending, got {:?}",
+        report.outcome
+    );
+    assert_eq!(
+        harness.fake.stream(&stale).expect("stale stream").text,
+        "Let me look at two things first.\n\n",
+        "the append landed provider-side"
+    );
+
+    assert!(harness.document.reset_answer());
+    harness
+        .document
+        .activity_finished(item("act-0"), ReplyActivityState::Completed, None, None);
+    let before = harness.fake.calls().len();
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+    assert!(
+        harness.fake.calls()[before..].contains(&"chat.delete".to_string()),
+        "the stale stream is retracted: {:?}",
+        &harness.fake.calls()[before..]
+    );
+    assert_eq!(harness.fake.deleted(), [stale.as_str()]);
+    let streams = harness.fake.streams();
+    assert_eq!(streams.len(), 1, "only the fresh stream remains");
+    assert_eq!(
+        streams[0].1.text, "",
+        "the fresh stream carries no narration"
+    );
+
+    harness.append("Here is what I found.\n\n");
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+    assert_eq!(
+        harness.fake.streams()[0].1.text,
+        "Here is what I found.\n\n",
+        "the answer streams on the fresh stream"
+    );
+}
+
 // ── No conventional fallback ─────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/extensions/packages/slack/tests/reply_sink_agent_api.rs
+++ b/crates/extensions/packages/slack/tests/reply_sink_agent_api.rs
@@ -275,15 +275,17 @@ async fn happy_path_streams_the_reply_through_the_native_agent_surface() {
         "nothing was read back on the happy path"
     );
 
-    // ControlCritical: attention before the paragraph ends → the held text
-    // goes out first (what the run said belongs before the block), then the
-    // block, then `suspended`.
+    // ControlCritical: a gate is raised for a tool call the same model call
+    // produced, so the text ahead of it ("Hi") was narration — the
+    // projection resets the answer before the block lands. The block goes
+    // out alone, then `suspended`; the narration reaches Slack nowhere.
     harness.document.activity_finished(
         item("act-0"),
         ReplyActivityState::Completed,
         Some(preview("Runbook opened")),
         None,
     );
+    assert!(harness.document.reset_answer());
     harness.document.require_attention(ReplyAttention {
         kind: ReplyAttentionKind::Approval,
         headline: text("Approve writing report.md"),
@@ -310,7 +312,6 @@ async fn happy_path_streams_the_reply_through_the_native_agent_surface() {
             "chunks": [
                 { "type": "plan_update", "title": "Thinking paused" },
                 { "type": "task_update", "id": "act-0", "title": "Read runbook", "status": "complete" },
-                { "type": "markdown_text", "text": "Hi" },
                 {
                     "type": "markdown_text",
                     "text": "\n> **Approval needed:** Approve writing report.md\n> The run wants to write report.md in your workspace.\n"
@@ -394,7 +395,7 @@ async fn happy_path_streams_the_reply_through_the_native_agent_surface() {
     // carrying everything still held and `session_status: active`.
     harness
         .document
-        .finalize_answer(answer("HiHello world!"), Vec::new());
+        .finalize_answer(answer("Hello world!"), Vec::new());
     harness.document.complete();
     let report = harness.reconcile(ReplyReconcilePoint::Terminal).await;
     assert_applied(&report);
@@ -422,7 +423,7 @@ async fn happy_path_streams_the_reply_through_the_native_agent_surface() {
     );
     assert_eq!(
         stream.text,
-        "Hi\n> **Approval needed:** Approve writing report.md\n> The run wants to write report.md in your workspace.\nHello world!"
+        "\n> **Approval needed:** Approve writing report.md\n> The run wants to write report.md in your workspace.\nHello world!"
     );
     assert_eq!(
         stream.task_updates.len(),
@@ -443,7 +444,7 @@ async fn happy_path_streams_the_reply_through_the_native_agent_surface() {
     assert_eq!(checkpoint["terminal"], "applied");
     assert_eq!(checkpoint["session_status"], "active");
     assert_eq!(checkpoint["stream"]["ts"], ts);
-    assert_eq!(checkpoint["stream"]["appended_chars"], 14);
+    assert_eq!(checkpoint["stream"]["appended_chars"], 12);
     assert_eq!(checkpoint["generation"], 1);
     assert!(checkpoint["tasks"]["act-1"].is_string());
 }
@@ -1095,18 +1096,24 @@ async fn an_answer_rewritten_under_the_stream_is_re_presented_in_full() {
     );
     let calls = harness.fake.calls();
     assert_eq!(
-        calls[calls.len() - 2..],
-        ["chat.stopStream", "chat.startStream"],
-        "close the stale stream, open a fresh one"
+        calls[calls.len() - 3..],
+        ["chat.stopStream", "chat.delete", "chat.startStream"],
+        "close the stale stream, retract it, open a fresh one"
     );
     assert_eq!(
         harness.fake.bodies(SlackWebApiMethod::ChatStopStream)[0],
         json!({ "channel": DM, "ts": first, "session_status": "processing" }),
         "re-presenting keeps the session processing"
     );
+    assert_eq!(
+        harness.fake.bodies(SlackWebApiMethod::ChatDelete),
+        [json!({ "channel": DM, "ts": first })],
+        "the stale stream's message is retracted, never left beside the fresh one"
+    );
+    assert_eq!(harness.fake.deleted(), [first]);
     let streams = harness.fake.streams();
-    assert_eq!(streams.len(), 2);
-    assert_eq!(streams[1].1.text, "Goodbye");
+    assert_eq!(streams.len(), 1, "only the fresh stream remains");
+    assert_eq!(streams[0].1.text, "Goodbye");
     // The fresh stream re-presents everything the stale one showed: here
     // the canonical text, complete, so it goes out whole even before the
     // terminal; with no task there is no header to repeat.
@@ -1115,7 +1122,140 @@ async fn an_answer_rewritten_under_the_stream_is_re_presented_in_full() {
         json!([{ "type": "markdown_text", "text": "Goodbye" }]),
         "the re-presented stream opens with the full canonical text"
     );
-    assert!(streams[1].1.plan_updates.is_empty());
+    assert!(streams[0].1.plan_updates.is_empty());
+}
+
+// ── Narration ────────────────────────────────────────────────────────────
+
+/// The common shape: a one-line "Let me look." before the tool call. No
+/// paragraph boundary, so the paragraph hold never sends it; when the tool
+/// call proves it was narration the document resets the answer, and the
+/// stream opens with the plan header and task card alone. The narration
+/// appears in no request.
+#[tokio::test]
+async fn a_held_narration_line_never_reaches_slack() {
+    let mut harness = Harness::dm();
+    harness.append("Let me look.");
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Opened).await);
+    assert!(harness.fake.streams().is_empty(), "held text opens nothing");
+
+    assert!(harness.document.reset_answer());
+    harness
+        .document
+        .activity_started(item("act-0"), text("Search Slack"), None);
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+    let streams = harness.fake.streams();
+    assert_eq!(streams.len(), 1);
+    assert_eq!(streams[0].1.text, "");
+    assert_eq!(
+        streams[0].1.plan_updates,
+        [json!({ "type": "plan_update", "title": "Thinking" })]
+    );
+    assert!(harness.fake.deleted().is_empty(), "nothing to retract");
+
+    harness.append("Here is what I found.\n\n");
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+    assert_eq!(
+        harness.fake.streams()[0].1.text,
+        "Here is what I found.\n\n"
+    );
+    let bodies = harness
+        .fake
+        .requests()
+        .iter()
+        .map(|request| {
+            String::from_utf8_lossy(request.body.as_deref().unwrap_or_default()).into_owned()
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        bodies.iter().all(|body| !body.contains("Let me look.")),
+        "narration never reaches slack: {bodies:?}"
+    );
+}
+
+/// Narration that had a complete paragraph before the tool call was already
+/// streamed. The reset makes the shown prefix stale: the sink closes that
+/// stream, retracts its message with `chat.delete`, and opens a fresh stream
+/// carrying the plan header and task card, where the answer then streams.
+#[tokio::test]
+async fn a_streamed_narration_paragraph_is_retracted_when_the_answer_resets() {
+    let mut harness = Harness::dm();
+    harness.append("Let me look at two things first.\n\n");
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Opened).await);
+    let stale = harness.stream_ts();
+    assert_eq!(
+        harness.fake.stream(&stale).expect("stale stream").text,
+        "Let me look at two things first.\n\n"
+    );
+
+    assert!(harness.document.reset_answer());
+    harness
+        .document
+        .activity_started(item("act-0"), text("Search Slack"), None);
+    let before = harness.fake.calls().len();
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+    assert_eq!(
+        harness.fake.calls()[before..],
+        ["chat.stopStream", "chat.delete", "chat.startStream"],
+        "close the stale stream, retract it, open a fresh one"
+    );
+    assert_eq!(harness.fake.deleted(), [stale.as_str()]);
+    let streams = harness.fake.streams();
+    assert_eq!(streams.len(), 1, "only the fresh stream remains");
+    let (fresh, stream) = &streams[0];
+    assert_ne!(fresh, &stale);
+    assert_eq!(stream.text, "", "the fresh stream carries no narration");
+    assert_eq!(
+        stream.task_updates,
+        [
+            json!({ "type": "task_update", "id": "act-0", "title": "Search Slack", "status": "in_progress" })
+        ]
+    );
+
+    harness.append("Here is what I found.\n\n");
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+    assert_eq!(
+        harness.fake.calls().last().map(String::as_str),
+        Some("chat.appendStream")
+    );
+    assert_eq!(
+        harness.fake.stream(fresh).expect("fresh stream").text,
+        "Here is what I found.\n\n"
+    );
+}
+
+/// A retraction whose `chat.delete` never gets an answer is retried: the
+/// next reconcile finds the stale stream already closed, deletes it, and
+/// opens the fresh stream exactly once.
+#[tokio::test]
+async fn a_lost_retraction_answer_is_retried_without_a_second_fresh_stream() {
+    let mut harness = Harness::dm();
+    harness.append("Let me look at two things first.\n\n");
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Opened).await);
+    let stale = harness.stream_ts();
+
+    assert!(harness.document.reset_answer());
+    harness
+        .document
+        .activity_started(item("act-0"), text("Search Slack"), None);
+    harness.fake.inject(Fault::TransportBeforeAccept {
+        method: SlackWebApiMethod::ChatDelete,
+    });
+    let report = harness.reconcile(ReplyReconcilePoint::Progress).await;
+    assert!(
+        matches!(report.outcome, ReplySinkOutcome::Retryable { .. }),
+        "a transport failure on the retraction is retried, got {:?}",
+        report.outcome
+    );
+    let before = harness.fake.calls().len();
+    assert_applied(&harness.reconcile(ReplyReconcilePoint::Progress).await);
+    assert_eq!(
+        harness.fake.calls()[before..],
+        ["chat.stopStream", "chat.delete", "chat.startStream"],
+        "the retry closes (already closed: tolerated), retracts, and opens once"
+    );
+    assert_eq!(harness.fake.deleted(), [stale]);
+    assert_eq!(harness.fake.streams().len(), 1);
 }
 
 // ── No conventional fallback ─────────────────────────────────────────────
@@ -1380,9 +1520,14 @@ async fn a_terminal_rewrite_re_presents_natively_without_a_conventional_post() {
         harness.fake.posted().is_empty(),
         "a terminal rewrite never posts the answer conventionally"
     );
+    assert_eq!(
+        harness.fake.deleted(),
+        [stale_ts.as_str()],
+        "the stale stream's message is retracted"
+    );
     let streams = harness.fake.streams();
-    assert_eq!(streams.len(), 2, "stale stream + one fresh terminal stream");
-    let fresh_ts = streams[1].0.clone();
+    assert_eq!(streams.len(), 1, "one fresh terminal stream remains");
+    let fresh_ts = streams[0].0.clone();
     assert_ne!(fresh_ts, stale_ts);
     let fresh = harness.fake.stream(&fresh_ts).expect("fresh stream");
     assert_eq!(

--- a/crates/extensions/packages/slack/tests/support/fake_slack_agent_api.rs
+++ b/crates/extensions/packages/slack/tests/support/fake_slack_agent_api.rs
@@ -202,7 +202,7 @@ impl FakeSlackAgentApi {
 
     /// Messages retracted through `chat.delete`, in order.
     pub fn deleted(&self) -> Vec<String> {
-        self.state.lock().unwrap().deleted.clone()
+        self.lock().deleted.clone()
     }
 
     pub fn stream(&self, ts: &str) -> Option<FakeStream> {

--- a/crates/extensions/packages/slack/tests/support/fake_slack_agent_api.rs
+++ b/crates/extensions/packages/slack/tests/support/fake_slack_agent_api.rs
@@ -85,6 +85,8 @@ pub enum Fault {
     TransportAfterAccept { method: SlackWebApiMethod },
     /// The transport fails before the request reaches the provider.
     TransportBeforeAccept { method: SlackWebApiMethod },
+    /// The host's egress policy refuses the request before the network.
+    EgressDenied { method: SlackWebApiMethod },
     /// `{"ok":false,"error":"<error>"}` with HTTP 200.
     SlackError {
         method: SlackWebApiMethod,
@@ -106,6 +108,7 @@ impl Fault {
             | Self::ServerError { method }
             | Self::TransportAfterAccept { method }
             | Self::TransportBeforeAccept { method }
+            | Self::EgressDenied { method }
             | Self::SlackError { method, .. }
             | Self::InvalidBody { method }
             | Self::BareOk { method } => *method,
@@ -302,6 +305,9 @@ impl RestrictedEgress for FakeSlackAgentApi {
             }
             Some(Fault::TransportBeforeAccept { .. }) => {
                 return Err(transport_error("connection refused before write"));
+            }
+            Some(Fault::EgressDenied { .. }) => {
+                return Err(RestrictedEgressError::PolicyDenied);
             }
             Some(Fault::SlackError { error, .. }) => return Ok(slack_error(error)),
             Some(Fault::TransportAfterAccept { .. }) => {

--- a/crates/extensions/packages/slack/tests/support/fake_slack_agent_api.rs
+++ b/crates/extensions/packages/slack/tests/support/fake_slack_agent_api.rs
@@ -127,6 +127,8 @@ struct State {
     /// Slack's shape for a message rendered only from blocks.
     read_back_omits_text: bool,
     streams: BTreeMap<String, FakeStream>,
+    /// `ts` of every message deleted through `chat.delete`, in order.
+    deleted: Vec<String>,
     sessions: Vec<SessionCall>,
     posted: Vec<PostedMessage>,
     uploads: BTreeMap<String, StagedUpload>,
@@ -196,6 +198,11 @@ impl FakeSlackAgentApi {
             .iter()
             .map(|(ts, stream)| (ts.clone(), stream.clone()))
             .collect()
+    }
+
+    /// Messages retracted through `chat.delete`, in order.
+    pub fn deleted(&self) -> Vec<String> {
+        self.state.lock().unwrap().deleted.clone()
     }
 
     pub fn stream(&self, ts: &str) -> Option<FakeStream> {
@@ -568,8 +575,17 @@ fn handle(
             }
             ok(json!({ "ok": true, "file": file }))
         }
-        SlackWebApiMethod::ChatDelete
-        | SlackWebApiMethod::ConversationsOpen
+        SlackWebApiMethod::ChatDelete => {
+            let Some(ts) = field("ts") else {
+                return Ok(slack_error("message_not_found"));
+            };
+            if state.streams.remove(&ts).is_none() {
+                return Ok(slack_error("message_not_found"));
+            }
+            state.deleted.push(ts);
+            ok(json!({ "ok": true }))
+        }
+        SlackWebApiMethod::ConversationsOpen
         | SlackWebApiMethod::ReactionsAdd
         | SlackWebApiMethod::ReactionsRemove => ok(json!({ "ok": true })),
     })

--- a/crates/product/ironclaw_assistant/src/delivery_coordinator/publication/tests.rs
+++ b/crates/product/ironclaw_assistant/src/delivery_coordinator/publication/tests.rs
@@ -1287,11 +1287,13 @@ async fn a_text_microburst_coalesces_and_the_latest_text_precedes_tool_activity(
         .iter()
         .find(|r| !r.revision.document.activities.is_empty())
         .unwrap();
+    let document = &with_tool.revision.document;
     assert_eq!(
-        with_tool.revision.document.answer.text.as_str(),
-        "partial answer 63",
-        "the reconcile that shows the tool already carries the latest text: desired state, never a stale interleaving"
+        document.narration.last().map(|entry| entry.text.as_str()),
+        Some("partial answer 63"),
+        "the reconcile that shows the tool already carries the latest text — as narration, since the tool call proved it was not the answer: desired state, never a stale interleaving"
     );
+    assert_eq!(document.answer.text.as_str(), "");
 }
 
 // ─── Terminal attachments: workspace bytes ride the terminal reconcile ─────

--- a/crates/product/ironclaw_assistant/src/projection/live_progress.rs
+++ b/crates/product/ironclaw_assistant/src/projection/live_progress.rs
@@ -358,12 +358,12 @@ fn thinking_id(run_id: TurnRunId, segment_index: u64) -> String {
     format!("thinking:{run_id}:{segment_index}")
 }
 
-/// Stable per-(run, answer-phase) item id: one live text item per model
+/// Stable per-(run, answer call) item id: one live text item per model
 /// call, so a call the loop went on past keeps its own item (re-homed as
 /// narration) while the next call's text streams as a new one. The format
 /// the browser keyed on before replies were published progressively.
-fn text_phase_id(run_id: TurnRunId, phase: u64) -> String {
-    format!("text:{run_id}:{phase}")
+fn text_call_id(run_id: TurnRunId, call: u64) -> String {
+    format!("text:{run_id}:{call}")
 }
 
 fn work_summary_id(run_id: TurnRunId, sequence: u64) -> String {
@@ -410,10 +410,10 @@ struct ProjectionReplyCheckpoint {
     answer_fingerprint: u64,
     #[serde(default)]
     answer_finalized: bool,
-    /// The answer phase the three fields above describe; a new phase starts
+    /// The answer call the three fields above describe; a new call starts
     /// its own text item from nothing.
     #[serde(default)]
-    answer_phase: u64,
+    answer_call: u64,
     /// How many narration entries (calls the loop went on past) have been
     /// republished under their phase id with the narration flag.
     #[serde(default)]
@@ -563,7 +563,7 @@ impl LiveProjectionPublisher {
                 scope,
                 sequence,
                 ThreadLiveProjectionItem::Text {
-                    id: text_phase_id(run_id, entry.phase),
+                    id: text_call_id(run_id, entry.call),
                     run_id,
                     body: entry.text.as_str().to_string(),
                     narration: true,
@@ -572,9 +572,9 @@ impl LiveProjectionPublisher {
         }
         checkpoint.narration_published = document.narration.len();
 
-        // The current phase's text under its own id. A new phase starts
-        // from nothing; the earlier phase's item keeps the text it showed.
-        if document.answer.phase != checkpoint.answer_phase {
+        // The current call's text under its own id. A new call starts from
+        // nothing; the earlier call's item keeps the text it showed.
+        if document.answer.call != checkpoint.answer_call {
             checkpoint.answer_len = 0;
             checkpoint.answer_fingerprint = 0;
             checkpoint.answer_finalized = false;
@@ -592,14 +592,14 @@ impl LiveProjectionPublisher {
                 scope,
                 sequence,
                 ThreadLiveProjectionItem::Text {
-                    id: text_phase_id(run_id, document.answer.phase),
+                    id: text_call_id(run_id, document.answer.call),
                     run_id,
                     body: answer.to_string(),
                     narration: false,
                 },
             );
         }
-        checkpoint.answer_phase = document.answer.phase;
+        checkpoint.answer_call = document.answer.call;
         checkpoint.answer_len = answer.len();
         checkpoint.answer_fingerprint = answer_fingerprint;
         checkpoint.answer_finalized = document.answer.finalized;

--- a/crates/product/ironclaw_assistant/src/projection/live_progress.rs
+++ b/crates/product/ironclaw_assistant/src/projection/live_progress.rs
@@ -198,14 +198,18 @@ pub(super) fn product_items_for_live_update(
         .items
         .iter()
         .filter_map(|item| match item {
-            ThreadLiveProjectionItem::Text { id, run_id, body } => {
-                Some(ProductProjectionItem::Text {
-                    id: id.clone(),
-                    run_id: Some(*run_id),
-                    body: body.clone(),
-                    finalized: false,
-                })
-            }
+            ThreadLiveProjectionItem::Text {
+                id,
+                run_id,
+                body,
+                narration,
+            } => Some(ProductProjectionItem::Text {
+                id: id.clone(),
+                run_id: Some(*run_id),
+                body: body.clone(),
+                finalized: false,
+                narration: *narration,
+            }),
             ThreadLiveProjectionItem::Thinking { id, run_id, body } => {
                 Some(ProductProjectionItem::Thinking {
                     id: id.clone(),
@@ -354,8 +358,12 @@ fn thinking_id(run_id: TurnRunId, segment_index: u64) -> String {
     format!("thinking:{run_id}:{segment_index}")
 }
 
-fn legacy_text_id(run_id: TurnRunId) -> String {
-    format!("text:{run_id}")
+/// Stable per-(run, answer-phase) item id: one live text item per model
+/// call, so a call the loop went on past keeps its own item (re-homed as
+/// narration) while the next call's text streams as a new one. The format
+/// the browser keyed on before replies were published progressively.
+fn text_phase_id(run_id: TurnRunId, phase: u64) -> String {
+    format!("text:{run_id}:{phase}")
 }
 
 fn work_summary_id(run_id: TurnRunId, sequence: u64) -> String {
@@ -402,6 +410,14 @@ struct ProjectionReplyCheckpoint {
     answer_fingerprint: u64,
     #[serde(default)]
     answer_finalized: bool,
+    /// The answer phase the three fields above describe; a new phase starts
+    /// its own text item from nothing.
+    #[serde(default)]
+    answer_phase: u64,
+    /// How many narration entries (calls the loop went on past) have been
+    /// republished under their phase id with the narration flag.
+    #[serde(default)]
+    narration_published: usize,
     /// How many CLOSED reasoning segments have been published with their
     /// final text (the open tail is tracked by fingerprint below, because
     /// `append_reasoning` grows it in place without changing the count).
@@ -531,6 +547,38 @@ impl LiveProjectionPublisher {
             checkpoint.open_reasoning_fingerprint = 0;
         }
 
+        // A call the loop went on past is narration: it republishes once,
+        // under the id it streamed as, flagged so the browser re-homes it
+        // into the run's activity — ahead of the activity that proved it
+        // narration and of the next phase's text. The republish carries the
+        // phase's final text even when coalesced revisions skipped its tail.
+        for entry in document
+            .narration
+            .iter()
+            .skip(checkpoint.narration_published)
+        {
+            let sequence = self.next_live_sequence();
+            self.publish_live_item(
+                owner,
+                scope,
+                sequence,
+                ThreadLiveProjectionItem::Text {
+                    id: text_phase_id(run_id, entry.phase),
+                    run_id,
+                    body: entry.text.as_str().to_string(),
+                    narration: true,
+                },
+            );
+        }
+        checkpoint.narration_published = document.narration.len();
+
+        // The current phase's text under its own id. A new phase starts
+        // from nothing; the earlier phase's item keeps the text it showed.
+        if document.answer.phase != checkpoint.answer_phase {
+            checkpoint.answer_len = 0;
+            checkpoint.answer_fingerprint = 0;
+            checkpoint.answer_finalized = false;
+        }
         let answer = document.answer.text.as_str();
         let answer_fingerprint = text_fingerprint(answer);
         if !answer.is_empty()
@@ -544,12 +592,14 @@ impl LiveProjectionPublisher {
                 scope,
                 sequence,
                 ThreadLiveProjectionItem::Text {
-                    id: legacy_text_id(run_id),
+                    id: text_phase_id(run_id, document.answer.phase),
                     run_id,
                     body: answer.to_string(),
+                    narration: false,
                 },
             );
         }
+        checkpoint.answer_phase = document.answer.phase;
         checkpoint.answer_len = answer.len();
         checkpoint.answer_fingerprint = answer_fingerprint;
         checkpoint.answer_finalized = document.answer.finalized;

--- a/crates/product/ironclaw_assistant/src/projection/reply.rs
+++ b/crates/product/ironclaw_assistant/src/projection/reply.rs
@@ -148,10 +148,6 @@ struct RunReply {
     document: ReplyDocument,
     revision: u64,
     terminal_pending: bool,
-    /// The answer text of the model calls that already finished, in order.
-    /// `ModelTextDelta` carries the *cumulative* text of the current call,
-    /// so the document's answer is this prefix plus that text.
-    finished_phases_text: String,
 }
 
 impl RunReply {
@@ -161,39 +157,32 @@ impl RunReply {
             document: ReplyDocument::default(),
             revision: 0,
             terminal_pending: false,
-            finished_phases_text: String::new(),
         }
     }
 
-    /// Move the answer to `finished phases + current`: an append when the new
-    /// text extends what is shown, a rewrite otherwise (a model call that
-    /// restarted its text, or a rewrite under the stream).
-    fn fold_answer(&mut self, current_phase_text: &str, folded: &mut Folded) {
+    /// The answer is the current model call's cumulative text (that is what
+    /// `ModelTextDelta` carries): an append when the new text extends what
+    /// is shown, a rewrite otherwise (a call that restarted its text, or a
+    /// rewrite under the stream).
+    fn fold_answer(&mut self, call_text: &str, folded: &mut Folded) {
         let shown = self.document.answer.text.as_str();
-        let mut wanted = self.finished_phases_text.clone();
-        if !wanted.is_empty()
-            && !current_phase_text.is_empty()
-            && !wanted.ends_with(char::is_whitespace)
-        {
-            wanted.push_str("\n\n");
-        }
-        wanted.push_str(current_phase_text);
-        if wanted == shown {
+        if call_text == shown {
             return;
         }
-        if let Some(suffix) = wanted.strip_prefix(shown)
+        if let Some(suffix) = call_text.strip_prefix(shown)
             && !self.document.answer.truncated
         {
             folded.note(self.document.append_answer(suffix));
         } else {
-            folded.note(self.document.rewrite_answer(&wanted));
+            folded.note(self.document.rewrite_answer(call_text));
         }
     }
 
-    /// A model call ended (or another began): whatever the answer shows is
-    /// now finished text; the next call's cumulative text lands after it.
-    fn close_text_phase(&mut self) {
-        self.finished_phases_text = self.document.answer.text.as_str().to_string();
+    /// The current call failed: its fragment is neither answer nor narration.
+    fn discard_answer(&mut self, folded: &mut Folded) {
+        if !self.document.answer.text.as_str().is_empty() {
+            folded.note(self.document.rewrite_answer(""));
+        }
     }
 
     /// Anything that is not more reasoning ends the open reasoning segment:
@@ -532,6 +521,13 @@ fn fold_milestone(
     if !matches!(kind, LoopHostMilestoneKind::ModelReasoningDelta { .. }) {
         run.close_open_reasoning(folded);
     }
+    // The loop went on after the last model call: that call's text was
+    // narration, not the answer — the document moves it out of the answer
+    // (`reset_answer`) before the arm below records what the loop did next,
+    // so a capability row lands after the narration that announced it.
+    if loop_continued_past_the_model_call(kind) {
+        folded.note(run.document.reset_answer());
+    }
     match kind {
         LoopHostMilestoneKind::IterationStarted { iteration } => {
             if *iteration <= 1 {
@@ -551,7 +547,6 @@ fn fold_milestone(
                 run.document
                     .note_phase(ironclaw_extension_contracts::reply::ReplyPhase::Thinking),
             );
-            run.close_text_phase();
         }
         LoopHostMilestoneKind::ModelReasoningDelta { safe_delta } => {
             let text = sanitize_model_visible_text(safe_delta.as_str());
@@ -572,16 +567,13 @@ fn fold_milestone(
             }
             run.fold_answer(&stripped, folded);
         }
-        LoopHostMilestoneKind::ModelCompleted { .. } => run.close_text_phase(),
+        // A completed call stays the answer until the loop proves otherwise
+        // (see `loop_continued_past_the_model_call`) or the run ends.
+        LoopHostMilestoneKind::ModelCompleted { .. } => {}
         // The failed call's fragment is not finished text: drop it so a
-        // retried call (a fresh `ModelStarted`) starts from the phases that
-        // actually completed instead of freezing "Wor\n\nWorld" into the reply.
-        LoopHostMilestoneKind::ModelFailed { .. } => {
-            let finished = run.finished_phases_text.clone();
-            if run.document.answer.text.as_str() != finished {
-                folded.note(run.document.rewrite_answer(&finished));
-            }
-        }
+        // retried call (a fresh `ModelStarted`) starts from nothing instead
+        // of freezing "Wor" into the reply.
+        LoopHostMilestoneKind::ModelFailed { .. } => run.discard_answer(folded),
         LoopHostMilestoneKind::CapabilityInvoked {
             activity_id,
             capability_id,
@@ -704,6 +696,21 @@ fn fold_milestone(
     false
 }
 
+/// Milestones that prove the loop went on after a model call — so that call
+/// was not the run's final assistant message and its text was narration.
+/// A gate counts: it is raised for a tool call the same model call produced.
+fn loop_continued_past_the_model_call(kind: &LoopHostMilestoneKind) -> bool {
+    matches!(
+        kind,
+        LoopHostMilestoneKind::ModelStarted { .. }
+            | LoopHostMilestoneKind::CapabilityInvoked { .. }
+            | LoopHostMilestoneKind::CapabilityCompleted { .. }
+            | LoopHostMilestoneKind::CapabilityFailed { .. }
+            | LoopHostMilestoneKind::GateBlocked { .. }
+            | LoopHostMilestoneKind::Blocked { .. }
+    )
+}
+
 /// A finish for a row this document never saw start (the invoke milestone was
 /// lost, or only the terminal one reached us) still needs its title: the
 /// capability id, not the activity id.
@@ -761,16 +768,18 @@ fn fold_terminal_facts(run: &mut RunReply, facts: &TerminalReplyFacts, folded: &
                 .map(sanitize_model_visible_text)
                 .unwrap_or_default();
             // The transcript row finalizes only the run's FINAL assistant
-            // message. When the progressive answer already ends with it (the
-            // earlier model calls' streamed text precedes it), finalize IN
-            // PLACE: replacing the shown text with its own tail would break
-            // every stream presentation's prefix-extension invariant — a
-            // stream sink's terminal reconcile would see a rewrite and
-            // present the answer a second time beside the stream. A
-            // canonical text the shown text does not end with is a genuine
-            // rewrite and replaces it; so does any text once the progressive
-            // bound truncated, because the canonical row is the only
-            // complete copy.
+            // message — the same text the progressive answer holds, since
+            // every earlier call's text was demoted to thinking when the
+            // loop went on. Finalize IN PLACE whenever the shown text ends
+            // with the canonical one (a trailing-whitespace difference, or
+            // the empty canonical of a run with nothing to report):
+            // replacing it with its own tail would break every stream
+            // presentation's prefix-extension invariant — a stream sink's
+            // terminal reconcile would see a rewrite and present the answer
+            // a second time beside the stream. A canonical text the shown
+            // text does not end with is a genuine rewrite and replaces it;
+            // so does any text once the progressive bound truncated, because
+            // the canonical row is the only complete copy.
             let shown = run.document.answer.text.as_str();
             let text = if !run.document.answer.truncated && shown.ends_with(canonical.as_str()) {
                 shown.to_string()

--- a/crates/product/ironclaw_assistant/src/projection/reply.rs
+++ b/crates/product/ironclaw_assistant/src/projection/reply.rs
@@ -769,8 +769,8 @@ fn fold_terminal_facts(run: &mut RunReply, facts: &TerminalReplyFacts, folded: &
                 .unwrap_or_default();
             // The transcript row finalizes only the run's FINAL assistant
             // message — the same text the progressive answer holds, since
-            // every earlier call's text was demoted to thinking when the
-            // loop went on. Finalize IN PLACE whenever the shown text ends
+            // every earlier call's text moved to narration (`reset_answer`)
+            // when the loop went on. Finalize IN PLACE whenever the shown text ends
             // with the canonical one (a trailing-whitespace difference, or
             // the empty canonical of a run with nothing to report):
             // replacing it with its own tail would break every stream

--- a/crates/product/ironclaw_assistant/src/projection/reply/tests.rs
+++ b/crates/product/ironclaw_assistant/src/projection/reply/tests.rs
@@ -952,6 +952,61 @@ fn text_ahead_of_a_gate_is_narration_not_answer() {
     assert_eq!(document.answer.phase, 2);
 }
 
+/// Narration is bounded like every facet of this display document (the
+/// durable transcript keeps every model call in full): at most
+/// `REPLY_MAX_NARRATION_ENTRIES` entries, each cut to
+/// `REPLY_NARRATION_ENTRY_MAX_BYTES` on a character boundary. The answer
+/// still resets and moves to the next phase past the bound.
+#[test]
+fn narration_is_bounded_like_reasoning() {
+    use ironclaw_extension_contracts::reply::{
+        REPLY_MAX_NARRATION_ENTRIES, REPLY_NARRATION_ENTRY_MAX_BYTES,
+    };
+    let fixture = fixture("narration-bounds");
+    let long = "é".repeat(REPLY_NARRATION_ENTRY_MAX_BYTES);
+    for phase in 1..=(REPLY_MAX_NARRATION_ENTRIES as u64 + 1) {
+        fixture.observe(LoopHostMilestoneKind::ModelStarted {
+            requested_model_profile_id: None,
+        });
+        fixture.observe(LoopHostMilestoneKind::ModelTextDelta {
+            safe_text: if phase == 1 {
+                long.clone()
+            } else {
+                format!("phase {phase}")
+            },
+        });
+        fixture.observe(LoopHostMilestoneKind::CapabilityInvoked {
+            activity_id: CapabilityActivityId::new(),
+            capability_id: CapabilityId::new("acme.search").unwrap(),
+        });
+    }
+    let document = fixture.document();
+    assert_eq!(document.narration.len(), REPLY_MAX_NARRATION_ENTRIES);
+    assert_eq!(
+        document.narration[0].text.as_str().len(),
+        REPLY_NARRATION_ENTRY_MAX_BYTES,
+        "cut to the byte bound on a character boundary"
+    );
+    assert!(
+        document.narration[0]
+            .text
+            .as_str()
+            .chars()
+            .all(|c| c == 'é')
+    );
+    assert_eq!(
+        document.narration.last().map(|entry| entry.text.as_str()),
+        Some("phase 32"),
+        "the entry past the bound is dropped"
+    );
+    assert_eq!(document.answer.text.as_str(), "");
+    assert_eq!(
+        document.answer.phase,
+        REPLY_MAX_NARRATION_ENTRIES as u64 + 2,
+        "the answer still moves on past the bound"
+    );
+}
+
 /// A call's provider reasoning stays reasoning and its narration stays
 /// narration: two facets, never merged.
 #[test]

--- a/crates/product/ironclaw_assistant/src/projection/reply/tests.rs
+++ b/crates/product/ironclaw_assistant/src/projection/reply/tests.rs
@@ -84,12 +84,12 @@ fn fixture(label: &str) -> Fixture {
     }
 }
 
-/// The document's narration as `(phase, text)` pairs.
+/// The document's narration as `(call, text)` pairs.
 fn narration(document: &ironclaw_extension_contracts::reply::ReplyDocument) -> Vec<(u64, String)> {
     document
         .narration
         .iter()
-        .map(|entry| (entry.phase, entry.text.as_str().to_string()))
+        .map(|entry| (entry.call, entry.text.as_str().to_string()))
         .collect()
 }
 
@@ -173,7 +173,7 @@ fn a_failed_model_calls_partial_text_is_discarded_when_the_call_is_retried() {
         document.narration.is_empty(),
         "a failed call's fragment is dropped, not kept as narration"
     );
-    assert_eq!(document.answer.phase, 1, "a retry is not a new phase");
+    assert_eq!(document.answer.call, 1, "a retry is not a new call");
 }
 
 #[test]
@@ -801,7 +801,7 @@ fn a_revision_floor_seeds_numbering_for_a_run_rebuilt_on_another_process() {
 /// moment the loop does anything after a call other than end the run — here
 /// a capability invocation — that call's text was narration ("I’ll research
 /// this first."): it moves to the document's narration under its phase and
-/// the answer starts empty as the next phase. This is the transcript's own
+/// the answer starts empty for the next call. This is the transcript's own
 /// rule (only the final assistant message is the answer), applied
 /// progressively.
 #[test]
@@ -843,8 +843,8 @@ fn a_finished_calls_text_becomes_narration_once_a_capability_follows_it() {
         "the tool call proves the text was narration"
     );
     assert_eq!(
-        document.answer.phase, 2,
-        "the answer moved on to the next phase"
+        document.answer.call, 2,
+        "the answer moved on to the next call"
     );
     assert_eq!(
         narration(&document),
@@ -875,7 +875,7 @@ fn a_finished_calls_text_becomes_narration_once_a_capability_follows_it() {
     });
     let document = fixture.document();
     assert_eq!(document.answer.text.as_str(), "Actually, here it is.");
-    assert_eq!(document.answer.phase, 2);
+    assert_eq!(document.answer.call, 2);
     assert_eq!(document.narration.len(), 1);
 }
 
@@ -909,7 +909,7 @@ fn a_finished_calls_text_becomes_narration_once_another_call_follows_it() {
     });
     let document = fixture.document();
     assert_eq!(document.answer.text.as_str(), "Done.");
-    assert_eq!(document.answer.phase, 2);
+    assert_eq!(document.answer.call, 2);
 }
 
 /// Text ahead of a gate is narration by construction: the gate comes from a
@@ -949,7 +949,7 @@ fn text_ahead_of_a_gate_is_narration_not_answer() {
     let document = fixture.document();
     assert_eq!(document.answer.text.as_str(), "");
     assert_eq!(document.narration.len(), 1, "the reset is idempotent");
-    assert_eq!(document.answer.phase, 2);
+    assert_eq!(document.answer.call, 2);
 }
 
 /// Narration is bounded like every facet of this display document (the
@@ -964,15 +964,15 @@ fn narration_is_bounded_like_reasoning() {
     };
     let fixture = fixture("narration-bounds");
     let long = "é".repeat(REPLY_NARRATION_ENTRY_MAX_BYTES);
-    for phase in 1..=(REPLY_MAX_NARRATION_ENTRIES as u64 + 1) {
+    for call in 1..=(REPLY_MAX_NARRATION_ENTRIES as u64 + 1) {
         fixture.observe(LoopHostMilestoneKind::ModelStarted {
             requested_model_profile_id: None,
         });
         fixture.observe(LoopHostMilestoneKind::ModelTextDelta {
-            safe_text: if phase == 1 {
+            safe_text: if call == 1 {
                 long.clone()
             } else {
-                format!("phase {phase}")
+                format!("call {call}")
             },
         });
         fixture.observe(LoopHostMilestoneKind::CapabilityInvoked {
@@ -996,12 +996,12 @@ fn narration_is_bounded_like_reasoning() {
     );
     assert_eq!(
         document.narration.last().map(|entry| entry.text.as_str()),
-        Some("phase 32"),
+        Some("call 32"),
         "the entry past the bound is dropped"
     );
     assert_eq!(document.answer.text.as_str(), "");
     assert_eq!(
-        document.answer.phase,
+        document.answer.call,
         REPLY_MAX_NARRATION_ENTRIES as u64 + 2,
         "the answer still moves on past the bound"
     );
@@ -1072,7 +1072,7 @@ fn terminal_facts_matching_the_final_calls_text_finalize_in_place() {
         "The answer is 42.",
         "the progressive answer is the final call's text alone"
     );
-    assert_eq!(document.answer.phase, 2);
+    assert_eq!(document.answer.call, 2);
     assert_eq!(
         narration(&document),
         vec![(1, "Let me check the workspace.".to_string())]
@@ -1099,10 +1099,7 @@ fn terminal_facts_matching_the_final_calls_text_finalize_in_place() {
     assert!(document.answer.finalized);
     assert_eq!(document.outcome, Some(ReplyOutcome::Completed));
     assert_eq!(document.answer.text.as_str(), "The answer is 42.");
-    assert_eq!(
-        document.answer.phase, 2,
-        "finalization keeps the final phase"
-    );
+    assert_eq!(document.answer.call, 2, "finalization keeps the final call");
     assert_eq!(
         document.narration.len(),
         1,

--- a/crates/product/ironclaw_assistant/src/projection/reply/tests.rs
+++ b/crates/product/ironclaw_assistant/src/projection/reply/tests.rs
@@ -84,6 +84,15 @@ fn fixture(label: &str) -> Fixture {
     }
 }
 
+/// The document's narration as `(phase, text)` pairs.
+fn narration(document: &ironclaw_extension_contracts::reply::ReplyDocument) -> Vec<(u64, String)> {
+    document
+        .narration
+        .iter()
+        .map(|entry| (entry.phase, entry.text.as_str().to_string()))
+        .collect()
+}
+
 impl Fixture {
     fn milestone(&self, kind: LoopHostMilestoneKind) -> LoopHostMilestone {
         LoopHostMilestone {
@@ -158,7 +167,13 @@ fn a_failed_model_calls_partial_text_is_discarded_when_the_call_is_retried() {
     fixture.observe(LoopHostMilestoneKind::ModelTextDelta {
         safe_text: "World".to_string(),
     });
-    assert_eq!(fixture.document().answer.text.as_str(), "World");
+    let document = fixture.document();
+    assert_eq!(document.answer.text.as_str(), "World");
+    assert!(
+        document.narration.is_empty(),
+        "a failed call's fragment is dropped, not kept as narration"
+    );
+    assert_eq!(document.answer.phase, 1, "a retry is not a new phase");
 }
 
 #[test]
@@ -782,9 +797,17 @@ fn a_revision_floor_seeds_numbering_for_a_run_rebuilt_on_another_process() {
     );
 }
 
+/// The answer is the text of the current model call, nothing else. The
+/// moment the loop does anything after a call other than end the run — here
+/// a capability invocation — that call's text was narration ("I’ll research
+/// this first."): it moves to the document's narration under its phase and
+/// the answer starts empty as the next phase. This is the transcript's own
+/// rule (only the final assistant message is the answer), applied
+/// progressively.
 #[test]
-fn model_text_is_cumulative_per_call_and_calls_concatenate_as_phases() {
-    let fixture = fixture("phases");
+fn a_finished_calls_text_becomes_narration_once_a_capability_follows_it() {
+    let fixture = fixture("narration-capability");
+    let activity_id = CapabilityActivityId::new();
     fixture.observe(LoopHostMilestoneKind::ModelStarted {
         requested_model_profile_id: None,
     });
@@ -796,13 +819,44 @@ fn model_text_is_cumulative_per_call_and_calls_concatenate_as_phases() {
     });
     assert_eq!(
         fixture.document().answer.text.as_str(),
-        "I’ll research this first."
+        "I’ll research this first.",
+        "the current call's cumulative text is the provisional answer"
     );
     fixture.observe(LoopHostMilestoneKind::ModelCompleted {
         effective_model_profile_id: ironclaw_loop_contracts::ModelProfileId::new("test-model")
             .unwrap(),
     });
-    // A tool runs, then a second model call streams its own cumulative text.
+    assert_eq!(
+        fixture.document().answer.text.as_str(),
+        "I’ll research this first.",
+        "a completed call stays the answer until the loop continues"
+    );
+
+    fixture.observe(LoopHostMilestoneKind::CapabilityInvoked {
+        activity_id,
+        capability_id: CapabilityId::new("acme.search").unwrap(),
+    });
+    let document = fixture.document();
+    assert_eq!(
+        document.answer.text.as_str(),
+        "",
+        "the tool call proves the text was narration"
+    );
+    assert_eq!(
+        document.answer.phase, 2,
+        "the answer moved on to the next phase"
+    );
+    assert_eq!(
+        narration(&document),
+        vec![(1, "I’ll research this first.".to_string())],
+        "the narration is kept under the phase it streamed as"
+    );
+    assert!(document.reasoning.is_empty(), "narration is not reasoning");
+    assert_eq!(document.activities.len(), 1);
+
+    // The next call's cumulative text is the answer again; a call that
+    // restarts its text (shorter cumulative text) is a rewrite, not an
+    // append, and not a new call.
     fixture.observe(LoopHostMilestoneKind::ModelStarted {
         requested_model_profile_id: None,
     });
@@ -812,32 +866,130 @@ fn model_text_is_cumulative_per_call_and_calls_concatenate_as_phases() {
     fixture.observe(LoopHostMilestoneKind::ModelTextDelta {
         safe_text: "Here is the final answer.".to_string(),
     });
-    let document = fixture.document();
     assert_eq!(
-        document.answer.text.as_str(),
-        "I’ll research this first.\n\nHere is the final answer.",
-        "each model call's text lands after the previous call's, never duplicated"
+        fixture.document().answer.text.as_str(),
+        "Here is the final answer."
     );
-    // A call that restarts its text (shorter cumulative text) is a rewrite,
-    // not an append.
     fixture.observe(LoopHostMilestoneKind::ModelTextDelta {
         safe_text: "Actually, here it is.".to_string(),
     });
-    assert_eq!(
-        fixture.document().answer.text.as_str(),
-        "I’ll research this first.\n\nActually, here it is."
-    );
+    let document = fixture.document();
+    assert_eq!(document.answer.text.as_str(), "Actually, here it is.");
+    assert_eq!(document.answer.phase, 2);
+    assert_eq!(document.narration.len(), 1);
 }
 
-/// A tool run streams text in more than one model call (pre-tool commentary,
-/// then the answer), but the durable transcript finalizes only the run's
-/// final assistant message. The canonical text is the final phase of what
-/// was already streamed, so finalization must converge IN PLACE — replacing
-/// the shown text with its own tail would break every stream presentation's
-/// prefix-extension invariant (the Slack terminal reconcile would see a
-/// rewrite and duplicate the answer beside the stream).
+/// A call that ended without a tool call but did not end the run (the loop
+/// nudged the model on, or drained queued follow-up input) is narration too:
+/// the next call starting demotes it.
 #[test]
-fn terminal_facts_matching_the_final_phase_finalize_in_place() {
+fn a_finished_calls_text_becomes_narration_once_another_call_follows_it() {
+    let fixture = fixture("narration-next-call");
+    fixture.observe(LoopHostMilestoneKind::ModelStarted {
+        requested_model_profile_id: None,
+    });
+    fixture.observe(LoopHostMilestoneKind::ModelTextDelta {
+        safe_text: "Let me write the file:".to_string(),
+    });
+    fixture.observe(LoopHostMilestoneKind::ModelCompleted {
+        effective_model_profile_id: ironclaw_loop_contracts::ModelProfileId::new("test-model")
+            .unwrap(),
+    });
+    fixture.observe(LoopHostMilestoneKind::ModelStarted {
+        requested_model_profile_id: None,
+    });
+    let document = fixture.document();
+    assert_eq!(document.answer.text.as_str(), "");
+    assert_eq!(
+        narration(&document),
+        vec![(1, "Let me write the file:".to_string())]
+    );
+    fixture.observe(LoopHostMilestoneKind::ModelTextDelta {
+        safe_text: "Done.".to_string(),
+    });
+    let document = fixture.document();
+    assert_eq!(document.answer.text.as_str(), "Done.");
+    assert_eq!(document.answer.phase, 2);
+}
+
+/// Text ahead of a gate is narration by construction: the gate comes from a
+/// tool call the same model call produced. It is demoted when the gate
+/// blocks, so no surface shows it beside the attention block.
+#[test]
+fn text_ahead_of_a_gate_is_narration_not_answer() {
+    let fixture = fixture("narration-gate");
+    fixture.observe(LoopHostMilestoneKind::ModelStarted {
+        requested_model_profile_id: None,
+    });
+    fixture.observe(LoopHostMilestoneKind::ModelTextDelta {
+        safe_text: "Let me send the summary.".to_string(),
+    });
+    fixture.observe(LoopHostMilestoneKind::ModelCompleted {
+        effective_model_profile_id: ironclaw_loop_contracts::ModelProfileId::new("test-model")
+            .unwrap(),
+    });
+    fixture.observe(LoopHostMilestoneKind::GateBlocked {
+        iteration: 1,
+        gate_kind: LoopGateKind::Approval,
+    });
+    let document = fixture.document();
+    assert_eq!(document.answer.text.as_str(), "");
+    assert_eq!(
+        narration(&document),
+        vec![(1, "Let me send the summary.".to_string())]
+    );
+    assert_eq!(
+        document.attention.as_ref().map(|attention| attention.kind),
+        Some(ReplyAttentionKind::Approval)
+    );
+    fixture.observe(LoopHostMilestoneKind::Blocked {
+        gate_ref: LoopGateRef::new("gate:approval-1").unwrap(),
+        checkpoint_id: TurnCheckpointId::new(),
+    });
+    let document = fixture.document();
+    assert_eq!(document.answer.text.as_str(), "");
+    assert_eq!(document.narration.len(), 1, "the reset is idempotent");
+    assert_eq!(document.answer.phase, 2);
+}
+
+/// A call's provider reasoning stays reasoning and its narration stays
+/// narration: two facets, never merged.
+#[test]
+fn narration_is_kept_apart_from_the_calls_reasoning() {
+    let fixture = fixture("narration-order");
+    fixture.observe(LoopHostMilestoneKind::ModelStarted {
+        requested_model_profile_id: None,
+    });
+    fixture.observe(LoopHostMilestoneKind::ModelReasoningDelta {
+        safe_delta: "Looking at the repo".to_string(),
+    });
+    fixture.observe(LoopHostMilestoneKind::ModelTextDelta {
+        safe_text: "Let me check.".to_string(),
+    });
+    fixture.observe(LoopHostMilestoneKind::CapabilityInvoked {
+        activity_id: CapabilityActivityId::new(),
+        capability_id: CapabilityId::new("acme.search").unwrap(),
+    });
+    let document = fixture.document();
+    assert_eq!(
+        document
+            .reasoning
+            .iter()
+            .map(|segment| segment.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Looking at the repo"]
+    );
+    assert!(!document.reasoning_open);
+    assert_eq!(narration(&document), vec![(1, "Let me check.".to_string())]);
+    assert_eq!(document.answer.text.as_str(), "");
+}
+
+/// The durable transcript finalizes only the run's final assistant message,
+/// which is exactly the final call's streamed text: finalization converges
+/// IN PLACE (no rewrite), so no stream presentation sees a prefix break at
+/// the terminal. The earlier call's text is already narration.
+#[test]
+fn terminal_facts_matching_the_final_calls_text_finalize_in_place() {
     let live = fixture("terminal-in-place");
     live.observe(LoopHostMilestoneKind::ModelStarted {
         requested_model_profile_id: None,
@@ -859,12 +1011,23 @@ fn terminal_facts_matching_the_final_phase_finalize_in_place() {
         effective_model_profile_id: ironclaw_loop_contracts::ModelProfileId::new("scripted")
             .unwrap(),
     });
+    let document = live.document();
     assert_eq!(
-        live.document().answer.text.as_str(),
-        "Let me check the workspace.\n\nThe answer is 42.",
-        "the progressive answer joins the finished phases"
+        document.answer.text.as_str(),
+        "The answer is 42.",
+        "the progressive answer is the final call's text alone"
+    );
+    assert_eq!(document.answer.phase, 2);
+    assert_eq!(
+        narration(&document),
+        vec![(1, "Let me check the workspace.".to_string())]
     );
 
+    let revision_before = live
+        .projection
+        .snapshot(&live.scope, live.run_id)
+        .expect("tracked")
+        .revision;
     let snapshot = live.projection.apply_terminal_facts(
         &live.scope,
         live.run_id,
@@ -880,11 +1043,17 @@ fn terminal_facts_matching_the_final_phase_finalize_in_place() {
     let document = &snapshot.document;
     assert!(document.answer.finalized);
     assert_eq!(document.outcome, Some(ReplyOutcome::Completed));
+    assert_eq!(document.answer.text.as_str(), "The answer is 42.");
     assert_eq!(
-        document.answer.text.as_str(),
-        "Let me check the workspace.\n\nThe answer is 42.",
-        "a canonical text that is the shown text's final phase finalizes in place"
+        document.answer.phase, 2,
+        "finalization keeps the final phase"
     );
+    assert_eq!(
+        document.narration.len(),
+        1,
+        "finalization leaves the narration alone"
+    );
+    assert_eq!(snapshot.revision, revision_before + 1);
 }
 
 /// The empty-transcript completion (`answer: None` — nothing to report, or a

--- a/crates/product/ironclaw_assistant/src/projection/tests/live_progress_stream.rs
+++ b/crates/product/ironclaw_assistant/src/projection/tests/live_progress_stream.rs
@@ -318,7 +318,7 @@ async fn a_finished_calls_text_is_republished_as_narration_ahead_of_the_capabili
             .unwrap(),
     };
     // This run's live items as they are published: text and narration as
-    // `kind@phase:body` (the phase parsed from the item id), tools as
+    // `kind@call:body` (the call parsed from the item id), tools as
     // `tool:capability:status`. Other items are ignored.
     let describe = |item: &ProductProjectionItem| match item {
         ProductProjectionItem::Text {
@@ -328,11 +328,11 @@ async fn a_finished_calls_text_is_republished_as_narration_ahead_of_the_capabili
             narration,
             ..
         } if *observed_run_id == Some(run_id) => {
-            let phase = id
+            let call = id
                 .strip_prefix(&format!("text:{run_id}:"))
-                .unwrap_or_else(|| panic!("live text ids are per phase: {id}"));
+                .unwrap_or_else(|| panic!("live text ids are per call: {id}"));
             let kind = if *narration { "narration" } else { "text" };
-            Some(format!("{kind}@{phase}:{body}"))
+            Some(format!("{kind}@{call}:{body}"))
         }
         ProductProjectionItem::CapabilityActivity(activity) => Some(format!(
             "tool:{}:{:?}",
@@ -431,7 +431,7 @@ async fn a_finished_calls_text_is_republished_as_narration_ahead_of_the_capabili
     assert_eq!(
         read_items(&mut subscription, describe, 2).await,
         vec!["text@2:Here is the final answer.".to_string()],
-        "finalization republishes the final phase once, in place; terminal documents ignore stray text"
+        "finalization republishes the final call once, in place; terminal documents ignore stray text"
     );
 }
 

--- a/crates/product/ironclaw_assistant/src/projection/tests/live_progress_stream.rs
+++ b/crates/product/ironclaw_assistant/src/projection/tests/live_progress_stream.rs
@@ -252,7 +252,7 @@ async fn fresh_product_event_stream_compacts_buffered_assistant_text_to_latest_s
         })
         .await
         .unwrap();
-    let expected_id = format!("text:{run_id}");
+    let expected_id = format!("text:{run_id}:1");
     let text_bodies = events
         .iter()
         .filter_map(|event| match event.payload() {
@@ -284,11 +284,27 @@ async fn fresh_product_event_stream_compacts_buffered_assistant_text_to_latest_s
     assert!(!wire.contains(secret_like_token));
 }
 
+/// One live text item per model call. A call the loop went on past (a
+/// capability followed it) was narration: its item is republished once,
+/// flagged, AHEAD of the capability card that proved it, and the next call's
+/// text streams under the next phase id. The transcript row then finalizes
+/// the final call's text in place under that id.
 #[tokio::test]
-async fn model_text_phases_concatenate_under_one_live_id_and_the_transcript_row_wins() {
-    let fixture = live_projection_fixture("webui-text-phases");
+async fn a_finished_calls_text_is_republished_as_narration_ahead_of_the_capability_card() {
+    let fixture = live_projection_fixture("webui-narration");
     let scope = fixture.scope.clone();
     let run_id = TurnRunId::new();
+    let activity_id = CapabilityActivityId::new();
+    let mut subscription = fixture
+        .services
+        .product_event_stream()
+        .subscribe(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(fixture.user_id.clone()),
+            scope: scope.clone(),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
     let milestone = |kind| LoopHostMilestone {
         scope: scope.clone(),
         actor: None,
@@ -297,22 +313,68 @@ async fn model_text_phases_concatenate_under_one_live_id_and_the_transcript_row_
         loop_driver_id: LoopDriverId::new("test_loop").unwrap(),
         kind,
     };
+    let model_completed = || LoopHostMilestoneKind::ModelCompleted {
+        effective_model_profile_id: ironclaw_loop_contracts::ModelProfileId::new("test-model")
+            .unwrap(),
+    };
+    // This run's live items as they are published: text and narration as
+    // `kind@phase:body` (the phase parsed from the item id), tools as
+    // `tool:capability:status`. Other items are ignored.
+    let describe = |item: &ProductProjectionItem| match item {
+        ProductProjectionItem::Text {
+            id,
+            run_id: observed_run_id,
+            body,
+            narration,
+            ..
+        } if *observed_run_id == Some(run_id) => {
+            let phase = id
+                .strip_prefix(&format!("text:{run_id}:"))
+                .unwrap_or_else(|| panic!("live text ids are per phase: {id}"));
+            let kind = if *narration { "narration" } else { "text" };
+            Some(format!("{kind}@{phase}:{body}"))
+        }
+        ProductProjectionItem::CapabilityActivity(activity) => Some(format!(
+            "tool:{}:{:?}",
+            activity.capability_id, activity.status
+        )),
+        _ => None,
+    };
+    // Read live items until `expected` of them arrived (or a second of
+    // silence proves fewer did).
+    async fn read_items(
+        subscription: &mut ironclaw_product_contracts::projection::ProjectionStreamSubscription,
+        describe: impl Fn(&ProductProjectionItem) -> Option<String>,
+        expected: usize,
+    ) -> Vec<String> {
+        let mut seen = Vec::new();
+        while seen.len() < expected {
+            let Ok(next) =
+                tokio::time::timeout(std::time::Duration::from_secs(1), subscription.next()).await
+            else {
+                break;
+            };
+            let envelope = next
+                .expect("live projection subscription remains open")
+                .expect("live projection event remains valid");
+            if let ProductOutboundPayload::ProjectionUpdate { state } = envelope.payload() {
+                seen.extend(state.items.iter().filter_map(&describe));
+            }
+        }
+        seen
+    }
 
-    // `ModelTextDelta` carries the cumulative text of the current model
-    // call; a second call's text lands after the first call's.
     for kind in [
         LoopHostMilestoneKind::ModelStarted {
             requested_model_profile_id: None,
         },
         LoopHostMilestoneKind::ModelTextDelta {
-            safe_text: "I’ll research".to_string(),
-        },
-        LoopHostMilestoneKind::ModelTextDelta {
             safe_text: "I’ll research this first.".to_string(),
         },
-        LoopHostMilestoneKind::ModelCompleted {
-            effective_model_profile_id: ironclaw_loop_contracts::ModelProfileId::new("test-model")
-                .unwrap(),
+        model_completed(),
+        LoopHostMilestoneKind::CapabilityInvoked {
+            activity_id,
+            capability_id: CapabilityId::new("builtin.http").unwrap(),
         },
         LoopHostMilestoneKind::ModelStarted {
             requested_model_profile_id: None,
@@ -320,9 +382,10 @@ async fn model_text_phases_concatenate_under_one_live_id_and_the_transcript_row_
         LoopHostMilestoneKind::ModelTextDelta {
             safe_text: "Here is the final answer.".to_string(),
         },
+        model_completed(),
         LoopHostMilestoneKind::Completed {
             completion_kind: LoopCompletionKind::FinalReply,
-            exit_id: LoopExitId::new("exit:webui-text-phases").unwrap(),
+            exit_id: LoopExitId::new("exit:webui-narration").unwrap(),
         },
     ] {
         fixture
@@ -331,54 +394,20 @@ async fn model_text_phases_concatenate_under_one_live_id_and_the_transcript_row_
             .await
             .unwrap();
     }
-    let live_text = |events: &[ProductOutboundEnvelope]| {
-        events
-            .iter()
-            .flat_map(|event| match event.payload() {
-                ProductOutboundPayload::ProjectionUpdate { state } => state
-                    .items
-                    .iter()
-                    .filter_map(|item| match item {
-                        ProductProjectionItem::Text {
-                            id,
-                            run_id: observed_run_id,
-                            body,
-                            finalized,
-                        } if *observed_run_id == Some(run_id) => {
-                            Some((id.clone(), body.clone(), *finalized))
-                        }
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>(),
-                _ => Vec::new(),
-            })
-            .collect::<Vec<_>>()
-    };
-    let events = fixture
-        .services
-        .product_event_stream()
-        .drain(ProjectionSubscriptionRequest {
-            actor: TurnActor::new(fixture.user_id.clone()),
-            scope: scope.clone(),
-            after_cursor: None,
-        })
-        .await
-        .unwrap();
     assert_eq!(
-        live_text(&events),
-        vec![(
-            format!("text:{run_id}"),
-            "I’ll research this first.\n\nHere is the final answer.".to_string(),
-            false,
-        )],
-        "one stable live text id per run carries every model call's text in order"
+        read_items(&mut subscription, describe, 4).await,
+        vec![
+            "text@1:I’ll research this first.".to_string(),
+            "narration@1:I’ll research this first.".to_string(),
+            "tool:builtin.http:Started".to_string(),
+            "text@2:Here is the final answer.".to_string(),
+        ],
+        "the first call streams as the provisional answer, the tool call republishes it as narration ahead of the card, and the final call streams under the next phase"
     );
 
-    // The durable terminal facts finalize the answer. The transcript row is
-    // the shown text's final phase, so finalization converges IN PLACE —
-    // replacing the shown text with its own tail is the rewrite shape that
-    // duplicated answers on every stream surface. A stray delta after the
-    // terminal changes nothing.
+    // The durable terminal facts finalize the final call's text in place —
+    // one republish of the same text under the same id — and a stray delta
+    // after the terminal changes nothing.
     fixture.sink.projection.apply_terminal_facts(
         &scope,
         run_id,
@@ -399,24 +428,10 @@ async fn model_text_phases_concatenate_under_one_live_id_and_the_transcript_row_
         }))
         .await
         .unwrap();
-    let events = fixture
-        .services
-        .product_event_stream()
-        .drain(ProjectionSubscriptionRequest {
-            actor: TurnActor::new(fixture.user_id.clone()),
-            scope: scope.clone(),
-            after_cursor: None,
-        })
-        .await
-        .unwrap();
     assert_eq!(
-        live_text(&events),
-        vec![(
-            format!("text:{run_id}"),
-            "I’ll research this first.\n\nHere is the final answer.".to_string(),
-            false,
-        )],
-        "finalization keeps the shown text (the canonical row is its final phase) and terminal documents ignore stray text"
+        read_items(&mut subscription, describe, 2).await,
+        vec!["text@2:Here is the final answer.".to_string()],
+        "finalization republishes the final phase once, in place; terminal documents ignore stray text"
     );
 }
 
@@ -467,6 +482,7 @@ async fn provider_cadence_text_updates_are_not_visibly_batched() {
         .unwrap();
 
     let mut text_bodies = Vec::new();
+    let mut narration_bodies = Vec::new();
     for _ in 0..8 {
         let envelope = tokio::time::timeout(std::time::Duration::from_secs(1), subscription.next())
             .await
@@ -481,12 +497,24 @@ async fn provider_cadence_text_updates_are_not_visibly_batched() {
                 ProductProjectionItem::Text {
                     run_id: observed_run_id,
                     body,
+                    narration,
                     ..
-                } if *observed_run_id == Some(run_id) => text_bodies.push(body.clone()),
+                } if *observed_run_id == Some(run_id) => {
+                    if *narration {
+                        narration_bodies.push(body.clone());
+                    } else {
+                        text_bodies.push(body.clone());
+                    }
+                }
                 ProductProjectionItem::CapabilityActivity(activity)
                     if activity.invocation_id == InvocationId::from_uuid(activity_id.as_uuid()) =>
                 {
                     assert_eq!(text_bodies, ["first", "second", "third"]);
+                    assert_eq!(
+                        narration_bodies,
+                        ["third"],
+                        "the tool call republishes the call's text as narration, once, ahead of the card"
+                    );
                     return;
                 }
                 _ => {}

--- a/crates/product/ironclaw_assistant/src/projection/tests/reply_sink.rs
+++ b/crates/product/ironclaw_assistant/src/projection/tests/reply_sink.rs
@@ -172,8 +172,8 @@ async fn projection_reply_sink_publishes_each_facet_as_the_live_items_the_browse
     assert!(
         items.iter().any(|item| matches!(
             item,
-            ProductProjectionItem::Text { id, run_id: Some(run), body, finalized: false }
-                if *run == fixture.run_id && body == "Here is " && id == &format!("text:{}", fixture.run_id)
+            ProductProjectionItem::Text { id, run_id: Some(run), body, finalized: false, .. }
+                if *run == fixture.run_id && body == "Here is " && id == &format!("text:{}:1", fixture.run_id)
         )),
         "the cumulative answer becomes the run's live text item: {items:?}"
     );

--- a/crates/product/ironclaw_assistant/src/projection/tests/runtime_stream.rs
+++ b/crates/product/ironclaw_assistant/src/projection/tests/runtime_stream.rs
@@ -301,9 +301,10 @@ async fn initial_runtime_items_order_live_text_before_terminal_status() {
             cursor: cursor(11),
             thread_id,
             items: vec![ironclaw_event_streams::ThreadLiveProjectionItem::Text {
-                id: format!("text:{live_run}"),
+                id: format!("text:{live_run}:1"),
                 run_id: live_run,
                 body: "live text before terminal".to_string(),
+                narration: false,
             }],
         }),
     ));

--- a/crates/product/ironclaw_assistant/src/projection/turn_events.rs
+++ b/crates/product/ironclaw_assistant/src/projection/turn_events.rs
@@ -388,6 +388,7 @@ async fn finalized_reply_projection_item(
         run_id: Some(event.run_id),
         body,
         finalized: true,
+        narration: false,
     }))
 }
 

--- a/crates/product/ironclaw_openai_compat/src/streaming.rs
+++ b/crates/product/ironclaw_openai_compat/src/streaming.rs
@@ -148,16 +148,20 @@ fn chat_sse_stream(
                         let payload_view = payload_view(envelope.payload());
                         match payload_view.text {
                             PayloadText::None => {}
-                            PayloadText::Update(text) => match state.delta_for(text) {
-                                Ok(Some(delta)) => yield Ok(chat_text_delta_event(&public_id, created, &model, delta)),
-                                Ok(None) => {}
-                                Err(error) => {
-                                    yield Ok(openai_error_event(error));
-                                    return;
+                            PayloadText::Updates(updates) => {
+                                for update in updates {
+                                    match state.delta_for(update) {
+                                        Ok(Some(delta)) => yield Ok(chat_text_delta_event(&public_id, created, &model, delta)),
+                                        Ok(None) => {}
+                                        Err(error) => {
+                                            yield Ok(openai_error_event(error));
+                                            return;
+                                        }
+                                    }
                                 }
-                            },
+                            }
                             PayloadText::Final(text) => {
-                                match state.delta_for(text) {
+                                match state.delta_for(TextUpdate::final_reply(text)) {
                                     Ok(Some(delta)) => yield Ok(chat_text_delta_event(&public_id, created, &model, delta)),
                                     Ok(None) => {}
                                     Err(error) => {
@@ -245,24 +249,28 @@ fn response_sse_stream(
                         let payload_view = payload_view(envelope.payload());
                         match payload_view.text {
                             PayloadText::None => {}
-                            PayloadText::Update(text) => match state.delta_for(text) {
-                                Ok(Some(delta)) => {
-                                    yield Ok(response_text_delta_event(
-                                        &public_id,
-                                        &item_id,
-                                        sequence_number,
-                                        delta,
-                                    ));
-                                    sequence_number += 1;
+                            PayloadText::Updates(updates) => {
+                                for update in updates {
+                                    match state.delta_for(update) {
+                                        Ok(Some(delta)) => {
+                                            yield Ok(response_text_delta_event(
+                                                &public_id,
+                                                &item_id,
+                                                sequence_number,
+                                                delta,
+                                            ));
+                                            sequence_number += 1;
+                                        }
+                                        Ok(None) => {}
+                                        Err(error) => {
+                                            yield Ok(response_stream_error_event(error));
+                                            return;
+                                        }
+                                    }
                                 }
-                                Ok(None) => {}
-                                Err(error) => {
-                                    yield Ok(response_stream_error_event(error));
-                                    return;
-                                }
-                            },
+                            }
                             PayloadText::Final(text) => {
-                                match state.delta_for(text) {
+                                match state.delta_for(TextUpdate::final_reply(text)) {
                                     Ok(Some(delta)) => {
                                         yield Ok(response_text_delta_event(
                                             &public_id,
@@ -279,7 +287,7 @@ fn response_sse_stream(
                                     }
                                 }
                                 if !state.is_empty() {
-                                    yield Ok(response_text_done_event(&item_id, sequence_number, state.text()));
+                                    yield Ok(response_text_done_event(&item_id, sequence_number, &state.text()));
                                     sequence_number += 1;
                                 }
                                 yield Ok(response_terminal_event(
@@ -289,7 +297,7 @@ fn response_sse_stream(
                                     created,
                                     model.clone(),
                                     OpenAiResponseStatus::Completed,
-                                    state.text(),
+                                    &state.text(),
                                 ));
                                 return;
                             }
@@ -298,7 +306,7 @@ fn response_sse_stream(
                             TerminalStatus::None => {}
                             TerminalStatus::Completed => {
                                 if !state.is_empty() {
-                                    yield Ok(response_text_done_event(&item_id, sequence_number, state.text()));
+                                    yield Ok(response_text_done_event(&item_id, sequence_number, &state.text()));
                                     sequence_number += 1;
                                 }
                                 yield Ok(response_terminal_event(
@@ -308,7 +316,7 @@ fn response_sse_stream(
                                     created,
                                     model.clone(),
                                     OpenAiResponseStatus::Completed,
-                                    state.text(),
+                                    &state.text(),
                                 ));
                                 return;
                             }
@@ -320,7 +328,7 @@ fn response_sse_stream(
                                     created,
                                     model.clone(),
                                     OpenAiResponseStatus::Failed,
-                                    state.text(),
+                                    &state.text(),
                                 ));
                                 return;
                             }
@@ -332,7 +340,7 @@ fn response_sse_stream(
                                     created,
                                     model.clone(),
                                     OpenAiResponseStatus::Cancelled,
-                                    state.text(),
+                                    &state.text(),
                                 ));
                                 return;
                             }
@@ -398,13 +406,64 @@ fn stream_timeout_error() -> OpenAiCompatHttpError {
     OpenAiCompatHttpError::from_kind(503, true, OpenAiCompatErrorKind::ServiceUnavailable, None)
 }
 
+/// One text update from the projection: the phase it belongs to (the live
+/// text item id — one per model call) and that phase's cumulative body. The
+/// durable transcript row (finalized) and the final-reply payload belong to
+/// whichever phase is current: they confirm it, never start one.
+struct TextUpdate<'a> {
+    phase: &'a str,
+    body: &'a str,
+    confirms_current_phase: bool,
+}
+
+impl<'a> TextUpdate<'a> {
+    fn final_reply(body: &'a str) -> Self {
+        Self {
+            phase: "",
+            body,
+            confirms_current_phase: true,
+        }
+    }
+}
+
+/// Between two answer phases (a model call the loop went on past, then the
+/// next call): the completion stays one message, so the phases read as
+/// paragraphs rather than as a rewrite the client cannot express.
+const PHASE_SEPARATOR: &str = "\n\n";
+
 #[derive(Default)]
 struct TextDeltaState {
+    /// The text of the phases already closed, each followed by the separator.
+    closed: String,
+    /// The phase `text` tracks, once any live text arrived.
+    phase: Option<String>,
+    /// Every phase seen: a closed phase republished (its narration flag
+    /// arriving) is already streamed and changes nothing.
+    seen: Vec<String>,
+    /// Text streamed for the current phase.
     text: String,
 }
 
 impl TextDeltaState {
-    fn delta_for(&mut self, next: &str) -> Result<Option<String>, OpenAiCompatHttpError> {
+    fn delta_for(
+        &mut self,
+        update: TextUpdate<'_>,
+    ) -> Result<Option<String>, OpenAiCompatHttpError> {
+        let mut separator = "";
+        if !update.confirms_current_phase && self.phase.as_deref() != Some(update.phase) {
+            if self.seen.iter().any(|seen| seen == update.phase) {
+                return Ok(None);
+            }
+            if !self.text.is_empty() {
+                self.closed.push_str(&self.text);
+                self.closed.push_str(PHASE_SEPARATOR);
+                separator = PHASE_SEPARATOR;
+            }
+            self.seen.push(update.phase.to_string());
+            self.phase = Some(update.phase.to_string());
+            self.text.clear();
+        }
+        let next = update.body;
         let consumed = self.text.len();
         if next.len() == consumed {
             if next.as_bytes() != self.text.as_bytes() {
@@ -430,11 +489,12 @@ impl TextDeltaState {
         }
         let delta = &next[consumed..];
         self.text.push_str(delta);
-        Ok(Some(delta.to_string()))
+        Ok(Some(format!("{separator}{delta}")))
     }
 
-    fn text(&self) -> &str {
-        &self.text
+    /// Everything streamed so far: the closed phases, then the current one.
+    fn text(&self) -> String {
+        format!("{}{}", self.closed, self.text)
     }
 
     fn is_empty(&self) -> bool {
@@ -452,7 +512,7 @@ enum TerminalStatus {
 
 enum PayloadText<'a> {
     None,
-    Update(&'a str),
+    Updates(Vec<TextUpdate<'a>>),
     Final(&'a str),
 }
 
@@ -482,31 +542,37 @@ fn payload_view(payload: &ProductOutboundPayload) -> PayloadView<'_> {
 }
 
 fn projection_state_view(state: &ProductProjectionState) -> PayloadView<'_> {
-    let mut text = PayloadText::None;
+    let mut updates = Vec::new();
     let mut terminal_status = TerminalStatus::None;
-    for item in state.items.iter().rev() {
+    for item in &state.items {
         match item {
-            ProductProjectionItem::Text { body, .. } if matches!(text, PayloadText::None) => {
-                text = PayloadText::Update(body.as_str());
-            }
-            ProductProjectionItem::RunStatus { status, .. }
-                if matches!(terminal_status, TerminalStatus::None) =>
-            {
+            ProductProjectionItem::Text {
+                id,
+                body,
+                finalized,
+                ..
+            } => updates.push(TextUpdate {
+                phase: id.as_str(),
+                body: body.as_str(),
+                confirms_current_phase: *finalized,
+            }),
+            ProductProjectionItem::RunStatus { status, .. } => {
                 terminal_status = match status.as_str() {
                     "completed" => TerminalStatus::Completed,
                     "failed" | "killed" => TerminalStatus::Failed,
                     "cancelled" => TerminalStatus::Cancelled,
-                    _ => TerminalStatus::None,
+                    _ => terminal_status,
                 };
             }
             _ => {}
         }
-        if !matches!(text, PayloadText::None) && !matches!(terminal_status, TerminalStatus::None) {
-            break;
-        }
     }
     PayloadView {
-        text,
+        text: if updates.is_empty() {
+            PayloadText::None
+        } else {
+            PayloadText::Updates(updates)
+        },
         terminal_status,
     }
 }

--- a/crates/product/ironclaw_openai_compat/src/streaming.rs
+++ b/crates/product/ironclaw_openai_compat/src/streaming.rs
@@ -161,7 +161,7 @@ fn chat_sse_stream(
                                 }
                             }
                             PayloadText::Final(text) => {
-                                match state.delta_for(TextUpdate::final_reply(text)) {
+                                match state.delta_for(TextUpdate::Confirm { body: text }) {
                                     Ok(Some(delta)) => yield Ok(chat_text_delta_event(&public_id, created, &model, delta)),
                                     Ok(None) => {}
                                     Err(error) => {
@@ -270,7 +270,7 @@ fn response_sse_stream(
                                 }
                             }
                             PayloadText::Final(text) => {
-                                match state.delta_for(TextUpdate::final_reply(text)) {
+                                match state.delta_for(TextUpdate::Confirm { body: text }) {
                                     Ok(Some(delta)) => {
                                         yield Ok(response_text_delta_event(
                                             &public_id,
@@ -287,7 +287,7 @@ fn response_sse_stream(
                                     }
                                 }
                                 if !state.is_empty() {
-                                    yield Ok(response_text_done_event(&item_id, sequence_number, &state.text()));
+                                    yield Ok(response_text_done_event(&item_id, sequence_number, state.text()));
                                     sequence_number += 1;
                                 }
                                 yield Ok(response_terminal_event(
@@ -297,7 +297,7 @@ fn response_sse_stream(
                                     created,
                                     model.clone(),
                                     OpenAiResponseStatus::Completed,
-                                    &state.text(),
+                                    state.text(),
                                 ));
                                 return;
                             }
@@ -306,7 +306,7 @@ fn response_sse_stream(
                             TerminalStatus::None => {}
                             TerminalStatus::Completed => {
                                 if !state.is_empty() {
-                                    yield Ok(response_text_done_event(&item_id, sequence_number, &state.text()));
+                                    yield Ok(response_text_done_event(&item_id, sequence_number, state.text()));
                                     sequence_number += 1;
                                 }
                                 yield Ok(response_terminal_event(
@@ -316,7 +316,7 @@ fn response_sse_stream(
                                     created,
                                     model.clone(),
                                     OpenAiResponseStatus::Completed,
-                                    &state.text(),
+                                    state.text(),
                                 ));
                                 return;
                             }
@@ -328,7 +328,7 @@ fn response_sse_stream(
                                     created,
                                     model.clone(),
                                     OpenAiResponseStatus::Failed,
-                                    &state.text(),
+                                    state.text(),
                                 ));
                                 return;
                             }
@@ -340,7 +340,7 @@ fn response_sse_stream(
                                     created,
                                     model.clone(),
                                     OpenAiResponseStatus::Cancelled,
-                                    &state.text(),
+                                    state.text(),
                                 ));
                                 return;
                             }
@@ -406,42 +406,35 @@ fn stream_timeout_error() -> OpenAiCompatHttpError {
     OpenAiCompatHttpError::from_kind(503, true, OpenAiCompatErrorKind::ServiceUnavailable, None)
 }
 
-/// One text update from the projection: the phase it belongs to (the live
-/// text item id — one per model call) and that phase's cumulative body. The
-/// durable transcript row (finalized) and the final-reply payload belong to
-/// whichever phase is current: they confirm it, never start one.
-struct TextUpdate<'a> {
-    phase: &'a str,
-    body: &'a str,
-    confirms_current_phase: bool,
+/// One text update from the projection.
+enum TextUpdate<'a> {
+    /// A call's cumulative body: one live text item per model call, keyed
+    /// by the item id.
+    Call { id: &'a str, body: &'a str },
+    /// A call the loop went on past, republished flagged. Already streamed
+    /// when it was the current call; its body is bounded by the document
+    /// (it may be shorter than what streamed) and never a rewrite.
+    Narration { id: &'a str, body: &'a str },
+    /// The durable transcript row or the final-reply payload: confirms the
+    /// current call, never starts one.
+    Confirm { body: &'a str },
 }
 
-impl<'a> TextUpdate<'a> {
-    fn final_reply(body: &'a str) -> Self {
-        Self {
-            phase: "",
-            body,
-            confirms_current_phase: true,
-        }
-    }
-}
-
-/// Between two answer phases (a model call the loop went on past, then the
-/// next call): the completion stays one message, so the phases read as
+/// Between two answer calls (a model call the loop went on past, then the
+/// next call): the completion stays one message, so the calls read as
 /// paragraphs rather than as a rewrite the client cannot express.
-const PHASE_SEPARATOR: &str = "\n\n";
+const CALL_SEPARATOR: &str = "\n\n";
 
 #[derive(Default)]
 struct TextDeltaState {
-    /// The text of the phases already closed, each followed by the separator.
-    closed: String,
-    /// The phase `text` tracks, once any live text arrived.
-    phase: Option<String>,
-    /// Every phase seen: a closed phase republished (its narration flag
-    /// arriving) is already streamed and changes nothing.
+    /// Everything streamed so far, separators included.
+    streamed: String,
+    /// Where the current call's text begins in `streamed`.
+    call_start: usize,
+    /// The call (live text item id) the text past `call_start` belongs to.
+    call: Option<String>,
+    /// Every call seen, so a republish of a closed one changes nothing.
     seen: Vec<String>,
-    /// Text streamed for the current phase.
-    text: String,
 }
 
 impl TextDeltaState {
@@ -449,37 +442,36 @@ impl TextDeltaState {
         &mut self,
         update: TextUpdate<'_>,
     ) -> Result<Option<String>, OpenAiCompatHttpError> {
+        let (id, body, lenient) = match update {
+            TextUpdate::Call { id, body } => (Some(id), body, false),
+            TextUpdate::Narration { id, body } => (Some(id), body, true),
+            TextUpdate::Confirm { body } => (None, body, false),
+        };
         let mut separator = "";
-        if !update.confirms_current_phase && self.phase.as_deref() != Some(update.phase) {
-            if self.seen.iter().any(|seen| seen == update.phase) {
+        if let Some(id) = id
+            && self.call.as_deref() != Some(id)
+        {
+            if self.seen.iter().any(|seen| seen == id) {
                 return Ok(None);
             }
-            if !self.text.is_empty() {
-                self.closed.push_str(&self.text);
-                self.closed.push_str(PHASE_SEPARATOR);
-                separator = PHASE_SEPARATOR;
+            if self.call_start < self.streamed.len() {
+                self.streamed.push_str(CALL_SEPARATOR);
+                separator = CALL_SEPARATOR;
             }
-            self.seen.push(update.phase.to_string());
-            self.phase = Some(update.phase.to_string());
-            self.text.clear();
+            self.seen.push(id.to_string());
+            self.call = Some(id.to_string());
+            self.call_start = self.streamed.len();
         }
-        let next = update.body;
-        let consumed = self.text.len();
-        if next.len() == consumed {
-            if next.as_bytes() != self.text.as_bytes() {
-                return Err(OpenAiCompatHttpError::from_kind(
-                    500,
-                    false,
-                    OpenAiCompatErrorKind::Internal,
-                    None,
-                ));
+        let current = &self.streamed[self.call_start..];
+        let consumed = current.len();
+        let extends = body.len() >= consumed
+            && body.is_char_boundary(consumed)
+            && body.as_bytes().starts_with(current.as_bytes());
+        if !extends {
+            if lenient {
+                // A bounded republish of text this stream already carried.
+                return Ok(None);
             }
-            return Ok(None);
-        }
-        if next.len() < consumed
-            || !next.is_char_boundary(consumed)
-            || !next.as_bytes().starts_with(self.text.as_bytes())
-        {
             return Err(OpenAiCompatHttpError::from_kind(
                 500,
                 false,
@@ -487,18 +479,21 @@ impl TextDeltaState {
                 None,
             ));
         }
-        let delta = &next[consumed..];
-        self.text.push_str(delta);
+        if body.len() == consumed {
+            return Ok(None);
+        }
+        let delta = &body[consumed..];
+        self.streamed.push_str(delta);
         Ok(Some(format!("{separator}{delta}")))
     }
 
-    /// Everything streamed so far: the closed phases, then the current one.
-    fn text(&self) -> String {
-        format!("{}{}", self.closed, self.text)
+    /// Everything streamed so far.
+    fn text(&self) -> &str {
+        &self.streamed
     }
 
     fn is_empty(&self) -> bool {
-        self.text.is_empty()
+        self.streamed.is_empty()
     }
 }
 
@@ -550,11 +545,22 @@ fn projection_state_view(state: &ProductProjectionState) -> PayloadView<'_> {
                 id,
                 body,
                 finalized,
+                narration,
                 ..
-            } => updates.push(TextUpdate {
-                phase: id.as_str(),
-                body: body.as_str(),
-                confirms_current_phase: *finalized,
+            } => updates.push(if *finalized {
+                TextUpdate::Confirm {
+                    body: body.as_str(),
+                }
+            } else if *narration {
+                TextUpdate::Narration {
+                    id: id.as_str(),
+                    body: body.as_str(),
+                }
+            } else {
+                TextUpdate::Call {
+                    id: id.as_str(),
+                    body: body.as_str(),
+                }
             }),
             ProductProjectionItem::RunStatus { status, .. } => {
                 terminal_status = match status.as_str() {

--- a/crates/product/ironclaw_openai_compat/tests/streaming_handlers_contract.rs
+++ b/crates/product/ironclaw_openai_compat/tests/streaming_handlers_contract.rs
@@ -197,6 +197,68 @@ async fn chat_stream_ignores_a_late_republish_of_a_closed_phase() {
     );
 }
 
+/// The Responses lane through the same calls: each delta, then
+/// `response.output_text.done` and `response.completed` carrying the
+/// accumulated text with exactly one separator.
+#[tokio::test]
+async fn responses_stream_carries_each_answer_call_as_a_paragraph_of_one_message() {
+    let streamer = Arc::new(QueuedStreamer::new());
+    streamer.push_response(vec![
+        projection_phase_envelope(
+            "resp-1",
+            "text:run-1:1",
+            "Let me look at the long thing.",
+            false,
+        ),
+        projection_phase_envelope("resp-2", "text:run-1:1", "Let me look", true),
+        projection_phase_envelope("resp-3", "text:run-1:2", "Here you go.", false),
+        run_status_envelope("resp-4", "completed"),
+    ]);
+    let router = router(streamer);
+
+    let response = router
+        .oneshot(post_json(
+            "/v1/responses",
+            json!({"model": "gpt-reborn", "stream": true, "input": "look"}),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(response.status(), http::StatusCode::OK);
+    let raw = response_body(response).await;
+    assert!(!raw.contains("event: error"), "raw SSE: {raw}");
+    let events = raw
+        .lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+        .collect::<Vec<_>>();
+    let deltas = events
+        .iter()
+        .filter(|event| event["type"] == "response.output_text.delta")
+        .filter_map(|event| event["delta"].as_str().map(str::to_string))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        deltas,
+        ["Let me look at the long thing.", "\n\nHere you go."],
+        "raw SSE: {raw}"
+    );
+    let accumulated = "Let me look at the long thing.\n\nHere you go.";
+    let done = events
+        .iter()
+        .find(|event| event["type"] == "response.output_text.done")
+        .expect("output_text.done");
+    assert_eq!(done["text"].as_str(), Some(accumulated), "raw SSE: {raw}");
+    let completed = events
+        .iter()
+        .find(|event| event["type"] == "response.completed")
+        .expect("response.completed");
+    assert!(
+        completed
+            .to_string()
+            .contains(&accumulated.replace('\n', "\\n")),
+        "response.completed carries the accumulated text: {completed}"
+    );
+}
+
 /// Drive one streamed chat completion and return its content deltas in
 /// order, asserting the stream ended cleanly.
 async fn chat_delta_contents(streamer: Arc<QueuedStreamer>) -> Vec<String> {

--- a/crates/product/ironclaw_openai_compat/tests/streaming_handlers_contract.rs
+++ b/crates/product/ironclaw_openai_compat/tests/streaming_handlers_contract.rs
@@ -108,6 +108,125 @@ async fn chat_stream_carries_each_answer_phase_as_a_paragraph_of_one_completion(
     assert!(raw.contains("[DONE]"), "raw SSE: {raw}");
 }
 
+/// The narration republish carries the document's bounded copy of the
+/// phase, which can be shorter than what already streamed. It confirms the
+/// phase and adds nothing; it is never the rewrite that ends the stream.
+#[tokio::test]
+async fn chat_stream_ignores_a_shorter_narration_republish_of_the_current_phase() {
+    let streamer = Arc::new(QueuedStreamer::new());
+    streamer.push_chat(vec![
+        projection_phase_envelope(
+            "chat-1",
+            "text:run-1:1",
+            "Let me look at the long thing.",
+            false,
+        ),
+        projection_phase_envelope("chat-2", "text:run-1:1", "Let me look", true),
+        projection_phase_envelope("chat-3", "text:run-1:2", "Here you go.", false),
+        run_status_envelope("chat-4", "completed"),
+    ]);
+    let router = router(streamer.clone());
+
+    let response = router
+        .oneshot(post_json(
+            "/v1/chat/completions",
+            json!({
+                "model": "gpt-reborn",
+                "stream": true,
+                "messages": [{"role": "user", "content": "look"}]
+            }),
+        ))
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), http::StatusCode::OK);
+    let raw = response_body(response).await;
+    assert!(!raw.contains("event: error"), "raw SSE: {raw}");
+    let contents = raw
+        .lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+        .filter_map(|chunk| {
+            chunk["choices"][0]["delta"]["content"]
+                .as_str()
+                .map(str::to_string)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        contents,
+        ["Let me look at the long thing.", "\n\nHere you go."],
+        "raw SSE: {raw}"
+    );
+    assert!(raw.contains("[DONE]"), "raw SSE: {raw}");
+}
+
+/// The durable transcript row arrives under the transcript's own id, never
+/// a phase id: it confirms the current phase and never starts one, so the
+/// completion carries no second copy of the answer.
+#[tokio::test]
+async fn chat_stream_a_finalized_transcript_row_confirms_the_current_phase() {
+    let streamer = Arc::new(QueuedStreamer::new());
+    streamer.push_chat(vec![
+        projection_phase_envelope("chat-1", "text:run-1:1", "Let me look.", false),
+        projection_phase_envelope("chat-2", "text:run-1:1", "Let me look.", true),
+        projection_phase_envelope("chat-3", "text:run-1:2", "Here you go.", false),
+        finalized_text_envelope("chat-4", "message-7", "Here you go."),
+        run_status_envelope("chat-5", "completed"),
+    ]);
+    assert_eq!(
+        chat_delta_contents(streamer).await,
+        ["Let me look.", "\n\nHere you go."]
+    );
+}
+
+/// A republish of a phase the lane already moved past (a late narration
+/// flag, a replayed frame) changes nothing: no third paragraph, no extra
+/// separator.
+#[tokio::test]
+async fn chat_stream_ignores_a_late_republish_of_a_closed_phase() {
+    let streamer = Arc::new(QueuedStreamer::new());
+    streamer.push_chat(vec![
+        projection_phase_envelope("chat-1", "text:run-1:1", "Let me look.", false),
+        projection_phase_envelope("chat-2", "text:run-1:2", "Here you go.", false),
+        projection_phase_envelope("chat-3", "text:run-1:1", "Let me look.", true),
+        run_status_envelope("chat-4", "completed"),
+    ]);
+    assert_eq!(
+        chat_delta_contents(streamer).await,
+        ["Let me look.", "\n\nHere you go."]
+    );
+}
+
+/// Drive one streamed chat completion and return its content deltas in
+/// order, asserting the stream ended cleanly.
+async fn chat_delta_contents(streamer: Arc<QueuedStreamer>) -> Vec<String> {
+    let router = router(streamer);
+    let response = router
+        .oneshot(post_json(
+            "/v1/chat/completions",
+            json!({
+                "model": "gpt-reborn",
+                "stream": true,
+                "messages": [{"role": "user", "content": "look"}]
+            }),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(response.status(), http::StatusCode::OK);
+    let raw = response_body(response).await;
+    assert!(!raw.contains("event: error"), "raw SSE: {raw}");
+    assert!(raw.contains("[DONE]"), "raw SSE: {raw}");
+    raw.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+        .filter_map(|chunk| {
+            chunk["choices"][0]["delta"]["content"]
+                .as_str()
+                .map(str::to_string)
+        })
+        .collect()
+}
+
 #[tokio::test]
 async fn responses_stream_emits_response_events_without_projection_cursor() {
     let streamer = Arc::new(QueuedStreamer::new());
@@ -964,6 +1083,25 @@ fn projection_phase_envelope(
                     body: text.to_string(),
                     finalized: false,
                     narration,
+                }],
+            )
+            .expect("projection state"),
+        },
+    )
+}
+
+fn finalized_text_envelope(cursor: &str, id: &str, text: &str) -> ProductOutboundEnvelope {
+    envelope(
+        cursor,
+        ProductOutboundPayload::ProjectionUpdate {
+            state: ProductProjectionState::new(
+                "thread-a",
+                vec![ProductProjectionItem::Text {
+                    id: id.to_string(),
+                    run_id: None,
+                    body: text.to_string(),
+                    finalized: true,
+                    narration: false,
                 }],
             )
             .expect("projection state"),

--- a/crates/product/ironclaw_openai_compat/tests/streaming_handlers_contract.rs
+++ b/crates/product/ironclaw_openai_compat/tests/streaming_handlers_contract.rs
@@ -60,6 +60,54 @@ async fn chat_stream_emits_openai_chunks_without_projection_cursor() {
     assert_eq!(streamer.chat_calls(), 1);
 }
 
+/// Live text arrives one item per model call (the phase in the item id). A
+/// call the loop went on past is republished flagged as narration — already
+/// streamed, nothing more goes out — and the next call's text is a new
+/// phase: the completion stays one message, so the phases read as
+/// paragraphs, never as a rewrite.
+#[tokio::test]
+async fn chat_stream_carries_each_answer_phase_as_a_paragraph_of_one_completion() {
+    let streamer = Arc::new(QueuedStreamer::new());
+    streamer.push_chat(vec![
+        projection_phase_envelope("chat-1", "text:run-1:1", "Let me look.", false),
+        projection_phase_envelope("chat-2", "text:run-1:1", "Let me look.", true),
+        projection_phase_envelope("chat-3", "text:run-1:2", "Here you go.", false),
+        run_status_envelope("chat-4", "completed"),
+    ]);
+    let router = router(streamer.clone());
+
+    let response = router
+        .oneshot(post_json(
+            "/v1/chat/completions",
+            json!({
+                "model": "gpt-reborn",
+                "stream": true,
+                "messages": [{"role": "user", "content": "look"}]
+            }),
+        ))
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), http::StatusCode::OK);
+    let raw = response_body(response).await;
+    let contents = raw
+        .lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+        .filter_map(|chunk| {
+            chunk["choices"][0]["delta"]["content"]
+                .as_str()
+                .map(str::to_string)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        contents,
+        ["Let me look.", "\n\nHere you go."],
+        "raw SSE: {raw}"
+    );
+    assert!(raw.contains("[DONE]"), "raw SSE: {raw}");
+}
+
 #[tokio::test]
 async fn responses_stream_emits_response_events_without_projection_cursor() {
     let streamer = Arc::new(QueuedStreamer::new());
@@ -90,8 +138,19 @@ async fn responses_stream_emits_response_events_without_projection_cursor() {
 async fn keepalive_is_suppressed_and_non_monotonic_rebase_fails_safely() {
     let streamer = Arc::new(QueuedStreamer::new());
     streamer.push_response(vec![keepalive_envelope("keepalive")]);
-    streamer.push_response(vec![projection_text_envelope("first", "hello")]);
-    streamer.push_response(vec![projection_text_envelope("rebase", "he")]);
+    // The same phase going backwards: a rewrite the client cannot express.
+    streamer.push_response(vec![projection_phase_envelope(
+        "first",
+        "text:run-1:1",
+        "hello",
+        false,
+    )]);
+    streamer.push_response(vec![projection_phase_envelope(
+        "rebase",
+        "text:run-1:1",
+        "he",
+        false,
+    )]);
     let router = router(streamer);
 
     let response = router
@@ -119,8 +178,19 @@ async fn keepalive_is_suppressed_and_non_monotonic_rebase_fails_safely() {
 #[tokio::test]
 async fn chat_stream_non_monotonic_rebase_fails_safely() {
     let streamer = Arc::new(QueuedStreamer::new());
-    streamer.push_chat(vec![projection_text_envelope("first", "hello")]);
-    streamer.push_chat(vec![projection_text_envelope("rebase", "jello")]);
+    // The same phase rewritten: a rewrite the client cannot express.
+    streamer.push_chat(vec![projection_phase_envelope(
+        "first",
+        "text:run-1:1",
+        "hello",
+        false,
+    )]);
+    streamer.push_chat(vec![projection_phase_envelope(
+        "rebase",
+        "text:run-1:1",
+        "jello",
+        false,
+    )]);
     let router = router(streamer);
 
     let response = router
@@ -869,6 +939,31 @@ fn projection_text_envelope(cursor: &str, text: &str) -> ProductOutboundEnvelope
                     run_id: None,
                     body: text.to_string(),
                     finalized: false,
+                    narration: false,
+                }],
+            )
+            .expect("projection state"),
+        },
+    )
+}
+
+fn projection_phase_envelope(
+    cursor: &str,
+    id: &str,
+    text: &str,
+    narration: bool,
+) -> ProductOutboundEnvelope {
+    envelope(
+        cursor,
+        ProductOutboundPayload::ProjectionUpdate {
+            state: ProductProjectionState::new(
+                "thread-a",
+                vec![ProductProjectionItem::Text {
+                    id: id.to_string(),
+                    run_id: None,
+                    body: text.to_string(),
+                    finalized: false,
+                    narration,
                 }],
             )
             .expect("projection state"),

--- a/crates/product/ironclaw_webui/CONTRACT.md
+++ b/crates/product/ironclaw_webui/CONTRACT.md
@@ -303,15 +303,25 @@ route (tenant/user-scoped tool-approval settings), not an operator route.
   I/O never gates individual text frames; drain/poll remains only for
   compatibility surfaces without subscriptions.
 - Live assistant text is cumulative within one model call and keyed by both
-  turn run and model-call phase. A later model call therefore starts a new
-  assistant item instead of replacing an earlier utterance from the same run.
-  The SPA marks the prior phase as no longer streaming, retains it as
-  intermediate text, and upgrades only the latest phase when the durable final
-  reply arrives. If the run fails before a final reply, the SPA removes the
-  still-streaming unfinished phase and shows the typed, actionable run failure
-  instead, while preserving earlier completed phases; a late projection frame
-  cannot restore the unfinished draft. These phase items remain
-  live-projection/session state rather than durable transcript records.
+  turn run and model call (`text:{run}:{call}`). A later model call therefore
+  starts a new assistant item instead of replacing an earlier utterance from
+  the same run. A call the loop went on past (a capability invocation, a
+  gate, or another call followed it) was narration, not the answer: the
+  projection republishes its item once under the same id with
+  `narration: true`, ahead of the capability card that proved it. The SPA
+  gives that item its own `narration` role and renders it inside the run's
+  collapsible activity, like reasoning and tool cards, never as a bubble;
+  every `assistant` predicate excludes it by construction. The trailing
+  unflagged call is the streaming bubble; the durable final reply converges
+  into it by identity and collapses earlier unflagged calls, while narration
+  stays with the run's activity. The live and durable rails are independent,
+  so a flagged republish may arrive after the final reply and still joins
+  the activity; a late unflagged call for a finalized run is ignored. If the
+  run fails before a final reply, the SPA removes the still-streaming
+  unfinished call and shows the typed, actionable run failure instead, while
+  preserving earlier completed items; a late projection frame cannot restore
+  the unfinished draft. These items remain live-projection/session state
+  rather than durable transcript records.
 - Active assistant phases render accumulated Markdown through Streamdown's
   incomplete-Markdown-aware streaming mode. The product projection boundary
   publishes cumulative text at most once per 16 ms browser-paint interval,

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/activity-run.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/activity-run.test.ts
@@ -206,10 +206,9 @@ test("ActivityRun renders a narration phase as a settled note inside the run", (
   const item = context.globalThis.__testExports.ActivityItem({
     item: {
       id: "text-text:run-1:1",
-      role: "assistant",
+      role: "narration",
       content: "Let me look.",
       isFinalReply: false,
-      isNarration: true,
       turnRunId: "run-1",
     },
     activeRunId: "run-1",

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/activity-run.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/activity-run.test.ts
@@ -19,7 +19,7 @@ function activityRunSourceForTest() {
     }
     lines.push(line.replace("export function ActivityRun", "function ActivityRun"));
   }
-  return `${lines.join("\n")}\nglobalThis.__testExports = { ActivityRun };`;
+  return `${lines.join("\n")}\nglobalThis.__testExports = { ActivityRun, ActivityItem };`;
 }
 
 test("ActivityRun keeps running tool activity collapsed by default", () => {
@@ -180,3 +180,45 @@ function containsScalar(node, expected) {
   if (!node || typeof node !== "object" || !Array.isArray(node.values)) return false;
   return node.values.some((value) => containsScalar(value, expected));
 }
+
+test("ActivityRun renders a narration phase as a settled note inside the run", () => {
+  const rendered = [];
+  const context = {
+    globalThis: {},
+    html: (strings, ...values) => ({ strings: Array.from(strings), values }),
+    Icon(props) {
+      rendered.push(`icon:${props.name}`);
+    },
+    MarkdownRenderer(props) {
+      rendered.push(`markdown:${props.content}:streaming=${props.streaming}`);
+    },
+    React: {
+      useMemo: (factory) => factory(),
+      useState: (initial) => [typeof initial === "function" ? initial() : initial, () => {}],
+    },
+    summarizeActivity: () => ({ label: "Activity", hasError: false }),
+    useT: () => (key) => key,
+    ToolActivity() {},
+    messageBelongsToActiveRun: () => false,
+  };
+
+  vm.runInNewContext(activityRunSourceForTest(), context);
+  const item = context.globalThis.__testExports.ActivityItem({
+    item: {
+      id: "text-text:run-1:1",
+      role: "assistant",
+      content: "Let me look.",
+      isFinalReply: false,
+      isNarration: true,
+      turnRunId: "run-1",
+    },
+    activeRunId: "run-1",
+  });
+
+  assert.ok(item, "a narration phase is an activity item, never dropped");
+  assert.equal(
+    hasComponentNamed(item, "NoteItem"),
+    true,
+    "narration renders as a note like reasoning does",
+  );
+});

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/activity-run.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/activity-run.test.ts
@@ -220,4 +220,10 @@ test("ActivityRun renders a narration phase as a settled note inside the run", (
     true,
     "narration renders as a note like reasoning does",
   );
+  assert.ok(
+    item.strings.join("").includes('kind="narration"'),
+    `the note is a narration note: ${item.strings.join("|")}`,
+  );
+  assert.ok(containsScalar(item, "Let me look."), "the note carries the narration text");
+  assert.ok(!containsScalar(item, true), "narration is settled text, never streaming");
 });

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
@@ -20,7 +20,7 @@ type ActivityItemProps = {
 };
 
 type NoteItemProps = {
-  icon: "spark" | "chat";
+  kind: "reasoning" | "narration";
   content?: string;
   streaming?: boolean;
 };
@@ -74,17 +74,17 @@ function ActivityItem({ item, activeRunId }: ActivityItemProps) {
       messageBelongsToActiveRun(item, activeRunId);
     return (
       <NoteItem
-        icon="spark"
+        kind="reasoning"
         content={item.content}
         streaming={isStreaming}
       />
     );
   }
 
-  if (item.role === "assistant" && item.isNarration === true) {
+  if (item.role === "narration") {
     // A model call the loop went on past: what the assistant said before
     // the tool call that followed it. Settled text, never streaming.
-    return <NoteItem icon="chat" content={item.content} />;
+    return <NoteItem kind="narration" content={item.content} />;
   }
 
   if (item.role === "tool_activity" || hasToolCalls(item)) {
@@ -97,10 +97,12 @@ function ActivityItem({ item, activeRunId }: ActivityItemProps) {
   return null;
 }
 
-function NoteItem({ icon, content, streaming = false }: NoteItemProps) {
+function NoteItem({ kind, content, streaming = false }: NoteItemProps) {
   if (!content) return null;
+  const icon = kind === "reasoning" ? "spark" : "chat";
+  const testId = kind === "reasoning" ? "activity-reasoning" : "activity-narration";
   return (
-    <div className="flex min-w-0 gap-3" data-testid={`activity-${icon === "spark" ? "reasoning" : "narration"}`}>
+    <div className="flex min-w-0 gap-3" data-testid={testId}>
       <div
         className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-white/10 bg-iron-800 text-iron-100"
       >

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/activity-run.tsx
@@ -19,7 +19,8 @@ type ActivityItemProps = {
   activeRunId: string | null;
 };
 
-type ReasoningItemProps = {
+type NoteItemProps = {
+  icon: "spark" | "chat";
   content?: string;
   streaming?: boolean;
 };
@@ -72,11 +73,18 @@ function ActivityItem({ item, activeRunId }: ActivityItemProps) {
     const isStreaming =
       messageBelongsToActiveRun(item, activeRunId);
     return (
-      <ReasoningItem
+      <NoteItem
+        icon="spark"
         content={item.content}
         streaming={isStreaming}
       />
     );
+  }
+
+  if (item.role === "assistant" && item.isNarration === true) {
+    // A model call the loop went on past: what the assistant said before
+    // the tool call that followed it. Settled text, never streaming.
+    return <NoteItem icon="chat" content={item.content} />;
   }
 
   if (item.role === "tool_activity" || hasToolCalls(item)) {
@@ -89,14 +97,14 @@ function ActivityItem({ item, activeRunId }: ActivityItemProps) {
   return null;
 }
 
-function ReasoningItem({ content, streaming = false }: ReasoningItemProps) {
+function NoteItem({ icon, content, streaming = false }: NoteItemProps) {
   if (!content) return null;
   return (
-    <div className="flex min-w-0 gap-3">
+    <div className="flex min-w-0 gap-3" data-testid={`activity-${icon === "spark" ? "reasoning" : "narration"}`}>
       <div
         className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-white/10 bg-iron-800 text-iron-100"
       >
-        <Icon name="spark" className="h-4 w-4" />
+        <Icon name={icon} className="h-4 w-4" />
       </div>
       <div className="min-w-0 flex-1 border-l-2 border-white/10 pl-3 text-iron-300 v2-chat-readable-width">
         <MarkdownRenderer

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-groups.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-groups.test.ts
@@ -558,3 +558,70 @@ test("groupMessages: activity run falls back to tool update timestamps", () => {
     ["tool-web", "tool-list", "tool-nearai"],
   );
 });
+
+test("groupMessages: narration phases render inside the activity run ahead of their tool card, the streaming answer stays a bubble", () => {
+  const grouped = groupMessages([
+    { id: "u1", role: "user", content: "find it", turnRunId: "run-1" },
+    {
+      id: "text-text:run-1:1",
+      role: "assistant",
+      content: "Let me look.",
+      isFinalReply: false,
+      isStreaming: false,
+      isNarration: true,
+      turnRunId: "run-1",
+    },
+    {
+      id: "tool-read",
+      role: "tool_activity",
+      toolName: "read",
+      turnRunId: "run-1",
+    },
+    {
+      id: "text-text:run-1:2",
+      role: "assistant",
+      content: "Here you go.",
+      isFinalReply: false,
+      isStreaming: true,
+      turnRunId: "run-1",
+    },
+  ]);
+
+  assert.deepEqual(
+    grouped.map((item) => (item.type === "activity-run" ? item.id : item.message.id)),
+    ["u1", "activity-run-text-text:run-1:1", "text-text:run-1:2"],
+  );
+  assert.deepEqual(
+    grouped[1].activity.map((item) => item.id),
+    ["text-text:run-1:1", "tool-read"],
+    "the narration sits ahead of the tool call that followed it",
+  );
+});
+
+test("groupMessages: a final reply keeps its run's narration inside the activity run", () => {
+  const grouped = groupMessages([
+    { id: "u1", role: "user", content: "find it", turnRunId: "run-1" },
+    {
+      id: "text-text:run-1:1",
+      role: "assistant",
+      content: "Let me look.",
+      isFinalReply: false,
+      isStreaming: false,
+      isNarration: true,
+      turnRunId: "run-1",
+    },
+    { id: "tool-read", role: "tool_activity", toolName: "read", turnRunId: "run-1" },
+    {
+      id: "reply-run-1",
+      role: "assistant",
+      content: "Here you go.",
+      isFinalReply: true,
+      turnRunId: "run-1",
+    },
+  ]);
+
+  assert.deepEqual(
+    grouped.map((item) => (item.type === "activity-run" ? item.id : item.message.id)),
+    ["u1", "activity-run-text-text:run-1:1", "reply-run-1"],
+  );
+});

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-groups.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-groups.test.ts
@@ -564,11 +564,10 @@ test("groupMessages: narration phases render inside the activity run ahead of th
     { id: "u1", role: "user", content: "find it", turnRunId: "run-1" },
     {
       id: "text-text:run-1:1",
-      role: "assistant",
+      role: "narration",
       content: "Let me look.",
       isFinalReply: false,
       isStreaming: false,
-      isNarration: true,
       turnRunId: "run-1",
     },
     {
@@ -603,11 +602,10 @@ test("groupMessages: a final reply keeps its run's narration inside the activity
     { id: "u1", role: "user", content: "find it", turnRunId: "run-1" },
     {
       id: "text-text:run-1:1",
-      role: "assistant",
+      role: "narration",
       content: "Let me look.",
       isFinalReply: false,
       isStreaming: false,
-      isNarration: true,
       turnRunId: "run-1",
     },
     { id: "tool-read", role: "tool_activity", toolName: "read", turnRunId: "run-1" },

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-groups.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-groups.ts
@@ -2,7 +2,9 @@
    same-run activity arrives after assistant text, render that activity before
    the text so tools stay at the top of the run during streaming and after the
    final answer, including when a later user follow-up has already been
-   appended. */
+   appended. Assistant text the projection flagged as narration (a model call
+   the loop went on past) is activity too: it renders inside the run, ahead
+   of the tool card that followed it, never as a bubble. */
 export function groupMessages(messages) {
   const renderableMessages = messages.filter(
     (message) => !isEmptyIntermediateAssistantPhase(message),
@@ -139,6 +141,7 @@ function messageRenderKey(message) {
   const isActiveAssistantReply =
     message?.role === "assistant" &&
     message?.isFinalReply === false &&
+    message?.isNarration !== true &&
     message?.isStreaming === true;
   if (runId && (isFinalAssistantReply(message) || isActiveAssistantReply)) {
     return `assistant-reply-${runId}`;
@@ -165,8 +168,13 @@ function isStreamingAssistantText(msg) {
     msg?.role === "assistant" &&
     !hasToolCalls(msg) &&
     msg.isFinalReply === false &&
+    msg.isNarration !== true &&
     Boolean(turnRunIdForMessage(msg))
   );
+}
+
+function isNarration(msg) {
+  return msg?.role === "assistant" && msg.isNarration === true;
 }
 
 function isEmptyIntermediateAssistantPhase(msg) {
@@ -191,7 +199,12 @@ function isEmptyIntermediateAssistantPhase(msg) {
 }
 
 function isActivity(msg) {
-  return msg.role === "thinking" || msg.role === "tool_activity" || hasToolCalls(msg);
+  return (
+    msg.role === "thinking" ||
+    msg.role === "tool_activity" ||
+    hasToolCalls(msg) ||
+    isNarration(msg)
+  );
 }
 
 function hasToolCalls(msg) {

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-groups.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-groups.ts
@@ -2,9 +2,9 @@
    same-run activity arrives after assistant text, render that activity before
    the text so tools stay at the top of the run during streaming and after the
    final answer, including when a later user follow-up has already been
-   appended. Assistant text the projection flagged as narration (a model call
-   the loop went on past) is activity too: it renders inside the run, ahead
-   of the tool card that followed it, never as a bubble. */
+   appended. Narration (a model call the loop went on past, its own role
+   like reasoning) is activity too: it renders inside the run, ahead of the
+   tool card that followed it, never as a bubble. */
 export function groupMessages(messages) {
   const renderableMessages = messages.filter(
     (message) => !isEmptyIntermediateAssistantPhase(message),
@@ -141,7 +141,6 @@ function messageRenderKey(message) {
   const isActiveAssistantReply =
     message?.role === "assistant" &&
     message?.isFinalReply === false &&
-    message?.isNarration !== true &&
     message?.isStreaming === true;
   if (runId && (isFinalAssistantReply(message) || isActiveAssistantReply)) {
     return `assistant-reply-${runId}`;
@@ -168,13 +167,8 @@ function isStreamingAssistantText(msg) {
     msg?.role === "assistant" &&
     !hasToolCalls(msg) &&
     msg.isFinalReply === false &&
-    msg.isNarration !== true &&
     Boolean(turnRunIdForMessage(msg))
   );
-}
-
-function isNarration(msg) {
-  return msg?.role === "assistant" && msg.isNarration === true;
 }
 
 function isEmptyIntermediateAssistantPhase(msg) {
@@ -201,9 +195,9 @@ function isEmptyIntermediateAssistantPhase(msg) {
 function isActivity(msg) {
   return (
     msg.role === "thinking" ||
+    msg.role === "narration" ||
     msg.role === "tool_activity" ||
-    hasToolCalls(msg) ||
-    isNarration(msg)
+    hasToolCalls(msg)
   );
 }
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-types.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-types.ts
@@ -5,6 +5,10 @@ export const CHAT_MESSAGE_ROLES = Object.freeze({
   ERROR: "error",
   TOOL_ACTIVITY: "tool_activity",
   THINKING: "thinking",
+  /** Live assistant text the loop went on past (a tool call followed it):
+   *  progress narration that belongs with the run's activity, never the
+   *  answer. Set from the projection's `narration` flag. */
+  NARRATION: "narration",
   IMAGE: "image",
 } as const);
 
@@ -43,10 +47,6 @@ export type ChatMessage = {
   error?: string;
   errorKey?: string;
   toolCalls?: unknown[];
-  /** Live assistant text the loop went on past (a tool call followed it):
-   *  progress narration that belongs with the run's activity, not the
-   *  answer. Set from the projection's `narration` flag. */
-  isNarration?: boolean;
   [key: string]: unknown;
 };
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-types.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/message-types.ts
@@ -43,6 +43,10 @@ export type ChatMessage = {
   error?: string;
   errorKey?: string;
   toolCalls?: unknown[];
+  /** Live assistant text the loop went on past (a tool call followed it):
+   *  progress narration that belongs with the run's activity, not the
+   *  answer. Set from the projection's `narration` flag. */
+  isNarration?: boolean;
   [key: string]: unknown;
 };
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/stream-order-memory.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/stream-order-memory.ts
@@ -56,12 +56,15 @@ export function replaceAssistantReplyForRun(messages, replyMessage, runId) {
       isFinalAssistantMessage(message) && message.turnRunId === runId,
   );
   if (replacementIndex < 0) {
+    // The streaming answer is the run's last live phase; narration phases
+    // (calls the loop went on past) are activity and never the answer.
     for (let index = currentMessages.length - 1; index >= 0; index -= 1) {
       const message = currentMessages[index];
       if (
         message?.role === "assistant" &&
         message.turnRunId === runId &&
-        message.isFinalReply === false
+        message.isFinalReply === false &&
+        message.isNarration !== true
       ) {
         replacementIndex = index;
         break;
@@ -77,12 +80,15 @@ export function replaceAssistantReplyForRun(messages, replyMessage, runId) {
     currentMessages[replacementIndex],
     replyMessage,
   );
+  // Earlier unflagged phases collapse into the final reply; narration stays
+  // with the run's activity, the way reasoning and tool cards do.
   return next.filter(
     (message, index) =>
       index === replacementIndex ||
       message?.role !== "assistant" ||
       message.turnRunId !== runId ||
-      message.isFinalReply !== false,
+      message.isFinalReply !== false ||
+      message.isNarration === true,
   );
 }
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/stream-order-memory.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/stream-order-memory.ts
@@ -22,7 +22,11 @@ export function isFinalAssistantForRun(message, runId) {
 }
 
 export function isRunActivityMessage(message) {
-  return message?.role === "tool_activity" || message?.role === "thinking";
+  return (
+    message?.role === "tool_activity" ||
+    message?.role === "thinking" ||
+    message?.role === "narration"
+  );
 }
 
 export function carryFinalAssistantOrderFlags(fresh, current) {
@@ -56,15 +60,14 @@ export function replaceAssistantReplyForRun(messages, replyMessage, runId) {
       isFinalAssistantMessage(message) && message.turnRunId === runId,
   );
   if (replacementIndex < 0) {
-    // The streaming answer is the run's last live phase; narration phases
-    // (calls the loop went on past) are activity and never the answer.
+    // The streaming answer is the run's last live phase; narration (its
+    // own role) is activity and never the answer.
     for (let index = currentMessages.length - 1; index >= 0; index -= 1) {
       const message = currentMessages[index];
       if (
         message?.role === "assistant" &&
         message.turnRunId === runId &&
-        message.isFinalReply === false &&
-        message.isNarration !== true
+        message.isFinalReply === false
       ) {
         replacementIndex = index;
         break;
@@ -80,15 +83,15 @@ export function replaceAssistantReplyForRun(messages, replyMessage, runId) {
     currentMessages[replacementIndex],
     replyMessage,
   );
-  // Earlier unflagged phases collapse into the final reply; narration stays
-  // with the run's activity, the way reasoning and tool cards do.
+  // Earlier phases collapse into the final reply; narration is not an
+  // assistant message and stays with the run's activity, the way reasoning
+  // and tool cards do.
   return next.filter(
     (message, index) =>
       index === replacementIndex ||
       message?.role !== "assistant" ||
       message.turnRunId !== runId ||
-      message.isFinalReply !== false ||
-      message.isNarration === true,
+      message.isFinalReply !== false,
   );
 }
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.test.ts
@@ -578,6 +578,85 @@ test("useChatEvents: final_reply replaces matching streamed projection bubble", 
   assert.equal(harness.isProcessing, false);
 });
 
+test("useChatEvents: a narration republish marks its phase and leaves the streaming answer alone", () => {
+  const harness = createUseChatEventsHarness();
+  const projection = (items) =>
+    harness.handleEvent({ type: "projection_update", frame: { state: { items } } });
+
+  projection([
+    { run_status: { run_id: "run-1", status: "running" } },
+    { text: { id: "text:run-1:1", run_id: "run-1", body: "Let me look." } },
+  ]);
+  assert.deepEqual(
+    Array.from(harness.messages, (message) => [message.id, message.isStreaming, message.isNarration]),
+    [["text-text:run-1:1", true, false]],
+    "the first call's text streams as the provisional answer",
+  );
+
+  // The tool call proved the text was narration: the item is republished
+  // flagged under the id it streamed as.
+  projection([
+    { text: { id: "text:run-1:1", run_id: "run-1", body: "Let me look.", narration: true } },
+  ]);
+  assert.deepEqual(
+    Array.from(harness.messages, (message) => [message.id, message.content, message.isStreaming, message.isNarration]),
+    [["text-text:run-1:1", "Let me look.", false, true]],
+  );
+
+  projection([{ text: { id: "text:run-1:2", run_id: "run-1", body: "Here you go." } }]);
+  // A late republish of the narration must not settle the streaming answer.
+  projection([
+    { text: { id: "text:run-1:1", run_id: "run-1", body: "Let me look.", narration: true } },
+  ]);
+  assert.deepEqual(
+    Array.from(harness.messages, (message) => [message.id, message.isStreaming, message.isNarration]),
+    [
+      ["text-text:run-1:1", false, true],
+      ["text-text:run-1:2", true, false],
+    ],
+    "one message per phase; the narration is settled, the answer keeps streaming",
+  );
+});
+
+test("useChatEvents: final_reply keeps its run's narration and converges only the streaming answer", () => {
+  const harness = createUseChatEventsHarness();
+  const projection = (items) =>
+    harness.handleEvent({ type: "projection_update", frame: { state: { items } } });
+
+  projection([
+    { run_status: { run_id: "run-1", status: "running" } },
+    { text: { id: "text:run-1:1", run_id: "run-1", body: "Let me look." } },
+  ]);
+  projection([
+    { text: { id: "text:run-1:1", run_id: "run-1", body: "Let me look.", narration: true } },
+  ]);
+  projection([{ text: { id: "text:run-1:2", run_id: "run-1", body: "Here you" } }]);
+  harness.handleEvent({
+    type: "final_reply",
+    frame: {
+      reply: {
+        turn_run_id: "run-1",
+        text: "Here you go.",
+        generated_at: "2026-09-02T13:00:00Z",
+      },
+    },
+  });
+
+  assert.deepEqual(
+    Array.from(harness.messages, (message) => [
+      message.id,
+      message.content,
+      message.isFinalReply,
+      message.isNarration,
+    ]),
+    [
+      ["text-text:run-1:1", "Let me look.", false, true],
+      ["reply-run-1", "Here you go.", true, undefined],
+    ],
+    "the narration stays with the run's activity; the final reply replaces the streaming answer alone",
+  );
+});
+
 test("useChatEvents: final_reply collapses earlier assistant phases from the same run", () => {
   const harness = createUseChatEventsHarness();
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.test.ts
@@ -588,8 +588,8 @@ test("useChatEvents: a narration republish marks its phase and leaves the stream
     { text: { id: "text:run-1:1", run_id: "run-1", body: "Let me look." } },
   ]);
   assert.deepEqual(
-    Array.from(harness.messages, (message) => [message.id, message.isStreaming, message.isNarration]),
-    [["text-text:run-1:1", true, false]],
+    Array.from(harness.messages, (message) => [message.id, message.isStreaming, message.role]),
+    [["text-text:run-1:1", true, "assistant"]],
     "the first call's text streams as the provisional answer",
   );
 
@@ -599,8 +599,8 @@ test("useChatEvents: a narration republish marks its phase and leaves the stream
     { text: { id: "text:run-1:1", run_id: "run-1", body: "Let me look.", narration: true } },
   ]);
   assert.deepEqual(
-    Array.from(harness.messages, (message) => [message.id, message.content, message.isStreaming, message.isNarration]),
-    [["text-text:run-1:1", "Let me look.", false, true]],
+    Array.from(harness.messages, (message) => [message.id, message.content, message.isStreaming, message.role]),
+    [["text-text:run-1:1", "Let me look.", false, "narration"]],
   );
 
   projection([{ text: { id: "text:run-1:2", run_id: "run-1", body: "Here you go." } }]);
@@ -609,10 +609,10 @@ test("useChatEvents: a narration republish marks its phase and leaves the stream
     { text: { id: "text:run-1:1", run_id: "run-1", body: "Let me look.", narration: true } },
   ]);
   assert.deepEqual(
-    Array.from(harness.messages, (message) => [message.id, message.isStreaming, message.isNarration]),
+    Array.from(harness.messages, (message) => [message.id, message.isStreaming, message.role]),
     [
-      ["text-text:run-1:1", false, true],
-      ["text-text:run-1:2", true, false],
+      ["text-text:run-1:1", false, "narration"],
+      ["text-text:run-1:2", true, "assistant"],
     ],
     "one message per phase; the narration is settled, the answer keeps streaming",
   );
@@ -647,11 +647,11 @@ test("useChatEvents: final_reply keeps its run's narration and converges only th
       message.id,
       message.content,
       message.isFinalReply,
-      message.isNarration,
+      message.role,
     ]),
     [
-      ["text-text:run-1:1", "Let me look.", false, true],
-      ["reply-run-1", "Here you go.", true, undefined],
+      ["text-text:run-1:1", "Let me look.", false, "narration"],
+      ["reply-run-1", "Here you go.", true, "assistant"],
     ],
     "the narration stays with the run's activity; the final reply replaces the streaming answer alone",
   );
@@ -685,10 +685,10 @@ test("useChatEvents: a narration republish that arrives after the final reply st
   ]);
 
   assert.deepEqual(
-    Array.from(harness.messages, (message) => [message.id, message.isFinalReply, message.isNarration]),
+    Array.from(harness.messages, (message) => [message.id, message.isFinalReply, message.role]),
     [
-      ["reply-run-1", true, undefined],
-      ["text-text:run-1:1", false, true],
+      ["reply-run-1", true, "assistant"],
+      ["text-text:run-1:1", false, "narration"],
     ],
     "the narration lands (the grouping places it inside the run's activity); the stale phase does not",
   );

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.test.ts
@@ -657,6 +657,43 @@ test("useChatEvents: final_reply keeps its run's narration and converges only th
   );
 });
 
+test("useChatEvents: a narration republish that arrives after the final reply still joins the run's activity", () => {
+  const harness = createUseChatEventsHarness();
+  const projection = (items) =>
+    harness.handleEvent({ type: "projection_update", frame: { state: { items } } });
+
+  projection([
+    { run_status: { run_id: "run-1", status: "running" } },
+    { text: { id: "text:run-1:1", run_id: "run-1", body: "Let me look." } },
+    { text: { id: "text:run-1:2", run_id: "run-1", body: "Here you" } },
+  ]);
+  harness.handleEvent({
+    type: "final_reply",
+    frame: {
+      reply: {
+        turn_run_id: "run-1",
+        text: "Here you go.",
+        generated_at: "2026-09-02T13:00:00Z",
+      },
+    },
+  });
+  // The live rail delivers the flagged republish after the durable final
+  // reply; an unflagged late phase for the run stays ignored.
+  projection([
+    { text: { id: "text:run-1:1", run_id: "run-1", body: "Let me look.", narration: true } },
+    { text: { id: "text:run-1:2", run_id: "run-1", body: "Here you go." } },
+  ]);
+
+  assert.deepEqual(
+    Array.from(harness.messages, (message) => [message.id, message.isFinalReply, message.isNarration]),
+    [
+      ["reply-run-1", true, undefined],
+      ["text-text:run-1:1", false, true],
+    ],
+    "the narration lands (the grouping places it inside the run's activity); the stale phase does not",
+  );
+});
+
 test("useChatEvents: final_reply collapses earlier assistant phases from the same run", () => {
   const harness = createUseChatEventsHarness();
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.ts
@@ -810,21 +810,21 @@ function applyProjectionItems({
               message?.role === "assistant" &&
               message.turnRunId === textRunId &&
               message.isFinalReply === false &&
-              message.isNarration !== true &&
               typeof message.id === "string" &&
               message.id.startsWith("text-"),
           );
         }
+        // Narration is its own role, like reasoning: every `assistant`
+        // predicate excludes it by construction.
         const next = {
           ...(existing >= 0 ? phaseAware[existing] : {}),
           id: messageId,
-          role: "assistant",
+          role: narration ? "narration" : "assistant",
           content: item.text.body || "",
           timestamp: phaseAware[existing]?.timestamp || new Date().toISOString(),
           turnRunId: phaseAware[existing]?.turnRunId || textRunId,
           isFinalReply: finalizedText,
           isStreaming: !finalizedText && !narration,
-          isNarration: narration,
         };
         if (existing >= 0) {
           const copy = [...phaseAware];

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.ts
@@ -784,8 +784,13 @@ function applyProjectionItems({
                   : message,
               )
             : prev;
+        // Once the run's final reply is rendered, late answer phases are
+        // stale and ignored — but a narration republish is activity for the
+        // run's collapsible section, and the live and durable rails are
+        // independent, so it may legitimately arrive after the final reply.
         if (
           textRunId &&
+          !narration &&
           phaseAware.some((m) => isFinalAssistantForRun(m, textRunId))
         ) {
           return phaseAware;

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChatEvents.ts
@@ -747,6 +747,11 @@ function applyProjectionItems({
       // truth for clearing pendingGate/processing.
       const textRunId = item.text.run_id || null;
       const finalizedText = item.text.finalized === true;
+      // The loop went on past the model call that produced this text (a
+      // tool call followed it): the item is republished, flagged, under the
+      // id it streamed as. It is progress narration for the activity run,
+      // never a new streaming phase.
+      const narration = item.text.narration === true;
       const messageId = `${finalizedText ? "msg" : "text"}-${item.text.id}`;
       if (
         textRunId &&
@@ -765,16 +770,20 @@ function applyProjectionItems({
         ) {
           return prev;
         }
-        const phaseAware = textRunId
-          ? prev.map((message) =>
-              message?.role === "assistant" &&
-              message.turnRunId === textRunId &&
-              message.isFinalReply === false &&
-              message.id !== messageId
-                ? { ...message, isStreaming: false }
-                : message,
-            )
-          : prev;
+        // A new phase's text (one live item per model call) settles the
+        // earlier phases of the run; a narration republish is not a new
+        // phase and leaves the streaming answer alone.
+        const phaseAware =
+          textRunId && !narration
+            ? prev.map((message) =>
+                message?.role === "assistant" &&
+                message.turnRunId === textRunId &&
+                message.isFinalReply === false &&
+                message.id !== messageId
+                  ? { ...message, isStreaming: false }
+                  : message,
+              )
+            : prev;
         if (
           textRunId &&
           phaseAware.some((m) => isFinalAssistantForRun(m, textRunId))
@@ -786,16 +795,17 @@ function applyProjectionItems({
           (m) => m.id === messageId || (timelineMessageId && m.id === timelineMessageId),
         );
         if (existing < 0 && finalizedText && textRunId) {
-          // Converge by identity, never by content: the run's live streaming
-          // bubble (a `text-…` projection item) IS the same logical answer
-          // the durable transcript finalizes, even when their strings differ
-          // (the live text concatenates every model call's streamed phases;
-          // the transcript row holds only the final one).
+          // Converge by identity, never by content: the run's last live
+          // streaming bubble (the final phase's `text-…` projection item)
+          // IS the same logical answer the durable transcript finalizes,
+          // even when their strings differ. Earlier phases are narration
+          // and stay in the activity run.
           existing = phaseAware.findLastIndex(
             (message) =>
               message?.role === "assistant" &&
               message.turnRunId === textRunId &&
               message.isFinalReply === false &&
+              message.isNarration !== true &&
               typeof message.id === "string" &&
               message.id.startsWith("text-"),
           );
@@ -808,7 +818,8 @@ function applyProjectionItems({
           timestamp: phaseAware[existing]?.timestamp || new Date().toISOString(),
           turnRunId: phaseAware[existing]?.turnRunId || textRunId,
           isFinalReply: finalizedText,
-          isStreaming: !finalizedText,
+          isStreaming: !finalizedText && !narration,
+          isNarration: narration,
         };
         if (existing >= 0) {
           const copy = [...phaseAware];

--- a/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
+++ b/crates/product/ironclaw_webui/tests/webui_v2_handlers_contract.rs
@@ -8000,6 +8000,7 @@ fn make_projection_update_envelope(cursor: &str) -> ProductOutboundEnvelope {
                     run_id: None,
                     body: "projection body".to_string(),
                     finalized: false,
+                    narration: false,
                 }],
             )
             .expect("projection state"),

--- a/crates/product/ironclaw_webui/tests/webui_v2_schema_contract.rs
+++ b/crates/product/ironclaw_webui/tests/webui_v2_schema_contract.rs
@@ -166,6 +166,7 @@ fn projection_state() -> ProductProjectionState {
                 run_id: None,
                 body: "hello".to_string(),
                 finalized: false,
+                narration: false,
             },
             ProductProjectionItem::RunStatus {
                 run_id: run_id(),

--- a/docs/internal/design/2026-08-31-progressive-reply-publication.md
+++ b/docs/internal/design/2026-08-31-progressive-reply-publication.md
@@ -140,13 +140,13 @@ approval/auth context      ─┘
   the host from the trigger class and conversation model at target
   registration.
 - Item identities: activity id = invocation uuid, attachment id = attachment
-  id, answer = one row per answer *phase* (one model call), so every edge
+  id, answer = one row per answer *call* (one model call), so every edge
   can upsert rather than duplicate.
 - The answer is the text of the current model call, nothing else. The
   moment the loop does anything after a call other than end the run — a
   capability invocation, a gate, another call — that call was not the run's
   final assistant message: `reset_answer` moves its text into the
-  document's `narration` (under its phase) and the next phase starts empty.
+  document's `narration` (under its call) and the next call's answer starts empty.
   This is the transcript's own rule (only the final assistant message is the
   answer) applied progressively; the terminal fold then confirms in place
   instead of merging. Narration is a facet of its own — never reasoning —
@@ -353,14 +353,14 @@ regardless of route; the coordinator is transport-blind.
 - The projection checkpoint fingerprints the answer text (a same-length
   rewrite republishes) and maps `ReplyStatusKind` and activity provenance
   back onto the live item fields the browser already renders.
-- One live text item per model call, keyed `text:{run}:{phase}` — the shape
+- One live text item per model call, keyed `text:{run}:{call}` — the shape
   the browser rendered before this design, and the one every streaming
   protocol shares (a text part per step). A phase the loop went past is
   republished once under its own id with `narration: true`, ahead of the
-  capability card that proved it and carrying the phase's final text even
+  capability card that proved it and carrying the call's final text even
   when coalesced revisions skipped its tail. The browser folds flagged items
   into the run's collapsible activity (ahead of the tool card), keeps the
-  unflagged trailing phase as the streaming bubble, converges the durable
+  unflagged trailing call as the streaming bubble, converges the durable
   final reply into that bubble by identity, and keeps narration through the
   final reply the way it keeps reasoning and tool cards. The browser never
   infers narration from message order, which frame replay makes unreliable.
@@ -500,7 +500,7 @@ regardless of route; the coordinator is transport-blind.
 | Projection composes bounded, redacted documents; terminal from durable facts; phases; disclosure; capacity | `crates/product/ironclaw_assistant/src/projection/reply/tests.rs` | `cargo test -p ironclaw_assistant --lib -- projection::reply` |
 | Publication worker: stream vs message cadence, session target, disclosure, retry/ambiguous/permanent/unauthorized/stop, another-node resume with persisted checkpoint and generation change, held lease, heartbeat, retry checkpoint, microburst coalescing, attachments — plus the corrected order (desired revision durable before every provider call; provider-independent preparation before the claim; the sink timeout clamped to the lease TTL), the boot sweep resuming an open publication with no journal signal, and the journal acknowledgement awaited behind a stable observer id | `crates/product/ironclaw_assistant/src/delivery_coordinator/publication/tests.rs` (24) | `cargo test -p ironclaw_assistant --lib -- publication` |
 | Observer cutover: answer via the sink, notices/prompts via the delivery half, nothing-to-report, attachments, resolution-ack dedupe, working indicator retraction after settlement | `crates/product/ironclaw_assistant/tests/run_delivery_contract.rs` (79), `tests/outbound_delivery_contract.rs` (35) | `cargo test -p ironclaw_assistant` |
-| WebUI live items from the projection sink; cursor rebasing; one text item per phase with narration flagged ahead of the capability card; tool failure redaction | `crates/product/ironclaw_assistant/src/projection/tests/{reply_sink,live_progress_stream,runtime_stream}.rs` | `cargo test -p ironclaw_assistant --lib -- projection` |
+| WebUI live items from the projection sink; cursor rebasing; one text item per call with narration flagged ahead of the capability card; tool failure redaction | `crates/product/ironclaw_assistant/src/projection/tests/{reply_sink,live_progress_stream,runtime_stream}.rs` | `cargo test -p ironclaw_assistant --lib -- projection` |
 | Telegram terminal-only sink; Slack Agent sink against a stateful fake Agent API (incl. the fail-closed ambiguous `chat.startStream` — never a second stream, never a conventional post beside a possible ghost — and the no-resend rule when read-back is unavailable for a text-carrying pending); canonical `app_manifest.json` / docs / egress lockstep | `crates/extensions/packages/telegram/src/tests/reply.rs`, `crates/extensions/packages/slack/tests/{reply_sink_agent_api,agent_app_manifest_lockstep}.rs` | `cargo test -p ironclaw_telegram_extension`, `cargo test -p ironclaw_slack_extension` |
 | Activation refuses a declared reply without a real sink; host bridge binds no fake sink | `crates/extensions/ironclaw_extension_host/src/{entrypoint,generic_host}.rs` tests | `cargo test -p ironclaw_extension_host` |
 | Channel-host Slack DM journeys ride the Agent wire end-to-end through the production assembly: gate/auth prompts as streamed attention with the message-path copy (approval instruction; auth headline + private-DM setup link; `Shared` strips the link), working state as session status (`processing`/`suspended`), final replies at the single stream close, exactly-once under gate-resolution ack races, and a bare threaded `approve` resolving via the observer's source-conversation route record with no delivered prompt message | `crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs` (54, incl. `bare_approve_in_dm_resolves_gate_recorded_by_observer`); the scripted coordinator feeds the shared `ReplyProjection` the loop's milestones, standing in for `ReplyProjectionMilestoneSink` | `cargo test -p ironclaw_extension_host` |

--- a/docs/internal/design/2026-08-31-progressive-reply-publication.md
+++ b/docs/internal/design/2026-08-31-progressive-reply-publication.md
@@ -140,16 +140,25 @@ approval/auth context      ─┘
   the host from the trigger class and conversation model at target
   registration.
 - Item identities: activity id = invocation uuid, attachment id = attachment
-  id, answer = one row per run; so every edge can upsert rather than
-  duplicate.
+  id, answer = one row per answer *phase* (one model call), so every edge
+  can upsert rather than duplicate.
+- The answer is the text of the current model call, nothing else. The
+  moment the loop does anything after a call other than end the run — a
+  capability invocation, a gate, another call — that call was not the run's
+  final assistant message: `reset_answer` moves its text into the
+  document's `narration` (under its phase) and the next phase starts empty.
+  This is the transcript's own rule (only the final assistant message is the
+  answer) applied progressively; the terminal fold then confirms in place
+  instead of merging. Narration is a facet of its own — never reasoning —
+  because it is what the assistant said, not how it thought; the WebUI
+  shows it inside the run's activity, a stream surface never shows it.
 - As built: `ReplyProjection::observe_milestone` folds; `ModelTextDelta`
   is the *cumulative* text of the current model call, so the projection
-  tracks finished-call text per run and calls `append_answer` for growth
-  and `rewrite_answer` for anything else (the document carries
-  `append_reasoning`/`close_reasoning` — the open reasoning segment a close
-  seals — a `work: ReplyStatusKind` hint on `set_status`, and
-  `ReplyActivityProvenance` on finished activities so the WebUI keeps
-  provider/runtime/output-size badges). A revision's reconcile point is
+  calls `append_answer` for growth and `rewrite_answer` for anything else
+  (the document carries `append_reasoning`/`close_reasoning` — the open
+  reasoning segment a close seals — a `work: ReplyStatusKind` hint on
+  `set_status`, and `ReplyActivityProvenance` on finished activities so the
+  WebUI keeps provider/runtime/output-size badges). A revision's reconcile point is
   classified from what actually changed (attention transitions and the
   finalized answer are control-critical). Terminal facts come only from
   `apply_terminal_facts` (durable transcript row + committed run status;
@@ -344,6 +353,17 @@ regardless of route; the coordinator is transport-blind.
 - The projection checkpoint fingerprints the answer text (a same-length
   rewrite republishes) and maps `ReplyStatusKind` and activity provenance
   back onto the live item fields the browser already renders.
+- One live text item per model call, keyed `text:{run}:{phase}` — the shape
+  the browser rendered before this design, and the one every streaming
+  protocol shares (a text part per step). A phase the loop went past is
+  republished once under its own id with `narration: true`, ahead of the
+  capability card that proved it and carrying the phase's final text even
+  when coalesced revisions skipped its tail. The browser folds flagged items
+  into the run's collapsible activity (ahead of the tool card), keeps the
+  unflagged trailing phase as the streaming bubble, converges the durable
+  final reply into that bubble by identity, and keeps narration through the
+  final reply the way it keeps reasoning and tool cards. The browser never
+  infers narration from message order, which frame replay makes unreliable.
 
 ## 9. Slack native Agent *(implemented in `crates/extensions/packages/slack`; live workspace untouched)*
 
@@ -366,9 +386,18 @@ regardless of route; the coordinator is transport-blind.
   `markdown_text` chunk as its own block, so progress text goes out by whole
   paragraph: a delta is published through its last blank line outside a code
   fence, a paragraph past `SLACK_TEXT_HOLD_MAX_CHARS` flushes at its last
-  sentence end, and the terminal, a finalized canonical answer, or a new
-  attention block flushes everything still held (what the run said belongs
-  before the block). The `plan_update` lifecycle label rides only with real
+  sentence end, and the terminal or a finalized canonical answer flushes
+  everything still held. Nothing flushes ahead of an attention block: a gate
+  is raised for a tool call the same model call produced, so text ahead of
+  it is narration by construction and the document resets it. That hold is
+  also why a one-line narration never reaches Slack at all. A narration
+  paragraph already streamed when the loop went on, or a canonical text that
+  is not an extension of the shown prefix, is a rewrite under the stream:
+  the sink closes the stale stream, retracts its message with `chat.delete`
+  (a message already gone is the retraction it wanted; a lost answer
+  retries), and opens a fresh stream carrying the plan header, task cards,
+  and whatever text the document shows now — so exactly one stream is ever
+  left standing and it never shows narration. The `plan_update` lifecycle label rides only with real
   `task_update` cards, because Slack renders a header without a task as an
   empty message: a tool-less answer has no header, its thinking state is the
   session status, and no synthetic task is ever invented to make one render
@@ -471,7 +500,7 @@ regardless of route; the coordinator is transport-blind.
 | Projection composes bounded, redacted documents; terminal from durable facts; phases; disclosure; capacity | `crates/product/ironclaw_assistant/src/projection/reply/tests.rs` | `cargo test -p ironclaw_assistant --lib -- projection::reply` |
 | Publication worker: stream vs message cadence, session target, disclosure, retry/ambiguous/permanent/unauthorized/stop, another-node resume with persisted checkpoint and generation change, held lease, heartbeat, retry checkpoint, microburst coalescing, attachments — plus the corrected order (desired revision durable before every provider call; provider-independent preparation before the claim; the sink timeout clamped to the lease TTL), the boot sweep resuming an open publication with no journal signal, and the journal acknowledgement awaited behind a stable observer id | `crates/product/ironclaw_assistant/src/delivery_coordinator/publication/tests.rs` (24) | `cargo test -p ironclaw_assistant --lib -- publication` |
 | Observer cutover: answer via the sink, notices/prompts via the delivery half, nothing-to-report, attachments, resolution-ack dedupe, working indicator retraction after settlement | `crates/product/ironclaw_assistant/tests/run_delivery_contract.rs` (79), `tests/outbound_delivery_contract.rs` (35) | `cargo test -p ironclaw_assistant` |
-| WebUI live items from the projection sink; cursor rebasing; text phases under one id; tool failure redaction | `crates/product/ironclaw_assistant/src/projection/tests/{reply_sink,live_progress_stream,runtime_stream}.rs` | `cargo test -p ironclaw_assistant --lib -- projection` |
+| WebUI live items from the projection sink; cursor rebasing; one text item per phase with narration flagged ahead of the capability card; tool failure redaction | `crates/product/ironclaw_assistant/src/projection/tests/{reply_sink,live_progress_stream,runtime_stream}.rs` | `cargo test -p ironclaw_assistant --lib -- projection` |
 | Telegram terminal-only sink; Slack Agent sink against a stateful fake Agent API (incl. the fail-closed ambiguous `chat.startStream` — never a second stream, never a conventional post beside a possible ghost — and the no-resend rule when read-back is unavailable for a text-carrying pending); canonical `app_manifest.json` / docs / egress lockstep | `crates/extensions/packages/telegram/src/tests/reply.rs`, `crates/extensions/packages/slack/tests/{reply_sink_agent_api,agent_app_manifest_lockstep}.rs` | `cargo test -p ironclaw_telegram_extension`, `cargo test -p ironclaw_slack_extension` |
 | Activation refuses a declared reply without a real sink; host bridge binds no fake sink | `crates/extensions/ironclaw_extension_host/src/{entrypoint,generic_host}.rs` tests | `cargo test -p ironclaw_extension_host` |
 | Channel-host Slack DM journeys ride the Agent wire end-to-end through the production assembly: gate/auth prompts as streamed attention with the message-path copy (approval instruction; auth headline + private-DM setup link; `Shared` strips the link), working state as session status (`processing`/`suspended`), final replies at the single stream close, exactly-once under gate-resolution ack races, and a bare threaded `approve` resolving via the observer's source-conversation route record with no delivered prompt message | `crates/extensions/ironclaw_extension_host/src/channel_host/e2e_tests.rs` (54, incl. `bare_approve_in_dm_resolves_gate_recorded_by_observer`); the scripted coordinator feeds the shared `ReplyProjection` the loop's milestones, standing in for `ReplyProjectionMilestoneSink` | `cargo test -p ironclaw_extension_host` |

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -243,6 +243,10 @@ struct PreambleToolReplyGateway {
     preamble: &'static str,
     answer: &'static str,
     calls: Mutex<usize>,
+    /// When set, the first call waits for a permit after streaming its
+    /// preamble and before registering the tool call, so a journey can let
+    /// the preamble reach the wire first.
+    hold_before_tool: Option<tokio::sync::Semaphore>,
 }
 
 impl PreambleToolReplyGateway {
@@ -251,6 +255,20 @@ impl PreambleToolReplyGateway {
             preamble,
             answer,
             calls: Mutex::new(0),
+            hold_before_tool: None,
+        }
+    }
+
+    fn holding_before_tool(preamble: &'static str, answer: &'static str) -> Self {
+        Self {
+            hold_before_tool: Some(tokio::sync::Semaphore::new(0)),
+            ..Self::new(preamble, answer)
+        }
+    }
+
+    fn release_tool(&self) {
+        if let Some(hold) = &self.hold_before_tool {
+            hold.add_permits(1);
         }
     }
 }
@@ -284,6 +302,13 @@ impl HostManagedModelGateway for PreambleToolReplyGateway {
             return Ok(HostManagedModelResponse::assistant_reply(self.answer));
         }
         sink.safe_text_update(self.preamble.to_string()).await;
+        if let Some(hold) = &self.hold_before_tool {
+            let permit = hold
+                .acquire()
+                .await
+                .expect("preamble gateway semaphore remains open");
+            permit.forget();
+        }
         let search = CapabilityId::new("builtin.extension_search").expect("capability id");
         let tool = capabilities
             .tool_definitions()
@@ -1657,15 +1682,61 @@ async fn slack_final_reply_flows_through_the_real_delivery_coordinator(
 
 /// A Slack tool run whose model streams pre-tool commentary, executes a real
 /// capability, and then streams the answer — the multi-phase shape the live
-/// stack produces. The progressive reply concatenates both phases while the
-/// durable transcript finalizes only the final one, so this journey pins the
-/// exactly-once invariant end to end: one Agent stream carrying the
-/// commentary, a task card, and the answer; one close; and the terminal
-/// answer NEVER also posted as a conventional `chat.postMessage`.
+/// stack produces. The commentary is a model call the loop went on past:
+/// the projection resets the answer when the tool call proves it was
+/// narration, and a one-line narration never had a paragraph boundary, so
+/// it reaches Slack nowhere. This pins that and the exactly-once invariant
+/// end to end: one Agent stream carrying a task card and the answer; one
+/// close; the narration in no request; and the terminal answer NEVER also
+/// posted as a conventional `chat.postMessage`.
 #[tokio::test(flavor = "multi_thread")]
 async fn slack_tool_run_with_streamed_preamble_answers_exactly_once() {
-    const PREAMBLE: &str = "Let me search the catalog first.";
-    const ANSWER: &str = "The catalog holds a web-access extension.";
+    slack_tool_run_with_preamble(
+        "Let me search the catalog first.",
+        "The catalog holds a web-access extension.",
+        PreambleExpectation::HeldAndNeverSent,
+    )
+    .await;
+}
+
+/// Narration that had a complete paragraph before the tool call was already
+/// streamed when the tool call proved it narration. Through the production
+/// wiring (reducer → publication worker → sink → captured network), the
+/// sink closes that stream, retracts its message with `chat.delete`, and
+/// opens a fresh stream for the task card and the answer — exactly one
+/// stream is left standing and it carries no narration.
+#[tokio::test(flavor = "multi_thread")]
+async fn slack_tool_run_retracts_a_streamed_preamble_paragraph() {
+    slack_tool_run_with_preamble(
+        "Let me search the catalog first.\n\nStarting with the web results.",
+        "The catalog holds a web-access extension.",
+        PreambleExpectation::StreamedThenRetracted,
+    )
+    .await;
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PreambleExpectation {
+    /// A one-line narration: held by the paragraph rule, never sent.
+    HeldAndNeverSent,
+    /// A narration paragraph: streamed, then retracted with `chat.delete`.
+    StreamedThenRetracted,
+}
+
+async fn slack_tool_run_with_preamble(
+    preamble: &'static str,
+    answer: &'static str,
+    expectation: PreambleExpectation,
+) {
+    // The narration's first sentence: the text that must reach no surviving
+    // request in either shape.
+    let narration = preamble.split('\n').next().expect("a preamble line");
+    let gateway = Arc::new(match expectation {
+        PreambleExpectation::HeldAndNeverSent => PreambleToolReplyGateway::new(preamble, answer),
+        PreambleExpectation::StreamedThenRetracted => {
+            PreambleToolReplyGateway::holding_before_tool(preamble, answer)
+        }
+    });
     let group = RebornIntegrationGroup::builder()
         .storage(StorageMode::LibSql)
         .extension_delivery()
@@ -1742,11 +1813,37 @@ async fn slack_tool_run_with_streamed_preamble_answers_exactly_once() {
         true,
     )
     .await;
-    inbound.register_scope_gateway_for_test(
-        vendor_scope.clone(),
-        Arc::new(PreambleToolReplyGateway::new(PREAMBLE, ANSWER)),
-    );
+    let scope_gateway: Arc<dyn HostManagedModelGateway> =
+        Arc::clone(&gateway) as Arc<dyn HostManagedModelGateway>;
+    inbound.register_scope_gateway_for_test(vendor_scope.clone(), scope_gateway);
 
+    // The ingress drain below waits for the whole turn, so the tool call is
+    // released from a task that watches the wire: once the narration
+    // paragraph has streamed, the gateway may register the tool call that
+    // proves it narration.
+    let releaser = (expectation == PreambleExpectation::StreamedThenRetracted).then(|| {
+        let recorder = inbound.capability_recorder.clone();
+        let gateway = Arc::clone(&gateway);
+        tokio::spawn(async move {
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+            let streamed = loop {
+                let streamed = recorder
+                    .network_http_requests()
+                    .iter()
+                    .filter(|request| {
+                        request.url.ends_with("/api/chat.startStream")
+                            || request.url.ends_with("/api/chat.appendStream")
+                    })
+                    .any(|request| String::from_utf8_lossy(&request.body).contains(narration));
+                if streamed || tokio::time::Instant::now() >= deadline {
+                    break streamed;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            };
+            gateway.release_tool();
+            streamed
+        })
+    });
     let timestamp = now_unix().to_string();
     let signature = slack_signature(&timestamp, &body);
     let status = ingress
@@ -1770,6 +1867,14 @@ async fn slack_tool_run_with_streamed_preamble_answers_exactly_once() {
     let run_id = observer
         .accepted_run_id()
         .expect("the accepted Slack event must identify its submitted run");
+    if let Some(releaser) = releaser {
+        assert!(
+            releaser
+                .await
+                .expect("the releaser task runs to completion"),
+            "the narration paragraph must stream before the tool call is released"
+        );
+    }
     let coordinator = inbound.turn_coordinator_for_test();
     wait_for_run_status_in_scope(&coordinator, &vendor_scope, run_id, TurnStatus::Completed).await;
     let durable_reply = inbound
@@ -1787,7 +1892,7 @@ async fn slack_tool_run_with_streamed_preamble_answers_exactly_once() {
         durable_reply
             .content
             .as_deref()
-            .is_some_and(|content| content.contains(ANSWER)),
+            .is_some_and(|content| content.contains(answer)),
         "the durable transcript finalizes the answer: {durable_reply:?}"
     );
 
@@ -1816,61 +1921,142 @@ async fn slack_tool_run_with_streamed_preamble_answers_exactly_once() {
     // be on the wire when the exactly-once pins below read it.
     assert_delivered_attempt(services, &vendor_scope).await;
     let requests = inbound.captured_network_requests_for_test();
-    let stream_opens: Vec<serde_json::Value> = requests
-        .iter()
-        .filter(|request| request.url.ends_with("/api/chat.startStream"))
-        .map(|request| {
-            serde_json::from_slice(&request.body).expect("chat.startStream body is JSON")
-        })
-        .collect();
-    assert_eq!(
-        stream_opens.len(),
-        1,
-        "one logical reply opens exactly one Agent stream: {stream_opens:?}"
-    );
-    assert!(
-        stream_opens[0]["chunks"]
-            .as_array()
-            .is_some_and(|chunks| !chunks.is_empty()),
-        "the one stream opens carrying renderable content: {}",
-        stream_opens[0]
-    );
-    let streamed: String = requests
-        .iter()
-        .filter(|request| {
-            request.url.ends_with("/api/chat.startStream")
-                || request.url.ends_with("/api/chat.appendStream")
-                || request.url.ends_with("/api/chat.stopStream")
-        })
-        .map(|request| String::from_utf8_lossy(&request.body).into_owned())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(
-        streamed.contains(PREAMBLE) && streamed.contains(ANSWER),
-        "the stream carries both streamed phases: {streamed}"
-    );
-    assert!(
-        streamed.contains("task_update"),
-        "the real capability call rides the stream as a task card: {streamed}"
-    );
-    assert_eq!(
+    let bodies = |suffix: &str| -> Vec<(serde_json::Value, String)> {
         requests
             .iter()
-            .filter(|request| request.url.ends_with("/api/chat.stopStream"))
-            .count(),
-        1,
-        "the stream is closed exactly once"
-    );
-    let conventional: Vec<String> = requests
-        .iter()
-        .filter(|request| request.url.ends_with("/api/chat.postMessage"))
-        .map(|request| String::from_utf8_lossy(&request.body).into_owned())
-        .filter(|body| body.contains(ANSWER) || body.contains(PREAMBLE))
-        .collect();
+            .filter(|request| request.url.ends_with(suffix))
+            .map(|request| {
+                let raw = String::from_utf8_lossy(&request.body).into_owned();
+                (
+                    serde_json::from_str(&raw).expect("slack request body is JSON"),
+                    raw,
+                )
+            })
+            .collect()
+    };
+    let stream_opens = bodies("/api/chat.startStream");
+    let appends = bodies("/api/chat.appendStream");
+    let stops = bodies("/api/chat.stopStream");
+    let deletes = bodies("/api/chat.delete");
+    let conventional = bodies("/api/chat.postMessage");
     assert!(
-        conventional.is_empty(),
-        "the terminal answer is never also posted as a conventional message: {conventional:?}"
+        conventional
+            .iter()
+            .all(|(_, raw)| !raw.contains(answer) && !raw.contains(narration)),
+        "the answer is never also posted as a conventional message: {conventional:?}"
     );
+    match expectation {
+        PreambleExpectation::HeldAndNeverSent => {
+            assert_eq!(
+                stream_opens.len(),
+                1,
+                "one logical reply opens exactly one Agent stream: {stream_opens:?}"
+            );
+            assert_eq!(
+                stops.len(),
+                1,
+                "the stream is closed exactly once: {stops:?}"
+            );
+            assert!(deletes.is_empty(), "nothing streamed, nothing to retract");
+            let streamed = stream_opens
+                .iter()
+                .chain(&appends)
+                .chain(&stops)
+                .map(|(_, raw)| raw.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                streamed.contains(answer) && streamed.contains("task_update"),
+                "the stream carries the task card and the answer: {streamed}"
+            );
+            assert!(
+                requests
+                    .iter()
+                    .all(|request| !String::from_utf8_lossy(&request.body).contains(narration)),
+                "held narration reaches slack nowhere"
+            );
+        }
+        PreambleExpectation::StreamedThenRetracted => {
+            // The recorded Slack answers every `chat.startStream` with the
+            // same `ts`, so streams are told apart by wire order, which is
+            // unambiguous: close the stale stream, retract it, open the
+            // fresh one, close that at the terminal.
+            let ordered = requests
+                .iter()
+                .enumerate()
+                .map(|(index, request)| {
+                    (
+                        index,
+                        request.url.rsplit('/').next().unwrap_or_default(),
+                        String::from_utf8_lossy(&request.body).into_owned(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let index_of = |method: &str, nth: usize| {
+                ordered
+                    .iter()
+                    .filter(|(_, seen, _)| *seen == method)
+                    .nth(nth)
+                    .map(|(index, _, _)| *index)
+                    .unwrap_or_else(|| panic!("expected {method} request #{nth}: {ordered:?}"))
+            };
+            assert_eq!(
+                stream_opens.len(),
+                2,
+                "the stale stream and the fresh one: {ordered:?}"
+            );
+            assert_eq!(
+                stops.len(),
+                2,
+                "one close for retraction, one at the terminal: {ordered:?}"
+            );
+            assert_eq!(deletes.len(), 1, "exactly one retraction: {ordered:?}");
+            let stale_open = index_of("chat.startStream", 0);
+            let stale_close = index_of("chat.stopStream", 0);
+            let retraction = index_of("chat.delete", 0);
+            let fresh_open = index_of("chat.startStream", 1);
+            let terminal_close = index_of("chat.stopStream", 1);
+            assert!(
+                stale_open < stale_close
+                    && stale_close < retraction
+                    && retraction < fresh_open
+                    && fresh_open < terminal_close,
+                "close the stale stream, retract it, open the fresh one, close it at the terminal: {ordered:?}"
+            );
+            assert_eq!(
+                stops[0].0["session_status"].as_str(),
+                Some("processing"),
+                "retracting keeps the session processing"
+            );
+            assert_eq!(
+                deletes[0].0["ts"], stops[0].0["ts"],
+                "the retracted message is the stream closed first"
+            );
+            for (index, _, body) in &ordered {
+                if body.contains(narration) {
+                    assert!(
+                        *index < retraction,
+                        "narration only ever reached the retracted stream: {ordered:?}"
+                    );
+                }
+                if body.contains(answer) {
+                    // The fresh stream may open already carrying the answer
+                    // when the reset and the terminal coalesce into one
+                    // reconcile; either way it is never on the stale stream.
+                    assert!(
+                        *index >= fresh_open,
+                        "the answer streams only on the fresh stream: {ordered:?}"
+                    );
+                }
+            }
+            assert!(
+                ordered[fresh_open].2.contains("task_update")
+                    && !ordered[fresh_open].2.contains(narration),
+                "the fresh stream opens with the task card and no narration: {}",
+                ordered[fresh_open].2
+            );
+        }
+    }
 }
 
 /// DEL-10: the bundled Telegram package — one manifest plus the adapter


### PR DESCRIPTION
## Summary

- **The answer is the current model call's text, nothing else.** Live QA on `51582d3930` showed Slack (and Telegram) answering "Let me find the conversation first.\n\nYour latest message to Firat was: hello." — the progressive reply concatenated every model call's streamed text, and the terminal fold kept it because the transcript's final message was its suffix. The reply reducer now applies the transcript's own rule progressively: the moment the loop does anything after a call other than end the run (a capability invocation, a gate, another call), that call's text was narration — `ReplyDocument::reset_answer` moves it into a new typed `narration` facet under its answer *call* and the next call's answer starts empty. Provider reasoning stays reasoning; narration is what the assistant said, not how it thought.
- **WebUI: one live text item per model call again** (`text:{run}:{call}`, the pre-#8006 shape the WebUI spec already promised and the one every streaming protocol shares). A call the loop went past is republished once under its own id with `narration: true`, ahead of the capability card that proved it; the browser gives it its own `narration` role (like `thinking`), renders it inside the run's collapsible activity, keeps the trailing call as the streaming bubble, converges the durable final reply into that bubble by identity, and keeps narration through the final reply the way it keeps reasoning and tool cards. Every `assistant` predicate excludes narration by construction. No retraction concept on the wire; the browser never infers narration from message order.
- **Slack: streaming stays; narration never shows.** A one-line narration never had a paragraph boundary, so the paragraph hold never sent it and now nothing ever will. Held text no longer flushes ahead of an attention block (text ahead of a gate is narration by construction). A narration paragraph already streamed, or any genuine rewrite under the stream — including an append whose answer was lost before the reset — now closes the stale stream, **retracts its message with `chat.delete`** (already in the allowlist), and opens the fresh stream: one stream is ever left standing. A delete that Slack refuses outright (a retention policy) leaves the stale message and still delivers the answer, deliberately and pinned by a test; a rate-limited, lost, or unauthorized delete keeps its usual outcome. Telegram, terminal-only, posts the final call's text instead of the concatenation for free.
- **OpenAI-compatible lane** keyed on nothing but the cumulative body and returned an internal error on any non-extension update, so a reset would have broken it: it now tracks calls by item id (`Call` / `Narration` / `Confirm` updates) and emits a paragraph separator between them; a narration republish adds nothing even when the document's bounded copy is shorter than what streamed; the durable transcript row confirms the current call; a same-call rewrite still fails safely.

**Review rounds folded in (CodeRabbit, IronLoop, and a local 8-reviewer pass):** finalized+narration refused at the product boundary; the applied-then-lost, rate-limited, refused, and lost-append-then-reset retraction shapes each pinned; narration promoted from a flag to a role; the ordinal renamed `call` (distinct from the document lifecycle `phase`) before it ships persisted; the WebUI module spec (`CONTRACT.md`) updated; narration bound tests; the compat lane's update kinds as an enum over one buffer.

## Change Type

- [x] Bug fix

## Linked Issue

None (live-QA defect on #8006; see the PR conversation there).

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy` over every touched crate, `--all-targets --all-features -- -D warnings` (`ironclaw_extension_contracts`, `ironclaw_product_contracts`, `ironclaw_event_streams`, `ironclaw_assistant`, `ironclaw_openai_compat`, `ironclaw_slack_extension`, `ironclaw_webui`)
- [x] `cargo build` (via the test builds below)
- [x] Relevant tests pass: see Test Strategy
- [ ] `--features integration`: Not applicable — no database-backed behavior changed (the document is process state; the checkpoint is additive with `serde(default)`)
- [ ] Manual testing: pending live validation on the QA deployment (Slack DM with a tool call; Slack approval mid-run; WebUI activity run) — the two items the crate tiers cannot prove are `chat.delete` on a stopped Agent stream message and WebUI ordering under real timing
- [ ] `pr-shepherd`: not run

## Test Strategy

User behavior: A tool-using run shows only the final assistant message as the answer on every surface. In the WebUI the pre-tool narration sits inside the collapsible activity run above the tool card; in Slack it never appears; in Telegram the single post is the final message.

Risk areas:
- [x] Browser
- [x] Side effect
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: contract — `reset_answer_moves_the_answer_to_narration_and_is_ignored_once_finalized_or_terminal`, `projection_text_narration_is_live_only`; reducer — `a_finished_calls_text_becomes_narration_once_a_capability_follows_it`, `…once_another_call_follows_it`, `text_ahead_of_a_gate_is_narration_not_answer`, `narration_is_kept_apart_from_the_calls_reasoning`, `narration_is_bounded_like_reasoning`, `terminal_facts_matching_the_final_calls_text_finalize_in_place`, failed-call test extended; live publisher — `a_finished_calls_text_is_republished_as_narration_ahead_of_the_capability_card`, cadence test distinguishes the flagged republish; publication worker — microburst test asserts the narration facet; compat lane — `chat_stream_carries_each_answer_phase_as_a_paragraph_of_one_completion`, `chat_stream_ignores_a_shorter_narration_republish_of_the_current_phase`, `chat_stream_a_finalized_transcript_row_confirms_the_current_phase`, `chat_stream_ignores_a_late_republish_of_a_closed_phase`, the two rebase tests keyed on one call; Slack sink — `held_text_is_not_flushed_ahead_of_an_attention_block`, journeys `a_held_narration_line_never_reaches_slack`, `a_streamed_narration_paragraph_is_retracted_when_the_answer_resets`, `a_lost_retraction_answer_is_retried_without_a_second_fresh_stream` (both fault shapes), `a_refused_retraction_leaves_the_stale_message_and_still_delivers_the_answer`, `a_rate_limited_retraction_is_retried_before_the_fresh_stream_opens`, `a_lost_narration_append_followed_by_a_reset_retracts_the_stale_stream`, happy path and both re-present journeys now pin the exact `stopStream → delete → startStream` sequence (fake API deletes for real); frontend vitest — grouping (narration inside the run ahead of its card; kept through the final reply), hook (flagged republish leaves the streaming answer alone; final reply keeps narration; a republish after the final reply still joins the activity), activity run renders narration as a note.
- Reborn integration: `slack_tool_run_with_streamed_preamble_answers_exactly_once` flipped — the narration reaches no Slack request; new `slack_tool_run_retracts_a_streamed_preamble_paragraph` holds the tool call until the paragraph is on the wire, then pins the retraction through the production wiring.
- Recorded fixture: Not applicable — no model tool-choice or request shape changed.
- Browser E2E: Not applicable — the Playwright suite is not run in PR CI; frontend behavior is pinned at the vitest tier through the real hook, grouping, and component sources.
- Backend or runtime: Not applicable — no persistence change.
- Live canary: Not applicable — supplemental only; manual live validation listed above.

What the tests prove: the document never holds narration in the answer; each surface's exact wire (live items in order, Slack request sequences, compat deltas) for a tool run with narration; the retraction is idempotent under a lost delete; the final reply converges in place under the final phase.

Commands run:
```
cargo test -p ironclaw_extension_contracts -p ironclaw_event_streams -p ironclaw_product_contracts -p ironclaw_assistant
cargo test -p ironclaw_openai_compat
cargo test -p ironclaw_slack_extension
cargo test -p ironclaw_webui
cargo test -p ironclaw_integration_tests --test reborn_integration_extension_delivery -- slack_tool_run
pnpm lint && pnpm typecheck && pnpm exec vitest run   # in crates/product/ironclaw_webui/frontend
```

## Security Impact

None beyond one additional use of an already-allowlisted Slack method (`chat.delete`, bot-owned messages only).

## Reborn Trust-Boundary Checklist

- [x] No new trust-bearing types. `ReplyNarration` is display text bounded like the answer.
- [x] N/A — no untrusted content path changes (narration is model-visible-sanitized text on the same path as the answer).
- [x] N/A — no hashes.
- [x] New wire field `ProductProjectionItem::Text.narration` and live-item field `ThreadLiveProjectionItem::Text.narration`: every match site audited (`grep -rn "ProductProjectionItem::Text\|ThreadLiveProjectionItem::Text" crates`); consumers that ignore it (`{ .. }`) are the composition compat serve and the compat streamer, which now reads it by id.
- [x] `serde(default)` on the new fields fails closed: absent → `narration: false` (a normal text item), `phase` → 1.
- [x] `narration` is bounded (`REPLY_MAX_NARRATION_ENTRIES` = 32, `REPLY_NARRATION_ENTRY_MAX_BYTES` = 8 KiB, char-boundary cut); the phase counter is saturating.
- [x] N/A — no error class changes; a refused `chat.delete` degrades (logged, stale message left) rather than failing the reply; a lost one is `Retryable`.
- [x] N/A.

## Database Impact

None.

## Compatibility and rollback

- Wire: additive optional booleans; old browsers ignore them and see per-phase text items (the pre-#8006 shape they already handled). Live text ids change from `text:{run}` to `text:{run}:{phase}`; only runs live across the deploy are affected (a new bubble id for the in-flight phase).
- Checkpoints: the projection reply checkpoint gains two `serde(default)` fields; an old checkpoint republishes the current phase once. Slack checkpoints are unchanged.
- Rollback: revert the PR; no data migration.

## Follow-ups

- History after a reload rebuilds tool cards from durable events but not narration (same as reasoning today); rendering the transcript's tool-call messages' text inside the activity run would close that gap.
- If Slack should surface narration inside its collapsible plan section (as the plan title), that is a rendering decision on top of the narration facet.
- A Telegram-tier preamble journey (the defect was reported there too): the sink reads the same `answer.text` facet the reducer pins and its terminal post is unit-tested against documents, but a journey through the Telegram webhook needs the Telegram setup refactored into a helper.
- Zero-retraction Slack (hold all text to the terminal) remains a one-line policy in the sink if the rare visible retraction is unwanted.
