### PR TITLE
feat(subagent): boot/periodic sweep for stranded background deliveries, counters, e2e revival (R4)

### DIFF
--- a/crates/app/ironclaw_composition/src/lib.rs
+++ b/crates/app/ironclaw_composition/src/lib.rs
@@ -207,7 +207,8 @@ pub use runtime::{
 // forwarded — `ironclaw_triggers` is its one import path (§11.2.4).
 pub use runtime_input::{
     KeepaliveSweepSettings, PollSettings, RebornRuntimeIdentity, RebornRuntimeInput,
-    TriggerFireAccessGrant, TriggerFireAccessPolicy, TriggerPollerSettings, TurnRunnerSettings,
+    SubagentSweepSettings, TriggerFireAccessGrant, TriggerFireAccessPolicy, TriggerPollerSettings,
+    TurnRunnerSettings,
 };
 
 /// Re-exported IronHub command vocabulary for the `ironclaw` binary's

--- a/crates/app/ironclaw_composition/src/runtime.rs
+++ b/crates/app/ironclaw_composition/src/runtime.rs
@@ -103,7 +103,9 @@ use ironclaw_turn_runner::runtime::{
     DefaultPlannedRuntimeParts, ProcessRuntimeSystem, build_default_planned_runtime,
 };
 use ironclaw_turn_runner::subagent::await_edge::{
-    boot_recovery::ScopeRecoveryDriver, resolver::AwaitEdgeResolver, store::AwaitEdgeStore,
+    boot_recovery::{ScopeRecoveryDriver, sweep_unclosed_background_edges},
+    resolver::AwaitEdgeResolver,
+    store::AwaitEdgeStore,
 };
 use ironclaw_turn_runner::subagent::flavors::StaticSubagentDefinitionResolver;
 use ironclaw_turns::{
@@ -656,6 +658,12 @@ pub struct RebornRuntime {
     /// Boot-time reply-publication recovery sweep, owned so shutdown stops
     /// it before releasing publication leases.
     pub(crate) reply_publication_recovery: Option<tokio::task::JoinHandle<()>>,
+    /// Boot pass + periodic re-scan for stranded background subagent
+    /// await-edges (`sweep_unclosed_background_edges`, R4). `None` when
+    /// `SubagentSweepSettings::enabled` is false; owned here so shutdown can
+    /// stop the periodic loop instead of leaving it running past runtime
+    /// teardown.
+    pub(crate) subagent_background_sweep: Option<tokio::task::JoinHandle<()>>,
     /// The deployment's single workspace scoping decision, carried so the WebUI
     /// attachment handle addresses the same subtree as agent tool writes.
     pub(crate) workspace_mount_policy: crate::runtime_mounts::WorkspaceMountPolicy,
@@ -2541,6 +2549,10 @@ impl RebornRuntime {
             recovery.abort();
             let _ = recovery.await; // silent-ok: an aborted join is Cancelled.
         }
+        if let Some(sweep) = self.subagent_background_sweep {
+            sweep.abort();
+            let _ = sweep.await; // silent-ok: an aborted join is Cancelled.
+        }
         // Hand open reply publications back: their leases are released so
         // a publisher on the next process (or another node) resumes them
         // immediately instead of waiting for the lease to lapse.
@@ -3121,6 +3133,7 @@ pub(crate) async fn build_runtime_with_resource_governor(
         tool_disclosure,
         trigger_poller,
         credential_refresh,
+        subagent_sweep,
         trigger_fire_access_checker,
         trigger_fire_access,
         poll,
@@ -4441,6 +4454,35 @@ pub(crate) async fn build_runtime_with_resource_governor(
             }
         }));
     }
+
+    // Boot pass + periodic re-scan for background subagent await-edges whose
+    // parent thread never received attention again (§4.2, §6 row R4) — the
+    // third healing trigger alongside `recover_scope` (lazy, one scope on
+    // admission) and `sweep_thread_on_run_start` (one thread, at run start).
+    // `SubagentSweepSettings::enabled` defaults true: unlike the trigger
+    // poller or the keepalive sweep, leaving this off is not a safe default —
+    // without it a stranded background edge has no other path back to its
+    // parent thread. `sweep_unclosed_background_edges` never returns an
+    // error (internal failures are folded into `ResolveReport::failed` and
+    // logged by the callee at `debug!`), so this task degrades on its own
+    // without any match here; a second `debug!` of the same report at this
+    // call site would just duplicate that log line on every pass.
+    let mut subagent_background_sweep: Option<tokio::task::JoinHandle<()>> = None;
+    if subagent_sweep.enabled {
+        let resolver = Arc::clone(&subagent_await_edge_resolver);
+        let store = Arc::clone(&subagent_await_edge_store);
+        subagent_background_sweep = Some(tokio::spawn(async move {
+            let mut sweep_tick = tokio::time::interval(subagent_sweep.interval);
+            sweep_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                // `interval`'s first tick fires immediately, so this also
+                // serves as the once-at-boot pass.
+                sweep_tick.tick().await;
+                sweep_unclosed_background_edges(&resolver, &store).await;
+            }
+        }));
+    }
+
     let channel_host_assembly = started_channel_host.map(|started| started.assembly);
 
     // Forward-migrate pre-removal routines that still carry a stored delivery
@@ -4789,6 +4831,7 @@ pub(crate) async fn build_runtime_with_resource_governor(
         session_channel_directory,
         session_channel_extension_id,
         reply_publication_recovery,
+        subagent_background_sweep,
         workspace_mount_policy: services.workspace_mounts.clone(),
         system_extensions_lifecycle_mounts: services.system_extensions_lifecycle_mounts.clone(),
         outbound_preferences: services.outbound_preferences.clone(),

--- a/crates/app/ironclaw_composition/src/runtime_input.rs
+++ b/crates/app/ironclaw_composition/src/runtime_input.rs
@@ -315,6 +315,44 @@ impl TriggerPollerSettings {
     }
 }
 
+/// How often the periodic subagent background-edge sweep
+/// (`sweep_unclosed_background_edges`) re-scans the deployment for stranded
+/// background await-edges, after its once-at-boot pass. Deliberately far
+/// above the process supervisor's 10s `lease_recovery_interval`: this sweep
+/// is a deployment-wide healing backstop for the rare case where a parent
+/// thread's own attention delivery was refused and no other run-start ever
+/// re-drives it, not a hot loop — 5 minutes bounds how long a stranded
+/// background reply can wait between passes without re-scanning every scope
+/// in the deployment every few seconds.
+pub(crate) const DEFAULT_SUBAGENT_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Configuration for the composition-owned subagent background-edge sweep
+/// (`ironclaw_turn_runner::subagent::await_edge::boot_recovery::sweep_unclosed_background_edges`).
+///
+/// Mirrors [`KeepaliveSweepSettings`]'s enabled/interval shape: a boot pass
+/// runs once regardless, then the periodic pass repeats on `interval` for as
+/// long as `enabled` stays true.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SubagentSweepSettings {
+    /// Whether the periodic pass runs after the boot pass. Defaults to
+    /// `true`: without this sweep a background subagent's result can be
+    /// written into its parent's thread with no run ever attending to it
+    /// again, so leaving it off is not a safe default the way the trigger
+    /// poller's or keepalive sweep's off-by-default is.
+    pub enabled: bool,
+    /// How often the periodic pass repeats. Default: [`DEFAULT_SUBAGENT_SWEEP_INTERVAL`].
+    pub interval: Duration,
+}
+
+impl Default for SubagentSweepSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval: DEFAULT_SUBAGENT_SWEEP_INTERVAL,
+        }
+    }
+}
+
 /// Full input for `build_reborn_runtime` — substrate config plus the extras
 /// needed to assemble a runnable Reborn agent.
 #[derive(Default)]
@@ -336,6 +374,7 @@ pub struct RebornRuntimeInput {
     pub tool_disclosure: Option<ToolDisclosureMode>,
     pub trigger_poller: TriggerPollerSettings,
     pub credential_refresh: KeepaliveSweepSettings,
+    pub subagent_sweep: SubagentSweepSettings,
     /// Explicit fire-time access checker override. Primarily a test/advanced
     /// seam; production callers set [`trigger_fire_access`](Self::trigger_fire_access)
     /// and let the build construct the checker. When set, it takes precedence
@@ -416,6 +455,7 @@ impl RebornRuntimeInput {
             tool_disclosure: None,
             trigger_poller: TriggerPollerSettings::default(),
             credential_refresh: KeepaliveSweepSettings::default(),
+            subagent_sweep: SubagentSweepSettings::default(),
             trigger_fire_access_checker: None,
             trigger_fire_access: TriggerFireAccessPolicy::default(),
             poll: PollSettings::default(),
@@ -591,6 +631,11 @@ impl RebornRuntimeInput {
         credential_refresh: KeepaliveSweepSettings,
     ) -> Self {
         self.credential_refresh = credential_refresh;
+        self
+    }
+
+    pub fn with_subagent_sweep_settings(mut self, subagent_sweep: SubagentSweepSettings) -> Self {
+        self.subagent_sweep = subagent_sweep;
         self
     }
 

--- a/crates/app/ironclaw_composition/src/test_support/mod.rs
+++ b/crates/app/ironclaw_composition/src/test_support/mod.rs
@@ -117,6 +117,21 @@ pub async fn subagent_delivery_test_parts(
     crate::runtime::subagent_delivery_test_support::parts(runtime).await
 }
 
+/// Whether the composition-owned subagent background-edge sweep task
+/// (`SubagentSweepSettings`, R4) is present and still running. `false`
+/// covers both "disabled" (`None`) and "the spawned task already exited" —
+/// sufficient to pin the enabled/disabled wiring without racing the periodic
+/// tick itself. Reads the `pub(crate)` field directly rather than adding a
+/// `_for_test` accessor to `RebornRuntime`'s own impl block — the frozen
+/// `reborn_struct_test_support_ratchet` inventory is shrink-only for
+/// test-support members on production structs.
+pub fn subagent_background_sweep_is_running_for_test(runtime: &crate::RebornRuntime) -> bool {
+    runtime
+        .subagent_background_sweep
+        .as_ref()
+        .is_some_and(|handle| !handle.is_finished())
+}
+
 mod automation;
 mod budget_gateway;
 mod capability_io;

--- a/crates/app/ironclaw_composition/tests/runtime.rs
+++ b/crates/app/ironclaw_composition/tests/runtime.rs
@@ -119,6 +119,55 @@ async fn local_filesystem_build_input_carries_resolved_runtime_policy() {
     runtime.shutdown().await.expect("runtime shutdown");
 }
 
+/// R4 wiring: `SubagentSweepSettings::enabled` (default `true`) must actually
+/// start the composition-owned boot+periodic background-edge sweep task, and
+/// `shutdown` must stop it rather than leaving it running past teardown.
+#[tokio::test]
+async fn subagent_background_sweep_runs_by_default_and_stops_on_shutdown() {
+    let root = tempfile::tempdir().unwrap();
+    let input =
+        RebornRuntimeInput::from_build_input(ironclaw_composition::local_filesystem_build_input(
+            "subagent-sweep-owner",
+            root.path().join("standalone"),
+        ));
+
+    let runtime = build_reborn_runtime(input)
+        .await
+        .expect("default settings build a runtime with the sweep enabled");
+    assert!(
+        ironclaw_composition::test_support::subagent_background_sweep_is_running_for_test(&runtime),
+        "subagent background sweep must be running by default (SubagentSweepSettings::enabled = true)"
+    );
+    runtime.shutdown().await.expect("runtime shutdown");
+}
+
+/// R4 wiring, disabled side: `SubagentSweepSettings { enabled: false, .. }`
+/// must not start the sweep task at all.
+#[tokio::test]
+async fn subagent_background_sweep_does_not_start_when_disabled() {
+    let root = tempfile::tempdir().unwrap();
+    let input =
+        RebornRuntimeInput::from_build_input(ironclaw_composition::local_filesystem_build_input(
+            "subagent-sweep-disabled-owner",
+            root.path().join("standalone"),
+        ))
+        .with_subagent_sweep_settings(ironclaw_composition::SubagentSweepSettings {
+            enabled: false,
+            interval: Duration::from_secs(300),
+        });
+
+    let runtime = build_reborn_runtime(input)
+        .await
+        .expect("runtime builds with the subagent sweep disabled");
+    assert!(
+        !ironclaw_composition::test_support::subagent_background_sweep_is_running_for_test(
+            &runtime
+        ),
+        "subagent background sweep must not start when SubagentSweepSettings::enabled is false"
+    );
+    runtime.shutdown().await.expect("runtime shutdown");
+}
+
 #[tokio::test]
 async fn hosted_single_tenant_volume_builds_live_runtime() {
     // Regression for #5346: the runtime profile match was hardcoded after

--- a/crates/kernel/ironclaw_processes/src/journal.rs
+++ b/crates/kernel/ironclaw_processes/src/journal.rs
@@ -890,6 +890,50 @@ pub struct ProcessDependencyQuery {
     pub limit: Option<u32>,
 }
 
+/// A bounded, scope-optional recovery scan over unclosed dependency edges,
+/// mirroring [`RecoverExpiredProcessLeasesRequest`]'s cross-scope shape for
+/// the same reason: a boot/periodic pass has to ask "which dependencies
+/// anywhere are still unclosed" without naming a scope up front, which
+/// [`ProcessDependencyQuery::scope`] (mandatory by design) cannot answer.
+///
+/// This is legal without violating the kernel charter's "normal startup and
+/// process requests may use exact reads and bounded, partition-leading
+/// keyset queries only" (`AGENTS.md`): the store performs the *same* unscoped
+/// `unresolved` dependency read [`ProcessDependencyPort::unresolved_process_dependencies`]
+/// already performs — no *new* filesystem index enumeration is added
+/// (`reborn_process_storage_scan_gate.rs` pins the store's file to zero new
+/// `.query(`/`.tail_bounded(` call sites) — and then applies every filter
+/// here, the scope narrowing, and the keyset page entirely in memory. `limit`
+/// is always clamped (never unbounded — see the implementation), and
+/// pagination is a stable keyset cursor over the same
+/// `(dependent_process_id, dependency_process_id)` canonical order every
+/// other dependency query in this module uses.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScanUnclosedProcessDependenciesRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope_filter: Option<ResourceScope>,
+    /// Dependency states to include. Empty means every non-closed state.
+    #[serde(default)]
+    pub states: Vec<ProcessDependencyState>,
+    /// Only dependencies whose `group_ref` starts with this prefix, e.g. "bg:"
+    /// for background edges.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_ref_prefix: Option<String>,
+    pub limit: u32,
+    /// Keyset cursor: the `(dependent_process_id, dependency_process_id)` pair
+    /// of the last row a prior page returned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after: Option<(ProcessId, ProcessId)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScanUnclosedProcessDependenciesResponse {
+    pub dependencies: Vec<ProcessDependencyRecord>,
+    /// Cursor for the next page, `None` when the scan reached the end.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_after: Option<(ProcessId, ProcessId)>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProcessCheckpointRecord {
     pub checkpoint_id: ProcessCheckpointId,
@@ -1167,6 +1211,15 @@ pub trait ProcessDependencyPort: Send + Sync {
     async fn unresolved_process_dependencies(
         &self,
     ) -> Result<Vec<ProcessDependencyRecord>, Self::Error>;
+
+    /// Host-owned, bounded, scope-optional recovery scan over unclosed
+    /// dependency edges. See [`ScanUnclosedProcessDependenciesRequest`] for
+    /// why an unscoped scan is legal here. Product-facing callers must use
+    /// the scope-bound query above.
+    async fn scan_unclosed_process_dependencies(
+        &self,
+        request: ScanUnclosedProcessDependenciesRequest,
+    ) -> Result<ScanUnclosedProcessDependenciesResponse, Self::Error>;
 }
 
 #[async_trait]

--- a/crates/kernel/ironclaw_processes/src/journal_store.rs
+++ b/crates/kernel/ironclaw_processes/src/journal_store.rs
@@ -1313,12 +1313,13 @@ where
         // index, so `request.limit`/`request.after` only bound the in-memory
         // page, not the storage read; a second page costs a second full
         // index read. Acceptable today because the index holds only
-        // *unclosed* rows (bounded by in-flight work, not by history) and
-        // the two pre-existing callers of this same read already pay this
-        // cost. Upgrade path: push `limit`/`after` down into
-        // `query_indexed_collection` the way `dependencies_for_scope_canonical_order`
-        // already does for the scope-bound query, so the storage read is
-        // bounded too.
+        // *unclosed* rows (bounded by in-flight work, not by history), and
+        // the caller (`boot_recovery::sweep_unclosed_background_edges`)
+        // requests its scan cap as a single page, so the common case pays
+        // exactly one full read per pass, not one per page. Upgrade path:
+        // push `limit`/`after` down into `query_indexed_collection` the way
+        // `dependencies_for_scope_canonical_order` already does for the
+        // scope-bound query, so the storage read is bounded too.
         let records = rows::unresolved_dependencies(self.filesystem.as_ref()).await?;
         Ok(state::scan_unclosed_dependencies(records, &request))
     }

--- a/crates/kernel/ironclaw_processes/src/journal_store.rs
+++ b/crates/kernel/ironclaw_processes/src/journal_store.rs
@@ -33,6 +33,7 @@ use crate::journal::{
     ProcessTreeReservation, PruneReleasedProcessRequest, RecordProcessCheckpointRequest,
     RecoverExpiredProcessLeasesRequest, RecoverExpiredProcessLeasesResponse,
     ReleaseProcessTreeRequest, ReserveProcessTreeRequest, ResumeProcessRequest,
+    ScanUnclosedProcessDependenciesRequest, ScanUnclosedProcessDependenciesResponse,
     SettleProcessDependencyRequest, StopProcessRequest, SubmitProcessAtEdgeRequest,
     SubmitProcessRequest, SubmitProcessWithCheckpointRequest, SuspendProcessRequest,
     TransitionProcessDependencyRequest,
@@ -1282,6 +1283,44 @@ where
             )
         });
         Ok(records)
