### PR TITLE
fix(webui): align slash-command metadata

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/chat-input.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/chat-input.tsx
@@ -683,7 +683,7 @@ export function ChatInput({
                       onMouseEnter={() => selectMenuIndex(index)}
                       onClick={() => completeMenuCommand(command)}
                       className={[
-                        "flex w-full items-start gap-2.5 rounded-lg border-l-2 px-2.5 py-2 text-left",
+                        "grid w-full grid-cols-1 items-start gap-x-2.5 gap-y-1.5 rounded-lg border-l-2 px-2.5 py-2 text-left sm:grid-cols-[18rem_minmax(0,1fr)]",
                         isActive
                           ? "border-[var(--v2-accent)] bg-[var(--v2-accent-soft)]"
                           : "border-transparent hover:bg-[var(--v2-surface-soft)]",
@@ -691,7 +691,7 @@ export function ChatInput({
                     >
                       <span
                         className={[
-                          "shrink-0 rounded-md border px-1.5 py-0.5 font-mono leading-4 text-[var(--v2-text-strong)]",
+                          "w-fit max-w-full truncate rounded-md border px-1.5 py-0.5 font-mono leading-4 text-[var(--v2-text-strong)]",
                           isActive
                             ? "border-[color-mix(in_srgb,var(--v2-accent)_40%,var(--v2-panel-border))] bg-[var(--v2-surface)]"
                             : "border-[var(--v2-panel-border)] bg-[var(--v2-surface-soft)]",
@@ -699,7 +699,7 @@ export function ChatInput({
                       >
                         /<span className="text-signal">{matchedPrefix}</span>{restOfName}
                       </span>
-                      <span className="flex min-w-0 flex-1 flex-col">
+                      <span className="flex min-w-0 w-full flex-col">
                         <span
                           className={[
                             "truncate text-sm font-medium",

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/chat-input.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/chat-input.tsx
@@ -683,7 +683,7 @@ export function ChatInput({
                       onMouseEnter={() => selectMenuIndex(index)}
                       onClick={() => completeMenuCommand(command)}
                       className={[
-                        "grid w-full grid-cols-1 items-start gap-x-2.5 gap-y-1.5 rounded-lg border-l-2 px-2.5 py-2 text-left sm:grid-cols-[18rem_minmax(0,1fr)]",
+                        "grid w-full grid-cols-1 items-start gap-x-2.5 gap-y-1.5 rounded-lg border-l-2 px-2.5 py-2 text-left lg:grid-cols-[18rem_minmax(0,1fr)]",
                         isActive
                           ? "border-[var(--v2-accent)] bg-[var(--v2-accent-soft)]"
                           : "border-transparent hover:bg-[var(--v2-surface-soft)]",

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/chat-input.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/chat-input.test.ts
@@ -1284,7 +1284,7 @@ test("ChatInput command-menu rows render the title and description", () => {
   assert.ok(rowText.includes(MENU_COMMANDS[0].description));
 });
 
-test("ChatInput command-menu rows use aligned metadata columns and stack on narrow screens", () => {
+test("ChatInput command-menu rows align at wide viewports and stack in sidebar-constrained panes", () => {
   const { tree } = renderChatInput({
     disabled: false,
     sendDisabled: false,
@@ -1297,7 +1297,8 @@ test("ChatInput command-menu rows use aligned metadata columns and stack on narr
   const rowClass = templateProps(modelRow).className;
   assert.match(rowClass, /\bgrid\b/);
   assert.match(rowClass, /\bgrid-cols-1\b/);
-  assert.match(rowClass, /sm:grid-cols-\[18rem_minmax\(0,1fr\)\]/);
+  assert.doesNotMatch(rowClass, /sm:grid-cols-/);
+  assert.match(rowClass, /lg:grid-cols-\[18rem_minmax\(0,1fr\)\]/);
 
   const commandBadge = findNode(
     modelRow,

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/chat-input.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/lib/chat-input.test.ts
@@ -1284,6 +1284,35 @@ test("ChatInput command-menu rows render the title and description", () => {
   assert.ok(rowText.includes(MENU_COMMANDS[0].description));
 });
 
+test("ChatInput command-menu rows use aligned metadata columns and stack on narrow screens", () => {
+  const { tree } = renderChatInput({
+    disabled: false,
+    sendDisabled: false,
+    canCancel: false,
+    draft: "/mo",
+    commands: MENU_COMMANDS,
+  });
+
+  const modelRow = findCommandOption(tree, "model");
+  const rowClass = templateProps(modelRow).className;
+  assert.match(rowClass, /\bgrid\b/);
+  assert.match(rowClass, /\bgrid-cols-1\b/);
+  assert.match(rowClass, /sm:grid-cols-\[18rem_minmax\(0,1fr\)\]/);
+
+  const commandBadge = findNode(
+    modelRow,
+    (node) => {
+      const className = templateProps(node).className;
+      return typeof className === "string" &&
+        className.includes("font-mono") &&
+        className.includes("rounded-md");
+    },
+  );
+  assert.ok(commandBadge, "expected the command badge inside the menu row");
+  assert.match(templateProps(commandBadge).className, /\bw-fit\b/);
+  assert.match(templateProps(commandBadge).className, /\bmax-w-full\b/);
+});
+
 test("ChatInput command-menu footer shows the usage hint for the active row only", () => {
   // The usage hint moved from an inline line inside the active row (which
   // made that one row taller than its neighbors — see the visual-design

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -36,7 +36,7 @@ them in the same commit; re-derive any of them with:
   | wc -l`.
 - Top-level Rust bins: `ls tests/*.rs | wc -l`.
 - E2E files: `ls tests/e2e/scenarios/test_*.py | wc -l`.
-- E2E test *functions* (the §2 "889" figure — every `test_*` function or
+- E2E test *functions* (the §2 "893" figure — every `test_*` function or
   method, top-level or in a class, across all 103 files; this is an exhaustive
   syntactic count, not filtered by active/legacy status):
   ```
@@ -50,7 +50,7 @@ them in the same commit; re-derive any of them with:
   print(n)
   "
   ```
-- E2E collected pytest items (the §6 "1180 top-level tests" figure — pytest's
+- E2E collected pytest items (the §6 "1184 top-level tests" figure — pytest's
   own collection count, which differs from the syntactic function count above
   when a function is parametrized, skipped at collection, or a class groups
   several `test_*` methods under one node): `cd tests/e2e && python3 -m pytest
@@ -102,7 +102,7 @@ assertions) and `tests/e2e/AGENTS.md` (pytest fixtures, Playwright, mock LLM).
 
 Totals: **61** group scenarios · **63** flat integration bins (56 in
 `tests/integration/`, 7 in `tests/integration/auth/`) · **39** top-level Rust bins ·
-**103** Python scenario files (**889** test functions) registered in the active
+**103** Python scenario files (**893** test functions) registered in the active
 Reborn coverage map below. Section 6 separately inventories retained and legacy
 Python scenarios, so its exhaustive totals are intentionally broader.
 
@@ -414,7 +414,7 @@ enums), `trace_format.rs`, `trace_llm_tests.rs`,
 
 ---
 
-## 6. Python E2E scenarios — `tests/e2e/scenarios/` (103 files, 1180 top-level tests)
+## 6. Python E2E scenarios — `tests/e2e/scenarios/` (103 files, 1184 top-level tests)
 
 This is an exhaustive inventory, not a claim that every retained scenario is
 currently executable. Current Reborn coverage starts `ironclaw serve` through the
@@ -434,6 +434,7 @@ entries.
 | Reload the page and still see history, tool cards, and in-progress turns | `test_reborn_webui_v2_legacy_sse_history.py` (10), `test_reborn_webui_v2_legacy_message_persistence.py`, `test_message_persistence.py` (10) |
 | Type a draft while a run is processing | `test_reborn_webui_v2_smoke.py::test_reborn_v2_composer_accepts_draft_while_run_is_processing` |
 | Click "+ New" or open a thread and start typing immediately — focus lands in the composer without a second click | `test_reborn_webui_v2_smoke.py::test_reborn_v2_composer_takes_focus_from_sidebar_navigation` |
+| Read slash-command metadata in a single-column layout when the default sidebar constrains a tablet-width chat pane | `test_reborn_webui_v2_smoke.py::test_reborn_v2_command_menu_stacks_in_sidebar_constrained_viewport` |
 | Start a new chat while a run is active (the #5256 deadlock regression) | `test_reborn_webui_v2_smoke.py` |
 | Page through older messages/threads without losing scroll position | `test_reborn_webui_v2_smoke.py::test_reborn_v2_timeline_pagination`, `…::test_reborn_v2_loading_older_messages_preserves_viewport` |
 | Keep DOM bounded on huge histories, without SSE timer leaks | `test_reborn_webui_v2_legacy_dom_resource_limits.py` (4) |

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -325,6 +325,8 @@ SEL_V2 = {
     "appearance_theme_light": "[data-testid='appearance-theme-light']",
     "appearance_theme_dark": "[data-testid='appearance-theme-dark']",
     "chat_composer":  "[data-testid='chat-composer']",  # message textarea on /chat
+    "command_menu_listbox": "#chat-command-menu-listbox",
+    "command_menu_option": "#chat-command-menu-listbox [role='option']",
     "chat_cancel_run": "[data-testid='chat-cancel-run']",
     "attachment_file_input": "input[type=file][multiple]",
     "typing_indicator": "[data-testid='typing-indicator']",

--- a/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
+++ b/tests/e2e/scenarios/test_reborn_webui_v2_smoke.py
@@ -3480,6 +3480,47 @@ async def test_reborn_v2_messages_omit_identity_labels(reborn_v2_page):
     await expect(assistant_bubble).not_to_contain_text("IronClaw")
 
 
+async def test_reborn_v2_command_menu_stacks_in_sidebar_constrained_viewport(
+    reborn_v2_page, reborn_v2_server
+):
+    """The tablet-width chat pane keeps command metadata in one column."""
+    async with httpx.AsyncClient(headers=reborn_bearer_headers()) as client:
+        thread_id = await _create_thread(client, reborn_v2_server)
+
+    await reborn_v2_page.set_viewport_size({"width": 768, "height": 720})
+    await reborn_v2_page.goto(
+        f"{reborn_v2_server}/chat/{thread_id}?token={REBORN_V2_AUTH_TOKEN}"
+    )
+    composer = reborn_v2_page.locator(SEL_V2["chat_composer"])
+    await expect(composer).to_be_visible(timeout=15000)
+    await composer.fill("/")
+
+    listbox = reborn_v2_page.locator(SEL_V2["command_menu_listbox"])
+    options = reborn_v2_page.locator(SEL_V2["command_menu_option"])
+    await expect(listbox).to_be_visible()
+    assert await options.count() > 5
+    metrics = await options.first.evaluate(
+        """row => {
+          const style = getComputedStyle(row);
+          const command = row.children[0].getBoundingClientRect();
+          const metadata = row.children[1].getBoundingClientRect();
+          return {
+            commandLeft: command.left,
+            commandTop: command.top,
+            metadataLeft: metadata.left,
+            metadataTop: metadata.top,
+            metadataWidth: metadata.width,
+            contentWidth: row.clientWidth
+              - parseFloat(style.paddingLeft)
+              - parseFloat(style.paddingRight),
+          };
+        }"""
+    )
+    assert abs(metrics["commandLeft"] - metrics["metadataLeft"]) <= 1, metrics
+    assert metrics["metadataTop"] > metrics["commandTop"], metrics
+    assert abs(metrics["metadataWidth"] - metrics["contentWidth"]) <= 1, metrics
+
+
 async def test_reborn_v2_response_links_open_in_new_tab(reborn_v2_page):
     """Links inside an assistant reply open in a new tab."""
     composer = reborn_v2_page.locator(SEL_V2["chat_composer"])


### PR DESCRIPTION
## Summary

- Replace variable-width flex rows with a consistent responsive grid in the slash-command menu.
- Align command titles and descriptions to the same desktop column.
- Stack command metadata on narrow screens and safely truncate long command names.
- Add regression coverage for the desktop grid and narrow-screen layout contract.

<img width="888" height="369" alt="image" src="https://github.com/user-attachments/assets/b9999703-4444-4690-8ff6-23668890cc21" />
<img width="411" height="491" alt="image" src="https://github.com/user-attachments/assets/0ee3ef04-a7e5-465f-b7e4-65cba0942380" />



## Linked Issue

Closes #8065

## Validation

- [x] `corepack pnpm test`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm build`
- [x] `bash scripts/pre-commit-safety.sh`

## Security Impact

No. This is a presentation-only change.

## Database Impact

No schema, migration, or persistence changes.

## Blast Radius

Limited to row layout inside the WebUI slash-command menu.

## Rollback Plan

Revert this PR to restore the previous flex-based command-menu rows.

---

Review track: standard