### PR TITLE
fix(host-api): avoid malformed preview range panic

### DIFF
--- a/crates/contracts/ironclaw_host_api/src/model_result_preview.rs
+++ b/crates/contracts/ironclaw_host_api/src/model_result_preview.rs
@@ -272,7 +272,10 @@ fn redact_embedded_structured_text(text: &mut String, depth: usize) -> bool {
         };
         start..end
     };
-    let Ok(mut nested) = serde_json::from_str(&text[range.clone()]) else {
+    let Some(candidate) = text.get(range.clone()) else {
+        return redact_unparsed_credential_text(text);
+    };
+    let Ok(mut nested) = serde_json::from_str(candidate) else {
         return redact_unparsed_credential_text(text);
     };
     if !redact_structured_credential_values(&mut nested, depth) {

--- a/crates/contracts/ironclaw_host_api/tests/model_result_preview_contract.rs
+++ b/crates/contracts/ironclaw_host_api/tests/model_result_preview_contract.rs
@@ -23,6 +23,7 @@ fn redacts_nested_and_malformed_structured_credentials() {
     for input in [malformed, reversed_delimiters, deep] {
         let preview = ModelResultPreview::redacted(input).expect("preview is redacted");
         assert!(preview.as_str().contains("safe-context"));
+        assert!(preview.as_str().contains("[redacted]"));
         assert!(!preview.as_str().contains(canary));
     }
 }

--- a/crates/contracts/ironclaw_host_api/tests/model_result_preview_contract.rs
+++ b/crates/contracts/ironclaw_host_api/tests/model_result_preview_contract.rs
@@ -9,13 +9,18 @@ fn redacts_nested_and_malformed_structured_credentials() {
         "content": format!(r#"1| {{"password":"{canary}"}}]"#),
     })
     .to_string();
+    let reversed_delimiters = json!({
+        "marker": "safe-context",
+        "content": "] api key {",
+    })
+    .to_string();
     let mut deeply_nested = json!({"password": canary});
     for _ in 0..20 {
         deeply_nested = json!([deeply_nested]);
     }
     let deep = json!({"marker": "safe-context", "content": deeply_nested.to_string()}).to_string();
 
-    for input in [malformed, deep] {
+    for input in [malformed, reversed_delimiters, deep] {
         let preview = ModelResultPreview::redacted(input).expect("preview is redacted");
         assert!(preview.as_str().contains("safe-context"));
         assert!(!preview.as_str().contains(canary));

--- a/crates/product/ironclaw_webui/frontend/src/lib/api-boundary.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/lib/api-boundary.test.ts
@@ -95,7 +95,7 @@ test("notification setup rejects malformed successful responses", async () => {
   globalThis.fetch = async () =>
     new Response(
       JSON.stringify({
-        extension_id: "web-push",
+        extension_id: "web-app",
         requires_setup: false,
         enabled: "yes",
       }),
@@ -103,7 +103,7 @@ test("notification setup rejects malformed successful responses", async () => {
     );
 
   await assert.rejects(
-    getNotificationSetupStatus({ extensionId: "web-push" }),
+    getNotificationSetupStatus({ extensionId: "web-app" }),
     /invalid notification setup response/,
   );
 });


### PR DESCRIPTION
## Summary

- Prevent malformed embedded tool-result text from panicking when a closing JSON delimiter appears before the first opening delimiter.
- Replace unchecked byte-range slicing with a checked lookup and preserve the existing fail-closed full-text redaction fallback.
- Extend the existing host-API contract test with the production delimiter ordering that triggered the Railway restart.
- The unsafe slice path was introduced in `ba5e07cb8` on August 12, 2026; this PR contains no schema or wire-format changes.
- Refresh onto the main branch WebUI asset-test repair and replace two stale retired `web-push` fixture literals with the canonical `web-app` identity so the affected architecture bucket remains green.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: host API, WebUI, architecture, focused frontend, and regression-enforcement suites
- [ ] `cargo test -p <owning-crate> --features integration` if database-backed or runtime-integration behavior changed (not applicable: no database or runtime integration behavior changed)
- [ ] Manual testing: not deployed from this branch
- [ ] If a coding agent was used and supports it, `pr-shepherd` was run before requesting review

Scoped lint also passes:

- `cargo clippy -p ironclaw_host_api --all-targets --all-features -- -D warnings`

Additional validation passes for the CI-repair fixture: the full WebUI and architecture suites, both WebUI clippy configurations, frontend lint/typecheck, and the focused frontend unit test. GitHub Actions is green with 30 successful checks, 17 intentionally skipped checks, and 0 failing or pending checks, including Railway preview and all three affected Reborn crate buckets.

## Test Strategy

User behavior: Slack and WebUI runs receiving malformed nested tool-result text redact it and continue instead of crashing the service before reply publication.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [ ] Side effect
- [ ] Persistence
- [x] Security or permissions
- [ ] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: extended `redacts_nested_and_malformed_structured_credentials` with a closing-delimiter-before-opening-delimiter case.
- Reborn integration: Not applicable: the failure is inside the host-API value constructor and is covered through its public contract.
- Recorded fixture: Not applicable: no provider response format or network boundary changed.
- Browser E2E: Not applicable: no browser behavior changed.
- Backend or runtime: Not applicable: no runtime wiring changed.
- Live canary: Not applicable: this branch has not been deployed.

What the tests prove: malformed embedded structured text can no longer form an invalid Rust string range, sensitive content is still replaced with `[redacted]`, and existing valid/malformed/deeply nested redaction behavior remains intact.

Commands run:

- `cargo test -p ironclaw_host_api --test model_result_preview_contract redacts_nested_and_malformed_structured_credentials -- --exact`
- `cargo test -p ironclaw_host_api`
- `cargo clippy -p ironclaw_host_api --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p ironclaw_webui --all-features`
- `cargo clippy -p ironclaw_webui --all-features --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_webui -- -D warnings`
- `cargo test -p ironclaw_architecture_tests`
- `pnpm exec vitest run --project unit src/lib/api-boundary.test.ts`
- `pnpm lint`
- `python3 scripts/ci/regression-test-check.py --repo . --base origin/main --head HEAD --title "fix(host-api): avoid malformed preview range panic"`

## Security Impact

The credential-redaction path is made more fail-closed: an invalid candidate range now redacts the malformed string instead of indexing it and panicking. No permissions, authentication, network calls, file access, tool execution, or sandbox policy change.

## Reborn Trust-Boundary Checklist

N/A: no public trust-bearing types, prompt envelopes, hashes, status/error variants, serde defaults, queues, or runtime boundaries changed. The existing credential-redaction boundary remains intact and becomes panic-safe.

## Database Impact

None.

## Blast Radius

Limited to embedded structured-text handling inside `ModelResultPreview::redacted`. Valid JSON and the existing malformed/deep-nesting fallbacks retain their current behavior. The only new branch handles invalid string ranges by using the established full-text redaction fallback.

## Rollback Plan

Revert this pull request. The changes are source/test-only and require no data or schema rollback, though reverting the host-API fix would restore the production panic condition.

## Review Follow-Through

All current CI checks pass. The valid CodeRabbit assertion comment was addressed and its thread is resolved; there are no known follow-up changes.

---

**Review track**: C (credential-redaction safety path)

