### PR TITLE
fix(webui): keep the active slash command visible

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/chat-input.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/chat-input.tsx
@@ -27,6 +27,17 @@ import {
   shouldAutoFocusComposer,
 } from "../lib/chat-input-focus";
 
+function keepCommandOptionVisible(listbox, option) {
+  if (!listbox || !option) return;
+  const listboxRect = listbox.getBoundingClientRect();
+  const optionRect = option.getBoundingClientRect();
+  if (optionRect.top < listboxRect.top) {
+    listbox.scrollBy({ top: optionRect.top - listboxRect.top });
+  } else if (optionRect.bottom > listboxRect.bottom) {
+    listbox.scrollBy({ top: optionRect.bottom - listboxRect.bottom });
+  }
+}
+
 export function ChatInput({
   onSend,
   commands = [],
@@ -198,6 +209,7 @@ export function ChatInput({
   // Tracks the token as of the last `handleChange` (or mount), so typing that
   // changes the filtered set can reset the selection — see `handleChange`.
   const commandTokenRef = React.useRef(commandToken);
+  const commandMenuListRef = React.useRef(null);
   const hasCommandInventory = commands.length > 0;
   const hasMenuMatches = menuCommands.length > 0;
   // Broader than "has matches": when commands are available, the popover
@@ -216,6 +228,15 @@ export function ChatInput({
   );
   const activeMenuCommand =
     menuVisible && hasMenuMatches ? menuCommands[activeMenuIndex] : null;
+
+  React.useEffect(() => {
+    const listbox = commandMenuListRef.current;
+    if (!listbox || !activeMenuCommand) return;
+    const option = listbox.querySelector(
+      `#chat-command-option-${activeMenuCommand.name}`,
+    );
+    keepCommandOptionVisible(listbox, option);
+  }, [activeMenuCommand]);
 
   // Shared by every place `text` is set PROGRAMMATICALLY rather than via
   // `handleChange` (draft restore on a thread switch, an explicit
@@ -647,6 +668,7 @@ export function ChatInput({
             </div>
 
             <div
+              ref={commandMenuListRef}
               id="chat-command-menu-listbox"
               role="listbox"
               aria-label={t("chat.commandMenu")}
@@ -680,7 +702,13 @@ export function ChatInput({
                       role="option"
                       aria-selected={isActive}
                       onMouseDown={(e) => e.preventDefault()}
-                      onMouseEnter={() => selectMenuIndex(index)}
+                      onMouseEnter={(event) => {
+                        selectMenuIndex(index);
+                        keepCommandOptionVisible(
+                          commandMenuListRef.current,
+                          event.currentTarget,
+                        );
+                      }}
                       onClick={() => completeMenuCommand(command)}
                       className={[
                         "flex w-full items-start gap-2.5 rounded-lg border-l-2 px-2.5 py-2 text-left",

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/chat-input.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/chat-input.test.ts
@@ -1337,6 +1337,73 @@ test("ChatInput command-menu footer usage hint follows the active row after Arro
   assert.equal(usageAt(tree), MENU_COMMANDS[1].usage);
 });
 
+test("ChatInput keeps the active command-menu option inside the scroll viewport", () => {
+  const { render } = renderChatInputStateful({
+    getDraftByKey: { thread: "/mo" },
+  });
+
+  let tree = render({ draftKey: "thread", commands: MENU_COMMANDS });
+  const listbox = findNode(
+    tree,
+    (node) => node.props?.id === "chat-command-menu-listbox",
+  );
+  const listboxProps = templateProps(listbox);
+  const scrollCalls = [];
+  const options = new Map([
+    ["chat-command-option-model", {
+      getBoundingClientRect: () => ({ top: 20, bottom: 60 }),
+    }],
+    ["chat-command-option-modelinfo", {
+      getBoundingClientRect: () => ({ top: 95, bottom: 135 }),
+    }],
+  ]);
+  listboxProps.ref.current = {
+    getBoundingClientRect: () => ({ top: 20, bottom: 100 }),
+    querySelector: (selector) => options.get(selector.slice(1)) || null,
+    scrollBy: (options) => scrollCalls.push(options),
+  };
+
+  templateProps(findTextarea(tree)).onKeyDown({
+    key: "ArrowDown",
+    preventDefault: () => {},
+  });
+  tree = render({ draftKey: "thread", commands: MENU_COMMANDS });
+
+  assert.equal(extractText(findCommandOption(tree, "modelinfo")).includes("Model info"), true);
+  assert.equal(scrollCalls.length, 1);
+  assert.equal(scrollCalls[0].top, 35);
+});
+
+test("ChatInput scrolls a hovered command-menu option into view", () => {
+  const refs = [];
+  const { tree } = renderChatInput({
+    refs,
+    disabled: false,
+    sendDisabled: false,
+    canCancel: false,
+    draft: "/",
+    commands: MENU_COMMANDS,
+  });
+  const listbox = findNode(
+    tree,
+    (node) => node.props?.id === "chat-command-menu-listbox",
+  );
+  const scrollCalls = [];
+  templateProps(listbox).ref.current = {
+    getBoundingClientRect: () => ({ top: 20, bottom: 100 }),
+    scrollBy: (options) => scrollCalls.push(options),
+  };
+
+  templateProps(findCommandOption(tree, "status")).onMouseEnter({
+    currentTarget: {
+      getBoundingClientRect: () => ({ top: 90, bottom: 130 }),
+    },
+  });
+
+  assert.equal(scrollCalls.length, 1);
+  assert.equal(scrollCalls[0].top, 30);
+});
+
 test("ChatInput command-menu header shows a label and the match count out of the full inventory", () => {
   const { tree } = renderChatInput({
     disabled: false,

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -36,7 +36,7 @@ them in the same commit; re-derive any of them with:
   | wc -l`.
 - Top-level Rust bins: `ls tests/*.rs | wc -l`.
 - E2E files: `ls tests/e2e/scenarios/test_*.py | wc -l`.
-- E2E test *functions* (the §2 "889" figure — every `test_*` function or
+- E2E test *functions* (the §2 "893" figure — every `test_*` function or
   method, top-level or in a class, across all 103 files; this is an exhaustive
   syntactic count, not filtered by active/legacy status):
   ```
@@ -50,7 +50,7 @@ them in the same commit; re-derive any of them with:
   print(n)
   "
   ```
-- E2E collected pytest items (the §6 "1180 top-level tests" figure — pytest's
+- E2E collected pytest items (the §6 "1184 top-level tests" figure — pytest's
   own collection count, which differs from the syntactic function count above
   when a function is parametrized, skipped at collection, or a class groups
   several `test_*` methods under one node): `cd tests/e2e && python3 -m pytest
@@ -102,7 +102,7 @@ assertions) and `tests/e2e/AGENTS.md` (pytest fixtures, Playwright, mock LLM).
 
 Totals: **61** group scenarios · **63** flat integration bins (56 in
 `tests/integration/`, 7 in `tests/integration/auth/`) · **39** top-level Rust bins ·
-**103** Python scenario files (**889** test functions) registered in the active
+**103** Python scenario files (**893** test functions) registered in the active
 Reborn coverage map below. Section 6 separately inventories retained and legacy
 Python scenarios, so its exhaustive totals are intentionally broader.
 
@@ -414,7 +414,7 @@ enums), `trace_format.rs`, `trace_llm_tests.rs`,
 
 ---
 
-## 6. Python E2E scenarios — `tests/e2e/scenarios/` (103 files, 1181 top-level tests)
+## 6. Python E2E scenarios — `tests/e2e/scenarios/` (103 files, 1184 top-level tests)
 
 This is an exhaustive inventory, not a claim that every retained scenario is
 currently executable. Current Reborn coverage starts `ironclaw serve` through the

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -414,7 +414,7 @@ enums), `trace_format.rs`, `trace_llm_tests.rs`,
 
 ---
 
-## 6. Python E2E scenarios — `tests/e2e/scenarios/` (103 files, 1180 top-level tests)
+## 6. Python E2E scenarios — `tests/e2e/scenarios/` (103 files, 1181 top-level tests)
 
 This is an exhaustive inventory, not a claim that every retained scenario is
 currently executable. Current Reborn coverage starts `ironclaw serve` through the
@@ -434,6 +434,7 @@ entries.
 | Reload the page and still see history, tool cards, and in-progress turns | `test_reborn_webui_v2_legacy_sse_history.py` (10), `test_reborn_webui_v2_legacy_message_persistence.py`, `test_message_persistence.py` (10) |
 | Type a draft while a run is processing | `test_reborn_webui_v2_smoke.py::test_reborn_v2_composer_accepts_draft_while_run_is_processing` |
 | Click "+ New" or open a thread and start typing immediately — focus lands in the composer without a second click | `test_reborn_webui_v2_smoke.py::test_reborn_v2_composer_takes_focus_from_sidebar_navigation` |
+| Navigate a long slash-command menu without losing the active option below the scroll viewport | `test_reborn_webui_v2_smoke.py::test_reborn_v2_command_menu_keeps_keyboard_selection_visible` |
 | Start a new chat while a run is active (the #5256 deadlock regression) | `test_reborn_webui_v2_smoke.py` |
 | Page through older messages/threads without losing scroll position | `test_reborn_webui_v2_smoke.py::test_reborn_v2_timeline_pagination`, `…::test_reborn_v2_loading_older_messages_preserves_viewport` |
 | Keep DOM bounded on huge histories, without SSE timer leaks | `test_reborn_webui_v2_legacy_dom_resource_limits.py` (4) |

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -325,6 +325,8 @@ SEL_V2 = {
     "appearance_theme_light": "[data-testid='appearance-theme-light']",
     "appearance_theme_dark": "[data-testid='appearance-theme-dark']",
     "chat_composer":  "[data-testid='chat-composer']",  # message textarea on /chat
+    "command_menu_listbox": "#chat-command-menu-listbox",
+    "command_menu_option": "#chat-command-menu-listbox [role='option']",
     "chat_cancel_run": "[data-testid='chat-cancel-run']",
     "attachment_file_input": "input[type=file][multiple]",
     "typing_indicator": "[data-testid='typing-indicator']",

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -3480,6 +3480,50 @@ async def test_reborn_v2_messages_omit_identity_labels(reborn_v2_page):
     await expect(assistant_bubble).not_to_contain_text("IronClaw")
 
 
+async def test_reborn_v2_command_menu_keeps_keyboard_selection_visible(
+    reborn_v2_page, reborn_v2_server
+):
+    """Keyboard navigation scrolls the active slash command into view."""
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        thread_id = await _create_thread(client, reborn_v2_server)
+
+    await reborn_v2_page.goto(
+        f"{reborn_v2_server}/chat/{thread_id}?token={REBORN_V2_AUTH_TOKEN}"
+    )
+    composer = reborn_v2_page.locator(SEL_V2["chat_composer"])
+    await expect(composer).to_be_visible(timeout=15000)
+    await composer.fill("/")
+
+    listbox = reborn_v2_page.locator(SEL_V2["command_menu_listbox"])
+    options = reborn_v2_page.locator(SEL_V2["command_menu_option"])
+    await expect(listbox).to_be_visible()
+    option_count = await options.count()
+    assert option_count > 5, "the command inventory must overflow the bounded menu"
+
+    for _ in range(option_count - 1):
+        await composer.press("ArrowDown")
+
+    selected = listbox.locator('[role="option"][aria-selected="true"]')
+    await expect(selected).to_have_count(1)
+    metrics = await selected.evaluate(
+        """option => {
+          const listbox = option.closest('[role="listbox"]');
+          const optionRect = option.getBoundingClientRect();
+          const listboxRect = listbox.getBoundingClientRect();
+          return {
+            listboxBottom: listboxRect.bottom,
+            listboxTop: listboxRect.top,
+            optionBottom: optionRect.bottom,
+            optionTop: optionRect.top,
+            scrollTop: listbox.scrollTop,
+          };
+        }"""
+    )
+    assert metrics["scrollTop"] > 0, metrics
+    assert metrics["optionTop"] >= metrics["listboxTop"] - 1, metrics
+    assert metrics["optionBottom"] <= metrics["listboxBottom"] + 1, metrics
+
+
 async def test_reborn_v2_response_links_open_in_new_tab(reborn_v2_page):
     """Links inside an assistant reply open in a new tab."""
     composer = reborn_v2_page.locator(SEL_V2["chat_composer"])


### PR DESCRIPTION
## Summary

- Keep the active slash-command option inside the command menu's scroll viewport during keyboard navigation.
- Scroll partially hidden options into view when they are selected by mouse hover.
- Add regression coverage for keyboard and pointer navigation.
- Add a standalone Chromium E2E regression for the real browser geometry and scrolling behavior.

<img width="874" height="576" alt="iShot_2026-09-04_15 30 05" src="https://github.com/user-attachments/assets/3a83e4a0-fca1-4dec-84b3-dd5b5203b275" />

## Linked Issue

Closes #8063

## Validation

- [x] `corepack pnpm test`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm build`
- [x] `bash scripts/pre-commit-safety.sh`
- [x] `python -m pytest scenarios/test_reborn_webui_v2_smoke.py::test_reborn_v2_command_menu_keeps_keyboard_selection_visible -q`

## Security Impact

No. This only changes client-side command-menu scrolling behavior.

## Database Impact

No schema, migration, or persistence changes.

## Blast Radius

Limited to keyboard and pointer selection inside the WebUI slash-command menu.

## Rollback Plan

Revert this PR to restore the previous command-menu navigation behavior.

---

Review track: standard