### PR TITLE
fix(responses): send cancel reason the product surface accepts

### DIFF
--- a/crates/product/ironclaw_openai_compat/src/responses_workflow.rs
+++ b/crates/product/ironclaw_openai_compat/src/responses_workflow.rs
@@ -551,7 +551,9 @@ impl OpenAiResponsesWorkflow {
                     client_action_id: Some(format!("{}:cancel", response_id.as_str())),
                     thread_id: Some(thread_id.as_str().to_string()),
                     run_id: Some(run_ref.as_str().to_string()),
-                    reason: Some("cancelled by OpenAI-compatible Responses API".to_string()),
+                    // Must be a `ProductCancelReason` value: the product surface parses this
+                    // field and rejects anything outside that set, so free text 400s the route.
+                    reason: Some("user_requested".to_string()),
                 },
                 openai_product_activity_id(
                     "responses",

--- a/crates/product/ironclaw_openai_compat/tests/responses_workflow_handlers_contract.rs
+++ b/crates/product/ironclaw_openai_compat/tests/responses_workflow_handlers_contract.rs
@@ -31,6 +31,7 @@ use ironclaw_openai_compat::{
 use ironclaw_product_contracts::inbound::{
     ProductInboundAck, ProductInboundPayload, ProductRejection, ProductRejectionKind,
 };
+use ironclaw_product_contracts::inbound_requests::ProductCancelReason;
 use ironclaw_product_contracts::outbound::ProductOutboundEnvelope;
 use ironclaw_product_contracts::projection::ProjectionSubscriptionRequest;
 use ironclaw_product_contracts::surface::ProductSurface;
@@ -493,13 +494,15 @@ async fn responses_cancel_uses_product_surface_control_action() {
         cancel_request.client_action_id.as_deref(),
         Some(format!("{id}:cancel").as_str())
     );
-    assert!(
-        cancel_request
-            .reason
-            .as_deref()
-            .expect("cancel reason")
-            .contains("Responses API")
-    );
+    // The surface behind this fake parses `reason` into `ProductCancelReason` and rejects
+    // anything outside that set, so asserting the shape of the string is not enough — the value
+    // has to be one the real `into_command` would accept, or the route 400s in production while
+    // this test stays green.
+    let reason = cancel_request.reason.as_deref().expect("cancel reason");
+    let parsed: ProductCancelReason =
+        serde_json::from_value(serde_json::Value::String(reason.to_owned()))
+            .unwrap_or_else(|_| panic!("cancel reason {reason:?} is not a ProductCancelReason"));
+    assert_eq!(parsed, ProductCancelReason::UserRequested);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `POST /api/v1/responses/{id}/cancel` cannot succeed in any state: it returns `400 invalid_request` for in-progress and completed runs alike, and the run keeps going.
- `cancel_response` hardcodes `reason: Some("cancelled by OpenAI-compatible Responses API")`, but `parse_cancel_reason` accepts only the `ProductCancelReason` values (`user_requested`, `superseded`, `timeout`, `operator_requested`, `policy`). The handler sends a value its own validator refuses.
- Fix: send `user_requested`.
- The contract test could not catch it — it runs against `FakeProductSurface`, so `into_command` never executes, and it asserted the reason `contains("Responses API")`, pinning the value that breaks the route. It now parses the reason into `ProductCancelReason`.
- This is a specified surface, not an incidental mount: `docs/internal/reborn/contracts/openai-compatible-api.md` lists both cancel routes in its Route Surface table as `ProductSurface`-backed, and its Status line names "Responses create/retrieve/cancel" among the delivered slices.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #5990 — its acceptance criteria include "Create/get/cancel behavior is covered for missing, in-progress, completed, failed, and cancelled responses."

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_openai_compat` — 225 passed, 0 failed
- [x] Feature-gated integration suite — Not applicable: no database-backed or runtime-integration behavior changed, and `ironclaw_openai_compat` declares no `[features]`.
- [x] Manual testing: see Commands run.
- [ ] `pr-shepherd` — it takes a PR number, so I'll run it once this is open.

## Test Strategy

**User behavior:** an OpenAI-compatible client cancels an in-flight response and the run stops instead of running to completion.

**Risk areas:**

- [ ] Model behavior
- [ ] Browser
- [x] Side effect
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [ ] Cross-component behavior

Side effect is the only one ticked: the fix restores an intended side effect (run cancellation) that currently never happens. No new side effect is introduced.

**Tests added or updated:**

- Unit or contract: `responses_cancel_uses_product_surface_control_action` — the reason assertion now parses into `ProductCancelReason` instead of substring-matching.
- Reborn integration: none added. `tests/integration/cancel.rs` already covers cancellation, but through `harness.cancel_run(run_id)` below HTTP, so this change does not affect it.
- Recorded fixture: Not applicable: no model behavior involved.
- Browser E2E: Not applicable: no WebUI surface involved.
- Backend or runtime: Not applicable: no database, Docker, WASM, or MCP behavior involved.
- Live canary: none. Verified by hand against a local 1.4.0 instance instead (see Commands run).

**What the tests prove:** that the reason the Responses cancel path sends is a value the product surface's validator will accept. Per the TDD playbook an isolated bug fix belongs at the unit/contract tier, so this pins the bug in the existing contract test rather than adding a surface test. Before the change:

```
test responses_cancel_uses_product_surface_control_action ... FAILED
cancel reason "cancelled by OpenAI-compatible Responses API" is not a ProductCancelReason
```

Worth flagging for #5990: cancel has coverage on both sides of this gap and nothing in the middle — the integration test is below HTTP, the contract test is above it but against a fake — so nothing exercised cancel through HTTP into real validation, which is how this reached `main`.

**Commands run:**

```
cargo fmt --all -- --check                                                   # clean
cargo clippy --all --benches --tests --examples --all-features -- -D warnings # exit 0, 0 warnings
cargo build                                                                  # exit 0
cargo test -p ironclaw_openai_compat                                         # 225 passed, 0 failed
```

Each was also run on unmodified `main` (`d3e62cf`) first, with identical results, so the baseline is the same.

Manual, against a local 1.4.0 instance, driving the same `CANCEL_RUN_COMMAND` through the WebChat route where the validation field survives in the error envelope:

```
{"reason":"cancelled by OpenAI-compatible Responses API"}
-> 400 {"error":"invalid_request","kind":"validation","field":"reason","validation_code":"invalid_value"}

{"reason":"user_requested"}
-> 200 {"run_id":"…","status":"CancelRequested","already_terminal":false}
```

and the pending `POST /api/v1/responses` then returned `status: "cancelled"` before its 30s wait elapsed. Other candidates ruled out: `turn_run_ref` is `TurnRunId::to_string()`, a bare UUID `parse_run_id` accepts, and the colon in the generated `client_action_id` passes validation.

## Security Impact

None. The change alters one string constant in a request the caller is already authorized to make. It grants no capability, adds no network call, touches no secret, file access, tool execution, or sandbox policy. Scoping is untouched: `cancel_response` still resolves the response through `lookup_authorized` under the caller's own scope before doing anything, and that call is unchanged here. I did not measure a cross-user cancel — I measured a cross-user *retrieve*, which 404s — so treat the scoping statement as a reading of the unchanged code path rather than a result.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: who can construct them? — N/A: no such type added or changed. The value now sent is one of the existing `ProductCancelReason` variants.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive. — N/A: nothing here reaches a prompt.
- [x] Hashes declare purpose. — N/A: no hashing.
- [x] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. — N/A: no variants added or changed. `SanitizedCancelReason::UserRequested` was already the value produced when the field is absent, so no downstream match gains an arm.
- [x] Security/durability `serde(default)` fields fail closed or have migration tests. — N/A: no serde field changed.
- [x] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic. — N/A: no such structure touched.
- [x] Driver/operator-visible errors have stable class semantics. — N/A: no error class changed. The route stops returning `400 invalid_request` for a valid request, which is the bug being fixed.
- [x] Sandbox/native/host names accurately describe trust boundary. — N/A: no sandbox or host naming involved.

## Database Impact

None. No migrations, no schema change, nothing PostgreSQL- or libSQL-specific.

## Blast Radius

`ironclaw_openai_compat` only, and within it only `cancel_response`. The WebChat cancel route, `tests/integration/cancel.rs`, and the coordinator path are untouched.

What could break: anything consuming the cancel reason as free text would now read `user_requested`. Nothing does — the value is parsed into `SanitizedCancelReason` immediately, and the previous text never survived that parse because it was rejected. The behavior change is a route that returned `400` now returning `200` and cancelling the run, which is the intent of the endpoint.

## Rollback Plan

Revert the commit. There is no migration, no persisted state, and no new API surface, so reverting restores the previous behavior exactly — the cancel route returns to failing closed with `400` and runs continue to completion.

## Review Follow-Through

Three things I would rather ask than assume:

1. **`None` instead of `"user_requested"`** would also work, since `parse_cancel_reason` defaults to `SanitizedCancelReason::UserRequested` when the field is absent. I chose the explicit value; happy to switch.
2. **A typed field would make this unrepresentable.** `ProductCancelRunRequest.reason` is `Option<String>` while `ProductCancelReason` already exists in the same file. That change touches `ironclaw_product_contracts` and the WebChat handler, so I kept it out of this PR — glad to write it as a follow-up if you want it.
3. **The compat error envelope drops the validation field**: WebChat reports `field: "reason"`, the Responses route reports `param: null`. That is what made this hard to diagnose from the OpenAI-compatible surface. Left alone here as an unrelated concern.

And if the Responses cancel route is not a surface you want to keep, say so and I will close this — the same evidence would then argue for unmounting it rather than fixing it.

---

**Review track**: C (runtime)