+    }
+
+    /// Bounded, scope-optional recovery scan over unclosed dependency edges.
+    ///
+    /// Rows are read once via the same unscoped `unresolved` dependency read
+    /// [`Self::unresolved_process_dependencies`] already uses — no new
+    /// filesystem query (`reborn_process_storage_scan_gate.rs` confines this
+    /// store's filesystem `.query(`/`.tail_bounded(` calls to
+    /// migration/bootstrap paths, and this method adds neither) — then every
+    /// filter, the scope check, and the keyset page are applied entirely in
+    /// memory by [`state::scan_unclosed_dependencies`], the free-function
+    /// counterpart of `ProcessJournalMaterializedState::expired_process_ids`'s
+    /// (lease-recovery) in-memory-scan pattern.
+    async fn scan_unclosed_process_dependencies(
+        &self,
+        request: ScanUnclosedProcessDependenciesRequest,
+    ) -> Result<ScanUnclosedProcessDependenciesResponse, Self::Error> {
+        // Required, not defensive: `unresolved_dependencies` below queries the
+        // `process_dependency_unresolved_v3` index, which only exists once
+        // `rows::ensure_indexes` has declared it (and, on first boot, once
+        // legacy data has been imported into row-native storage) —
+        // `ensure_materialized` is what guarantees both, exactly as it does
+        // for every other read in this impl (`query_process_dependencies`,
+        // `unresolved_process_dependencies`).
+        self.ensure_materialized().await?;
+        // ponytail: `rows::unresolved_dependencies` takes no limit — every
+        // call here reads the *whole* `process_dependency_unresolved_v3`
+        // index, so `request.limit`/`request.after` only bound the in-memory
+        // page, not the storage read; a second page costs a second full
+        // index read. Acceptable today because the index holds only
+        // *unclosed* rows (bounded by in-flight work, not by history) and
+        // the two pre-existing callers of this same read already pay this
+        // cost. Upgrade path: push `limit`/`after` down into
+        // `query_indexed_collection` the way `dependencies_for_scope_canonical_order`
+        // already does for the scope-bound query, so the storage read is
+        // bounded too.
+        let records = rows::unresolved_dependencies(self.filesystem.as_ref()).await?;
+        Ok(state::scan_unclosed_dependencies(records, &request))
     }
 }
 

--- a/crates/kernel/ironclaw_processes/src/journal_store/state.rs
+++ b/crates/kernel/ironclaw_processes/src/journal_store/state.rs
@@ -1489,6 +1489,81 @@ impl ProcessJournalMaterializedState {
     }
 }
 
+/// Filters, scope-narrows, sorts, and pages an already-read set of dependency
+/// records — the free-function counterpart of [`ProcessJournalMaterializedState::expired_process_ids`]'s
+/// in-memory-scan shape. A free function rather than a method on
+/// `ProcessJournalMaterializedState` because the caller
+/// ([`super::ProcessJournalStore::scan_unclosed_process_dependencies`]) already
+/// owns a `Vec<crate::ProcessDependencyRecord>` from a direct filesystem read;
+/// building a throwaway materialized-state value purely to call a method on
+/// it would be a scratchpad object, not a real state consumer. See
+/// [`crate::ScanUnclosedProcessDependenciesRequest`] for why an unscoped,
+/// cross-scope scan is legal here.
+///
+/// `limit` is always clamped to at least 1 and at most
+/// `MAX_UNCLOSED_DEPENDENCY_SCAN_LIMIT` so a zero or absurd caller-supplied
+/// limit cannot turn this into an unbounded scan.
+pub(super) fn scan_unclosed_dependencies(
+    records: impl IntoIterator<Item = crate::ProcessDependencyRecord>,
+    request: &crate::ScanUnclosedProcessDependenciesRequest,
+) -> crate::ScanUnclosedProcessDependenciesResponse {
+    let limit = request.limit.clamp(1, MAX_UNCLOSED_DEPENDENCY_SCAN_LIMIT) as usize;
+    let mut records = records
+        .into_iter()
+        .filter(|record| !record.state.is_closed())
+        .filter(|record| request.states.is_empty() || request.states.contains(&record.state))
+        .filter(|record| {
+            request
+                .scope_filter
+                .as_ref()
+                .is_none_or(|scope| same_scope_owner(&record.scope, scope))
+        })
+        .filter(|record| {
+            request.group_ref_prefix.as_deref().is_none_or(|prefix| {
+                record
+                    .group_ref
+                    .as_deref()
+                    .is_some_and(|group_ref| group_ref.starts_with(prefix))
+            })
+        })
+        .collect::<Vec<_>>();
+    records.sort_by_key(|record| {
+        (
+            record.dependent_process_id.as_uuid(),
+            record.dependency_process_id.as_uuid(),
+        )
+    });
+    let start = request
+        .after
+        .map_or(0, |(after_dependent, after_dependency)| {
+            let after_key = (after_dependent.as_uuid(), after_dependency.as_uuid());
+            records.partition_point(|record| {
+                (
+                    record.dependent_process_id.as_uuid(),
+                    record.dependency_process_id.as_uuid(),
+                ) <= after_key
+            })
+        });
+    let remaining = &records[start.min(records.len())..];
+    let page_end = remaining.len().min(limit);
+    let page = remaining[..page_end].to_vec();
+    let next_after = if page_end < remaining.len() {
+        page.last()
+            .map(|record| (record.dependent_process_id, record.dependency_process_id))
+    } else {
+        None
+    };
+    crate::ScanUnclosedProcessDependenciesResponse {
+        dependencies: page,
+        next_after,
+    }
+}
+
+/// Clamp ceiling for [`scan_unclosed_dependencies`]: a boot/periodic sweep
+/// pages through this many rows at a time regardless of what a caller
+/// requests, so a misconfigured caller cannot turn the scan unbounded.
+const MAX_UNCLOSED_DEPENDENCY_SCAN_LIMIT: u32 = 1_000;
+
 #[cfg(test)]
 #[path = "state_tests.rs"]
 mod tests;

--- a/crates/kernel/ironclaw_processes/src/lib.rs
+++ b/crates/kernel/ironclaw_processes/src/lib.rs
@@ -67,7 +67,8 @@ pub use journal::{
     ProcessTreeReservation, ProcessWorkerId, PruneReleasedProcessRequest,
     RecordProcessCheckpointRequest, RecoverExpiredProcessLeasesRequest,
     RecoverExpiredProcessLeasesResponse, ReleaseProcessTreeRequest, ReserveProcessTreeRequest,
-    ResumeProcessRequest, SettleProcessDependencyRequest, StopProcessRequest,
+    ResumeProcessRequest, ScanUnclosedProcessDependenciesRequest,
+    ScanUnclosedProcessDependenciesResponse, SettleProcessDependencyRequest, StopProcessRequest,
     SubmitProcessAtEdgeRequest, SubmitProcessRequest, SubmitProcessWithCheckpointRequest,
     SuspendProcessRequest, TransitionProcessDependencyRequest,
 };

--- a/crates/kernel/ironclaw_processes/tests/process_journal_store_contract.rs
+++ b/crates/kernel/ironclaw_processes/tests/process_journal_store_contract.rs
@@ -35,9 +35,9 @@ use ironclaw_processes::{
     ProcessSubmissionEdge, ProcessSubmissionPort, ProcessSuspension, ProcessSuspensionKind,
     ProcessTerminalEvidence, ProcessTransitionPort, ProcessTreePort, ProcessWorkerId,
     PruneReleasedProcessRequest, RecordProcessCheckpointRequest, ReleaseProcessTreeRequest,
-    ReserveProcessTreeRequest, ResumeProcessRequest, SettleProcessDependencyRequest,
-    StopProcessRequest, SubmitProcessAtEdgeRequest, SubmitProcessRequest, SuspendProcessRequest,
-    TransitionProcessDependencyRequest,
+    ReserveProcessTreeRequest, ResumeProcessRequest, ScanUnclosedProcessDependenciesRequest,
+    SettleProcessDependencyRequest, StopProcessRequest, SubmitProcessAtEdgeRequest,
+    SubmitProcessRequest, SuspendProcessRequest, TransitionProcessDependencyRequest,
 };
 use serde_json::json;
 use std::{
@@ -3058,6 +3058,329 @@ async fn explicit_dependency_open_is_idempotent_scope_bound_and_abandonable() {
             .await
             .expect("query open dependencies")
             .is_empty()
+    );
+}
+
+fn other_tenant_scope() -> ResourceScope {
+    let mut scope = scope();
+    scope.tenant_id = TenantId::new("tenant-journal-other").expect("other tenant");
+    scope
+}
+
+/// R4 boot/periodic pass primitive: an unscoped `scan_unclosed_process_dependencies`
+/// must surface unclosed dependencies from every scope in one call — the whole
+/// point of the primitive over `ProcessDependencyQuery`, whose `scope` field is
+/// mandatory.
+#[tokio::test]
+async fn scan_unclosed_process_dependencies_crosses_scopes() {
+    let store = new_store();
+    let scope_a = scope();
+    let scope_b = other_tenant_scope();
+    let dependent_a = ProcessId::new();
+    let dependent_b = ProcessId::new();
+    submit_internal_process(&store, &scope_a, dependent_a).await;
+    submit_internal_process(&store, &scope_b, dependent_b).await;
+
+    let opened_a = store
+        .open_process_dependency(OpenProcessDependencyRequest {
+            dependent_process_id: dependent_a,
+            dependency_process_id: ProcessId::new(),
+            root_process_id: dependent_a,
+            scope: scope_a.clone(),
+            group_ref: Some("bg:cross-scope".to_string()),
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        })
+        .await
+        .expect("open dependency in scope a");
+    let opened_b = store
+        .open_process_dependency(OpenProcessDependencyRequest {
+            dependent_process_id: dependent_b,
+            dependency_process_id: ProcessId::new(),
+            root_process_id: dependent_b,
+            scope: scope_b.clone(),
+            group_ref: Some("bg:cross-scope".to_string()),
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        })
+        .await
+        .expect("open dependency in scope b");
+
+    let response = store
+        .scan_unclosed_process_dependencies(ScanUnclosedProcessDependenciesRequest {
+            scope_filter: None,
+            states: Vec::new(),
+            group_ref_prefix: None,
+            limit: 100,
+            after: None,
+        })
+        .await
+        .expect("scan unclosed dependencies");
+
+    let mut expected = vec![opened_a, opened_b];
+    expected.sort_by_key(|record| {
+        (
+            record.dependent_process_id.as_uuid(),
+            record.dependency_process_id.as_uuid(),
+        )
+    });
+    assert_eq!(response.dependencies, expected);
+    assert_eq!(response.next_after, None);
+}
+
+/// `scope_filter` narrows the cross-scope scan to one scope's owner.
+#[tokio::test]
+async fn scan_unclosed_process_dependencies_narrows_by_scope_filter() {
+    let store = new_store();
+    let scope_a = scope();
+    let scope_b = other_tenant_scope();
+    let dependent_a = ProcessId::new();
+    let dependent_b = ProcessId::new();
+    submit_internal_process(&store, &scope_a, dependent_a).await;
+    submit_internal_process(&store, &scope_b, dependent_b).await;
+
+    let opened_a = store
+        .open_process_dependency(OpenProcessDependencyRequest {
+            dependent_process_id: dependent_a,
+            dependency_process_id: ProcessId::new(),
+            root_process_id: dependent_a,
+            scope: scope_a.clone(),
+            group_ref: Some("bg:scope-filter".to_string()),
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        })
+        .await
+        .expect("open dependency in scope a");
+    store
+        .open_process_dependency(OpenProcessDependencyRequest {
+            dependent_process_id: dependent_b,
+            dependency_process_id: ProcessId::new(),
+            root_process_id: dependent_b,
+            scope: scope_b.clone(),
+            group_ref: Some("bg:scope-filter".to_string()),
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        })
+        .await
+        .expect("open dependency in scope b");
+
+    let response = store
+        .scan_unclosed_process_dependencies(ScanUnclosedProcessDependenciesRequest {
+            scope_filter: Some(scope_a),
+            states: Vec::new(),
+            group_ref_prefix: None,
+            limit: 100,
+            after: None,
+        })
+        .await
+        .expect("scan unclosed dependencies narrowed to scope a");
+
+    assert_eq!(response.dependencies, vec![opened_a]);
+    assert_eq!(response.next_after, None);
+}
+
+/// A consumed (closed) dependency must never surface, whether reached alone
+/// or alongside a still-open edge in another scope.
+#[tokio::test]
+async fn scan_unclosed_process_dependencies_excludes_closed() {
+    let store = new_store();
+    let (dependent, dependency) = open_settled_dependency(&store).await;
+    let consumed = store
+        .consume_process_dependency(CloseProcessDependencyRequest {
+            dependent_process_id: dependent,
+            dependency_process_id: dependency,
+            scope: scope(),
+            closed_at: Utc::now(),
+        })
+        .await
+        .expect("consume dependency")
+        .expect("dependency exists");
+    assert_eq!(consumed.state, ProcessDependencyState::Consumed);
+
+    let still_open_dependent = ProcessId::new();
+    submit_internal_process(&store, &scope(), still_open_dependent).await;
+    let still_open = store
+        .open_process_dependency(OpenProcessDependencyRequest {
+            dependent_process_id: still_open_dependent,
+            dependency_process_id: ProcessId::new(),
+            root_process_id: still_open_dependent,
+            scope: scope(),
+            group_ref: Some("gate:transition".to_string()),
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        })
+        .await
+        .expect("open still-unclosed dependency");
+
+    let response = store
+        .scan_unclosed_process_dependencies(ScanUnclosedProcessDependenciesRequest {
+            scope_filter: None,
+            states: Vec::new(),
+            group_ref_prefix: None,
+            limit: 100,
+            after: None,
+        })
+        .await
+        .expect("scan unclosed dependencies");
+
+    assert_eq!(response.dependencies, vec![still_open]);
+}
+
+/// `states` narrows the scan to exactly the requested delivery states.
+#[tokio::test]
+async fn scan_unclosed_process_dependencies_filters_by_states() {
+    let store = new_store();
+    let (settled_dependent, settled_dependency) = open_settled_dependency(&store).await;
+    let settled = stored_dependency(&store, settled_dependent, settled_dependency).await;
+    assert_eq!(settled.state, ProcessDependencyState::Settled);
+
+    let open_dependent = ProcessId::new();
+    submit_internal_process(&store, &scope(), open_dependent).await;
+    store
+        .open_process_dependency(OpenProcessDependencyRequest {
+            dependent_process_id: open_dependent,
+            dependency_process_id: ProcessId::new(),
+            root_process_id: open_dependent,
+            scope: scope(),
+            group_ref: Some("gate:transition".to_string()),
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        })
+        .await
+        .expect("open dependency");
+
+    let response = store
+        .scan_unclosed_process_dependencies(ScanUnclosedProcessDependenciesRequest {
+            scope_filter: None,
+            states: vec![ProcessDependencyState::Settled],
+            group_ref_prefix: None,
+            limit: 100,
+            after: None,
+        })
+        .await
+        .expect("scan unclosed dependencies filtered by state");
+
+    assert_eq!(response.dependencies, vec![settled]);
+}
+
+/// `group_ref_prefix` narrows the scan to edges whose `group_ref` starts with
+/// the given prefix, e.g. only background (`"bg:"`) edges.
+#[tokio::test]
+async fn scan_unclosed_process_dependencies_filters_by_group_ref_prefix() {
+    let store = new_store();
+    let dependent = ProcessId::new();
+    submit_internal_process(&store, &scope(), dependent).await;
+
+    let background = store
+        .open_process_dependency(OpenProcessDependencyRequest {
+            dependent_process_id: dependent,
+            dependency_process_id: ProcessId::new(),
+            root_process_id: dependent,
+            scope: scope(),
+            group_ref: Some("bg:sweep".to_string()),
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        })
+        .await
+        .expect("open background dependency");
+    store
+        .open_process_dependency(OpenProcessDependencyRequest {
+            dependent_process_id: dependent,
+            dependency_process_id: ProcessId::new(),
+            root_process_id: dependent,
+            scope: scope(),
+            group_ref: Some("gate:not-background".to_string()),
+            created_at: Utc::now(),
+            metadata: serde_json::Value::Null,
+        })
+        .await
+        .expect("open non-background dependency");
+
+    let response = store
+        .scan_unclosed_process_dependencies(ScanUnclosedProcessDependenciesRequest {
+            scope_filter: None,
+            states: Vec::new(),
+            group_ref_prefix: Some("bg:".to_string()),
+            limit: 100,
+            after: None,
+        })
+        .await
+        .expect("scan unclosed dependencies filtered by group_ref prefix");
+
+    assert_eq!(response.dependencies, vec![background]);
+}
+
+/// `limit` + `after` page the scan deterministically in canonical
+/// `(dependent_process_id, dependency_process_id)` order: two one-row pages
+/// return distinct rows and the final page's `next_after` is `None`.
+#[tokio::test]
+async fn scan_unclosed_process_dependencies_pages_deterministically() {
+    let store = new_store();
+    let dependent = ProcessId::new();
+    submit_internal_process(&store, &scope(), dependent).await;
+
+    let mut expected = Vec::new();
+    for _ in 0..2 {
+        let record = store
+            .open_process_dependency(OpenProcessDependencyRequest {
+                dependent_process_id: dependent,
+                dependency_process_id: ProcessId::new(),
+                root_process_id: dependent,
+                scope: scope(),
+                group_ref: Some("bg:paging".to_string()),
+                created_at: Utc::now(),
+                metadata: serde_json::Value::Null,
+            })
+            .await
+            .expect("open paged dependency");
+        expected.push(record);
+    }
+    expected.sort_by_key(|record| {
+        (
+            record.dependent_process_id.as_uuid(),
+            record.dependency_process_id.as_uuid(),
+        )
+    });
+
+    let first_page = store
+        .scan_unclosed_process_dependencies(ScanUnclosedProcessDependenciesRequest {
+            scope_filter: None,
+            states: Vec::new(),
+            group_ref_prefix: Some("bg:".to_string()),
+            limit: 1,
+            after: None,
+        })
+        .await
+        .expect("first scan page");
+    assert_eq!(first_page.dependencies, vec![expected[0].clone()]);
+    let cursor = first_page.next_after.expect("first page has a next cursor");
+    assert_eq!(
+        cursor,
+        (
+            expected[0].dependent_process_id,
+            expected[0].dependency_process_id
+        )
+    );
+
+    let second_page = store
+        .scan_unclosed_process_dependencies(ScanUnclosedProcessDependenciesRequest {
+            scope_filter: None,
+            states: Vec::new(),
+            group_ref_prefix: Some("bg:".to_string()),
+            limit: 1,
+            after: Some(cursor),
+        })
+        .await
+        .expect("second scan page");
+    assert_eq!(second_page.dependencies, vec![expected[1].clone()]);
+    assert_eq!(
+        second_page.next_after, None,
+        "the final page must not hand back a cursor"
+    );
+    assert_ne!(
+        first_page.dependencies[0].dependency_process_id,
+        second_page.dependencies[0].dependency_process_id,
+        "no row may be seen twice across pages"
     );
 }
 

