### PR TITLE
feat(subagent): concurrent-children cap (R2 debt) + verify the child-gate card replays (R3 3b)

### DIFF
--- a/crates/loop/ironclaw_loop_host/src/lib.rs
+++ b/crates/loop/ironclaw_loop_host/src/lib.rs
@@ -162,7 +162,8 @@ pub use subagent_prompt_port::{
     subagent_run_id_from_context,
 };
 pub use subagent_spawn_port::{
-    AwaitedChildSetRecord, DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID, DEFAULT_SUBAGENT_MAX_DEPTH,
+    AwaitedChildSetRecord, DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID,
+    DEFAULT_SUBAGENT_MAX_CONCURRENT_CHILDREN, DEFAULT_SUBAGENT_MAX_DEPTH,
     DEFAULT_SUBAGENT_MAX_SPAWN_PER_TURN, DEFAULT_SUBAGENT_MAX_TREE_DESCENDANTS,
     InMemoryAwaitEdgeWriter, JsonSpawnSubagentInputCodec, SpawnSubagentArgs,
     SpawnSubagentFlavorDescriptor, SpawnSubagentInputCodec, SpawnSubagentMode, SubagentDefinition,

--- a/crates/loop/ironclaw_loop_host/src/subagent_spawn_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/subagent_spawn_port.rs
@@ -787,7 +787,7 @@ impl SubagentSpawnCapabilityPort {
             .into_iter()
             .filter(|record| !record.status.is_terminal())
             .count();
-        if running_children as u32 >= self.limits.max_concurrent_children {
+        if running_children >= self.limits.max_concurrent_children as usize {
             return Ok(spawn_rejected("concurrent_children_cap_exceeded"));
         }
 

--- a/crates/loop/ironclaw_loop_host/src/subagent_spawn_port.rs
+++ b/crates/loop/ironclaw_loop_host/src/subagent_spawn_port.rs
@@ -44,6 +44,14 @@ use crate::{
 pub const DEFAULT_SUBAGENT_MAX_DEPTH: u32 = 1;
 pub const DEFAULT_SUBAGENT_MAX_SPAWN_PER_TURN: u32 = 4;
 pub const DEFAULT_SUBAGENT_MAX_TREE_DESCENDANTS: u32 = 16;
+/// Not smaller than `DEFAULT_SUBAGENT_MAX_SPAWN_PER_TURN` (4): a parent that
+/// spawns its full per-turn fanout in one turn must be able to have all of
+/// them alive at once without tripping this cap on its very first turn.
+/// Conservative relative to `DEFAULT_SUBAGENT_MAX_TREE_DESCENDANTS` (16): a
+/// parent may run half its lifetime tree budget concurrently before this cap
+/// bites, leaving headroom for a second turn's fanout while still bounding
+/// concurrent resource usage well under the absolute tree total.
+pub const DEFAULT_SUBAGENT_MAX_CONCURRENT_CHILDREN: u32 = 8;
 pub const DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID: &str = "builtin.spawn_subagent";
 const SPAWN_SUBAGENT_PROVIDER_TOOL_NAME: &str = "builtin__spawn_subagent";
 pub(crate) const SPAWN_SUBAGENT_DESCRIPTION: &str =
@@ -361,6 +369,7 @@ pub struct SubagentSpawnLimits {
     pub max_depth: u32,
     pub max_spawn_per_turn: u32,
     pub max_tree_descendants: u32,
+    pub max_concurrent_children: u32,
 }
 
 impl Default for SubagentSpawnLimits {
@@ -369,6 +378,7 @@ impl Default for SubagentSpawnLimits {
             max_depth: DEFAULT_SUBAGENT_MAX_DEPTH,
             max_spawn_per_turn: DEFAULT_SUBAGENT_MAX_SPAWN_PER_TURN,
             max_tree_descendants: DEFAULT_SUBAGENT_MAX_TREE_DESCENDANTS,
+            max_concurrent_children: DEFAULT_SUBAGENT_MAX_CONCURRENT_CHILDREN,
         }
     }
 }
@@ -757,6 +767,30 @@ impl SubagentSpawnCapabilityPort {
         if child_depth > self.limits.max_depth {
             return Ok(spawn_rejected("depth_cap_exceeded"));
         }
+
+        // ponytail: read-then-decide pre-check, not an atomic reservation
+        // like the kernel's tree cap — parallel spawn calls inside a single
+        // turn can race between this count and the child submission below
+        // and briefly overshoot `max_concurrent_children`. The overshoot is
+        // bounded by `max_spawn_per_turn` (the in-memory per-turn slot cap
+        // already reserved above via `reserve_spawn_slot`), and the durable
+        // tree cap (`max_tree_descendants`) still bounds the absolute total.
+        // Upgrade path: an atomic reserve-at-admission in the kernel's
+        // process-tree reservation, the way `spawn_tree_descendant_cap` is
+        // enforced in `apply_submit_process`.
+        let running_children = self
+            .deps
+            .agent_turn_runtime
+            .children_of(&self.run_context.scope, self.run_context.run_id)
+            .await
+            .map_err(map_turn_error)?
+            .into_iter()
+            .filter(|record| !record.status.is_terminal())
+            .count();
+        if running_children as u32 >= self.limits.max_concurrent_children {
+            return Ok(spawn_rejected("concurrent_children_cap_exceeded"));
+        }
+
         let parent_definition = self
             .deps
             .definition_resolver

--- a/crates/loop/ironclaw_loop_host/src/subagent_spawn_port/tests.rs
+++ b/crates/loop/ironclaw_loop_host/src/subagent_spawn_port/tests.rs
@@ -139,6 +139,7 @@ struct StaticCoordinator;
 
 struct StaticAgentTurnRuntime {
     record: Option<TurnRunRecord>,
+    children: Vec<TurnRunRecord>,
     cancels: std::sync::Mutex<Vec<CancelRunRequest>>,
     releases: std::sync::Mutex<Vec<(TurnScope, TurnRunId, u32)>>,
 }
@@ -157,9 +158,15 @@ impl StaticAgentTurnRuntime {
     fn new(record: Option<TurnRunRecord>) -> Self {
         Self {
             record,
+            children: Vec::new(),
             cancels: std::sync::Mutex::new(Vec::new()),
             releases: std::sync::Mutex::new(Vec::new()),
         }
+    }
+
+    fn with_children(mut self, children: Vec<TurnRunRecord>) -> Self {
+        self.children = children;
+        self
     }
 
     fn cancels(&self) -> Vec<CancelRunRequest> {
@@ -991,7 +998,7 @@ impl AgentTurnSpawnTreeRuntimePort for StaticAgentTurnRuntime {
         _scope: &TurnScope,
         _run_id: TurnRunId,
     ) -> Result<Vec<TurnRunRecord>, TurnError> {
-        Ok(Vec::new())
+        Ok(self.children.clone())
     }
 
     async fn get_run_record(
@@ -2833,6 +2840,106 @@ async fn invoke_spawn_rejects_depth_cap() {
         denied_reason(invoke_spawn(&port).await),
         "depth_cap_exceeded"
     );
+}
+
+fn child_record_with_status(run_context: &LoopRunContext, status: TurnStatus) -> TurnRunRecord {
+    TurnRunRecord {
+        run_id: TurnRunId::new(),
+        status,
+        ..turn_record(run_context, 0)
+    }
+}
+
+#[tokio::test]
+async fn invoke_spawn_rejects_when_concurrent_children_cap_is_exceeded() {
+    let context = test_run_context_with_agent_actor("spawn-concurrent-children").await;
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let running_children = vec![
+        child_record_with_status(&context, TurnStatus::Running),
+        child_record_with_status(&context, TurnStatus::Running),
+    ];
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: child_runs.clone(),
+        agent_turn_runtime: Arc::new(
+            StaticAgentTurnRuntime::new(Some(turn_record(&context, 0)))
+                .with_children(running_children),
+        ),
+        thread_service: Arc::new(InMemorySessionThreadService::default()),
+        await_edge_writer: Arc::new(InMemoryAwaitEdgeWriter),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
+            args: default_spawn_args(),
+        }),
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    let port = SubagentSpawnCapabilityPort::new(
+        Arc::new(AuthPassPort),
+        context,
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits {
+            max_concurrent_children: 2,
+            ..SubagentSpawnLimits::default()
+        },
+        deps,
+        Vec::new(),
+    );
+    authorize_spawn_input(&port);
+
+    assert_eq!(
+        denied_reason(invoke_spawn(&port).await),
+        "concurrent_children_cap_exceeded"
+    );
+    assert!(child_runs.requests().is_empty());
+}
+
+#[tokio::test]
+async fn invoke_spawn_allows_a_child_when_earlier_children_are_terminal() {
+    let context = test_run_context_with_agent_actor("spawn-concurrent-children-terminal").await;
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let mixed_children = vec![
+        child_record_with_status(&context, TurnStatus::Completed),
+        child_record_with_status(&context, TurnStatus::Failed),
+    ];
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: child_runs.clone(),
+        agent_turn_runtime: Arc::new(
+            StaticAgentTurnRuntime::new(Some(turn_record(&context, 0)))
+                .with_children(mixed_children),
+        ),
+        thread_service: Arc::new(InMemorySessionThreadService::default()),
+        await_edge_writer: Arc::new(InMemoryAwaitEdgeWriter),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
+            args: default_spawn_args(),
+        }),
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    let port = SubagentSpawnCapabilityPort::new(
+        Arc::new(AuthPassPort),
+        context,
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits {
+            max_concurrent_children: 2,
+            ..SubagentSpawnLimits::default()
+        },
+        deps,
+        Vec::new(),
+    );
+    authorize_spawn_input(&port);
+
+    assert!(matches!(
+        invoke_spawn(&port).await,
+        Resolution::Suspended(Suspension::DependentRun { .. })
+    ));
+    assert_eq!(child_runs.requests().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/product/ironclaw_assistant/tests/reborn_services_contract.rs
+++ b/crates/product/ironclaw_assistant/tests/reborn_services_contract.rs
@@ -119,6 +119,7 @@ use ironclaw_auth::{
     AuthAccountLastError, AuthAccountState, ChannelAuthAccountState, ChannelConnectionService,
     CredentialAccountId, CredentialAccountProjection, CredentialAccountStatus,
 };
+use ironclaw_event_log::{DurableEventLog, InMemoryDurableEventLog};
 use ironclaw_extension_contracts::external::ExternalConversationRef;
 use ironclaw_extension_contracts::hosted_mcp::HostedMcpAuthSelection;
 use ironclaw_extension_contracts::{
@@ -229,7 +230,9 @@ use ironclaw_turns::{
     AdmissionRejection, AdmissionRejectionReason, CancelRunRequest, CancelRunResponse,
     DefaultTurnCoordinator, GetRunStateRequest, ResumeTurnPrecondition, ResumeTurnRequest,
     ResumeTurnResponse, RetryTurnRequest, RetryTurnResponse, SubmitTurnRequest, SubmitTurnResponse,
-    TurnCapacityResource, TurnCoordinator, TurnError, TurnOriginKind, TurnRunState,
+    TurnBlockedGateKind, TurnBlockedGateMetadata, TurnCapacityResource, TurnCoordinator, TurnError,
+    TurnEventKind, TurnEventPage, TurnEventProjectionSource, TurnLifecycleEvent, TurnOriginKind,
+    TurnRunState,
 };
 use secrecy::SecretString;
 use serde::Serialize;
@@ -14891,6 +14894,185 @@ async fn list_threads_hides_automation_trigger_threads() {
         !thread_ids.contains(&automation_thread_id),
         "automation trigger threads should be accessible by direct id but hidden from the chat list",
     );
+}
+
+/// Fake `TurnEventProjectionSource` carrying exactly one pre-recorded
+/// `TurnEventKind::Blocked` event — standing in for the durable turn-lifecycle
+/// log a real subagent run's gate would already have committed to before any
+/// reader ever subscribes. Only `read_turn_events_after` matters:
+/// `TurnEventBridge::drain`
+/// (`crates/product/ironclaw_assistant/src/projection/turn_events.rs`) never
+/// calls the doc-hidden `read_turn_event_log_after` sibling.
+struct PreRecordedBlockedEventSource {
+    event: TurnLifecycleEvent,
+}
+
+#[async_trait]
+impl TurnEventProjectionSource for PreRecordedBlockedEventSource {
+    async fn read_turn_events_after(
+        &self,
+        _scope: &TurnScope,
+        _owner_user_id: Option<&UserId>,
+        after: Option<EventCursor>,
+        _limit: usize,
+    ) -> Result<TurnEventPage, TurnError> {
+        let entries = match after {
+            Some(cursor) if cursor >= self.event.cursor => Vec::new(),
+            _ => vec![self.event.clone()],
+        };
+        Ok(TurnEventPage {
+            entries,
+            next_cursor: self.event.cursor,
+            truncated: false,
+            rebase_required: None,
+        })
+    }
+
+    async fn read_turn_event_log_after(
+        &self,
+        _after: Option<EventCursor>,
+        _limit: usize,
+    ) -> Result<TurnEventPage, TurnError> {
+        Ok(TurnEventPage {
+            entries: Vec::new(),
+            next_cursor: EventCursor::default(),
+            truncated: false,
+            rebase_required: None,
+        })
+    }
+}
+
+/// The crux of subagent R3 slice 3b: a human opens a hidden child thread
+/// *after* the block already happened, so the gate card served to a cold
+/// reader must come from a durable replay, not a live-only push.
+///
+/// Pins two things through the real production seam
+/// (`RebornProjectionServices` -> `TurnEventBridge::drain`, not a
+/// `ProjectionStream` test double): a subagent's hidden child thread is
+/// listing-only hidden (absent from `list_threads`, reachable by direct id),
+/// and a `TurnEventKind::Blocked` event recorded on that thread *before* any
+/// subscriber exists still replays as a `GatePrompt` when a cold reader
+/// drains from `after_cursor: None` — exactly what a cold SSE connection
+/// sends (no `Last-Event-ID`), per
+/// `crates/product/ironclaw_webui/src/webui_v2/handlers.rs`.
+#[tokio::test]
+async fn a_hidden_child_thread_replays_its_pending_gate_to_a_cold_reader() {
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let caller = caller();
+    let child_thread_id = ThreadId::new("thread-subagent-child").expect("child thread id");
+
+    thread_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: thread_scope_for(&caller),
+            thread_id: Some(child_thread_id.clone()),
+            created_by_actor_id: caller.user_id.as_str().to_string(),
+            title: Some("Child agent run".to_string()),
+            metadata_json: Some(json!({ "kind": "subagent" }).to_string()),
+        })
+        .await
+        .expect("hidden child thread");
+
+    let coordinator = Arc::new(FakeTurnCoordinator::default());
+    let services = session_services(thread_service.clone(), coordinator.clone());
+
+    // Hidden is listing-only: the child thread never appears in the owner's
+    // chat list...
+    let listed = query_threads(
+        &services,
+        caller.clone(),
+        ProductListThreadsRequest::default(),
+    )
+    .await
+    .expect("list threads");
+    assert!(
+        !listed
+            .threads
+            .iter()
+            .any(|thread| thread.thread_id == child_thread_id),
+        "a hidden child thread must not appear in the owner's chat list"
+    );
+
+    // ...yet a direct-id read succeeds: hidden is a listing predicate, not an
+    // access boundary.
+    services
+        .get_timeline(
+            caller.clone(),
+            RebornTimelineRequest::new(child_thread_id.as_str()),
+        )
+        .await
+        .expect("a hidden child thread is reachable by direct id");
+
+    // The crux: record the run's Blocked gate on the durable turn-lifecycle
+    // log before any subscription exists, then drain from after=None (a cold
+    // reader) and prove the gate replays.
+    let gate_ref = approval_gate_ref(ApprovalRequestId::new()).expect("approval gate ref");
+    coordinator.set_parked_approval_gate(gate_ref.clone());
+    let run_id = TurnRunId::new();
+    let scope = caller.turn_scope(child_thread_id.clone());
+    let blocked_event = TurnLifecycleEvent {
+        // Matches `FakeTurnCoordinator::get_run_state`'s fixed
+        // `event_cursor: EventCursor(17)` — `blocked_prompt_payload` only
+        // renders a gate prompt when the durable event's cursor still agrees
+        // with the coordinator's current run state.
+        cursor: EventCursor(17),
+        scope: scope.clone(),
+        occurred_at: None,
+        owner_user_id: Some(caller.user_id.clone()),
+        run_id,
+        status: TurnStatus::BlockedApproval,
+        kind: TurnEventKind::Blocked,
+        blocked_gate: Some(TurnBlockedGateMetadata {
+            gate_ref: gate_ref.clone(),
+            gate_kind: TurnBlockedGateKind::Approval,
+            activity_id: None,
+            credential_requirements: Vec::new(),
+        }),
+        sanitized_reason: Some("approval_required".to_string()),
+        retryable: None,
+        detail: None,
+    };
+
+    let turn_event_source: Arc<dyn TurnEventProjectionSource> =
+        Arc::new(PreRecordedBlockedEventSource {
+            event: blocked_event,
+        });
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let reply_target_binding_ref =
+        ReplyTargetBindingRef::new("webui-test").expect("reply target binding ref");
+    let event_stream = ironclaw_assistant::projection::build_reborn_projection_services(
+        event_log,
+        reply_target_binding_ref,
+    )
+    .with_turn_events(turn_event_source, coordinator.clone())
+    .product_event_stream();
+
+    let services = services.with_event_stream(event_stream);
+
+    let drained = services
+        .stream_events(
+            caller.clone(),
+            RebornStreamEventsRequest {
+                thread_id: child_thread_id.to_string(),
+                after_cursor: None,
+            },
+        )
+        .await
+        .expect("a cold reader can drain a hidden child thread's projection");
+
+    let gate_view = drained
+        .events
+        .iter()
+        .find_map(|envelope| match &envelope.payload {
+            ProductOutboundPayload::GatePrompt(view) => Some(view.clone()),
+            _ => None,
+        })
+        .expect(
+            "a drain starting from after_cursor=None must replay the pending gate from the \
+             durable projection, not require a live push",
+        );
+
+    assert_eq!(gate_view.turn_run_id, run_id);
+    assert_eq!(gate_view.gate_ref, gate_ref.as_str());
 }
 
 #[tokio::test]

--- a/docs/internal/reborn/subagent-spawn/README.md
+++ b/docs/internal/reborn/subagent-spawn/README.md
@@ -574,9 +574,13 @@ the append-model design review.
   (authoring UX; `SubagentKindId` is already the primitive), and
   fleet-wide cross-session messaging (R6 covers the in-scope
   parent→child case). Evidence is changelog-grade — shipped-behavior
-  descriptions, not source. (status, 2026-09-02: the cap did not ship with
-  R2 and is open R2 debt for its own follow-up slice — the descendant cap
-  is the only admission bound today.)
+  descriptions, not source. (status, 2026-09-03: the cap shipped —
+  `SubagentSpawnLimits::max_concurrent_children` defaults to 8 and refuses
+  with the model-visible `spawn_rejected("concurrent_children_cap_exceeded")`,
+  like the fanout and depth caps beside it; it is a read-then-decide
+  pre-check, not an atomic reservation, so the remaining ceiling is a brief
+  overshoot under parallel spawns within one turn, bounded by the per-turn
+  and tree caps.)
 - **D9 ◇ Not in scope**: `TurnOwner` vs `TurnThreadOwner` stay separate
   types (ownership shape vs resolution disposition); no stored counters;
   never append to `completion_observer.rs`; new files < 800 lines;
@@ -651,8 +655,8 @@ work, in order — names map to the retired shape doc's slices for continuity:
 
 | # | Work | Contents | Was |
 | --- | --- | --- | --- |
-| R2 | **Background core** | Everything in §4.3 + integration tests: per-child beat, three-trigger healing, `ThreadBusy` heal (sweep-based), crash-replay idempotency, the failure-injection matrix. Plus a **concurrent-running-children cap** at spawn admission (same path as the descendant cap) — Claude Code's changelog shows this cap removed and re-added under production pressure; it is D10's "active children per parent" line made real — **shipped 2026-08 except the concurrent-running-children cap (open debt, own slice) and the boot pass (moved to R4, §4.2)** | slice 2 (reshaped: append model replaces wake-only Tasks 8–9) |
-| R3 | **Gate escalation walk** | 3a: a blocked child's approval/auth gate reaches the parent's owner as an actionable inbox item opening the child thread (shipped 2026-09); 3b: verify/land the WebUI gate card on a hidden child thread opened by URL; R3 is a prerequisite of the R9 enable, not the enable itself | slice 4 |
+| R2 | **Background core** | Everything in §4.3 + integration tests: per-child beat, three-trigger healing, `ThreadBusy` heal (sweep-based), crash-replay idempotency, the failure-injection matrix. Plus a **concurrent-running-children cap** at spawn admission (same path as the descendant cap) — Claude Code's changelog shows this cap removed and re-added under production pressure; it is D10's "active children per parent" line made real — **shipped 2026-08, including the concurrent-running-children cap (shipped 2026-09); only the boot pass remains, moved to R4 (§4.2)** | slice 2 (reshaped: append model replaces wake-only Tasks 8–9) |
+| R3 | **Gate escalation walk** | 3a: a blocked child's approval/auth gate reaches the parent's owner as an actionable inbox item opening the child thread (shipped 2026-09); 3b: a hidden child thread opened by URL already replayed its gate card correctly — verified, and pinned with a regression test on the cold-reader replay path (shipped 2026-09, no production change); R3 is a prerequisite of the R9 enable, not the enable itself | slice 4 |
 | R4 | **Counters, operator command, e2e revival** | `ResolveReport` counters; `ironclaw subagent edges`; un-ignore the five e2e tests via harness-side enablement; boot-recovery fairness | slice 5 |
 | R5 | **`subagent_inspect` + per-kind config** | Model-facing status/gate/byte-count metadata (never raw transcript); per-kind budget + model override. Plus the **degraded-result taxonomy**: `child_terminal_output` distinguishes clean success / partial-on-forced-cutoff / provider error — Claude Code shipped three separate fixes for children returning empty on rate-limit cutoff or fabricating success on API error; D10's lifecycle-taxonomy line; the parent model learns of a blocked child here | slice 6 |
 | R6 | **`subagent_extend` + human priority** | `activate(child, …, ParentAgent)` with consent-to-wake + budget window; `human_waiting` reservation marker | slice 7 |
@@ -743,6 +747,8 @@ Things no slice may break; each is enforced or pinned today.
 | Disabled-capability pins | `tests/integration/tool_call.rs` |
 | E2E suite (ignored until R4) | `tests/reborn_subagent_spawn_e2e.rs` |
 | Child gate → owner inbox (R3 3a) | `crates/product/ironclaw_assistant/src/run_outcome_observer.rs` (`child_gate_run`, `observe_child_gate_commit`) |
+| Hidden child thread replays its gate to a cold reader (R3 3b) | `crates/product/ironclaw_assistant/tests/reborn_services_contract.rs` (`a_hidden_child_thread_replays_its_pending_gate_to_a_cold_reader`) |
+| Concurrent-running-children cap at spawn admission (R2 debt) | `crates/loop/ironclaw_loop_host/src/subagent_spawn_port.rs`, tests in `subagent_spawn_port/tests.rs` (`invoke_spawn_rejects_when_concurrent_children_cap_is_exceeded`, `invoke_spawn_allows_a_child_when_earlier_children_are_terminal`) |
 
 Family rules: `crates/loop/AGENTS.md` and per-crate `AGENTS.md`/`README.md`
 files govern placement; `tests/integration/AGENTS.md` governs scenario
@@ -754,12 +760,25 @@ change.
 
 ## 9. Part II — pending work
 
-R3 slice 3a shipped 2026-09, PR #8046. Next: 3b (WebUI
-gate card on a hidden child thread opened by URL — verify first, it may
-already render), then the two R2 debts as their own slices
-(concurrent-running-children cap at spawn admission; the `ThreadBusy`
-immediate-re-enqueue optimization in `activate_parked_parent` — R2 already
-ships the sweep-based heal that parks and re-attends the edge; this debt is
-re-enqueueing into the now-live parent's queue right away instead of waiting
-for the next sweep). Plans are written here, spec-first against
-Part I, when a slice starts.
+R3 slice 3a shipped 2026-09, PR #8046. Slice 3b (2026-09) verified the WebUI
+gate card on a hidden child thread opened by URL already worked and shipped
+the regression test that pins it — no production change. The
+concurrent-running-children cap (§6 R2, D11) also shipped 2026-09. What
+remains:
+
+- The **`ThreadBusy` immediate-re-enqueue** optimization in
+  `activate_parked_parent` — R2 already ships the sweep-based heal that
+  parks and re-attends the edge; this debt is enqueueing into the now-live
+  parent's queue right away instead of waiting for the next sweep.
+- **R4**: counters, `ironclaw subagent edges`, un-ignoring the five e2e
+  tests via harness-side enablement, boot-recovery fairness.
+- **Newly identified, worth its own slice**: the tree-wide descendant cap
+  surfaces as a run-ending host error rather than a model-visible refusal,
+  unlike the fanout, depth, and new concurrency caps beside it. The kernel's
+  `ProcessTreeCapacityExceeded` maps through
+  `TurnErrorCategory::CapacityExceeded` →
+  `AgentLoopHostErrorKind::BudgetExceeded` in `map_turn_error`
+  (`subagent_spawn_port.rs`) and propagates as `Err`, which
+  `.claude/rules/tool-evidence.md` says a correctable failure should not do.
+
+Plans are written here, spec-first against Part I, when a slice starts.


### PR DESCRIPTION
## Summary

- **R3 slice 3b — verified, no production change.** The question was whether a human who opens a blocked subagent child's thread by URL actually sees the approval card. It already works, and every hop holds: `record_is_prepared_context_hidden` has exactly two call sites and both are listing filters, so a child thread stays out of the sidebar while remaining readable by id; the child scope carries the parent owner's `owner_user_id`, so the same human is authorized; and the gate card is rebuilt from the durable turn-event projection rather than a live-only push, so arriving after the block still shows it. This slice ships the regression test for that last property — the one a refactor could silently destroy.
- **R2 debt closed — a parent can no longer run unlimited children at once.** Spawn admission bounded fan-out three ways (per-turn slots, depth, tree-wide descendant total) but nothing bounded *concurrency*: the tree cap says how many children a tree may ever create, not how many may be alive simultaneously. `SubagentSpawnLimits::max_concurrent_children` (default 8) closes that, refusing model-visibly like the two caps beside it.
- **Docs**: §5 D11, §6 R2/R3 rows and §8 map updated; §9 Part II now lists what actually remains.

## Change Type

- [x] New feature
- [x] Documentation
- [ ] Bug fix

## Linked Issue

Related #4474 (background subagent umbrella). Scope is `docs/internal/reborn/subagent-spawn/README.md` §6 rows R2 and R3, and decision D11.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_loop_host --tests -- -D warnings` and `-p ironclaw_assistant --tests -- -D warnings` — clean
- [x] `cargo build` (crates build as part of the test runs)
- [x] Relevant tests pass: `cargo test -p ironclaw_loop_host subagent_spawn_port` — 66/66; `cargo test -p ironclaw_assistant --test reborn_services_contract` — green except one environmental failure (below); `cargo test -p ironclaw_architecture_tests` — all green, including the frozen test-support ratchet
- [ ] `--features integration`: Not applicable — no database-backed or runtime-integration behavior changed
- [x] Manual testing: `python3 scripts/ci/check-guidance.py` exit 0
- [ ] `pr-shepherd`: to run after CI

`reborn_services_contract::trace_reads_are_available_as_product_views` fails on the dev machine only: the local `~/.ironclaw/trace_contributions/policy.json` enrolls the caller, so the view attempts a network fetch and reports `TRACE_COMMONS_TEST_TOKEN is not set`. Unrelated to this diff.

**Red before green, for both behavioral pins.** Removing the `!record.status.is_terminal()` filter makes `invoke_spawn_allows_a_child_when_earlier_children_are_terminal` fail; inverting the 3b assertion to expect no gate makes that test fail. Neither test passes trivially.

## Test Strategy

User behavior: an agent that spawns many children can no longer keep an unbounded number running at once — it is told to wait and retry rather than having its run killed. Separately, a human who opens a blocked child's thread from an inbox notification still sees a working approve/deny card even when they arrive long after the block.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect (spawn admission refuses where it previously allowed)
- [ ] Persistence
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior (spawn port reads run-tree state; projection replay feeds the WebUI gate card)

Tests added or updated:
- Unit or contract: `invoke_spawn_rejects_when_concurrent_children_cap_is_exceeded` and `invoke_spawn_allows_a_child_when_earlier_children_are_terminal` (`crates/loop/ironclaw_loop_host/src/subagent_spawn_port/tests.rs`); `a_hidden_child_thread_replays_its_pending_gate_to_a_cold_reader` (`crates/product/ironclaw_assistant/tests/reborn_services_contract.rs`)
- Reborn integration: Not applicable — the cap is a pre-check inside spawn admission with a runtime-port double at crate tier; the 3b test already drives the real `TurnEventBridge` / `ProductRuntimeProjectionStream` seam rather than a fake
- Recorded fixture: Not applicable — no model behavior
- Browser E2E: Not applicable — 3b's finding is that the existing frontend path needs no change; the render condition is `activeThreadId && pendingGate`, with no dependency a child thread lacks
- Backend or runtime: Not applicable
- Live canary: Not applicable

What the tests prove: the cap refuses a spawn without submitting a child once the parent's non-terminal children reach the limit, and terminal children do not count toward it — so nobody can "fix" the cap by counting every child ever created. For 3b: a gate event recorded before any subscriber exists is replayed to a cold reader with the same run id and gate ref, so the notification's link keeps working for a human who arrives after the fact.

Commands run: `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=4 cargo test -p ironclaw_loop_host subagent_spawn_port`; `… cargo test -p ironclaw_assistant --test reborn_services_contract`; `… cargo test -p ironclaw_architecture_tests`; `… cargo clippy -p ironclaw_loop_host --tests -- -D warnings`; `… cargo clippy -p ironclaw_assistant --tests -- -D warnings`; `cargo fmt --check`; `python3 scripts/ci/check-guidance.py`.

## Security Impact

The cap narrows what a model may do — it refuses spawns that were previously admitted — so it cannot widen authority. It reads the caller's own run-tree state through the port the spawn path already holds; no new data crosses a boundary. The 3b change is test-only. No new ingress, credential, or approval path.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: none added.
- [x] Untrusted content into prompts: none — no prompt or content path touched.
- [x] Hashes: none added.
- [x] New/changed variants: none. `max_concurrent_children` is a new field on `SubagentSpawnLimits` with a default; the only construction sites are its own `Default` impl, composition's `::default()` call, and test-module literals (all updated and compiling).
- [x] `serde(default)` fields: none added.
- [x] Bounds: this change *is* a bound. Its own ceiling — a read-then-decide check can briefly overshoot under parallel spawns in one turn — is marked with a `ponytail:` naming the atomic-reservation upgrade path, and the overshoot stays bounded by the per-turn fanout cap and the durable tree cap.
- [x] Error classes: unchanged. The new refusal is a model-visible `spawn_rejected(...)`, matching the fanout and depth caps; the runtime-port error keeps its existing `map_turn_error` mapping.
- [x] Names: unchanged trust boundary.

## Database Impact

None.

## Blast Radius

`crates/loop/ironclaw_loop_host/src/subagent_spawn_port.rs` (one pre-check plus a limits field), its test module, one new test in `ironclaw_assistant`'s contract suite, and the design doc. Every spawn now performs one additional `children_of` read before creating a child. The capability remains deny-filtered in production until R9, so no production run reaches this path yet.

## Rollback Plan

Revert the branch. The cap is a pre-check with no durable state, so nothing persists to unwind; reverting restores the previous admission behavior exactly.

## Review Follow-Through

- Remaining R2 debt: the `ThreadBusy` immediate re-enqueue in `activate_parked_parent` (the sweep-based heal already ships; the debt is enqueueing into a now-live parent right away).
- Newly identified, recorded in §9 and worth its own slice: the tree-wide descendant cap surfaces as a **run-ending host error** rather than a model-visible refusal, unlike the fanout, depth and new concurrency caps. `ProcessTreeCapacityExceeded` maps through `TurnErrorCategory::CapacityExceeded` → `AgentLoopHostErrorKind::BudgetExceeded` in `map_turn_error` and propagates as `Err`, which `.claude/rules/tool-evidence.md` says a correctable failure should not do. Not fixed here because converting kernel capacity errors into refusals needs care not to mask genuine infra failures.
- Then R4: counters, `ironclaw subagent edges`, un-ignoring the five e2e tests via harness-side enablement, boot-recovery fairness.

---

**Review track**: B

🤖 Generated with [Claude Code](https://claude.com/claude-code)
