### PR TITLE
ci(nextest): give the whole-tree architecture scans real timeout headroom

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -64,3 +64,15 @@ slow-timeout = { period = "300s", terminate-after = 2 }
 [[profile.ci.overrides]]
 filter = "binary(~reborn_group_)"
 slow-timeout = { period = "28m", terminate-after = 1 }
+
+# ironclaw_architecture_tests: reborn_{extension_contract,loop_port,product_contract}_location_scan
+# and reborn_sealed_evidence_mint_ratchet each contain one whole-crates/-tree
+# scan test. On the last green run the location-scan tests finished at
+# 176.8s against the default 60s/3 = 180s hard kill; the very next run was
+# terminated at 180.008s. reborn_sealed_evidence_mint_ratchet rides the same
+# ladder to 136-141s. Locally these take ~110s. 60s/6 = 360s keeps the same
+# SLOW cadence but gives real headroom instead of raising the default for
+# every binary in the crate.
+[[profile.ci.overrides]]
+filter = 'binary(/_location_scan$/) | binary(~reborn_sealed_evidence_mint_ratchet)'
+slow-timeout = { period = "60s", terminate-after = 6 }


### PR DESCRIPTION
## Summary

- The three `ironclaw_architecture_tests` binaries `reborn_{extension_contract,loop_port,product_contract}_location_scan` each run one whole-`crates/`-tree scan. On the last green run of #8053 they finished at **176.8 s** against the `ci` profile's `60s × 3 = 180 s` hard kill; the very next run, with no code change touching their runtime, was terminated at 180.008 s. `reborn_sealed_evidence_mint_ratchet` rides the same ladder to 136–141 s.
- Add one `[[profile.ci.overrides]]` for that family at `60s × 6` (same SLOW cadence, real headroom). The default is unchanged for every other binary.

## Change Type

- [x] CI/Infrastructure

## Linked Issue

None — observed on #8053's CI (runs 33803597916 green at 176.8 s, 33810122502 terminated at 180.008 s).

## Validation

- [x] Match proven locally, not inferred: with the override's `period` temporarily set to `150s`, `cargo nextest run --profile ci -p ironclaw_architecture_tests -E 'binary(/_location_scan$/)'` produced **no** SLOW marker (tests take ~110 s locally); with `60s` restored, `SLOW [> 60.000s]` fires at 60 s for the three scans and all 21 tests pass.
- [ ] Not applicable: no Rust code changed.

## Test Strategy

User behavior: none. Risk areas: none (CI timeout policy for four test binaries).
Tests added or updated: Not applicable: nextest configuration.
What the tests prove: n/a. Commands run: see Validation.

## Security Impact

None.

## Reborn Trust-Boundary Checklist

N/A — CI configuration.

## Database Impact

None.

## Blast Radius

Four architecture-test binaries get 360 s instead of 180 s before termination. A genuine hang in one of them now takes 6 minutes to surface instead of 3.

## Rollback Plan

Delete the override block.

## Review Follow-Through

The same commit is cherry-picked onto #8053 so its architecture bucket stops flipping; when this lands it becomes a no-op there.

---

**Review track**: C (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