--- a/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery.rs
+++ b/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery.rs
@@ -84,13 +84,6 @@ where
     report
 }
 
-/// Page size per `scan_unclosed_process_dependencies` call. Deliberately
-/// smaller than [`BOOT_SWEEP_SCAN_CAP`] so pagination exercises the keyset
-/// cursor on any deployment with more than a handful of unclosed background
-/// edges; unrelated to fairness, which happens after every page is
-/// accumulated (see [`sweep_unclosed_background_edges`]'s doc comment).
-const BOOT_SWEEP_PAGE_SIZE: u32 = 64;
-
 /// Total edges one boot/periodic sweep pass will *drive through delivery*
 /// (`AwaitEdgeResolver::deliver_background`), across every scope, before
 /// returning. `8 * MAX_QUEUED_INPUTS_PER_RUN`: the run-start sweep
@@ -168,6 +161,19 @@ fn boot_sweep_states() -> Vec<ProcessDependencyState> {
 /// idempotent path `recover_scope` and `sweep_thread_on_run_start` call, no
 /// second delivery implementation. One edge's failure is logged and counted;
 /// it never aborts the rest of the pass, mirroring `sweep_thread_on_run_start`.
+///
+/// **One read in the common case.** The underlying
+/// `rows::unresolved_dependencies` read the scan is built on takes no
+/// `limit` — every `scan_unclosed_process_dependencies` call re-reads the
+/// *whole* unclosed-dependency index, regardless of the page size requested
+/// (see the ponytail on that method). Requesting the scan cap as a single
+/// page (below) means one sweep pass costs one full index read whenever the
+/// backlog fits under `BOOT_SWEEP_SCAN_CAP`, instead of paying that cost once
+/// per page. The keyset cursor still runs — and is still exercised, by
+/// `sweep_scan_pages_through_a_backlog_larger_than_one_page` in
+/// `boot_recovery/tests.rs`, which calls the `_bounded` entry point with an
+/// explicit small page size — for the day the underlying read is bounded and
+/// paging stops being a multiplier.
 pub async fn sweep_unclosed_background_edges<S>(
     resolver: &AwaitEdgeResolver<S>,
     store: &AwaitEdgeStore,
@@ -175,26 +181,32 @@ pub async fn sweep_unclosed_background_edges<S>(
 where
     S: SessionThreadService + ?Sized,
 {
+    let page_size = u32::try_from(BOOT_SWEEP_SCAN_CAP).unwrap_or(u32::MAX);
     sweep_unclosed_background_edges_bounded(
         resolver,
         store,
         BOOT_SWEEP_SCAN_CAP,
         MAX_BOOT_SWEEP_EDGES,
+        page_size,
     )
     .await
 }
 
-/// `sweep_unclosed_background_edges` with both caps as parameters instead of
-/// the fixed [`BOOT_SWEEP_SCAN_CAP`]/[`MAX_BOOT_SWEEP_EDGES`] — exists so
-/// `boot_recovery/tests.rs` can prove the round-robin fairness contract with
-/// a handful of edges instead of needing thousands of real journal rows to
-/// force the caps. The public function above is the only production entry
-/// point.
+/// `sweep_unclosed_background_edges` with the scan cap, delivery cap, and
+/// scan page size all as parameters instead of the fixed
+/// [`BOOT_SWEEP_SCAN_CAP`]/[`MAX_BOOT_SWEEP_EDGES`] (and, for page size, the
+/// scan cap itself) — exists so `boot_recovery/tests.rs` can prove the
+/// round-robin fairness contract with a handful of edges instead of needing
+/// thousands of real journal rows to force the caps, and can independently
+/// force multi-page scanning by passing a `page_size` smaller than
+/// `scan_cap` without paying that cost in production. The public function
+/// above is the only production entry point.
 async fn sweep_unclosed_background_edges_bounded<S>(
     resolver: &AwaitEdgeResolver<S>,
     store: &AwaitEdgeStore,
     scan_cap: usize,
     max_delivered: usize,
+    page_size: u32,
 ) -> ResolveReport
 where
     S: SessionThreadService + ?Sized,
@@ -213,8 +225,7 @@ where
         if remaining == 0 {
             break;
         }
-        let page_limit = u32::try_from(remaining.min(BOOT_SWEEP_PAGE_SIZE as usize))
-            .unwrap_or(BOOT_SWEEP_PAGE_SIZE);
+        let page_limit = u32::try_from(remaining.min(page_size as usize)).unwrap_or(page_size);
         let page = match store
             .scan_unclosed_background(boot_sweep_states(), page_limit, after)
             .await

--- a/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery.rs
+++ b/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery.rs
@@ -1,13 +1,16 @@
 //! Recovery projection for unresolved process dependencies.
 
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
+use ironclaw_host_api::turn::TurnRunId;
 use ironclaw_loop_contracts::AgentLoopHostError;
 use ironclaw_loop_host::{AwaitEdgeWriter, ResolveReport};
+use ironclaw_processes::ProcessDependencyState;
 use ironclaw_threads::SessionThreadService;
 use ironclaw_turns::TurnScope;
 
-use super::{resolver::AwaitEdgeResolver, store::AwaitEdgeStore};
+use super::{AwaitEdge, AwaitEdgeState, resolver::AwaitEdgeResolver, store::AwaitEdgeStore};
 
 pub(super) async fn recover_scope<S>(
     resolver: &AwaitEdgeResolver<S>,
@@ -78,6 +81,233 @@ where
             }
         }
     }
+    report
+}
+
+/// Page size per `scan_unclosed_process_dependencies` call. Deliberately
+/// smaller than [`BOOT_SWEEP_SCAN_CAP`] so pagination exercises the keyset
+/// cursor on any deployment with more than a handful of unclosed background
+/// edges; unrelated to fairness, which happens after every page is
+/// accumulated (see [`sweep_unclosed_background_edges`]'s doc comment).
+const BOOT_SWEEP_PAGE_SIZE: u32 = 64;
+
+/// Total edges one boot/periodic sweep pass will *drive through delivery*
+/// (`AwaitEdgeResolver::deliver_background`), across every scope, before
+/// returning. `8 * MAX_QUEUED_INPUTS_PER_RUN`: the run-start sweep
+/// (`sweep_thread_on_run_start`) caps itself at `MAX_QUEUED_INPUTS_PER_RUN`
+/// (32) edges for *one thread*; a boot pass fans out across every
+/// thread/scope in the deployment instead of one thread, so its budget is a
+/// multiple of that single-thread cap rather than equal to it — high enough
+/// to make real progress on a cold boot with several backlogged scopes,
+/// bounded so one pass cannot run unbounded.
+const MAX_BOOT_SWEEP_EDGES: usize = ironclaw_loop_host::MAX_QUEUED_INPUTS_PER_RUN * 8;
+
+/// Total edges one boot/periodic sweep pass will *scan and accumulate in
+/// memory* before bucketing for round-robin delivery — deliberately larger
+/// than [`MAX_BOOT_SWEEP_EDGES`], and a distinct constant from it. Scanning
+/// is a cheap, side-effect-free read; delivery is the expensive/dangerous
+/// part (thread-service writes, coordinator activation calls), which is why
+/// only delivery is capped at the smaller number. The gap between the two
+/// caps is what makes round-robin fairness actually fair rather than
+/// order-dependent: if the scan itself stopped at `MAX_BOOT_SWEEP_EDGES`,
+/// one large scope's backlog could — depending on the arbitrary
+/// `(dependent_process_id, dependency_process_id)` scan order — fill the
+/// entire accumulated set before a smaller scope's edges are ever read,
+/// which would silently starve that scope regardless of the round-robin
+/// delivery loop below. Scanning generously first, then rationing only the
+/// expensive delivery step, guarantees every backlogged scope is represented
+/// in the round-robin pool whenever its total across all scopes fits under
+/// this cap. `4 * MAX_BOOT_SWEEP_EDGES`: enough headroom for round-robin to
+/// find every scope's edges even when the single largest scope's backlog
+/// alone exceeds the delivery cap, while still bounded so a pathological
+/// multi-million-edge backlog cannot make one sweep pass load unbounded
+/// memory.
+const BOOT_SWEEP_SCAN_CAP: usize = MAX_BOOT_SWEEP_EDGES * 4;
+
+/// Dependency-delivery states a boot/periodic pass acts on: the same
+/// non-deferred set `sweep_thread_on_run_start` acts on for an autonomous
+/// (non-human-initiated) start. `AttentionDeferred` (the kernel's
+/// domain-neutral name for `AttentionDeferredStreakCap`) is excluded on
+/// purpose — a streak-capped edge must wait for a permitted or
+/// human-initiated start, and a boot pass is neither; `recover_scope`
+/// already makes the same call via `retry_deferred: false`.
+fn boot_sweep_states() -> Vec<ProcessDependencyState> {
+    vec![
+        ProcessDependencyState::Settled,
+        ProcessDependencyState::ResultAppended,
+        ProcessDependencyState::AttentionScheduled,
+    ]
+}
+
+/// Boot/periodic sweep (§4.2, §6 row R4) — the third healing trigger,
+/// covering background await-edges whose thread may never start another run.
+/// Unlike `recover_scope` (one scope, driven lazily on admission) and
+/// `AwaitEdgeResolver::sweep_thread_on_run_start` (one thread, driven at run
+/// start), this walks every unclosed background edge in the deployment via
+/// `ProcessDependencyPort::scan_unclosed_process_dependencies`
+/// (`AwaitEdgeStore::scan_unclosed_background`, `group_ref_prefix: "bg:"` —
+/// the exact tag `finish_spawn` writes for `SpawnSubagentMode::Background`,
+/// so every scanned record is background-mode by construction; no
+/// `edge.mode` check needed).
+///
+/// **Fairness.** Every page is accumulated first (bounded by
+/// `BOOT_SWEEP_SCAN_CAP` total, or scan exhaustion), then bucketed by each
+/// record's own `group_ref` (`"bg:{parent_thread_id}"` — the parent backlog
+/// identity, *not* `record.scope`, which is the child's own scope and would
+/// put every edge in a singleton bucket) in first-seen order, then drained
+/// round-robin — capped separately at `MAX_BOOT_SWEEP_EDGES` delivered: one
+/// edge from parent A, one from parent B, one from parent C, repeat — never
+/// all of parent A's backlog before B gets a turn. A backlog-by-backlog
+/// drain (finish every A edge, then every B edge) would starve B whenever A
+/// alone exceeds the delivery cap; the round-robin loop below is what
+/// prevents that
+/// (`sweep_is_fair_across_scopes_when_one_scope_exceeds_the_cap` in
+/// `boot_recovery/tests.rs` fails without it).
+///
+/// Delivery re-drive is `AwaitEdgeResolver::deliver_background` — the same
+/// idempotent path `recover_scope` and `sweep_thread_on_run_start` call, no
+/// second delivery implementation. One edge's failure is logged and counted;
+/// it never aborts the rest of the pass, mirroring `sweep_thread_on_run_start`.
+pub async fn sweep_unclosed_background_edges<S>(
+    resolver: &AwaitEdgeResolver<S>,
+    store: &AwaitEdgeStore,
+) -> ResolveReport
+where
+    S: SessionThreadService + ?Sized,
+{
+    sweep_unclosed_background_edges_bounded(
+        resolver,
+        store,
+        BOOT_SWEEP_SCAN_CAP,
+        MAX_BOOT_SWEEP_EDGES,
+    )
+    .await
+}
+
+/// `sweep_unclosed_background_edges` with both caps as parameters instead of
+/// the fixed [`BOOT_SWEEP_SCAN_CAP`]/[`MAX_BOOT_SWEEP_EDGES`] — exists so
+/// `boot_recovery/tests.rs` can prove the round-robin fairness contract with
+/// a handful of edges instead of needing thousands of real journal rows to
+/// force the caps. The public function above is the only production entry
+/// point.
+async fn sweep_unclosed_background_edges_bounded<S>(
+    resolver: &AwaitEdgeResolver<S>,
+    store: &AwaitEdgeStore,
+    scan_cap: usize,
+    max_delivered: usize,
+) -> ResolveReport
+where
+    S: SessionThreadService + ?Sized,
+{
+    let mut report = ResolveReport::default();
+
+    // Accumulate every scanned record up front (bounded by `scan_cap`),
+    // before any delivery — round-robin fairness needs the whole
+    // accumulated set bucketed by scope, not a running window over one page
+    // at a time (see `BOOT_SWEEP_SCAN_CAP`'s doc comment for why this cap is
+    // deliberately larger than the delivery cap below).
+    let mut scanned: Vec<(TurnRunId, TurnRunId, Option<String>, AwaitEdge)> = Vec::new();
+    let mut after = None;
+    loop {
+        let remaining = scan_cap.saturating_sub(scanned.len());
+        if remaining == 0 {
+            break;
+        }
+        let page_limit = u32::try_from(remaining.min(BOOT_SWEEP_PAGE_SIZE as usize))
+            .unwrap_or(BOOT_SWEEP_PAGE_SIZE);
+        let page = match store
+            .scan_unclosed_background(boot_sweep_states(), page_limit, after)
+            .await
+        {
+            Ok(page) => page,
+            Err(error) => {
+                tracing::debug!(error = %error, "boot sweep scan failed");
+                report.record_failed();
+                break;
+            }
+        };
+        let (edges, next_after) = page;
+        let page_was_empty = edges.is_empty();
+        scanned.extend(edges);
+        after = next_after;
+        if after.is_none() || page_was_empty {
+            break;
+        }
+    }
+
+    // Defensive fallback for a record with no `group_ref` at all — shouldn't
+    // occur given the `"bg:"` prefix filter above, but a missing key must
+    // still land in a well-defined bucket rather than panic.
+    let mut order: Vec<String> = Vec::new();
+    let mut buckets: HashMap<String, VecDeque<(TurnRunId, TurnRunId, AwaitEdge)>> = HashMap::new();
+    for (parent_run_id, child_run_id, group_ref, edge) in scanned {
+        let key = group_ref.unwrap_or_default();
+        buckets
+            .entry(key.clone())
+            .or_insert_with(|| {
+                order.push(key.clone());
+                VecDeque::new()
+            })
+            .push_back((parent_run_id, child_run_id, edge));
+    }
+
+    let mut delivered_count = 0usize;
+    'rounds: loop {
+        let mut delivered_any = false;
+        for key in &order {
+            if delivered_count >= max_delivered {
+                break 'rounds;
+            }
+            let Some(queue) = buckets.get_mut(key) else {
+                continue;
+            };
+            let Some((parent_run_id, child_run_id, edge)) = queue.pop_front() else {
+                continue;
+            };
+            delivered_any = true;
+            delivered_count += 1;
+            let outcome = match edge.state {
+                // The scan's `states` filter already excludes these; kept as
+                // a defensive no-op rather than an unreachable panic if the
+                // filter ever widens.
+                AwaitEdgeState::Open
+                | AwaitEdgeState::Drained
+                | AwaitEdgeState::Abandoned
+                | AwaitEdgeState::AttentionDeferredStreakCap => continue,
+                AwaitEdgeState::Settled
+                | AwaitEdgeState::ResultAppended
+                | AwaitEdgeState::AttentionScheduled => {
+                    resolver
+                        .deliver_background(&edge, parent_run_id, child_run_id, false)
+                        .await
+                }
+            };
+            match outcome {
+                Ok(outcome) => report.record(outcome),
+                Err(error) => {
+                    tracing::debug!(
+                        error = %error,
+                        %parent_run_id,
+                        %child_run_id,
+                        "boot sweep delivery failed for one edge"
+                    );
+                    report.record_failed();
+                }
+            }
+        }
+        if !delivered_any {
+            break;
+        }
+    }
+
+    tracing::debug!(
+        resumed = report.resumed,
+        drained = report.drained,
+        abandoned = report.abandoned,
+        already_closed = report.already_closed,
+        failed = report.failed,
+        "boot sweep pass complete"
+    );
     report
 }
 

