### PR TITLE
test(webui): use the live extension id in the notification-setup boundary test

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/lib/api-boundary.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/lib/api-boundary.test.ts
@@ -95,7 +95,7 @@ test("notification setup rejects malformed successful responses", async () => {
   globalThis.fetch = async () =>
     new Response(
       JSON.stringify({
-        extension_id: "web-push",
+        extension_id: "web-app",
         requires_setup: false,
         enabled: "yes",
       }),
@@ -103,7 +103,7 @@ test("notification setup rejects malformed successful responses", async () => {
     );
 
   await assert.rejects(
-    getNotificationSetupStatus({ extensionId: "web-push" }),
+    getNotificationSetupStatus({ extensionId: "web-app" }),
     /invalid notification setup response/,
   );
 });


### PR DESCRIPTION
## Summary

- `main` has failed `Tests (Reborn)` since `666ebcbf0` (#8038): its new `api-boundary.test.ts` used `"web-push"` as an arbitrary example extension id, and the architecture gate `retired_web_push_spelling_stays_at_zero_occurrences` pins that retired spelling (renamed to `web-app` in #7477) at zero outside the persisted-compat allowlist.
- Rename the two occurrences to `"web-app"`. The function under test interpolates any id verbatim and has no channel-specific logic, so the string carries no persisted or compat meaning — renaming is correct; widening the allowlist would defeat its shrink-only invariant.

## Change Type

- [x] Bug fix

## Linked Issue

None — CI regression on `main`; no issue was filed for it.

## Validation

- [x] `cargo test -p ironclaw_architecture_tests retired_web_push_spelling_stays_at_zero_occurrences` — green with this change applied on the #8053 branch (which merged `main` and inherited the failure); red without it.
- [x] Frontend unit test file still passes (`pnpm vitest run src/lib/api-boundary.test.ts`) — the assertion is about a malformed response, not the id.
- [ ] Not applicable: no runtime, DB, or provider behavior touched.

## Test Strategy

User behavior: none — test fixture string only.

Risk areas: none.

Tests added or updated:
- Unit or contract: `api-boundary.test.ts` fixture id `web-push` → `web-app` (2 lines). Reason: the gate requires the live spelling; the test's assertion is unchanged.
- Reborn integration / Recorded fixture / Browser E2E / Backend or runtime / Live canary: Not applicable: fixture string in an existing unit test.

What the tests prove: the architecture gate passes again on `main`; the boundary test still rejects a malformed `enabled: "yes"` response.

Commands run: see Validation.

## Security Impact

None.

## Reborn Trust-Boundary Checklist

N/A — test fixture string.

## Database Impact

None.

## Blast Radius

One frontend unit-test file. Unblocks `Tests (Reborn)` for every PR that merges current `main`.

## Rollback Plan

Revert the commit.

## Review Follow-Through

Same commit is cherry-picked onto #8053 so its CI is green now; when this lands, that commit becomes a no-op at merge.

---

**Review track**: A (test fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
