### PR TITLE
fix(webui): follow authorizeTraceHold to trace-api.ts in the asset test

### DIFF
--- a/crates/product/ironclaw_webui/src/webui_v2/static_assets/assets.rs
+++ b/crates/product/ironclaw_webui/src/webui_v2/static_assets/assets.rs
@@ -674,10 +674,10 @@ mod tests {
         assert!(tab.contains("traceCommons.authorize"));
 
         // Authorize calls the POST endpoint and invalidates the credits query.
-        let settings_api = source_text("pages/settings/lib/settings-api.ts");
-        assert!(settings_api.contains("export function authorizeTraceHold"));
-        assert!(settings_api.contains("/authorize"));
-        assert!(settings_api.contains("method: \"POST\""));
+        let trace_api = source_text("pages/settings/lib/trace-api.ts");
+        assert!(trace_api.contains("export function authorizeTraceHold"));
+        assert!(trace_api.contains("/authorize"));
+        assert!(trace_api.contains("method: \"POST\""));
         let trace_hook = source_text("pages/settings/hooks/useTraceCredits.ts");
         assert!(trace_hook.contains("authorizeTraceHold"));
         assert!(trace_hook.contains("invalidateQueries({ queryKey: [\"trace-credits\"] })"));


### PR DESCRIPTION
## Summary

- **`main` is currently red and this unblocks every open PR.** The unit test `webui_v2::static_assets::assets::tests::sidebar_trace_credits_card_assets_are_embedded` panics, so `cargo test -p ironclaw_webui` fails for anyone who branches off `main`.
- Root cause: commit `666ebcbf08` ("refactor(webui): type and validate frontend API boundaries", #8038) created `frontend/src/pages/settings/lib/trace-api.ts` and moved the trace-credits API — `fetchTraceCredits`, `fetchAccountTraces`, `mintAccountLoginLink`, `authorizeTraceHold` — out of `pages/settings/lib/settings-api.ts`. That test reads frontend sources off disk via the `source_text(...)` helper, so it kept asserting against the old path and broke on the pure file move.
- Fix: point the three authorize assertions at the file that now owns the symbol. Nothing is deleted or weakened — `export function authorizeTraceHold`, `/authorize`, and `method: "POST"` were each verified present in `trace-api.ts`, and `pages/settings/hooks/useTraceCredits.ts` imports `authorizeTraceHold` from `../lib/trace-api`, so the test still pins the trace-credits UI end to end (Settings tab -> hook -> API module -> POST endpoint).
- Scope check: the full `ironclaw_webui` suite was run to catch any other assertion in this source-coupled module broken by `666ebcbf08` (#8038) or `7fc0c6a168` (#8039). There were none; this 4-line change is the whole fix.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check` (`cargo fmt` produced no changes)
- [x] `cargo clippy -p ironclaw_webui --all-features --tests -- -D warnings` — clean
- [x] `cargo build` (covered by the test build)
- [x] Relevant tests pass: `webui_v2::static_assets::assets::tests::sidebar_trace_credits_card_assets_are_embedded`, plus the full crate suite (`cargo test -p ironclaw_webui --all-features`: 500 passed, 0 failed)
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no database-backed or runtime-integration behavior changed.
- [x] Manual testing: read `pages/settings/lib/trace-api.ts` and `pages/settings/hooks/useTraceCredits.ts` directly to confirm the symbol really lives at the new path and is imported from there, rather than pattern-matching on the filename.
- [ ] If a coding agent was used and supports it, `pr-shepherd` was run before requesting review

## Test Strategy

User behavior: none changed. This repairs a test whose assertions had drifted from the frontend file layout after a refactor; the trace-credits UI behavior it pins is unchanged.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Tests added or updated:
- Unit or contract: updated `sidebar_trace_credits_card_assets_are_embedded` in `crates/product/ironclaw_webui/src/webui_v2/static_assets/assets.rs` to follow `authorizeTraceHold` to its new file.
- Reborn integration: Not applicable: no production code changed, so there is no wired behavior to drive through the harness.
- Recorded fixture: Not applicable: no model interaction involved.
- Browser E2E: Not applicable: no runtime UI behavior changed; the frontend move already landed in #8038.
- Backend or runtime: Not applicable: no backend or runtime code changed.
- Live canary: Not applicable: no deployed behavior changed.

What the tests prove: that the trace-credits surface is still wired end to end — the Settings Trace Commons tab calls `authorize.mutate(hold.submission_id)`, `useTraceCredits` imports `authorizeTraceHold` from `../lib/trace-api` and invalidates the `trace-credits` query, and `trace-api.ts` issues a `POST` to the `/authorize` endpoint. The same chain as before; only the file the middle link is read from changed.

Commands run:

```
IRONCLAW_DISABLE_OS_KEYCHAIN=1 cargo test -p ironclaw_webui --lib sidebar_trace_credits_card_assets_are_embedded
IRONCLAW_DISABLE_OS_KEYCHAIN=1 cargo test -p ironclaw_webui --all-features
cargo fmt
cargo clippy -p ironclaw_webui --all-features --tests -- -D warnings
```

## Security Impact

None.

## Reborn Trust-Boundary Checklist

N/A: test-only change, four lines inside one `#[cfg(test)]` assertion block. No production code, types, trust boundaries, or error variants are touched.

## Database Impact

None.

## Blast Radius

One test function in `crates/product/ironclaw_webui/src/webui_v2/static_assets/assets.rs`. No production code is compiled differently. The only way this breaks is if `trace-api.ts` is moved or renamed again — the same coupling that caused the original failure (see Review Follow-Through).

## Rollback Plan

`git revert` the commit. That restores the red test but changes no product behavior.

## Review Follow-Through

Worth a reviewer opinion, deliberately **not** done here to keep this PR minimal: this whole test module hardcodes frontend file paths, so a pure file move breaks it with a failure that names the assertion rather than the move. A targeted alternative would be to have these API-boundary assertions search across `pages/settings/lib/` for the symbol rather than one fixed file — which would have survived #8038 untouched. I would scope that narrowly (API-module assertions only) rather than loosening the module wholesale: for component and hook assertions the exact file *is* the contract being pinned, and searching a whole directory there would let a symbol drift into the wrong layer unnoticed. Happy to open a follow-up if reviewers agree.

---

**Review track**: A (docs/tests/chore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnyJ5Z54PQQPnS3VtLP3Qc
