### PR TITLE
fix(webui): add dismiss actions to command result cards

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/chat.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/chat.tsx
@@ -136,6 +136,7 @@ export function Chat({
     activeRun,
     send,
     runCommand,
+    dismissCommandResult,
     cancelRun,
     retryMessage,
     approve,
@@ -518,6 +519,7 @@ export function Chat({
             logsPath={logsPath}
             pending={activeThreadIsProcessing}
             commands={chatCommands}
+            onDismissCommandResult={dismissCommandResult}
           >
             {recoveryNotice &&
             (

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.test.ts
@@ -1,5 +1,8 @@
+// @vitest-environment happy-dom
+
 import assert from "node:assert/strict";
-import React from "react";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { test, vi } from "vitest";
 
@@ -15,6 +18,8 @@ vi.mock("../../../design-system/icons", async () => {
 
 vi.mock("../../../lib/toast", () => ({ toast: () => {} }));
 vi.mock("../../../lib/i18n", () => ({ useT: () => (key) => key }));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -53,21 +58,78 @@ test("a success result renders a heading, left-aligned field rows, and readable 
   );
 });
 
-test("a structured command result exposes an accessible dismissal action", async () => {
+test("every visible command-result variant invokes its dismissal callback", async () => {
   const { CommandResult } = await import("./command-result");
-  const html = renderToStaticMarkup(
-    React.createElement(CommandResult, {
+  const cases = [
+    {
+      label: "success card",
       response: {
         command: "status",
         result: { title: "Status", fields: [], lines: [] },
       },
-      onDismiss: () => {},
-    }),
-  );
+    },
+    {
+      label: "live command-list card",
+      response: {
+        command: "",
+        rejection: { kind: "invalid_request", message: "Available commands" },
+      },
+      commands: [
+        { name: "status", title: "Status", description: "d", usage: "/status" },
+      ],
+    },
+    {
+      label: "command-list fallback notice",
+      response: {
+        command: "",
+        rejection: { kind: "invalid_request", message: "Available commands" },
+      },
+      commands: [],
+    },
+    {
+      label: "denial notice",
+      response: {
+        command: "extension_install",
+        rejection: { kind: "access_denied", message: "Admin required" },
+      },
+    },
+  ];
 
-  assert.match(html, /data-testid="command-result-dismiss"/);
-  assert.match(html, /aria-label="common\.dismiss"/);
-  assert.match(html, /data-icon="close"/);
+  for (const testCase of cases) {
+    const onDismiss = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(
+          React.createElement(CommandResult, {
+            response: testCase.response,
+            commands: testCase.commands,
+            onDismiss,
+          }),
+        );
+      });
+      const dismiss = container.querySelector(
+        '[data-testid="command-result-dismiss"]',
+      );
+      assert.ok(dismiss, `${testCase.label} should expose a dismiss button`);
+      assert.equal(dismiss.getAttribute("aria-label"), "common.dismiss");
+      assert.ok(
+        dismiss.querySelector('[data-icon="close"]'),
+        `${testCase.label} should use the close icon`,
+      );
+      dismiss.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      assert.equal(
+        onDismiss.mock.calls.length,
+        1,
+        `${testCase.label} should invoke its callback once`,
+      );
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
+  }
 });
 
 test("a run-id-shaped field value renders monospace, truncatable, with a copy affordance", async () => {

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.test.ts
@@ -53,6 +53,23 @@ test("a success result renders a heading, left-aligned field rows, and readable 
   );
 });
 
+test("a structured command result exposes an accessible dismissal action", async () => {
+  const { CommandResult } = await import("./command-result");
+  const html = renderToStaticMarkup(
+    React.createElement(CommandResult, {
+      response: {
+        command: "status",
+        result: { title: "Status", fields: [], lines: [] },
+      },
+      onDismiss: () => {},
+    }),
+  );
+
+  assert.match(html, /data-testid="command-result-dismiss"/);
+  assert.match(html, /aria-label="common\.dismiss"/);
+  assert.match(html, /data-icon="close"/);
+});
+
 test("a run-id-shaped field value renders monospace, truncatable, with a copy affordance", async () => {
   const { CommandResult } = await import("./command-result");
   const runId = "1b9894d9-3f21-4a10-9abc-def012345678";

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.tsx
@@ -171,7 +171,24 @@ function CommandResultShell({ children }) {
   );
 }
 
-function CommandResultHeader({ title, badge = null }) {
+function CommandResultDismissButton({ onDismiss }) {
+  const t = useT();
+  if (!onDismiss) return null;
+  return (
+    <button
+      type="button"
+      data-testid="command-result-dismiss"
+      onClick={onDismiss}
+      aria-label={t("common.dismiss")}
+      title={t("common.dismiss")}
+      className="v2-button inline-grid h-6 w-6 shrink-0 place-items-center rounded-md text-[var(--v2-text-faint)] hover:bg-[var(--v2-surface-soft)] hover:text-[var(--v2-text-strong)]"
+    >
+      <Icon name="close" className="h-3.5 w-3.5" />
+    </button>
+  );
+}
+
+function CommandResultHeader({ title, badge = null, onDismiss }) {
   return (
     <div className="flex items-center gap-2 border-b border-[var(--v2-panel-border)] px-4 py-2.5">
       <Icon name="terminal" className="h-3.5 w-3.5 shrink-0 text-[var(--v2-text-faint)]" />
@@ -186,14 +203,15 @@ function CommandResultHeader({ title, badge = null }) {
           {badge}
         </span>
       )}
+      <CommandResultDismissButton onDismiss={onDismiss} />
     </div>
   );
 }
 
-function CommandSuccessResult({ result }) {
+function CommandSuccessResult({ result, onDismiss }) {
   return (
     <CommandResultShell>
-      <CommandResultHeader title={result.title} />
+      <CommandResultHeader title={result.title} onDismiss={onDismiss} />
       <ResultFields fields={result.fields} />
       <ResultLines lines={result.lines} />
     </CommandResultShell>
@@ -203,7 +221,7 @@ function CommandSuccessResult({ result }) {
 // Shared shell for both a genuine denial and the "available commands" help
 // text when the inventory hasn't loaded — a calm inline notice (role=status,
 // muted tones), not a card and not the old amber centered blob.
-function CommandNotice({ icon, message, testId }) {
+function CommandNotice({ icon, message, testId, onDismiss }) {
   return (
     <div
       data-testid={testId}
@@ -211,7 +229,8 @@ function CommandNotice({ icon, message, testId }) {
       className="mx-auto flex w-full max-w-lg items-start gap-2.5 rounded-xl border border-[var(--v2-panel-border)] bg-[var(--v2-surface-soft)] px-4 py-3 text-left text-sm leading-6 text-[var(--v2-text-muted)]"
     >
       <Icon name={icon} className="mt-0.5 h-4 w-4 shrink-0 text-[var(--v2-text-faint)]" />
-      <span className="whitespace-pre-wrap break-words">{message}</span>
+      <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">{message}</span>
+      <CommandResultDismissButton onDismiss={onDismiss} />
     </div>
   );
 }
@@ -247,7 +266,7 @@ function CommandListRows({ commands }) {
 // help-text blob. The blob remains the fallback when the inventory hasn't
 // loaded yet (composer mounted before `useChatCommands()` resolved, or the
 // fetch failed) — see useChatCommands.ts.
-function CommandListResult({ rejection, commands }) {
+function CommandListResult({ rejection, commands, onDismiss }) {
   const t = useT();
   if (!commands || commands.length === 0) {
     return (
@@ -255,24 +274,35 @@ function CommandListResult({ rejection, commands }) {
         icon="list"
         message={rejection.message}
         testId="command-result-list-fallback"
+        onDismiss={onDismiss}
       />
     );
   }
   return (
     <CommandResultShell>
-      <CommandResultHeader title={t("chat.commandListTitle")} badge={commands.length} />
+      <CommandResultHeader
+        title={t("chat.commandListTitle")}
+        badge={commands.length}
+        onDismiss={onDismiss}
+      />
       <CommandListRows commands={commands} />
     </CommandResultShell>
   );
 }
 
-export function CommandResult({ response, commands = [] }) {
+export function CommandResult({ response, commands = [], onDismiss = null }) {
   const kind = classifyCommandResponse(response);
   if (kind === COMMAND_RESULT_KIND.SUCCESS) {
-    return <CommandSuccessResult result={response.result} />;
+    return <CommandSuccessResult result={response.result} onDismiss={onDismiss} />;
   }
   if (kind === COMMAND_RESULT_KIND.COMMAND_LIST) {
-    return <CommandListResult rejection={response.rejection} commands={commands} />;
+    return (
+      <CommandListResult
+        rejection={response.rejection}
+        commands={commands}
+        onDismiss={onDismiss}
+      />
+    );
   }
   if (kind === COMMAND_RESULT_KIND.DENIAL) {
     return (
@@ -280,6 +310,7 @@ export function CommandResult({ response, commands = [] }) {
         icon="lock"
         message={response.rejection.message}
         testId="command-result-denial"
+        onDismiss={onDismiss}
       />
     );
   }

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.test.ts
@@ -41,12 +41,20 @@ vi.mock("./tool-activity", async () => {
 vi.mock("./command-result", async () => {
   const { createElement } = await import("react");
   return {
-    CommandResult: ({ response, commands }) =>
-      createElement("div", {
-        "data-testid": "command-result-mock",
-        "data-command": response?.command,
-        "data-commands-count": Array.isArray(commands) ? commands.length : -1,
-      }),
+    CommandResult: ({ response, commands, onDismiss }) =>
+      createElement(
+        "div",
+        {
+          "data-testid": "command-result-mock",
+          "data-command": response?.command,
+          "data-commands-count": Array.isArray(commands) ? commands.length : -1,
+        },
+        createElement(
+          "button",
+          { "data-testid": "command-result-dismiss-mock", onClick: onDismiss },
+          "dismiss",
+        ),
+      ),
   };
 });
 
@@ -256,6 +264,7 @@ test("untagged reasoning in an activity run renders Markdown", async () => {
 
 test("a SYSTEM message carrying a structured command result renders CommandResult, not the legacy markdown notice", async () => {
   const { MessageBubble } = await import("./message-bubble");
+  const onDismissCommandResult = vi.fn();
   const commands = [
     { name: "status", title: "Status", description: "d", usage: "/status" },
   ];
@@ -282,6 +291,7 @@ test("a SYSTEM message carrying a structured command result renders CommandResul
             timestamp: "2026-07-30T00:00:00.000Z",
           },
           commands,
+          onDismissCommandResult,
         }),
       );
     });
@@ -299,6 +309,10 @@ test("a SYSTEM message carrying a structured command result renders CommandResul
       /data-testid="markdown"/,
       "a structured command result must not also render through the legacy markdown notice path",
     );
+    container
+      .querySelector('[data-testid="command-result-dismiss-mock"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    assert.deepEqual(onDismissCommandResult.mock.calls, [["system-command-1"]]);
   } finally {
     act(() => root.unmount());
     container.remove();

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/message-bubble.tsx
@@ -67,6 +67,7 @@ type MessageBubbleProps = {
   // `commandResult` whose rejection is the "available commands" help case;
   // see command-result.tsx.
   commands?: CommandDescriptor[];
+  onDismissCommandResult?: (messageId: string) => void;
 };
 
 function formatTimestamp(value?: string) {
@@ -128,6 +129,7 @@ function MessageBubbleImpl({
   activeRunId,
   regressionArtifactExportEnabled = false,
   commands,
+  onDismissCommandResult,
 }: MessageBubbleProps) {
   const t = useT();
   const { role, content, images, attachments, generatedImages, isOptimistic, status, error, errorKey, toolCalls, timestamp, commandResult } = message;
@@ -276,7 +278,15 @@ function MessageBubbleImpl({
   ) {
     return (
       <React.Suspense fallback={null}>
-        <CommandResult response={commandResult} commands={commands} />
+        <CommandResult
+          response={commandResult}
+          commands={commands}
+          onDismiss={
+            onDismissCommandResult
+              ? () => onDismissCommandResult(message.id)
+              : undefined
+          }
+        />
       </React.Suspense>
     );
   }

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/message-list.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/message-list.tsx
@@ -132,6 +132,7 @@ export function MessageList({
   logsPath,
   pending = false,
   commands,
+  onDismissCommandResult,
   children,
 }) {
   const t = useT();
@@ -415,6 +416,7 @@ export function MessageList({
                     regressionArtifactExportEnabled
                   }
                   commands={commands}
+                  onDismissCommandResult={onDismissCommandResult}
                 />)
         )}
         {children}

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useChat.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useChat.ts
@@ -1183,6 +1183,20 @@ export function useChat(threadId) {
     [threadId, setMessages, seedThreadMessages, t],
   );
 
+  const dismissCommandResult = React.useCallback(
+    (messageId) => {
+      setMessages((previous) =>
+        previous.filter(
+          (message) =>
+            message.id !== messageId ||
+            message.role !== CHAT_MESSAGE_ROLES.SYSTEM ||
+            !message.commandResult,
+        ),
+      );
+    },
+    [setMessages],
+  );
+
   return {
     // v2-native
     messages,
@@ -1198,6 +1212,7 @@ export function useChat(threadId) {
     cooldownSeconds,
     send,
     runCommand,
+    dismissCommandResult,
     resolveGate,
     submitAuthToken,
     startOnboardingOAuth,

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useChat.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/hooks/useChat.ts
@@ -69,6 +69,14 @@ const AUTH_TOKEN_FLOW_TIMEOUT_MS = 30000;
 const AUTH_GATE_CREDENTIAL_STORED_ERROR =
   "credential_stored_gate_resolution_failed";
 const APPROVAL_GATE_PENDING_SEND_ERROR = "approval_gate_pending_send_blocked";
+// Command results and useHistory's in-memory cache share the lifetime of this
+// frontend module. Keep their sequence here rather than inside useChat so a
+// route change/remount cannot reuse a cached result's React key.
+let commandResultSequence = 1;
+
+function nextCommandResultMessageId() {
+  return `system-command-${commandResultSequence++}`;
+}
 
 type ChatSendOptions = {
   threadId?: string | null;
@@ -1137,7 +1145,7 @@ export function useChat(threadId) {
     async (text) => {
       const appendNotice = (content, executedThreadId, meta = {}) => {
         const notice = {
-          id: `system-command-${pendingSeqRef.current++}`,
+          id: nextCommandResultMessageId(),
           role: CHAT_MESSAGE_ROLES.SYSTEM,
           content,
           timestamp: new Date().toISOString(),

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/chat.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/chat.test.ts
@@ -997,6 +997,7 @@ test("Chat threads the server command inventory down to MessageList so a command
     { name: "status", title: "Status", description: "d", usage: "/status" },
     { name: "model", title: "Model", description: "d", usage: "/model" },
   ];
+  const dismissCommandResult = () => {};
   const { tree, components } = renderChat({
     activeThreadId: "thread-1",
     contextOverrides: { useChatCommands: () => commands },
@@ -1019,6 +1020,7 @@ test("Chat threads the server command inventory down to MessageList so a command
       loadMore: () => {},
       setSuggestions: () => {},
       submitAuthToken: async () => {},
+      dismissCommandResult,
     },
   });
 
@@ -1027,6 +1029,11 @@ test("Chat threads the server command inventory down to MessageList so a command
     componentProps(messageList, components.MessageList).commands,
     commands,
     "MessageList should receive the same command inventory the composer uses",
+  );
+  assert.equal(
+    componentProps(messageList, components.MessageList).onDismissCommandResult,
+    dismissCommandResult,
+    "MessageList should receive the command-result dismissal callback",
   );
 });
 

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChat-send.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChat-send.test.ts
@@ -5615,10 +5615,11 @@ function createParallelSendContext({
   isProcessing,
   createdThreadId = "thread-created",
   stateUpdates = [],
+  initialMessages = [],
 }: DynamicTestOptions = {}) {
   let sentBody = null;
   let createThreadCalls = 0;
-  let currentMessages = [];
+  let currentMessages = [...initialMessages];
   const seededByThread = new Map();
   const initialByIndex = new Map();
   // State slot order: cooldownUntil(0), now(1), activeRun(2),
@@ -5697,8 +5698,42 @@ function createParallelSendContext({
     context,
     sentBody: () => sentBody,
     createThreadCalls: () => createThreadCalls,
+    messages: () => currentMessages,
   };
 }
+
+test("useChat.dismissCommandResult removes only the selected ephemeral command result", () => {
+  const durableMessage = {
+    id: "assistant-1",
+    role: CHAT_MESSAGE_ROLES.ASSISTANT,
+    content: "Durable reply",
+  };
+  const firstCommandResult = {
+    id: "system-command-1",
+    role: CHAT_MESSAGE_ROLES.SYSTEM,
+    content: "Status",
+    commandResult: { command: "status", result: { title: "Status" } },
+  };
+  const secondCommandResult = {
+    id: "system-command-2",
+    role: CHAT_MESSAGE_ROLES.SYSTEM,
+    content: "Model",
+    commandResult: { command: "model", result: { title: "Model" } },
+  };
+  const { context, messages } = createParallelSendContext({
+    threadId: "thread-1",
+    initialMessages: [durableMessage, firstCommandResult, secondCommandResult],
+  });
+
+  runUseChatSource(context);
+  const chat = context.globalThis.__testExports.useChat("thread-1");
+  chat.dismissCommandResult("system-command-1");
+
+  assert.deepEqual(
+    messages().map((message) => message.id),
+    ["assistant-1", "system-command-2"],
+  );
+});
 
 test("useChat.send: starts a new chat while another thread's run is active", async () => {
   // Landing screen (no open thread), but a run on `thread-busy` is still

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChat-send.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/useChat-send.test.ts
@@ -5735,6 +5735,32 @@ test("useChat.dismissCommandResult removes only the selected ephemeral command r
   );
 });
 
+test("useChat.runCommand keeps command-result IDs unique across hook remounts", async () => {
+  const { context, messages } = createParallelSendContext({
+    threadId: "thread-1",
+  });
+  context.executeChatCommand = async () => ({
+    command: "status",
+    result: { title: "Status", fields: [], lines: [] },
+  });
+  context.renderCommandResultMarkdown = () => "**Status**";
+
+  runUseChatSource(context);
+  const firstMount = context.globalThis.__testExports.useChat("thread-1");
+  await firstMount.runCommand("/status");
+
+  context.React = createReactStub();
+  const secondMount = context.globalThis.__testExports.useChat("thread-1");
+  await secondMount.runCommand("/status");
+
+  assert.equal(messages().length, 2);
+  assert.notEqual(
+    messages()[0].id,
+    messages()[1].id,
+    "a remounted useChat instance must not reuse a cached command result's React key",
+  );
+});
+
 test("useChat.send: starts a new chat while another thread's run is active", async () => {
   // Landing screen (no open thread), but a run on `thread-busy` is still
   // tracked in activeRun. Starting a brand-new chat must create the thread


### PR DESCRIPTION
## Summary

- Add an accessible dismissal action to success, command-list, fallback, and denial command results.
- Thread the dismissal callback from `Chat` through `MessageList` and `MessageBubble`.
- Remove only the selected ephemeral command-result message while preserving durable chat messages and other command results.
- Add component, callback-plumbing, and hook-level regression coverage.

<img width="860" height="512" alt="iShot_2026-09-04_15 32 23" src="https://github.com/user-attachments/assets/29728935-a017-4170-be91-32db8e23b69d" />


## Linked Issue

Closes #8064

## Validation

- [x] `corepack pnpm test`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm build`
- [x] `bash scripts/pre-commit-safety.sh`

## Security Impact

No. The action only removes a client-local ephemeral command result from the rendered conversation.

## Database Impact

No schema, migration, or durable-message changes.

## Blast Radius

Limited to structured command-result presentation and its client-side message state.

## Rollback Plan

Revert this PR to remove the dismissal controls and restore the previous command-result behavior.

---

Review track: standard