### PR TITLE
fix(webui): preserve command result card height

### DIFF
--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.test.ts
@@ -204,7 +204,15 @@ test("a denial rejection renders as a calm inline notice, not the command-list o
   );
 
   assert.match(html, /data-testid="command-result-denial"/);
-  assert.match(html, /\bshrink-0\b/);
+  const denialNotice = html.match(
+    /<div[^>]*data-testid="command-result-denial"[^>]*>/,
+  )?.[0];
+  assert.ok(denialNotice, "expected the denial notice root");
+  assert.match(
+    denialNotice,
+    /\bshrink-0\b/,
+    "the denial notice root must preserve its intrinsic height",
+  );
   assert.match(html, /role="status"/);
   assert.match(html, /This command requires an admin account\./);
   assert.match(html, /data-icon="lock"/);

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.test.ts
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.test.ts
@@ -51,6 +51,13 @@ test("a success result renders a heading, left-aligned field rows, and readable 
     /text-center/,
     "the redesigned result must not regress to centered prose",
   );
+  const shell = html.match(/<div[^>]*data-testid="command-result"[^>]*>/)?.[0];
+  assert.ok(shell, "expected the command-result shell");
+  assert.match(
+    shell,
+    /\bshrink-0\b/,
+    "command-result cards must preserve their intrinsic height inside the transcript flex column",
+  );
 });
 
 test("a run-id-shaped field value renders monospace, truncatable, with a copy affordance", async () => {
@@ -197,6 +204,7 @@ test("a denial rejection renders as a calm inline notice, not the command-list o
   );
 
   assert.match(html, /data-testid="command-result-denial"/);
+  assert.match(html, /\bshrink-0\b/);
   assert.match(html, /role="status"/);
   assert.match(html, /This command requires an admin account\./);
   assert.match(html, /data-icon="lock"/);

--- a/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.tsx
+++ b/crates/product/ironclaw_webui/frontend/src/pages/chat/components/command-result.tsx
@@ -164,7 +164,7 @@ function CommandResultShell({ children }) {
   return (
     <div
       data-testid="command-result"
-      className="mx-auto w-full max-w-lg overflow-hidden rounded-2xl border border-[var(--v2-panel-border)] bg-[var(--v2-surface)] text-left shadow-[0_20px_45px_-24px_rgba(0,0,0,0.6)]"
+      className="mx-auto w-full max-w-lg shrink-0 overflow-hidden rounded-2xl border border-[var(--v2-panel-border)] bg-[var(--v2-surface)] text-left shadow-[0_20px_45px_-24px_rgba(0,0,0,0.6)]"
     >
       {children}
     </div>
@@ -208,7 +208,7 @@ function CommandNotice({ icon, message, testId }) {
     <div
       data-testid={testId}
       role="status"
-      className="mx-auto flex w-full max-w-lg items-start gap-2.5 rounded-xl border border-[var(--v2-panel-border)] bg-[var(--v2-surface-soft)] px-4 py-3 text-left text-sm leading-6 text-[var(--v2-text-muted)]"
+      className="mx-auto flex w-full max-w-lg shrink-0 items-start gap-2.5 rounded-xl border border-[var(--v2-panel-border)] bg-[var(--v2-surface-soft)] px-4 py-3 text-left text-sm leading-6 text-[var(--v2-text-muted)]"
     >
       <Icon name={icon} className="mt-0.5 h-4 w-4 shrink-0 text-[var(--v2-text-faint)]" />
       <span className="whitespace-pre-wrap break-words">{message}</span>


### PR DESCRIPTION
## Summary

- Prevent structured command-result cards from shrinking inside the transcript flex column.
- Apply the same protection to inline command notices and denial results.
- Keep scrolling on the outer message viewport instead of collapsing accumulated results.
- Add regression coverage for both card and notice variants.

<img width="894" height="708" alt="iShot_2026-09-04_15 36 36" src="https://github.com/user-attachments/assets/1c8fec7e-0acc-4856-b645-069c555e3c9b" />


## Linked Issue

Closes #8066

## Validation

- [x] `corepack pnpm test`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm build`
- [x] `bash scripts/pre-commit-safety.sh`

## Security Impact

No. This only changes client-side layout behavior.

## Database Impact

No schema, migration, or persistence changes.

## Blast Radius

Limited to structured command-result cards and notices in the WebUI transcript.

## Rollback Plan

Revert this PR to restore the previous flex sizing behavior.

---

Review track: standard