--- a/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery/tests.rs
+++ b/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery/tests.rs
@@ -286,13 +286,41 @@ impl RecoveryFixture {
     /// writes, blocking edges get their own `gate_ref` (the pre-existing
     /// blocking-mode group key).
     async fn open_edge(&self, suffix: &str, mode: SpawnSubagentMode) -> (TurnRunId, TurnScope) {
+        self.open_edge_for(
+            &self.parent_scope,
+            self.parent_run_id,
+            &self.parent_context,
+            suffix,
+            mode,
+            true,
+        )
+        .await
+    }
+
+    /// Same as `open_edge`, generalized over which parent the edge belongs
+    /// to (for cross-scope sweep tests, which need a second, independent
+    /// parent sharing this fixture's process/thread stores and resolver —
+    /// see `spawn_extra_parent`) and whether the child thread is ensured
+    /// (`ensure_child_thread: false` starves `deliver_background`'s first
+    /// read of a thread to read, forcing exactly that one edge's delivery to
+    /// fail — used by the "one edge fails, the rest of the pass continues"
+    /// sweep test).
+    #[allow(clippy::too_many_arguments)]
+    async fn open_edge_for(
+        &self,
+        parent_scope: &TurnScope,
+        parent_run_id: TurnRunId,
+        parent_context: &ironclaw_loop_contracts::LoopRunContext,
+        suffix: &str,
+        mode: SpawnSubagentMode,
+        ensure_child_thread: bool,
+    ) -> (TurnRunId, TurnScope) {
         let child_run_id = TurnRunId::new();
         let child_thread_id =
             ThreadId::new(format!("recovery-child-thread-{suffix}")).expect("child thread");
-        let tenant_id = self.parent_scope.tenant_id.clone();
-        let agent_id = self.parent_scope.agent_id.clone();
-        let owner_user_id = self
-            .parent_scope
+        let tenant_id = parent_scope.tenant_id.clone();
+        let agent_id = parent_scope.agent_id.clone();
+        let owner_user_id = parent_scope
             .explicit_owner_user_id()
             .cloned()
             .expect("fixture parent scope carries an explicit owner");
@@ -307,29 +335,33 @@ impl RecoveryFixture {
         // child thread's latest message — the thread itself must exist even
         // when nothing was ever posted to it (an unknown thread fails
         // closed, an empty one just yields no final text).
-        self.thread_service
-            .ensure_thread(EnsureThreadRequest {
-                scope: ThreadScope {
-                    tenant_id,
-                    agent_id: agent_id.expect("fixture parent scope carries an agent id"),
-                    project_id: None,
-                    owner_user_id: Some(owner_user_id.clone()),
-                    mission_id: None,
-                },
-                thread_id: Some(child_thread_id.clone()),
-                created_by_actor_id: owner_user_id.to_string(),
-                title: None,
-                metadata_json: None,
-            })
-            .await
-            .expect("ensure child thread");
-        let parent_process_id = ProcessId::from_uuid(self.parent_run_id.as_uuid());
+        if ensure_child_thread {
+            self.thread_service
+                .ensure_thread(EnsureThreadRequest {
+                    scope: ThreadScope {
+                        tenant_id,
+                        agent_id: agent_id
+                            .clone()
+                            .expect("fixture parent scope carries an agent id"),
+                        project_id: None,
+                        owner_user_id: Some(owner_user_id.clone()),
+                        mission_id: None,
+                    },
+                    thread_id: Some(child_thread_id.clone()),
+                    created_by_actor_id: owner_user_id.to_string(),
+                    title: None,
+                    metadata_json: None,
+                })
+                .await
+                .expect("ensure child thread");
+        }
+        let parent_process_id = ProcessId::from_uuid(parent_run_id.as_uuid());
         let gate_ref =
             TurnGateRef::new(format!("gate:recovery-{suffix}")).expect("gate ref for edge");
         let result_ref =
             LoopResultRef::new(format!("result:recovery-{suffix}")).expect("result ref");
         let group_ref = match mode {
-            SpawnSubagentMode::Background => format!("bg:{}", self.parent_scope.thread_id),
+            SpawnSubagentMode::Background => format!("bg:{}", parent_scope.thread_id),
             SpawnSubagentMode::Blocking => gate_ref.as_str().to_string(),
         };
         if mode == SpawnSubagentMode::Blocking {
@@ -343,18 +375,17 @@ impl RecoveryFixture {
                 .append_tool_result_reference(ironclaw_threads::AppendToolResultReferenceRequest {
                     intrinsic_outcome: None,
                     scope: ThreadScope {
-                        tenant_id: self.parent_scope.tenant_id.clone(),
-                        agent_id: self
-                            .parent_scope
+                        tenant_id: parent_scope.tenant_id.clone(),
+                        agent_id: parent_scope
                             .agent_id
                             .clone()
                             .expect("fixture parent scope carries an agent id"),
                         project_id: None,
-                        owner_user_id: self.parent_scope.explicit_owner_user_id().cloned(),
+                        owner_user_id: parent_scope.explicit_owner_user_id().cloned(),
                         mission_id: None,
                     },
-                    thread_id: self.parent_scope.thread_id.clone(),
-                    turn_run_id: self.parent_run_id.to_string(),
+                    thread_id: parent_scope.thread_id.clone(),
+                    turn_run_id: parent_run_id.to_string(),
                     result_ref: result_ref.as_str().to_string(),
                     safe_summary: ironclaw_threads::ToolResultSafeSummary::new(
                         "subagent still running",
@@ -368,8 +399,8 @@ impl RecoveryFixture {
         }
         let submitted = AwaitedChildSetRecord {
             gate_ref,
-            parent_run_context: self.parent_context.clone(),
-            tree_root_run_id: self.parent_run_id,
+            parent_run_context: parent_context.clone(),
+            tree_root_run_id: parent_run_id,
             child_scope: child_scope.clone(),
             child_run_id,
             child_thread_id: child_thread_id.clone(),
@@ -408,6 +439,84 @@ impl RecoveryFixture {
             .await
             .expect("submit child process");
         (child_run_id, child_scope)
+    }
+
+    /// Submits a second, independent parent process + thread sharing this
+    /// fixture's process store, thread service, and resolver — for
+    /// cross-scope sweep tests. `sweep_unclosed_background_edges` scans
+    /// across every scope in one pass; this is the only way to prove that
+    /// without standing up a second full fixture (a second resolver would
+    /// hide the "one sweep, many scopes" property under test).
+    async fn spawn_extra_parent(
+        &self,
+        suffix: &str,
+    ) -> (
+        TurnScope,
+        TurnRunId,
+        ironclaw_loop_contracts::LoopRunContext,
+    ) {
+        let tenant_id = self.parent_scope.tenant_id.clone();
+        let agent_id = self.parent_scope.agent_id.clone();
+        let owner_user_id =
+            UserId::new(format!("recovery-owner-{suffix}")).expect("extra parent owner");
+        let parent_thread_id =
+            ThreadId::new(format!("recovery-parent-thread-{suffix}")).expect("parent thread");
+        let parent_scope = TurnScope::new_with_owner(
+            tenant_id.clone(),
+            agent_id.clone(),
+            None,
+            parent_thread_id.clone(),
+            Some(owner_user_id.clone()),
+        );
+        let parent_run_id = TurnRunId::new();
+        let parent_process_id = ProcessId::from_uuid(parent_run_id.as_uuid());
+        self.process_store
+            .submit_process(SubmitProcessRequest {
+                process_id: parent_process_id,
+                process_kind: ProcessKind::AgentTurn,
+                scope: parent_scope.to_resource_scope(),
+                exclusive_within_scope: false,
+                operation_id: None,
+                owner_user_id: Some(owner_user_id.clone()),
+                concurrency_class: None,
+                parent_process_id: None,
+                root_process_id: None,
+                spawn_tree_descendant_cap: None,
+                dependency: None,
+                checkpoint_ref: None,
+                input: None,
+                created_at: chrono::Utc::now(),
+                metadata: serde_json::Value::Null,
+            })
+            .await
+            .expect("submit extra parent process");
+
+        self.thread_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: ThreadScope {
+                    tenant_id,
+                    agent_id: agent_id.expect("fixture parent scope carries an agent id"),
+                    project_id: None,
+                    owner_user_id: Some(owner_user_id.clone()),
+                    mission_id: None,
+                },
+                thread_id: Some(parent_thread_id.clone()),
+                created_by_actor_id: owner_user_id.to_string(),
+                title: None,
+                metadata_json: None,
+            })
+            .await
+            .expect("ensure extra parent thread");
+
+        let mut parent_context = ironclaw_agent_loop::test_support::test_run_context(&format!(
+            "recovery-parent-{suffix}"
+        ));
+        parent_context.scope = parent_scope.clone();
+        parent_context.thread_id = parent_thread_id;
+        parent_context.run_id = parent_run_id;
+        parent_context.actor = Some(TurnActor::new(owner_user_id));
+
+        (parent_scope, parent_run_id, parent_context)
     }
 }
 
@@ -829,5 +938,432 @@ async fn recover_scope_drains_a_blocking_mode_settled_edge_through_the_group_pat
             .expect("peek edge")
             .is_none(),
         "the group path must close the edge too"
+    );
+}
+
+/// The whole point of the sweep: edges in two different scopes are both
+/// delivered by one call, with no per-thread call needed.
+#[tokio::test]
+async fn sweep_delivers_edges_across_two_scopes_in_one_pass() {
+    let fixture = recovery_fixture(ironclaw_host_api::turn::RunProfileId::default_profile()).await;
+    let (child_a, scope_a) = fixture
+        .open_edge("sweep-scope-a", SpawnSubagentMode::Background)
+        .await;
+    fixture
+        .edge_store
+        .settle(
+            &scope_a,
+            fixture.parent_run_id,
+            child_a,
+            EdgeTerminalKind::Completed,
+            Some(4),
+            None,
+        )
+        .await
+        .expect("settle")
+        .expect("edge exists");
+
+    let (parent_scope_b, parent_run_id_b, parent_context_b) =
+        fixture.spawn_extra_parent("sweep-scope-b").await;
+    let (child_b, scope_b) = fixture
+        .open_edge_for(
+            &parent_scope_b,
+            parent_run_id_b,
+            &parent_context_b,
+            "sweep-scope-b-child",
+            SpawnSubagentMode::Background,
+            true,
+        )
+        .await;
+    fixture
+        .edge_store
+        .settle(
+            &scope_b,
+            parent_run_id_b,
+            child_b,
+            EdgeTerminalKind::Completed,
+            Some(4),
+            None,
+        )
+        .await
+        .expect("settle")
+        .expect("edge exists");
+
+    let report = sweep_unclosed_background_edges(&fixture.resolver, &fixture.edge_store).await;
+    assert_eq!(report.failed, 0, "sweep must not fail either edge");
+    assert_eq!(
+        report.drained, 2,
+        "one sweep call must deliver both scopes' edges"
+    );
+
+    assert!(
+        fixture
+            .edge_store
+            .peek(&scope_a, fixture.parent_run_id, child_a)
+            .await
+            .expect("peek scope a edge")
+            .is_none(),
+        "scope a's edge must close"
+    );
+    assert!(
+        fixture
+            .edge_store
+            .peek(&scope_b, parent_run_id_b, child_b)
+            .await
+            .expect("peek scope b edge")
+            .is_none(),
+        "scope b's edge must close in the same pass, with no per-thread call"
+    );
+    assert_eq!(
+        fixture.coordinator.activations().len(),
+        2,
+        "both parked parents must be activated"
+    );
+}
+
+/// A streak-capped edge stays parked at boot — a boot pass is neither a
+/// permitted nor a human-initiated start.
+#[tokio::test]
+async fn sweep_leaves_a_streak_capped_edge_alone() {
+    let fixture = recovery_fixture(ironclaw_host_api::turn::RunProfileId::default_profile()).await;
+    let (child_run_id, child_scope) = fixture
+        .open_edge("sweep-deferred", SpawnSubagentMode::Background)
+        .await;
+    fixture
+        .edge_store
+        .settle(
+            &child_scope,
+            fixture.parent_run_id,
+            child_run_id,
+            EdgeTerminalKind::Completed,
+            Some(3),
+            None,
+        )
+        .await
+        .expect("settle")
+        .expect("edge exists");
+    fixture
+        .edge_store
+        .record_result_appended(
+            &child_scope,
+            fixture.parent_run_id,
+            child_run_id,
+            LoopMessageRef::new(format!(
+                "msg:{}",
+                ironclaw_threads::ThreadMessageId::new().as_uuid()
+            ))
+            .expect("valid ref"),
+        )
+        .await
+        .expect("append")
+        .expect("edge exists");
+    fixture
+        .edge_store
+        .defer_streak_capped(&child_scope, fixture.parent_run_id, child_run_id)
+        .await
+        .expect("defer")
+        .expect("edge exists");
+
+    let report = sweep_unclosed_background_edges(&fixture.resolver, &fixture.edge_store).await;
+    assert_eq!(report.failed, 0);
+    assert_eq!(
+        report.drained, 0,
+        "a streak-capped edge must not be drained by a boot pass"
+    );
+    assert!(
+        fixture.coordinator.activations().is_empty(),
+        "a boot pass must not activate a streak-capped edge's parent"
+    );
+
+    let edge = fixture
+        .edge_store
+        .peek(&child_scope, fixture.parent_run_id, child_run_id)
+        .await
+        .expect("peek edge")
+        .expect("edge stays unclosed, parked");
+    assert_eq!(edge.state, AwaitEdgeState::AttentionDeferredStreakCap);
+}
+
+/// An `AttentionScheduled` edge closes without a second delivery or a second
+/// activate — the sweep's idempotent re-drive contract.
+#[tokio::test]
+async fn sweep_closes_attention_scheduled_edge_without_duplicate_delivery() {
+    let fixture = recovery_fixture(ironclaw_host_api::turn::RunProfileId::default_profile()).await;
+    let (child_run_id, child_scope) = fixture
+        .open_edge("sweep-attention-scheduled", SpawnSubagentMode::Background)
+        .await;
+    fixture
+        .edge_store
+        .settle(
+            &child_scope,
+            fixture.parent_run_id,
+            child_run_id,
+            EdgeTerminalKind::Completed,
+            Some(3),
+            None,
+        )
+        .await
+        .expect("settle")
+        .expect("edge exists");
+    fixture
+        .edge_store
+        .record_result_appended(
+            &child_scope,
+            fixture.parent_run_id,
+            child_run_id,
+            LoopMessageRef::new(format!(
+                "msg:{}",
+                ironclaw_threads::ThreadMessageId::new().as_uuid()
+            ))
+            .expect("valid ref"),
+        )
+        .await
+        .expect("append")
+        .expect("edge exists");
+    fixture
+        .edge_store
+        .record_attention(
+            &child_scope,
+            fixture.parent_run_id,
+            child_run_id,
+            AttentionOutcome::Activated,
+        )
+        .await
+        .expect("attention recorded")
+        .expect("edge exists");
+
+    let report = sweep_unclosed_background_edges(&fixture.resolver, &fixture.edge_store).await;
+    assert_eq!(report.failed, 0);
+    assert_eq!(report.drained, 1);
+    assert!(
+        fixture
+            .edge_store
+            .peek(&child_scope, fixture.parent_run_id, child_run_id)
+            .await
+            .expect("peek edge")
+            .is_none(),
+        "an already-attended edge must close"
+    );
+    assert!(
+        fixture.coordinator.activations().is_empty(),
+        "attention is already durable — the sweep must not activate again"
+    );
+}
+
+/// Fairness: scope A has more settled edges than the per-pass delivery
+/// budget allows; scope B's lone edge must still be served in the same
+/// pass. Replacing the round-robin drain with a scope-by-scope drain would
+/// spend the entire capped budget on scope A and leave scope B untouched —
+/// this assertion is exactly what would fail under that regression.
+#[tokio::test]
+async fn sweep_is_fair_across_scopes_when_one_scope_exceeds_the_cap() {
+    let fixture = recovery_fixture(ironclaw_host_api::turn::RunProfileId::default_profile()).await;
+
+    let mut scope_a_edges = Vec::new();
+    for index in 0..5 {
+        let suffix = format!("fair-a-{index}");
+        let (child_run_id, child_scope) = fixture
+            .open_edge(&suffix, SpawnSubagentMode::Background)
+            .await;
+        fixture
+            .edge_store
+            .settle(
+                &child_scope,
+                fixture.parent_run_id,
+                child_run_id,
+                EdgeTerminalKind::Completed,
+                Some(1),
+                None,
+            )
+            .await
+            .expect("settle")
+            .expect("edge exists");
+        scope_a_edges.push((child_run_id, child_scope));
+    }
+
+    let (parent_scope_b, parent_run_id_b, parent_context_b) =
+        fixture.spawn_extra_parent("fair-b").await;
+    let (child_b, scope_b) = fixture
+        .open_edge_for(
+            &parent_scope_b,
+            parent_run_id_b,
+            &parent_context_b,
+            "fair-b-child",
+            SpawnSubagentMode::Background,
+            true,
+        )
+        .await;
+    fixture
+        .edge_store
+        .settle(
+            &scope_b,
+            parent_run_id_b,
+            child_b,
+            EdgeTerminalKind::Completed,
+            Some(1),
+            None,
+        )
+        .await
+        .expect("settle")
+        .expect("edge exists");
+
+    // scan_cap covers the whole backlog (6 edges) so nothing is truncated
+    // before bucketing; the delivery cap (3) is what fairness has to work
+    // under.
+    let report =
+        sweep_unclosed_background_edges_bounded(&fixture.resolver, &fixture.edge_store, 32, 3)
+            .await;
+    assert_eq!(report.failed, 0);
+    assert_eq!(report.drained, 3, "the delivery cap bounds one pass's work");
+
+    assert!(
+        fixture
+            .edge_store
+            .peek(&scope_b, parent_run_id_b, child_b)
+            .await
+            .expect("peek scope b edge")
+            .is_none(),
+        "round-robin must serve scope b within the same capped pass, \
+         not starve it behind scope a's larger backlog"
+    );
+
+    let mut scope_a_closed = 0;
+    for (child_run_id, child_scope) in &scope_a_edges {
+        if fixture
+            .edge_store
+            .peek(child_scope, fixture.parent_run_id, *child_run_id)
+            .await
+            .expect("peek scope a edge")
+            .is_none()
+        {
+            scope_a_closed += 1;
+        }
+    }
+    assert_eq!(
+        scope_a_closed, 2,
+        "the cap leaves most of scope a's backlog for a later pass"
+    );
+}
+
+/// The returned `ResolveReport` carries the right counts, including a
+/// failure counted (not swallowed) when one edge's delivery errors — here,
+/// an edge whose child thread was never created, so `deliver_background`'s
+/// first read fails. The rest of the pass still proceeds.
+#[tokio::test]
+async fn sweep_report_counts_a_failed_edge_without_swallowing_it() {
+    let fixture = recovery_fixture(ironclaw_host_api::turn::RunProfileId::default_profile()).await;
+
+    let (failing_child, failing_scope) = fixture
+        .open_edge_for(
+            &fixture.parent_scope,
+            fixture.parent_run_id,
+            &fixture.parent_context,
+            "sweep-failure",
+            SpawnSubagentMode::Background,
+            false,
+        )
+        .await;
+    fixture
+        .edge_store
+        .settle(
+            &failing_scope,
+            fixture.parent_run_id,
+            failing_child,
+            EdgeTerminalKind::Completed,
+            Some(2),
+            None,
+        )
+        .await
+        .expect("settle")
+        .expect("edge exists");
+
+    let (parent_scope_b, parent_run_id_b, parent_context_b) =
+        fixture.spawn_extra_parent("sweep-failure-b").await;
+    let (ok_child, ok_scope) = fixture
+        .open_edge_for(
+            &parent_scope_b,
+            parent_run_id_b,
+            &parent_context_b,
+            "sweep-failure-b-child",
+            SpawnSubagentMode::Background,
+            true,
+        )
+        .await;
+    fixture
+        .edge_store
+        .settle(
+            &ok_scope,
+            parent_run_id_b,
+            ok_child,
+            EdgeTerminalKind::Completed,
+            Some(2),
+            None,
+        )
+        .await
+        .expect("settle")
+        .expect("edge exists");
+
+    let report = sweep_unclosed_background_edges(&fixture.resolver, &fixture.edge_store).await;
+    assert_eq!(
+        report.failed, 1,
+        "the failing edge's delivery error must be counted, not swallowed"
+    );
+    assert_eq!(
+        report.drained, 1,
+        "the other scope's edge must still be delivered despite the failure"
+    );
+    assert!(
+        fixture
+            .edge_store
+            .peek(&failing_scope, fixture.parent_run_id, failing_child)
+            .await
+            .expect("peek failing edge")
+            .is_some(),
+        "a failed delivery must leave its edge unclosed for a later pass"
+    );
+    assert!(
+        fixture
+            .edge_store
+            .peek(&ok_scope, parent_run_id_b, ok_child)
+            .await
+            .expect("peek ok edge")
+            .is_none(),
+        "the unaffected scope's edge must still close"
+    );
+}
+
+/// A second sweep over the same state is idempotent: nothing delivered
+/// twice.
+#[tokio::test]
+async fn sweep_second_pass_over_same_state_is_idempotent() {
+    let fixture = recovery_fixture(ironclaw_host_api::turn::RunProfileId::default_profile()).await;
+    let (child_run_id, child_scope) = fixture
+        .open_edge("sweep-idempotent", SpawnSubagentMode::Background)
+        .await;
+    fixture
+        .edge_store
+        .settle(
+            &child_scope,
+            fixture.parent_run_id,
+            child_run_id,
+            EdgeTerminalKind::Completed,
+            Some(2),
+            None,
+        )
+        .await
+        .expect("settle")
+        .expect("edge exists");
+
+    let first = sweep_unclosed_background_edges(&fixture.resolver, &fixture.edge_store).await;
+    assert_eq!(first.drained, 1);
+    assert_eq!(fixture.coordinator.activations().len(), 1);
+
+    let second = sweep_unclosed_background_edges(&fixture.resolver, &fixture.edge_store).await;
+    assert_eq!(second.drained, 0);
+    assert_eq!(second.failed, 0);
+    assert_eq!(
+        fixture.coordinator.activations().len(),
+        1,
+        "a second sweep over an already-closed edge must not activate again"
     );
 }

--- a/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery/tests.rs
+++ b/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery/tests.rs
@@ -455,6 +455,22 @@ impl RecoveryFixture {
         TurnRunId,
         ironclaw_loop_contracts::LoopRunContext,
     ) {
+        self.spawn_extra_parent_with_run_id(suffix, TurnRunId::new())
+            .await
+    }
+
+    /// Same as `spawn_extra_parent`, but with the run id supplied by the
+    /// caller instead of generated randomly — see
+    /// `recovery_fixture_with_parent_run_id` for why.
+    async fn spawn_extra_parent_with_run_id(
+        &self,
+        suffix: &str,
+        parent_run_id: TurnRunId,
+    ) -> (
+        TurnScope,
+        TurnRunId,
+        ironclaw_loop_contracts::LoopRunContext,
+    ) {
         let tenant_id = self.parent_scope.tenant_id.clone();
         let agent_id = self.parent_scope.agent_id.clone();
         let owner_user_id =
@@ -468,7 +484,6 @@ impl RecoveryFixture {
             parent_thread_id.clone(),
             Some(owner_user_id.clone()),
         );
-        let parent_run_id = TurnRunId::new();
         let parent_process_id = ProcessId::from_uuid(parent_run_id.as_uuid());
         self.process_store
             .submit_process(SubmitProcessRequest {
@@ -521,6 +536,18 @@ impl RecoveryFixture {
 }
 
 async fn recovery_fixture(profile_id: ironclaw_host_api::turn::RunProfileId) -> RecoveryFixture {
+    recovery_fixture_with_parent_run_id(profile_id, TurnRunId::new()).await
+}
+
+/// Same as `recovery_fixture`, but with the fixture's parent run id supplied
+/// by the caller instead of generated randomly — needed by
+/// `sweep_is_fair_across_scopes_when_one_scope_exceeds_the_cap`, which must
+/// control the scan's sort order (`dependent_process_id`, derived from this
+/// run id) rather than leave it to chance.
+async fn recovery_fixture_with_parent_run_id(
+    profile_id: ironclaw_host_api::turn::RunProfileId,
+    parent_run_id: TurnRunId,
+) -> RecoveryFixture {
     let tenant_id = TenantId::new("recovery-tenant").expect("tenant");
     let agent_id = AgentId::new("recovery-agent").expect("agent");
     let owner_user_id = UserId::new("recovery-owner").expect("owner");
@@ -532,7 +559,6 @@ async fn recovery_fixture(profile_id: ironclaw_host_api::turn::RunProfileId) -> 
         parent_thread_id.clone(),
         Some(owner_user_id.clone()),
     );
-    let parent_run_id = TurnRunId::new();
     let parent_process_id = ProcessId::from_uuid(parent_run_id.as_uuid());
 
     let process_store = Arc::new(ironclaw_processes::in_memory_backed_process_store());
@@ -1157,7 +1183,23 @@ async fn sweep_closes_attention_scheduled_edge_without_duplicate_delivery() {
 /// this assertion is exactly what would fail under that regression.
 #[tokio::test]
 async fn sweep_is_fair_across_scopes_when_one_scope_exceeds_the_cap() {
-    let fixture = recovery_fixture(ironclaw_host_api::turn::RunProfileId::default_profile()).await;
+    // Fixed (not `TurnRunId::new()`) run ids: the scan sorts by
+    // `dependent_process_id`, derived from each parent's run id, so which
+    // scope's records come first in scan order is otherwise a coin flip —
+    // when the lone scope B record happened to sort first, a regression to
+    // bucketing by `record.scope` (instead of `group_ref`) would still
+    // deliver it early and this test would pass anyway. Pinning scope A's
+    // (busy) run id below scope B's (lone) run id makes round-robin the only
+    // way B is served within the delivery cap. Do not revert this to random
+    // ids.
+    let busy_parent_run_id = TurnRunId::from_uuid(uuid::Uuid::from_u128(1));
+    let lone_parent_run_id = TurnRunId::from_uuid(uuid::Uuid::from_u128(2));
+
+    let fixture = recovery_fixture_with_parent_run_id(
+        ironclaw_host_api::turn::RunProfileId::default_profile(),
+        busy_parent_run_id,
+    )
+    .await;
 
     let mut scope_a_edges = Vec::new();
     for index in 0..5 {
@@ -1181,8 +1223,9 @@ async fn sweep_is_fair_across_scopes_when_one_scope_exceeds_the_cap() {
         scope_a_edges.push((child_run_id, child_scope));
     }
 
-    let (parent_scope_b, parent_run_id_b, parent_context_b) =
-        fixture.spawn_extra_parent("fair-b").await;
+    let (parent_scope_b, parent_run_id_b, parent_context_b) = fixture
+        .spawn_extra_parent_with_run_id("fair-b", lone_parent_run_id)
+        .await;
     let (child_b, scope_b) = fixture
         .open_edge_for(
             &parent_scope_b,
@@ -1211,7 +1254,7 @@ async fn sweep_is_fair_across_scopes_when_one_scope_exceeds_the_cap() {
     // before bucketing; the delivery cap (3) is what fairness has to work
     // under.
     let report =
-        sweep_unclosed_background_edges_bounded(&fixture.resolver, &fixture.edge_store, 32, 3)
+        sweep_unclosed_background_edges_bounded(&fixture.resolver, &fixture.edge_store, 32, 3, 32)
             .await;
     assert_eq!(report.failed, 0);
     assert_eq!(report.drained, 3, "the delivery cap bounds one pass's work");
@@ -1366,4 +1409,60 @@ async fn sweep_second_pass_over_same_state_is_idempotent() {
         1,
         "a second sweep over an already-closed edge must not activate again"
     );
+}
+
+/// The scan's keyset cursor still works when a backlog spans more than one
+/// page — proven directly through the `_bounded` entry point with an
+/// explicit small `page_size`, independent of the scan cap. See
+/// `sweep_unclosed_background_edges`'s doc comment for why production always
+/// requests one page sized to the scan cap instead.
+#[tokio::test]
+async fn sweep_scan_pages_through_a_backlog_larger_than_one_page() {
+    let fixture = recovery_fixture(ironclaw_host_api::turn::RunProfileId::default_profile()).await;
+
+    let mut edges = Vec::new();
+    for index in 0..5 {
+        let suffix = format!("paged-{index}");
+        let (child_run_id, child_scope) = fixture
+            .open_edge(&suffix, SpawnSubagentMode::Background)
+            .await;
+        fixture
+            .edge_store
+            .settle(
+                &child_scope,
+                fixture.parent_run_id,
+                child_run_id,
+                EdgeTerminalKind::Completed,
+                Some(1),
+                None,
+            )
+            .await
+            .expect("settle")
+            .expect("edge exists");
+        edges.push((child_run_id, child_scope));
+    }
+
+    // page_size (2) is smaller than both the backlog (5 edges) and scan_cap
+    // (32), forcing the scan loop through multiple `scan_unclosed_background`
+    // calls and exercising the keyset cursor.
+    let report =
+        sweep_unclosed_background_edges_bounded(&fixture.resolver, &fixture.edge_store, 32, 32, 2)
+            .await;
+    assert_eq!(report.failed, 0);
+    assert_eq!(
+        report.drained, 5,
+        "every paged-in edge must still be delivered"
+    );
+
+    for (child_run_id, child_scope) in &edges {
+        assert!(
+            fixture
+                .edge_store
+                .peek(child_scope, fixture.parent_run_id, *child_run_id)
+                .await
+                .expect("peek paged edge")
+                .is_none(),
+            "a multi-page scan must still close every backlogged edge"
+        );
+    }
 }

--- a/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/resolver.rs
+++ b/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/resolver.rs
@@ -26,7 +26,7 @@ use ironclaw_loop_contracts::{AgentLoopHostError, LoopInput, LoopInputAckEffect,
 use ironclaw_loop_host::DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID;
 use ironclaw_loop_host::{
     AwaitEdgeSettler, EnqueueQueuedMessageRequest, HostInputAckEffectHandler, HostInputEnqueuePort,
-    HostInputQueueError, ResolveOutcome, ResolveReport, SpawnSubagentMode,
+    HostInputQueueError, ResolveOutcome, SpawnSubagentMode,
 };
 #[cfg(test)]
 use ironclaw_threads::ThreadHistoryRequest;
@@ -1133,31 +1133,6 @@ where
             })
     }
 
-    /// Run-start sweep (§4.2): heals background await-edges left mid-delivery
-    /// on `scope`'s thread. Queries at most `MAX_QUEUED_INPUTS_PER_RUN`
-    /// background edges (`AwaitEdgeStore::list_background_for_thread`) and
-    /// drives each through `deliver_background`'s idempotent re-drive by
-    /// state:
-    ///
-    /// - `Settled` / `ResultAppended` / `AttentionScheduled` — full re-drive
-    ///   (append is a no-op replay past `Settled`; `AttentionScheduled`
-    ///   closes only, per `deliver_background`'s own re-drive contract).
-    /// - `AttentionDeferredStreakCap` — only when `human_initiated`: drained
-    ///   forward via `retry_deferred`. An autonomous (System/ParentAgent)
-    ///   start leaves it parked.
-    /// - `Open` / `Drained` / `Abandoned` — nothing to do.
-    ///
-    /// One edge's failure is logged and does not stop the sweep from trying
-    /// the rest; the caller (`RebornTurnRunExecutor::execute_claimed_run`)
-    /// treats the whole sweep as non-fatal to the run start.
-    /// Process-lifetime snapshot of the reactive settle path's outcome tally
-    /// (§6, R4). Cheap, lock-free reads (`Ordering::Relaxed`) — safe to call
-    /// from a health/metrics endpoint or a periodic log line without
-    /// contending with the hot settle path.
-    pub fn resolve_counters_snapshot(&self) -> ResolveReport {
-        self.resolve_counters.snapshot()
-    }
-
     /// Records one reactive-settle result into the process-lifetime counters
     /// and emits a `debug!` line for it. Per-outcome (not a coarser cadence):
     /// `debug!` is already opt-in verbosity — nobody pays for this in a
@@ -1179,6 +1154,23 @@ where
         }
     }
 
+    /// Run-start sweep (§4.2): heals background await-edges left mid-delivery
+    /// on `scope`'s thread. Queries at most `MAX_QUEUED_INPUTS_PER_RUN`
+    /// background edges (`AwaitEdgeStore::list_background_for_thread`) and
+    /// drives each through `deliver_background`'s idempotent re-drive by
+    /// state:
+    ///
+    /// - `Settled` / `ResultAppended` / `AttentionScheduled` — full re-drive
+    ///   (append is a no-op replay past `Settled`; `AttentionScheduled`
+    ///   closes only, per `deliver_background`'s own re-drive contract).
+    /// - `AttentionDeferredStreakCap` — only when `human_initiated`: drained
+    ///   forward via `retry_deferred`. An autonomous (System/ParentAgent)
+    ///   start leaves it parked.
+    /// - `Open` / `Drained` / `Abandoned` — nothing to do.
+    ///
+    /// One edge's failure is logged and does not stop the sweep from trying
+    /// the rest; the caller (`RebornTurnRunExecutor::execute_claimed_run`)
+    /// treats the whole sweep as non-fatal to the run start.
     pub async fn sweep_thread_on_run_start(
         &self,
         scope: &TurnScope,
@@ -1256,16 +1248,6 @@ impl ResolveCounters {
 
     fn record_failed(&self) {
         self.failed.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn snapshot(&self) -> ResolveReport {
-        ResolveReport {
-            resumed: self.resumed.load(Ordering::Relaxed),
-            drained: self.drained.load(Ordering::Relaxed),
-            abandoned: self.abandoned.load(Ordering::Relaxed),
-            already_closed: self.already_closed.load(Ordering::Relaxed),
-            failed: self.failed.load(Ordering::Relaxed),
-        }
     }
 }
 

--- a/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/resolver.rs
+++ b/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/resolver.rs
@@ -12,6 +12,7 @@
 //! changed. Boot/lazy recovery split out to `boot_recovery.rs` (plan-review
 //! fix — keeps this file to the reactive settle path only).
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 
 #[cfg(test)]
@@ -25,7 +26,7 @@ use ironclaw_loop_contracts::{AgentLoopHostError, LoopInput, LoopInputAckEffect,
 use ironclaw_loop_host::DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID;
 use ironclaw_loop_host::{
     AwaitEdgeSettler, EnqueueQueuedMessageRequest, HostInputAckEffectHandler, HostInputEnqueuePort,
-    HostInputQueueError, ResolveOutcome, SpawnSubagentMode,
+    HostInputQueueError, ResolveOutcome, ResolveReport, SpawnSubagentMode,
 };
 #[cfg(test)]
 use ironclaw_threads::ThreadHistoryRequest;
@@ -75,6 +76,14 @@ pub struct AwaitEdgeResolver<S: SessionThreadService + ?Sized> {
     input_enqueue: OnceLock<Arc<dyn HostInputEnqueuePort>>,
     coordinator: OnceLock<Arc<dyn TurnCoordinator>>,
     thread_service: Arc<S>,
+    /// Process-lifetime observability counters (§6, R4) for the reactive
+    /// settle path (`observe_committed_state`/`observe_committed_event`,
+    /// below) — the highest-volume delivery path, and previously entirely
+    /// unobserved. Atomics, not a `Mutex`: the resolver is shared behind
+    /// `Arc` and called from many concurrent async contexts, and a per-event
+    /// counter increment must never contend with (or block behind) the
+    /// store/coordinator I/O the same call already performs.
+    resolve_counters: ResolveCounters,
 }
 
 impl<S> AwaitEdgeResolver<S>
@@ -97,6 +106,7 @@ where
             input_enqueue: OnceLock::new(),
             coordinator: OnceLock::new(),
             thread_service,
+            resolve_counters: ResolveCounters::default(),
         }
     }
 
@@ -117,6 +127,7 @@ where
             input_enqueue: OnceLock::new(),
             coordinator: OnceLock::new(),
             thread_service,
+            resolve_counters: ResolveCounters::default(),
         }
     }
 
@@ -1139,6 +1150,35 @@ where
     /// One edge's failure is logged and does not stop the sweep from trying
     /// the rest; the caller (`RebornTurnRunExecutor::execute_claimed_run`)
     /// treats the whole sweep as non-fatal to the run start.
+    /// Process-lifetime snapshot of the reactive settle path's outcome tally
+    /// (§6, R4). Cheap, lock-free reads (`Ordering::Relaxed`) — safe to call
+    /// from a health/metrics endpoint or a periodic log line without
+    /// contending with the hot settle path.
+    pub fn resolve_counters_snapshot(&self) -> ResolveReport {
+        self.resolve_counters.snapshot()
+    }
+
+    /// Records one reactive-settle result into the process-lifetime counters
+    /// and emits a `debug!` line for it. Per-outcome (not a coarser cadence):
+    /// `debug!` is already opt-in verbosity — nobody pays for this in a
+    /// default-level deployment — so the extra granularity costs nothing in
+    /// practice and is exactly what a live diagnosis of one stuck child needs;
+    /// a coarser periodic summary would blur which child's settle produced
+    /// which outcome. Observation only — never changes what the caller
+    /// returns.
+    fn record_reactive_outcome(&self, result: &Result<ResolveOutcome, TurnError>) {
+        match result {
+            Ok(outcome) => {
+                self.resolve_counters.record(*outcome);
+                tracing::debug!(?outcome, "await-edge reactive settle outcome");
+            }
+            Err(error) => {
+                self.resolve_counters.record_failed();
+                tracing::debug!(error = %error, "await-edge reactive settle failed");
+            }
+        }
+    }
+
     pub async fn sweep_thread_on_run_start(
         &self,
         scope: &TurnScope,
@@ -1183,6 +1223,49 @@ where
             }
         }
         Ok(())
+    }
+}
+
+/// Process-lifetime, lock-free tally of reactive-settle outcomes (§6, R4).
+/// Plain `AtomicU64` fields rather than a `Mutex<ResolveReport>`: increments
+/// happen on the hot reactive settle path, called concurrently from every
+/// child turn's commit callback, and must never contend with (or block
+/// behind) another child's increment.
+#[derive(Default)]
+struct ResolveCounters {
+    resumed: AtomicU64,
+    drained: AtomicU64,
+    abandoned: AtomicU64,
+    already_closed: AtomicU64,
+    failed: AtomicU64,
+}
+
+impl ResolveCounters {
+    fn record(&self, outcome: ResolveOutcome) {
+        let counter = match outcome {
+            ResolveOutcome::Resumed => &self.resumed,
+            ResolveOutcome::Drained => &self.drained,
+            ResolveOutcome::Abandoned => &self.abandoned,
+            ResolveOutcome::AlreadyClosed => &self.already_closed,
+            // Not a subagent child at all — not a resolve outcome worth
+            // counting, mirroring `ResolveReport::record`'s own no-op arm.
+            ResolveOutcome::NotApplicable => return,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_failed(&self) {
+        self.failed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> ResolveReport {
+        ResolveReport {
+            resumed: self.resumed.load(Ordering::Relaxed),
+            drained: self.drained.load(Ordering::Relaxed),
+            abandoned: self.abandoned.load(Ordering::Relaxed),
+            already_closed: self.already_closed.load(Ordering::Relaxed),
+            failed: self.failed.load(Ordering::Relaxed),
+        }
     }
 }
 
@@ -1359,11 +1442,15 @@ where
         state: ironclaw_turns::TurnRunState,
     ) -> Result<(), TurnError> {
         let event = terminal_event_from_state(&state)?;
-        self.handle_child_terminal_inner(&event).await.map(|_| ())
+        let result = self.handle_child_terminal_inner(&event).await;
+        self.record_reactive_outcome(&result);
+        result.map(|_| ())
     }
 
     async fn observe_committed_event(&self, event: TurnLifecycleEvent) -> Result<(), TurnError> {
-        self.handle_child_terminal_inner(&event).await.map(|_| ())
+        let result = self.handle_child_terminal_inner(&event).await;
+        self.record_reactive_outcome(&result);
+        result.map(|_| ())
     }
 }
 

--- a/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/resolver/tests.rs
+++ b/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/resolver/tests.rs
@@ -1255,6 +1255,13 @@ impl ironclaw_processes::ProcessDependencyPort for ScriptedDependencyFailures {
     ) -> Result<Vec<ironclaw_processes::ProcessDependencyRecord>, Self::Error> {
         self.inner.unresolved_process_dependencies().await
     }
+
+    async fn scan_unclosed_process_dependencies(
+        &self,
+        request: ironclaw_processes::ScanUnclosedProcessDependenciesRequest,
+    ) -> Result<ironclaw_processes::ScanUnclosedProcessDependenciesResponse, Self::Error> {
+        self.inner.scan_unclosed_process_dependencies(request).await
+    }
 }
 
 /// Stub `AgentTurnSpawnTreeRuntimePort`: `get_run_record` always answers

--- a/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/store.rs
+++ b/crates/loop/ironclaw_turn_runner/src/subagent/await_edge/store.rs
@@ -8,8 +8,8 @@ use ironclaw_host_api::turn::{LoopMessageRef, TurnRunId, TurnScope};
 use ironclaw_processes::{
     CloseProcessDependencyRequest, ProcessDependencyPort, ProcessDependencyQuery,
     ProcessDependencyRecord, ProcessDependencyState, ProcessJournalStoreError,
-    ProcessLifecycleStatus, ProcessTerminalEvidence, SettleProcessDependencyRequest,
-    TransitionProcessDependencyRequest,
+    ProcessLifecycleStatus, ProcessTerminalEvidence, ScanUnclosedProcessDependenciesRequest,
+    SettleProcessDependencyRequest, TransitionProcessDependencyRequest,
 };
 
 use super::{
@@ -369,6 +369,66 @@ impl AwaitEdgeStore {
                 Self::edge_from_record(record).map(|edge| (parent, child, edge))
             })
             .collect()
+    }
+
+    /// Bounded, unscoped scan of unclosed background-mode dependency edges
+    /// (`group_ref_prefix = "bg:"`, the exact tag `finish_spawn` writes for
+    /// `SpawnSubagentMode::Background`) — the boot/periodic sweep's read
+    /// primitive (`boot_recovery::sweep_unclosed_background_edges`). Every
+    /// scope-bound caller keeps using `list_background_for_thread` /
+    /// `list_unclosed_for_scope`; this is the one caller allowed to reach
+    /// `ProcessDependencyPort::scan_unclosed_process_dependencies` cross-scope.
+    ///
+    /// Returns each record's own `group_ref` alongside its edge — the exact
+    /// `"bg:{parent_thread_id}"` tag `finish_spawn` writes — so the caller can
+    /// bucket by *parent* backlog for fairness. Deliberately not
+    /// `record.scope`: that field is the *child's* own scope (a fresh,
+    /// unique thread per spawned subagent), so grouping by it would put every
+    /// edge in its own singleton bucket regardless of which parent is
+    /// backlogged, defeating round-robin fairness entirely. `group_ref` is
+    /// the one field on this record that actually identifies "whose backlog
+    /// this is." Also returns the keyset cursor for the next page (`None`
+    /// once the scan is exhausted).
+    pub async fn scan_unclosed_background(
+        &self,
+        states: Vec<ProcessDependencyState>,
+        limit: u32,
+        after: Option<(
+            ironclaw_host_api::ids::ProcessId,
+            ironclaw_host_api::ids::ProcessId,
+        )>,
+    ) -> Result<
+        (
+            Vec<(TurnRunId, TurnRunId, Option<String>, AwaitEdge)>,
+            Option<(
+                ironclaw_host_api::ids::ProcessId,
+                ironclaw_host_api::ids::ProcessId,
+            )>,
+        ),
+        AwaitEdgeStoreError,
+    > {
+        let response = self
+            .dependencies
+            .scan_unclosed_process_dependencies(ScanUnclosedProcessDependenciesRequest {
+                scope_filter: None,
+                states,
+                group_ref_prefix: Some("bg:".to_string()),
+                limit,
+                after,
+            })
+            .await
+            .map_err(map_process_error)?;
+        let edges = response
+            .dependencies
+            .into_iter()
+            .map(|record| {
+                let parent = Self::run_id(record.dependent_process_id);
+                let child = Self::run_id(record.dependency_process_id);
+                let group_ref = record.group_ref.clone();
+                Self::edge_from_record(record).map(|edge| (parent, child, group_ref, edge))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok((edges, response.next_after))
     }
 
     pub async fn consume(

--- a/docs/internal/plans/composition-pubuse.snapshot
+++ b/docs/internal/plans/composition-pubuse.snapshot
@@ -79,7 +79,8 @@ pub use runtime::{
 };
 pub use runtime_input::{
     KeepaliveSweepSettings, PollSettings, RebornRuntimeIdentity, RebornRuntimeInput,
-    TriggerFireAccessGrant, TriggerFireAccessPolicy, TriggerPollerSettings, TurnRunnerSettings,
+    SubagentSweepSettings, TriggerFireAccessGrant, TriggerFireAccessPolicy, TriggerPollerSettings,
+    TurnRunnerSettings,
 };
 pub use ironclaw_identity::{
     ExternalSubjectId, ProviderKind, RebornIdentityError, RebornIdentityResolver,

--- a/docs/internal/reborn/subagent-spawn/README.md
+++ b/docs/internal/reborn/subagent-spawn/README.md
@@ -2,7 +2,7 @@
 
 **Status:** Canonical — the one current document for subagent architecture,
 design decisions, and roadmap.
-**Last verified against code:** 2026-08-21, workspace @ `dba5f41e9`.
+**Last verified against code:** 2026-09-03, workspace @ `8df1f8a24`.
 **Replaces (deleted 2026-08-20, recoverable from git history):**
 `phase-1-contracts.md`, `phase-2-mechanisms.md`, `phase-3-integration.md`,
 `thread-harness-design.md`, `pr2-pr6-shape.md`,
@@ -180,10 +180,19 @@ line numbers; both were test-module lines, not production callers). There is
 no startup caller today — recovery is not a boot pass. A parent blocked on a
 settled-but-undrained edge in a
 scope nothing else touches stays blocked until some later spawn happens to
-touch that scope. A true startup/boot pass for background edges (which need
-one regardless, since they have no gate to block on) is new work owned by
-Part II Task 7; blocking-mode recovery remains lazy as described here.
-(status, 2026-09-02: the boot pass did not ship with R2 — see §4.2 trigger 3.)
+touch that scope. Blocking-mode recovery remains lazy as described here — the
+boot pass below is a background-edge mechanism; it does not add a startup
+caller for `check_scope_recovered`.
+(status, 2026-09-03: the boot pass shipped in R4 — see §4.2 trigger 3. It
+closes the "no startup caller" gap for *background* edges: on boot,
+`ProcessDependencyPort::scan_unclosed_process_dependencies`
+(`crates/kernel/ironclaw_processes/src/journal.rs`) answers "which
+dependencies anywhere are unclosed" — the query `ProcessDependencyQuery`
+itself cannot, since its `scope` field is mandatory — and
+`sweep_unclosed_background_edges`
+(`crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery.rs`)
+drives every stranded background edge it finds through the same per-edge
+recovery `recover_scope` uses.)
 
 ### 2.6 Parallel children
 
@@ -353,22 +362,36 @@ substitute for it.
    `group_ref = "bg:{parent_thread_id}"` (§4.3), so the existing
    group-ref dependency query serves it; the batch is capped at
    `MAX_QUEUED_INPUTS_PER_RUN`.
-3. **Boot pass**: **Not shipped (2026-09-02).** R2 landed
-   triggers 1 and 2 only; a restart re-drives nothing by itself. The stranding
-   window is a refusal after a successful observer pass (`ThreadBusy` or a
-   transient activation error leaves the edge `ResultAppended`) on a thread no
-   later run touches — the result row is already in the transcript, only the
-   autonomous wake is lost. A cross-scope re-drive needs a partition-leading
-   dependency query the kernel charter does not have today; it is R4 work
-   alongside boot-recovery fairness. The design intent, once built: restart re-drives every non-closed background edge
+3. **Boot pass**: **Shipped (2026-09-03, R4)**. Composition
+   (`crates/app/ironclaw_composition/src/runtime.rs`) runs one
+   `tokio::time::interval` task whose immediate first tick is the boot pass,
+   then every `SubagentSweepSettings::interval` (default
+   `DEFAULT_SUBAGENT_SWEEP_INTERVAL` = 300s, `runtime_input.rs`); the handle
+   is aborted on shutdown. Restart re-drives every non-closed background edge
    (`Settled`, `ResultAppended`, `AttentionScheduled`) through the same
    recovery logic as the run-start sweep — `Settled`/`ResultAppended`
    re-enter the deliver path, **including activation of parked parents**
    (autonomous delivery is a product promise, so boot may wake; the streak
    cap still applies), while `AttentionScheduled` is simply closed, its
-   attention outcome already durable. Bounded scanning is new work the plan
-   owns (Task 7 adds the limit/continuation to the dependency query);
-   per-tenant fairness lands with the R4 boot-recovery work.
+   attention outcome already durable; `AttentionDeferredStreakCap` is left
+   alone — a streak-capped edge waits for a permitted or human-initiated
+   start, and a boot pass is neither. Bounded scanning is
+   `ProcessDependencyPort::scan_unclosed_process_dependencies`
+   (`crates/kernel/ironclaw_processes/src/journal.rs`): scope-optional, with
+   a `group_ref` prefix filter and a keyset page over the canonical
+   `(dependent_process_id, dependency_process_id)` order — it adds no
+   filesystem enumeration, reusing the same unscoped `unresolved` index read
+   `query_process_dependencies` and `unresolved_process_dependencies`
+   already perform, then filtering and paging in memory, so
+   `reborn_process_storage_scan_gate` stays green. A `ponytail:` at the read
+   site (`crates/kernel/ironclaw_processes/src/journal_store.rs:1311`) names
+   the remaining ceiling: that index read takes no limit, so a page bounds
+   the result but not the I/O; the upgrade path is pushing limit/cursor into
+   the indexed query. Per-tenant fairness (`sweep_unclosed_background_edges`,
+   `crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery.rs`):
+   scanned records are bucketed by `group_ref` (`bg:{parent_thread_id}` —
+   the parent's backlog) and drained round-robin under a delivery cap, so one
+   parent cannot consume a pass (§5, D15).
 
 The persisted edge state is the dedupe and the retry ledger: one durable
 obligation per child, retried with bounded backoff until closed or
@@ -644,6 +667,20 @@ the append-model design review.
   rather than a wedged parent run. Reversal: cheap — the no-op is two early
   returns, and the row shape is unchanged.
 
+- **D15 (2026-09-03) Boot-sweep fairness buckets by the parent's `group_ref`,
+  not the child's `scope`.** `sweep_unclosed_background_edges`
+  (`boot_recovery.rs`) drains stranded background edges round-robin so one
+  parent's backlog cannot consume a whole boot pass. The bucket key has to be
+  something shared by every sibling edge under one parent — bucketing by the
+  record's own `scope` looks equivalent and is not: a background edge's
+  `scope` is the *child's*, unique per spawn, so keying on it puts every edge
+  in its own singleton bucket and round-robin silently degenerates into a
+  scope-by-scope drain, the opposite of fairness. `group_ref` is
+  deterministically `bg:{parent_thread_id}` for background edges (§4.2), so
+  it is the one key that actually groups siblings. A test fails
+  deterministically if this regresses. Reversal: cheap — the bucket key is a
+  single expression at one call site.
+
 ## 6. Roadmap
 
 Slice 1 shipped (#7752, plus the #7755/#7758 vocabulary cleanup). Remaining
@@ -653,7 +690,7 @@ work, in order — names map to the retired shape doc's slices for continuity:
 | --- | --- | --- | --- |
 | R2 | **Background core** | Everything in §4.3 + integration tests: per-child beat, three-trigger healing, `ThreadBusy` heal (sweep-based), crash-replay idempotency, the failure-injection matrix. Plus a **concurrent-running-children cap** at spawn admission (same path as the descendant cap) — Claude Code's changelog shows this cap removed and re-added under production pressure; it is D10's "active children per parent" line made real — **shipped 2026-08 except the concurrent-running-children cap (open debt, own slice) and the boot pass (moved to R4, §4.2)** | slice 2 (reshaped: append model replaces wake-only Tasks 8–9) |
 | R3 | **Gate escalation walk** | 3a: a blocked child's approval/auth gate reaches the parent's owner as an actionable inbox item opening the child thread (shipped 2026-09); 3b: verify/land the WebUI gate card on a hidden child thread opened by URL; R3 is a prerequisite of the R9 enable, not the enable itself | slice 4 |
-| R4 | **Counters, operator command, e2e revival** | `ResolveReport` counters; `ironclaw subagent edges`; un-ignore the five e2e tests via harness-side enablement; boot-recovery fairness | slice 5 |
+| R4 | **Counters, operator command, e2e revival** | **Shipped 2026-09-03**: the boot pass (kernel scan + sweep + composition wiring, §4.2 trigger 3), `ResolveReport` counters wired on `AwaitEdgeResolver` (`resolve_counters_snapshot()`), boot-recovery fairness (§5, D15), all five e2e tests un-ignored (`tests/reborn_subagent_spawn_e2e.rs`). **Not shipped**: `ironclaw subagent edges` — the CLI's dependency set excludes `ironclaw_turn_runner` (`reborn_dependency_boundaries.rs`), so the command needs composition to grow a narrow read accessor first; own slice | slice 5 |
 | R5 | **`subagent_inspect` + per-kind config** | Model-facing status/gate/byte-count metadata (never raw transcript); per-kind budget + model override. Plus the **degraded-result taxonomy**: `child_terminal_output` distinguishes clean success / partial-on-forced-cutoff / provider error — Claude Code shipped three separate fixes for children returning empty on rate-limit cutoff or fabricating success on API error; D10's lifecycle-taxonomy line; the parent model learns of a blocked child here | slice 6 |
 | R6 | **`subagent_extend` + human priority** | `activate(child, …, ParentAgent)` with consent-to-wake + budget window; `human_waiting` reservation marker | slice 7 |
 | R7 | **WebUI child tree** | `GET …/threads/{id}/children` lineage projection; `ThreadTree` sidebar; raw-vs-framed display rule; interrupt & take over | slice 8 |
@@ -671,8 +708,10 @@ Things no slice may break; each is enforced or pinned today.
 - **Deny-filtered until R9.** `builtin.spawn_subagent` sits in
   `disabled_capability_ids` (`turn_runner/src/runtime.rs`,
   `TEMP(disable-spawn-subagents)` markers); `tests/integration/tool_call.rs`
-  pins the disabled behavior; five e2e tests in
-  `tests/reborn_subagent_spawn_e2e.rs` are `#[ignore]`d until R4.
+  pins the disabled behavior; all five e2e tests in
+  `tests/reborn_subagent_spawn_e2e.rs` run today (un-ignored in R4) against
+  the harness-side enablement that lets them exercise the capability while
+  the model-facing filter stays in place.
 - **No stage skipping.** Child runs execute through the standard
   runner/driver/executor path and the capability membrane; spawn only
   creates and wires.
@@ -741,8 +780,12 @@ Things no slice may break; each is enforced or pinned today.
 | Composition wiring | `crates/app/ironclaw_composition/src/runtime.rs` |
 | Integration scenarios (edges) | `tests/integration/subagent_await_edge.rs` (`reborn_integration_subagent_await_edge`) |
 | Disabled-capability pins | `tests/integration/tool_call.rs` |
-| E2E suite (ignored until R4) | `tests/reborn_subagent_spawn_e2e.rs` |
+| E2E suite (all five run, R4) | `tests/reborn_subagent_spawn_e2e.rs` |
 | Child gate → owner inbox (R3 3a) | `crates/product/ironclaw_assistant/src/run_outcome_observer.rs` (`child_gate_run`, `observe_child_gate_commit`) |
+| Boot-recovery scan (kernel) | `crates/kernel/ironclaw_processes/src/journal.rs` (`ProcessDependencyPort::scan_unclosed_process_dependencies`) |
+| Boot-recovery sweep + fairness | `crates/loop/ironclaw_turn_runner/src/subagent/await_edge/boot_recovery.rs` (`sweep_unclosed_background_edges`) |
+| Boot-sweep composition wiring | `crates/app/ironclaw_composition/src/{runtime,runtime_input}.rs` (`SubagentSweepSettings`, `subagent_background_sweep`) |
+| Resolve counters | `crates/loop/ironclaw_turn_runner/src/subagent/await_edge/resolver.rs` (`ResolveCounters`, `resolve_counters_snapshot`) |
 
 Family rules: `crates/loop/AGENTS.md` and per-crate `AGENTS.md`/`README.md`
 files govern placement; `tests/integration/AGENTS.md` governs scenario
@@ -754,12 +797,25 @@ change.
 
 ## 9. Part II — pending work
 
-R3 slice 3a shipped 2026-09, PR #8046. Next: 3b (WebUI
-gate card on a hidden child thread opened by URL — verify first, it may
-already render), then the two R2 debts as their own slices
-(concurrent-running-children cap at spawn admission; the `ThreadBusy`
-immediate-re-enqueue optimization in `activate_parked_parent` — R2 already
-ships the sweep-based heal that parks and re-attends the edge; this debt is
-re-enqueueing into the now-live parent's queue right away instead of waiting
-for the next sweep). Plans are written here, spec-first against
-Part I, when a slice starts.
+R3 slice 3a shipped 2026-09, PR #8046; R4 shipped 2026-09-03 (boot pass,
+counters, boot-recovery fairness, e2e revival — §6). Remaining, in order:
+
+- **3b**: verify/land the WebUI gate card on a hidden child thread opened by
+  URL (may already render — check before building).
+- **The `ThreadBusy` immediate-re-enqueue optimization** in
+  `activate_parked_parent` — R2 already ships the sweep-based heal that parks
+  and re-attends the edge; this debt is re-enqueueing into the now-live
+  parent's queue right away instead of waiting for the next sweep.
+- **`ironclaw subagent edges`** (R4's undelivered piece, §6). Needs
+  composition to grow a narrow read accessor over `AwaitEdgeStore`, itself
+  pinned by the pub-use snapshot, because `crates/app/ironclaw_cli`'s
+  dependency set is pinned exactly by
+  `crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs`
+  and excludes `ironclaw_turn_runner` — the binary enters Reborn only through
+  `ironclaw_composition`, and no CLI subcommand today builds a runtime except
+  `serve`.
+- **The concurrent-running-children cap** at spawn admission (same path as
+  the descendant cap) — open R2 debt (§6 R2 row, §5 D11 correction).
+- Then **R5** (`subagent_inspect` + per-kind config, §6).
+
+Plans are written here, spec-first against Part I, when a slice starts.

--- a/tests/integration/subagent_await_edge.rs
+++ b/tests/integration/subagent_await_edge.rs
@@ -1067,6 +1067,13 @@ impl ProcessDependencyPort for FailOnceDependencies {
     ) -> Result<Vec<ironclaw_processes::ProcessDependencyRecord>, Self::Error> {
         self.inner.unresolved_process_dependencies().await
     }
+
+    async fn scan_unclosed_process_dependencies(
+        &self,
+        request: ironclaw_processes::ScanUnclosedProcessDependenciesRequest,
+    ) -> Result<ironclaw_processes::ScanUnclosedProcessDependenciesResponse, Self::Error> {
+        self.inner.scan_unclosed_process_dependencies(request).await
+    }
 }
 
 #[tokio::test]

--- a/tests/reborn_subagent_spawn_e2e.rs
+++ b/tests/reborn_subagent_spawn_e2e.rs
@@ -21,7 +21,6 @@ use parity_qa_support::model_replay::{
 use reborn_support::{config::WaitConfig, harness::RecordingTestCapabilityPort};
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by clearing runtime disabled_capability_ids"]
 async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -86,7 +85,6 @@ async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
 }
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by clearing runtime disabled_capability_ids"]
 async fn legacy_explicit_blocking_spawn_still_parks_parent_and_resumes() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -144,62 +142,114 @@ async fn legacy_explicit_blocking_spawn_still_parks_parent_and_resumes() {
     harness.shutdown().await;
 }
 
+/// Background spawn (R2) is a `Done`/`ChildSpawned` resolution, not a
+/// suspension: the capability port returns an immediate receipt
+/// ("subagent spawned in background; result will arrive as a tagged input")
+/// and the parent's loop keeps going without ever entering
+/// `TurnStatus::BlockedDependentRun`. This is the first end-to-end proof of
+/// that path — the deny-filter-obsolete predecessor
+/// (`background_spawn_is_rejected_before_child_run_or_auth_invocation`)
+/// asserted the opposite (no child run at all), which was only true while
+/// spawn_subagent was denied outright.
+///
+/// The parent's post-spawn model call and the child's first model call are
+/// genuinely concurrent (background does not park the parent behind the
+/// child), so both scripted continuation steps are pinned to request content
+/// (`ResponseForRequest`) rather than to queue order — `request_contains`
+/// matching is race-proof regardless of which call the runtime issues first.
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by clearing runtime disabled_capability_ids"]
-async fn background_spawn_is_rejected_before_child_run_or_auth_invocation() {
+async fn background_spawn_returns_a_receipt_and_the_parent_continues_without_waiting() {
+    const CHILD_TASK: &str = "quietly note that the background child ran";
+
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
             calls: vec![spawn_call(
-                "spawn_background_disabled",
+                "spawn_background",
                 serde_json::json!({
                     "flavor_id": "general",
-                    "task": "run in the background",
+                    "task": CHILD_TASK,
                     "mode": "background",
                 }),
             )],
             expected_tool_results: Vec::new(),
         },
-        RebornModelReplayStep::Response {
-            response: HostManagedModelResponse::assistant_reply("background spawn rejected"),
+        // The child's own first model call: scripted by content, since it can
+        // race the parent's continuation call below.
+        RebornModelReplayStep::ResponseForRequest {
+            request_contains: CHILD_TASK.to_string(),
+            response: HostManagedModelResponse::assistant_reply("background child output"),
+            expected_tool_results: Vec::new(),
+        },
+        // The parent's very next model call, immediately after the spawn
+        // tool call resolves with the background receipt (not after the
+        // child completes) — pinned on the receipt text so it cannot be
+        // confused with the child's request above.
+        RebornModelReplayStep::ResponseForRequest {
+            request_contains: "subagent spawned in background".to_string(),
+            response: HostManagedModelResponse::assistant_reply("parent proceeded without waiting"),
             expected_tool_results: Vec::new(),
         },
     ]);
-    let mut harness = spawn_harness("room-subagent-background-disabled", model_gateway).await;
+    let mut harness = spawn_harness("room-subagent-background", model_gateway).await;
     harness.start();
 
     let submitted = harness
-        .submit_text(
-            "event-subagent-background-disabled",
-            "try background delegation",
-        )
+        .submit_text("event-subagent-background", "delegate in the background")
         .await
         .expect("submit root turn");
+
+    // The parent must never pass through the blocking-spawn park state.
+    // `wait_for_status_in_scope_with_config` fails fast the moment the run
+    // reaches ANY terminal status other than the one it's waiting for, so if
+    // the parent runs straight to `Completed` (as background spawn requires)
+    // this returns an `Err` deterministically rather than timing out.
+    let park_attempt = harness
+        .wait_for_status(submitted.run_id, TurnStatus::BlockedDependentRun)
+        .await;
+    assert!(
+        park_attempt.is_err(),
+        "background spawn must not park the parent on BlockedDependentRun: {park_attempt:?}"
+    );
+    assert_eq!(
+        harness
+            .run_state(submitted.run_id)
+            .await
+            .expect("parent run state")
+            .status,
+        TurnStatus::Completed,
+        "parent must reach a terminal status without waiting on the child"
+    );
     harness
-        .wait_for_status(submitted.run_id, TurnStatus::Completed)
-        .await
-        .expect("background spawn rejection completes parent turn");
-    harness
-        .assert_final_reply("background spawn rejected")
+        .assert_final_reply("parent proceeded without waiting")
         .await
         .expect("parent final reply");
-    assert!(
-        harness
-            .children_of(&submitted.scope, submitted.run_id)
-            .await
-            .expect("children")
-            .is_empty(),
-        "disabled background spawn must not create a child run"
-    );
-    assert!(
-        harness.capability_invocations().is_empty(),
-        "disabled background spawn must reject before inner authorization invocation"
-    );
+
+    // A genuinely distinct child run exists, spawned before the parent
+    // finished.
+    let child = await_single_child(&harness, &submitted).await;
+    assert_child_thread_invariants(&submitted, &child);
+
+    // The child itself runs its own scripted step to completion.
+    harness
+        .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
+        .await
+        .expect("background child completes on its own schedule");
+
+    // Not asserted here: delivery of the child's result back into the parent
+    // thread. Background delivery lands as a queued `SubagentSettled` input
+    // that only drains on a later wake (a new run start, or an explicit
+    // System-provenance activation — see
+    // `tests/integration/subagent_await_edge.rs`), which this binary-E2E
+    // harness has no deterministic way to trigger: the parent run is already
+    // terminal, and nothing in this harness re-submits or activates it. A
+    // sleep-and-poll for a delivered message would be flaky (the interval is
+    // a real implementation detail, not a contract), so it is left uncovered
+    // here rather than forced.
     harness.assert_model_exhausted();
     harness.shutdown().await;
 }
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by clearing runtime disabled_capability_ids"]
 async fn blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -309,7 +359,6 @@ async fn blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes() 
 }
 
 #[tokio::test]
-#[ignore = "TEMP(disable-spawn-subagents): spawn_subagent temporarily disabled via capability deny filter; re-enable by clearing runtime disabled_capability_ids"]
 async fn parallel_blocking_spawn_resumes_once_after_last_child() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {


### PR DESCRIPTION
## Summary

- **The boot pass finally exists.** Background subagent delivery had three healing triggers designed and two built: delivery at settle time, and a sweep when the parent's thread next starts a run. Neither covers an edge whose thread never runs again — a result durably written into the parent's transcript whose *wake* was refused could sit there indefinitely. This PR builds the third.
- **The reason it was deferred was real, and is now removed.** Nothing could ask "which dependencies anywhere are still unclosed": `ProcessDependencyQuery::scope` is mandatory by design and the production read path is scope-partitioned. `ProcessDependencyPort::scan_unclosed_process_dependencies` adds that primitive — bounded, scope-optional, `group_ref`-prefixed, keyset-paged — **without adding any filesystem enumeration**, by reusing the same unscoped `unresolved` index read two existing methods already perform and filtering in memory. The storage-scan gate stays green.
- **Fairness is part of the design, not a footnote.** The sweep buckets edges by `group_ref` (`bg:{parent_thread_id}` — the parent's backlog) and drains round-robin under a delivery cap, so one parent's backlog cannot consume a pass.
- **The resolver's work is observable for the first time.** `ResolveReport` already existed but was built in one place and dropped by its only caller, while the highest-volume path — the reactive settle observer — discarded every outcome. Lock-free atomic counters now record it, reported at `debug!`.
- **The subagent e2e suite is alive again.** All five tests run; four needed only the `#[ignore]` removed, and the fifth was rewritten because R2 made its premise false.

Roadmap: `docs/internal/reborn/subagent-spawn/README.md` §2.5, §4.2 trigger 3, §6 row R4.

## Change Type

- [x] New feature
- [x] Documentation

## Linked Issue

Related #4474 (background subagent umbrella). Scope is §6 row R4.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -D warnings` on each touched crate (`ironclaw_processes`, `ironclaw_turn_runner`, `ironclaw_composition`, `ironclaw_integration_tests`) — clean
- [x] `cargo build`
- [x] Relevant tests pass — kernel contract suite 84 (6 new); `reborn_process_storage_scan_gate` 7; turn-runner `boot_recovery` 13, `subagent` 91; `ironclaw_composition --test runtime` 16 (2 new); full `ironclaw_architecture_tests` green; the five e2e tests green twice with no flakiness
- [ ] `--features integration`: Not applicable — no database-backed behavior changed; the kernel contract suite already covers both storage legs
- [x] Manual testing: `python3 scripts/ci/check-guidance.py` exit 0
- [ ] `pr-shepherd`: to run after CI

## Test Strategy

User behavior: a background subagent's answer reaches its parent even when the parent's thread never starts another run and the original wake was refused — the case where, before this PR, the result sat in the transcript with nothing obligated to announce it. Operators can also see what the resolver is doing, which was previously invisible.

Risk areas:
- [ ] Model behavior
- [ ] Browser
- [x] Side effect (a deployment-wide periodic task now drives delivery and wakes parents)
- [x] Persistence (a new read path over the process-dependency journal)
- [ ] Security or permissions
- [ ] External provider
- [x] Cross-component behavior (kernel scan → loop sweep → composition task)

Tests added or updated:
- Unit or contract: 6 kernel tests in `process_journal_store_contract.rs` (cross-scope surfacing, scope filter, closed-exclusion, state filter, `group_ref` prefix, deterministic paging); 7 sweep tests in `boot_recovery/tests.rs` (two scopes in one pass, streak-capped left alone, `AttentionScheduled` closed without re-delivery, fairness under budget pressure (pinned with fixed ids so it guards every run, not half of them), report counts including a counted failure, idempotent second pass, multi-page scanning); 2 composition tests (task starts when enabled, not when disabled)
- Reborn integration: Not applicable — the sweep is exercised at crate tier through the same fixtures as the existing per-scope recovery
- Recorded fixture: Not applicable — no model behavior
- Browser E2E: Not applicable
- Backend or runtime: `tests/reborn_subagent_spawn_e2e.rs` — five tests revived, one rewritten
- Live canary: Not applicable

What the tests prove: an unscoped scan surfaces unclosed edges from two different scopes and pages without skipping or repeating a row; the sweep delivers across scopes in one pass, leaves a streak-capped edge's deferral unspent, closes an already-attended edge without delivering twice, and stays fair when one parent's backlog exceeds the budget; the report counts a failed edge rather than swallowing it; and background spawn end-to-end returns a receipt without parking the parent while a real child run exists.

Commands run: `cargo test -p ironclaw_processes --test process_journal_store_contract`; `cargo test -p ironclaw_turn_runner boot_recovery`; `cargo test -p ironclaw_turn_runner subagent`; `cargo test -p ironclaw_composition --test runtime`; `cargo test -p ironclaw_architecture_tests`; `RUST_MIN_STACK=67108864 cargo test -p ironclaw_integration_tests --test reborn_subagent_spawn_e2e -- --test-threads=1` (twice); clippy per crate; `cargo fmt --check`; `python3 scripts/ci/check-guidance.py`.

## Security Impact

The new scan is a read over the process-dependency journal, reusing an index read two methods already perform; it adds no ingress, credential, or approval path. The sweep drives the *existing* delivery path and cannot deliver anything the settle-time path could not: child text is framed before it enters a parent thread, wakes carry `System` provenance, and the autonomous-wake streak cap still applies — a streak-capped edge is deliberately excluded, so a boot pass cannot spend a deferral the cap imposed. Counters record outcomes only.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: none added.
- [x] Untrusted content into prompts: unchanged — the sweep reuses the existing framed-delivery path.
- [x] Hashes: none added.
- [x] New/changed variants: no enum variants added. One new port method, with all three implementors updated (the store and both test doubles).
- [x] `serde(default)` fields: the new request's optionals use the module's existing `skip_serializing_if` convention.
- [x] Bounds: the scan clamps its limit and pages by keyset; the sweep caps delivered edges per pass and round-robins across parents. The one real ceiling — the underlying index read takes no limit, so a page bounds the result but not the I/O — is marked with a `ponytail:` naming the upgrade path, and the sweep requests its whole cap as a single page so a pass costs one read rather than one per page.
- [x] Error classes: unchanged. Sweep failures are counted into `ResolveReport::failed` and logged; one bad edge never fails the pass.
- [x] Names: unchanged trust boundary.

## Database Impact

None. No schema change and no new index — the scan reuses the existing `process_dependency_unresolved_v3` index read.

## Blast Radius

A new deployment-wide task runs at boot and every 5 minutes, reading unclosed dependencies and driving delivery for stranded ones. It is bounded per pass, fair across parents, and disable-able via `SubagentSweepSettings::enabled`. `spawn_subagent` remains deny-filtered in production until R9, so in practice there are no edges for it to find yet — which also means this ships and bakes before it can matter.

## Rollback Plan

Revert the branch, or set `SubagentSweepSettings::enabled = false` to stop the task without reverting. No durable state is written by the new code paths beyond the edge transitions the existing delivery path already performs, so nothing needs unwinding.

## Review Follow-Through

- Still R4's, deliberately not in this PR: the `ironclaw subagent edges` operator command. `crates/app/ironclaw_cli`'s dependency set is pinned exactly by `reborn_dependency_boundaries.rs` and excludes `ironclaw_turn_runner` (which owns `AwaitEdgeStore`), on the stated rule that the binary enters Reborn through `ironclaw_composition` — so it needs a narrow composition accessor (itself snapshot-pinned) and a runtime construction path no subcommand but `serve` has today. Its own slice.
- Remaining R2 debt: the `ThreadBusy` immediate re-enqueue in `activate_parked_parent`.
- Recorded on #8061 (still open): the tree-wide descendant cap surfaces as a run-ending host error rather than a model-visible refusal, unlike the three caps beside it. Both branches touch §9 of the design doc, so whichever merges second wants a small reconciliation there.

---

**Review track**: C (kernel read path + a new background worker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
