### PR TITLE
feat(telegram): register the Bot API command menu at activation

### DIFF
--- a/.claude/skills/reborn-extension-surfaces/SKILL.md
+++ b/.claude/skills/reborn-extension-surfaces/SKILL.md
@@ -124,6 +124,10 @@ Re-verify the module list: `grep -n 'ID,' crates/extensions/ironclaw_extension_s
    not adapter code: the `[channel.ingress.registration]` /
    `[channel.ingress.deregistration]` recipes the host executes (worked
    example: `rg -n "channel.ingress.registration" crates/extensions/packages/telegram/manifest.toml`).
+   Additional activation-time vendor calls (e.g. registering a native command
+   menu) are `[[channel.ingress.activation_calls]]` /
+   `[[channel.ingress.deactivation_calls]]` recipes — never per-vendor host
+   code (worked example: Telegram's `setMyCommands` in the same manifest).
    The binary
    supplies the adapter to composition through the
    `RebornHostBindings::with_channel_extension_bindings` seam

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3795,6 +3795,7 @@ dependencies = [
 name = "ironclaw_architecture_tests"
 version = "0.1.0"
 dependencies = [
+ "ironclaw_assistant",
  "ironclaw_host_api",
  "ironclaw_product_contracts",
  "proc-macro2",

--- a/crates/app/ironclaw_architecture_tests/Cargo.toml
+++ b/crates/app/ironclaw_architecture_tests/Cargo.toml
@@ -19,6 +19,11 @@ ironclaw_host_api = { path = "../../contracts/ironclaw_host_api" }
 # turn-navigation window against the REAL DEFAULT_MAX_RETAINED_RUNS_PER_SESSION
 # rather than a transcribed copy that could drift with it.
 ironclaw_product_contracts = { path = "../../contracts/ironclaw_product_contracts" }
+# Dev-only, same reason: the Telegram command-menu gate compares the manifest's
+# menu entries against the REAL product command registry
+# (`product_command_descriptors()`) so a reworded description in the owner
+# cannot silently strand the vendor-registered copy.
+ironclaw_assistant = { path = "../../product/ironclaw_assistant" }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 syn = { version = "3", features = ["full"] }
 toml = "1.1"

--- a/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
@@ -849,12 +849,15 @@ fn reborn_contracts_crates_carry_a_checked_size_ceiling() {
         // `ReplySinkOutcome::retry_after` and `ReplyPhase::as_str` helpers,
         // were deleted after a workspace-wide consumer sweep. Count read
         // from this test's own failure message.
-        // 12_867 -> 12_878 (2026-09-03, channel command-menu registration):
-        // +11 lines for the `activation_calls`/`deactivation_calls` recipe
-        // lists on `ChannelIngressDescriptor` — declaration only; execution
-        // stays in ironclaw_extension_host's lifecycle. Count read from this
-        // test's own failure message.
-        ("ironclaw_extension_contracts", 12_878),
+        // 12_867 -> 12_930 (2026-09-03/04, channel command-menu registration):
+        // the `activation_calls`/`deactivation_calls` recipe lists on
+        // `ChannelIngressDescriptor`, the per-list cap in
+        // `ChannelDescriptor::validate` (`TooManyIngressVendorCalls`) so a
+        // manifest cannot declare an unbounded activation-time call sequence,
+        // and the cap's inline test. Declaration and shape validation only;
+        // execution stays in ironclaw_extension_host's lifecycle. Count read
+        // from this test's own failure message.
+        ("ironclaw_extension_contracts", 12_930),
         // Raised 17_501 -> 18_570 by #6831 (standardized messaging framework):
         // the growth is the `messaging` vocabulary — the StandardMessagingOp
         // enum, the 12-code error taxonomy, compiled-in canonical schema/prompt

--- a/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_dependency_boundaries.rs
@@ -849,7 +849,12 @@ fn reborn_contracts_crates_carry_a_checked_size_ceiling() {
         // `ReplySinkOutcome::retry_after` and `ReplyPhase::as_str` helpers,
         // were deleted after a workspace-wide consumer sweep. Count read
         // from this test's own failure message.
-        ("ironclaw_extension_contracts", 12_867),
+        // 12_867 -> 12_878 (2026-09-03, channel command-menu registration):
+        // +11 lines for the `activation_calls`/`deactivation_calls` recipe
+        // lists on `ChannelIngressDescriptor` — declaration only; execution
+        // stays in ironclaw_extension_host's lifecycle. Count read from this
+        // test's own failure message.
+        ("ironclaw_extension_contracts", 12_878),
         // Raised 17_501 -> 18_570 by #6831 (standardized messaging framework):
         // the growth is the `messaging` vocabulary — the StandardMessagingOp
         // enum, the 12-code error taxonomy, compiled-in canonical schema/prompt

--- a/crates/app/ironclaw_architecture_tests/tests/telegram_extension_gates.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/telegram_extension_gates.rs
@@ -447,11 +447,14 @@ fn reborn_context_free_of_v1_pairing_routes() {
 
 /// The Bot API command menu (`setMyCommands`, run as a manifest
 /// `activation_calls` recipe) must publish exactly the commands the channel
-/// declares — same names, same order — so the menu can never advertise a
-/// command the admission list would refuse, or hide one it accepts. Telegram's
-/// own grammar (1-32 chars of `a-z0-9_`, description 3-256 chars) is checked
-/// here too, because a violation only surfaces as a runtime activation
-/// failure otherwise.
+/// declares — same names, same order, and the descriptions the product
+/// command registry owns — so the menu can never advertise a command the
+/// admission list would refuse, hide one it accepts, or carry stale copy
+/// after the registry is reworded. Telegram's own grammar (1-32 chars of
+/// `a-z0-9_`, description 1-256 chars) is checked here too, because a
+/// violation only surfaces as a runtime activation failure otherwise. The
+/// clearing half must exist as a `deactivation_calls` recipe, not merely be
+/// allowlisted.
 #[test]
 fn telegram_command_menu_matches_the_declared_channel_commands() {
     let manifest_path = crate_path(
@@ -494,6 +497,8 @@ fn telegram_command_menu_matches_the_declared_channel_commands() {
         menu_names, declared,
         "the command menu must mirror [channel] commands exactly"
     );
+    let registry: Vec<ironclaw_assistant::ProductCommandDescriptor> =
+        ironclaw_assistant::product_command_descriptors().collect();
     for entry in menu {
         let name = entry["command"].as_str().expect("menu command name");
         assert!(
@@ -505,10 +510,33 @@ fn telegram_command_menu_matches_the_declared_channel_commands() {
         );
         let description = entry["description"].as_str().expect("menu description");
         assert!(
-            (3..=256).contains(&description.chars().count()),
+            (1..=256).contains(&description.chars().count()),
             "Bot API description bounds violated for {name:?}"
         );
+        let owner = registry
+            .iter()
+            .find(|descriptor| descriptor.name == name)
+            .unwrap_or_else(|| panic!("menu command /{name} is not in the product registry"));
+        assert_eq!(
+            description, owner.description,
+            "menu description for /{name} must match the product command registry \
+             (crates/product/ironclaw_assistant/src/commands.rs) — reword both together"
+        );
     }
+
+    // The clearing half must EXIST as a recipe; the egress allowlist alone
+    // (checked below) would keep passing after the recipe was deleted.
+    let deactivation_calls = channel["ingress"]["deactivation_calls"]
+        .as_array()
+        .expect("[[channel.ingress.deactivation_calls]] declared");
+    assert!(
+        deactivation_calls.iter().any(|call| {
+            call["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("/deleteMyCommands"))
+        }),
+        "deactivation must clear the command menu with a deleteMyCommands recipe"
+    );
 
     // Both menu calls must be on the egress allowlist, or activation fails
     // closed at resolve_vendor_call_target.

--- a/crates/app/ironclaw_architecture_tests/tests/telegram_extension_gates.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/telegram_extension_gates.rs
@@ -444,3 +444,91 @@ fn reborn_context_free_of_v1_pairing_routes() {
         offenders.join("\n")
     );
 }
+
+/// The Bot API command menu (`setMyCommands`, run as a manifest
+/// `activation_calls` recipe) must publish exactly the commands the channel
+/// declares — same names, same order — so the menu can never advertise a
+/// command the admission list would refuse, or hide one it accepts. Telegram's
+/// own grammar (1-32 chars of `a-z0-9_`, description 3-256 chars) is checked
+/// here too, because a violation only surfaces as a runtime activation
+/// failure otherwise.
+#[test]
+fn telegram_command_menu_matches_the_declared_channel_commands() {
+    let manifest_path = crate_path(
+        &workspace_root(),
+        "crates/extensions/packages/telegram/manifest.toml",
+    );
+    let manifest: toml::Table = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", manifest_path.display()))
+        .parse()
+        .expect("telegram manifest parses as TOML");
+
+    let channel = manifest.get("channel").expect("[channel] section");
+    let declared: Vec<&str> = channel["commands"]
+        .as_array()
+        .expect("[channel] commands list")
+        .iter()
+        .map(|value| value.as_str().expect("command name"))
+        .collect();
+
+    let activation_calls = channel["ingress"]["activation_calls"]
+        .as_array()
+        .expect("[[channel.ingress.activation_calls]] declared");
+    let menu_call = activation_calls
+        .iter()
+        .find(|call| {
+            call["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("/setMyCommands"))
+        })
+        .expect("a setMyCommands activation call");
+    let menu = menu_call["body"]["commands"]
+        .as_array()
+        .expect("setMyCommands body commands");
+
+    let menu_names: Vec<&str> = menu
+        .iter()
+        .map(|entry| entry["command"].as_str().expect("menu command name"))
+        .collect();
+    assert_eq!(
+        menu_names, declared,
+        "the command menu must mirror [channel] commands exactly"
+    );
+    for entry in menu {
+        let name = entry["command"].as_str().expect("menu command name");
+        assert!(
+            (1..=32).contains(&name.chars().count())
+                && name
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+            "Bot API command name grammar violated: {name:?}"
+        );
+        let description = entry["description"].as_str().expect("menu description");
+        assert!(
+            (3..=256).contains(&description.chars().count()),
+            "Bot API description bounds violated for {name:?}"
+        );
+    }
+
+    // Both menu calls must be on the egress allowlist, or activation fails
+    // closed at resolve_vendor_call_target.
+    let egress_paths: Vec<&str> = channel["egress"]
+        .as_array()
+        .expect("[[channel.egress]]")
+        .iter()
+        .flat_map(|target| {
+            target
+                .get("paths")
+                .and_then(toml::Value::as_array)
+                .into_iter()
+                .flatten()
+        })
+        .map(|value| value.as_str().expect("egress path"))
+        .collect();
+    for suffix in ["/setMyCommands", "/deleteMyCommands"] {
+        assert!(
+            egress_paths.iter().any(|path| path.ends_with(suffix)),
+            "egress allowlist must cover {suffix}"
+        );
+    }
+}

--- a/crates/app/ironclaw_composition/tests/first_party_manifest_v3_parity.rs
+++ b/crates/app/ironclaw_composition/tests/first_party_manifest_v3_parity.rs
@@ -898,6 +898,8 @@ fn telegram_v3_declares_only_the_bot_api_and_bounded_file_transfer_paths() {
         [
             "/bot{telegram_bot_token}/setWebhook",
             "/bot{telegram_bot_token}/deleteWebhook",
+            "/bot{telegram_bot_token}/setMyCommands",
+            "/bot{telegram_bot_token}/deleteMyCommands",
             "/bot{telegram_bot_token}/sendMessage",
             "/bot{telegram_bot_token}/deleteMessage",
             "/bot{telegram_bot_token}/setMessageReaction",

--- a/crates/contracts/ironclaw_extension_contracts/src/channel.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/channel.rs
@@ -16,6 +16,8 @@ use ironclaw_host_api::{
 use crate::recipe::{IngressVerificationRecipe, RecipeValidationError};
 
 const MAX_CHANNEL_COMMANDS: usize = 32;
+/// Per-list cap on `[channel.ingress]` `activation_calls`/`deactivation_calls`.
+const MAX_INGRESS_VENDOR_CALLS: usize = 8;
 const MAX_CHANNEL_COMMAND_NAME_BYTES: usize = 64;
 const MAX_CHANNEL_COMMAND_PREFIX_BYTES: usize = 32;
 
@@ -405,6 +407,14 @@ impl ChannelDescriptor {
                     return Err(ChannelDescriptorError::WebhookIngressWithoutRouteSuffix);
                 }
                 _ => {}
+            }
+            // The recipe lists share ONE lifecycle deadline while the host
+            // holds the global lifecycle lock — bound them so a manifest
+            // cannot declare an unbounded activation-time call sequence.
+            if ingress.activation_calls.len() > MAX_INGRESS_VENDOR_CALLS
+                || ingress.deactivation_calls.len() > MAX_INGRESS_VENDOR_CALLS
+            {
+                return Err(ChannelDescriptorError::TooManyIngressVendorCalls);
             }
         }
         for egress in &self.egress {
@@ -841,6 +851,10 @@ pub enum ChannelDescriptorError {
     #[error("egress target `{host}` declares an invalid path or transfer bound")]
     InvalidEgressConstraint { host: String },
     #[error(
+        "channel ingress activation_calls/deactivation_calls must each declare at most 8 recipes"
+    )]
+    TooManyIngressVendorCalls,
+    #[error(
         "authenticated_session ingress mounts no webhook route and must not declare a route_suffix"
     )]
     SessionIngressWithRouteSuffix,
@@ -1176,6 +1190,37 @@ kind = "authenticated_session"
                 channel.validate().unwrap_err(),
                 ChannelDescriptorError::InvalidCommands,
                 "expected invalid commands: {commands}"
+            );
+        }
+    }
+
+    #[test]
+    fn ingress_vendor_call_lists_are_bounded() {
+        let recipe = ChannelVendorCallRecipe {
+            method: ChannelVendorCallMethod::Post,
+            path: "/wire".to_string(),
+            body: None,
+            body_credentials: Vec::new(),
+        };
+        let mut channel: ChannelDescriptor = toml::from_str(documented_channel_toml()).unwrap();
+        let ingress = channel.ingress.as_mut().expect("fixture declares ingress");
+        ingress.activation_calls = vec![recipe.clone(); 8];
+        ingress.deactivation_calls = vec![recipe.clone(); 8];
+        channel.validate().unwrap();
+
+        for oversize in [true, false] {
+            let mut channel: ChannelDescriptor = toml::from_str(documented_channel_toml()).unwrap();
+            let ingress = channel.ingress.as_mut().expect("fixture declares ingress");
+            let list = if oversize {
+                &mut ingress.activation_calls
+            } else {
+                &mut ingress.deactivation_calls
+            };
+            *list = vec![recipe.clone(); 9];
+            assert_eq!(
+                channel.validate().unwrap_err(),
+                ChannelDescriptorError::TooManyIngressVendorCalls,
+                "a ninth recipe must fail validation (activation half: {oversize})"
             );
         }
     }

--- a/crates/contracts/ironclaw_extension_contracts/src/channel.rs
+++ b/crates/contracts/ironclaw_extension_contracts/src/channel.rs
@@ -641,6 +641,16 @@ pub struct ChannelIngressDescriptor {
     /// Idempotent, best-effort vendor-side unwiring run at deactivation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deregistration: Option<ChannelVendorCallRecipe>,
+    /// Additional idempotent vendor-side surface wiring run at activation,
+    /// after `registration` and in declared order — e.g. publishing the
+    /// channel's declared `commands` to the vendor's native command menu.
+    /// Same recipe grammar, same restricted egress, same fail-closed
+    /// activation semantics as `registration`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub activation_calls: Vec<ChannelVendorCallRecipe>,
+    /// Best-effort counterparts run at deactivation, after `deregistration`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deactivation_calls: Vec<ChannelVendorCallRecipe>,
     /// Present for webhook ingress (the mounted route's last path segment);
     /// absent for `authenticated_session` ingress, which mounts no webhook
     /// route. The pairing is enforced by [`ChannelDescriptor::validate`].

--- a/crates/extensions/ironclaw_extension_host/Cargo.toml
+++ b/crates/extensions/ironclaw_extension_host/Cargo.toml
@@ -106,7 +106,7 @@ ironclaw_resources = { path = "../../kernel/ironclaw_resources", features = ["te
 ironclaw_slack_extension = { path = "../packages/slack" }
 http-body-util = "0.1"
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time", "test-util"] }
 tower = { version = "0.5", features = ["util"] }
 # Installs a level-appropriate subscriber so a `tracing` body actually runs
 # under test: `tracing` short-circuits on the null dispatcher, so without one

--- a/crates/extensions/ironclaw_extension_host/src/lifecycle.rs
+++ b/crates/extensions/ironclaw_extension_host/src/lifecycle.rs
@@ -364,12 +364,13 @@ impl ExtensionHost {
         Ok(())
     }
 
-    /// Run one half of the declarative ingress-wiring pair.
+    /// Run one half of the declarative ingress-wiring pair, plus that half's
+    /// additional `activation_calls`/`deactivation_calls` surface recipes.
     ///
-    /// Absence of the section is a no-op, which is what "default no-op" used
-    /// to mean when these were trait methods — minus the trait surface. A
-    /// channel whose events URL is configured in the vendor's own console
-    /// (or which has no webhook at all) simply declares neither.
+    /// Absence of every section is a no-op, which is what "default no-op"
+    /// used to mean when these were trait methods — minus the trait surface.
+    /// A channel whose events URL is configured in the vendor's own console
+    /// (or which has no webhook at all) simply declares none.
     async fn run_ingress_registration(
         &self,
         record: &InstallationRecord,
@@ -381,42 +382,56 @@ impl ExtensionHost {
         let Some(ingress) = channel.ingress.as_ref() else {
             return Ok(());
         };
-        let recipe = match wiring {
-            IngressWiring::Register => ingress.registration.as_ref(),
-            IngressWiring::Deregister => ingress.deregistration.as_ref(),
+        // The ingress-wiring recipe runs first, then the additional surface
+        // calls in declared order (e.g. a command-menu registration).
+        let recipes: Vec<_> = match wiring {
+            IngressWiring::Register => ingress
+                .registration
+                .iter()
+                .chain(ingress.activation_calls.iter())
+                .collect(),
+            IngressWiring::Deregister => ingress
+                .deregistration
+                .iter()
+                .chain(ingress.deactivation_calls.iter())
+                .collect(),
         };
-        let Some(recipe) = recipe else {
+        if recipes.is_empty() {
             return Ok(());
-        };
-        // Resolve by method + path, never list order. A recipe with zero or
-        // multiple matching targets is ambiguous authority and fails closed.
-        let target = crate::channel_vendor_calls::resolve_vendor_call_target(
-            recipe,
-            channel.egress.as_slice(),
-        )
-        .map_err(|error| ChannelWiringError::Failed {
-            reason: error.to_string(),
-        })?;
+        }
         let egress = self.deps.egress.egress_for_channel(
             &record.extension_id,
             &record.installation_id,
             channel.egress.as_slice(),
         );
-        with_deadline(
-            self.deps.hook_deadline,
-            crate::channel_vendor_calls::run_vendor_call(
+        for recipe in recipes {
+            // Resolve by method + path, never list order. A recipe with zero
+            // or multiple matching targets is ambiguous authority and fails
+            // closed.
+            let target = crate::channel_vendor_calls::resolve_vendor_call_target(
                 recipe,
-                &target.host,
-                target.credential_handle.as_ref(),
-                &record.config,
-                egress.as_ref(),
-                wiring.label(),
-            ),
-        )
-        .await
-        .map_err(|error| ChannelWiringError::Failed {
-            reason: error.to_string(),
-        })
+                channel.egress.as_slice(),
+            )
+            .map_err(|error| ChannelWiringError::Failed {
+                reason: error.to_string(),
+            })?;
+            with_deadline(
+                self.deps.hook_deadline,
+                crate::channel_vendor_calls::run_vendor_call(
+                    recipe,
+                    &target.host,
+                    target.credential_handle.as_ref(),
+                    &record.config,
+                    egress.as_ref(),
+                    wiring.label(),
+                ),
+            )
+            .await
+            .map_err(|error| ChannelWiringError::Failed {
+                reason: error.to_string(),
+            })?;
+        }
+        Ok(())
     }
 
     /// Drop an installation record. This is the live removal path: the

--- a/crates/extensions/ironclaw_extension_host/src/lifecycle.rs
+++ b/crates/extensions/ironclaw_extension_host/src/lifecycle.rs
@@ -53,6 +53,29 @@ impl IngressWiring {
     }
 }
 
+/// One wiring half failed. `completed_calls` says whether a vendor-visible
+/// effect already landed before the failure, which is what decides whether
+/// the Register caller must unwind.
+struct WiringHalfFailure {
+    reason: String,
+    completed_calls: usize,
+}
+
+/// Label one vendor call so a persisted `last_error` names WHICH call failed —
+/// with several recipes per half, "ingress registration returned status 400"
+/// alone cannot distinguish the webhook wiring from a later surface call. The
+/// path's last segment is the vendor method name (template text, never a
+/// resolved secret).
+fn vendor_call_label(
+    wiring: IngressWiring,
+    recipe: &ironclaw_extension_contracts::channel::ChannelVendorCallRecipe,
+) -> String {
+    match recipe.path.rsplit('/').next().filter(|s| !s.is_empty()) {
+        Some(segment) => format!("{} ({segment})", wiring.label()),
+        None => wiring.label().to_string(),
+    }
+}
+
 /// Vendor-side ingress-wiring failure, redacted before it reaches a record.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 enum ChannelWiringError {
@@ -376,14 +399,61 @@ impl ExtensionHost {
         record: &InstallationRecord,
         wiring: IngressWiring,
     ) -> Result<(), ChannelWiringError> {
+        match wiring {
+            IngressWiring::Register => match self.run_wiring_half(record, wiring).await {
+                Ok(()) => Ok(()),
+                Err(failure) => {
+                    // A later recipe failed after an earlier one already
+                    // landed a vendor-visible effect (e.g. the webhook is
+                    // registered but activation will not publish): best-effort
+                    // run the Deregister half so the vendor is not left wired
+                    // to an extension that never activated.
+                    if failure.completed_calls > 0
+                        && let Err(unwind) = self
+                            .run_wiring_half(record, IngressWiring::Deregister)
+                            .await
+                    {
+                        tracing::debug!(
+                            extension_id = %record.extension_id,
+                            error = %unwind.reason,
+                            "unwind after failed activation wiring also failed"
+                        );
+                    }
+                    Err(ChannelWiringError::Failed {
+                        reason: failure.reason,
+                    })
+                }
+            },
+            IngressWiring::Deregister => {
+                self.run_wiring_half(record, wiring)
+                    .await
+                    .map_err(|failure| ChannelWiringError::Failed {
+                        reason: failure.reason,
+                    })
+            }
+        }
+    }
+
+    /// Run every recipe of one wiring half in declared order — the wiring
+    /// recipe first, then the additional surface calls.
+    ///
+    /// Failure policy differs per half: Register stops at the first failure
+    /// (the caller aborts activation and unwinds), while Deregister attempts
+    /// every recipe and reports only the first failure, because cleanup of one
+    /// vendor surface must not strand cleanup of the others. One deadline
+    /// bounds the whole half — the recipe list must not multiply the time the
+    /// lifecycle lock is held.
+    async fn run_wiring_half(
+        &self,
+        record: &InstallationRecord,
+        wiring: IngressWiring,
+    ) -> Result<(), WiringHalfFailure> {
         let Some(channel) = record.resolved.channel.as_ref() else {
             return Ok(());
         };
         let Some(ingress) = channel.ingress.as_ref() else {
             return Ok(());
         };
-        // The ingress-wiring recipe runs first, then the additional surface
-        // calls in declared order (e.g. a command-menu registration).
         let recipes: Vec<_> = match wiring {
             IngressWiring::Register => ingress
                 .registration
@@ -399,39 +469,73 @@ impl ExtensionHost {
         if recipes.is_empty() {
             return Ok(());
         }
+        // Resolve EVERY recipe's egress target before running any (by
+        // method + path, never list order; zero or multiple matches is
+        // ambiguous authority and fails closed) — a mis-declared later recipe
+        // must fail the transition before an earlier one reaches the live
+        // vendor.
+        let mut calls = Vec::with_capacity(recipes.len());
+        for recipe in recipes {
+            let target = crate::channel_vendor_calls::resolve_vendor_call_target(
+                recipe,
+                channel.egress.as_slice(),
+            )
+            .map_err(|error| WiringHalfFailure {
+                reason: error.to_string(),
+                completed_calls: 0,
+            })?;
+            calls.push((recipe, target));
+        }
         let egress = self.deps.egress.egress_for_channel(
             &record.extension_id,
             &record.installation_id,
             channel.egress.as_slice(),
         );
-        for recipe in recipes {
-            // Resolve by method + path, never list order. A recipe with zero
-            // or multiple matching targets is ambiguous authority and fails
-            // closed.
-            let target = crate::channel_vendor_calls::resolve_vendor_call_target(
-                recipe,
-                channel.egress.as_slice(),
-            )
-            .map_err(|error| ChannelWiringError::Failed {
-                reason: error.to_string(),
-            })?;
-            with_deadline(
-                self.deps.hook_deadline,
-                crate::channel_vendor_calls::run_vendor_call(
+        let mut completed_calls = 0usize;
+        let mut first_failure: Option<String> = None;
+        let outcome = with_deadline(self.deps.hook_deadline, async {
+            for (recipe, target) in &calls {
+                let label = vendor_call_label(wiring, recipe);
+                let result = crate::channel_vendor_calls::run_vendor_call(
                     recipe,
                     &target.host,
                     target.credential_handle.as_ref(),
                     &record.config,
                     egress.as_ref(),
-                    wiring.label(),
-                ),
-            )
-            .await
-            .map_err(|error| ChannelWiringError::Failed {
-                reason: error.to_string(),
-            })?;
+                    &label,
+                )
+                .await;
+                match result {
+                    Ok(()) => completed_calls += 1,
+                    Err(error) => match wiring {
+                        IngressWiring::Register => return Err(error),
+                        IngressWiring::Deregister => {
+                            tracing::debug!(
+                                extension_id = %record.extension_id,
+                                error = %error,
+                                "best-effort deactivation vendor call failed; continuing"
+                            );
+                            first_failure.get_or_insert(error.to_string());
+                        }
+                    },
+                }
+            }
+            Ok(())
+        })
+        .await;
+        match outcome {
+            Ok(()) => match first_failure {
+                None => Ok(()),
+                Some(reason) => Err(WiringHalfFailure {
+                    reason,
+                    completed_calls,
+                }),
+            },
+            Err(error) => Err(WiringHalfFailure {
+                reason: first_failure.unwrap_or_else(|| error.to_string()),
+                completed_calls,
+            }),
         }
-        Ok(())
     }
 
     /// Drop an installation record. This is the live removal path: the

--- a/crates/extensions/ironclaw_extension_host/src/lifecycle.rs
+++ b/crates/extensions/ironclaw_extension_host/src/lifecycle.rs
@@ -400,37 +400,58 @@ impl ExtensionHost {
         wiring: IngressWiring,
     ) -> Result<(), ChannelWiringError> {
         match wiring {
-            IngressWiring::Register => match self.run_wiring_half(record, wiring).await {
-                Ok(()) => Ok(()),
-                Err(failure) => {
-                    // A later recipe failed after an earlier one already
-                    // landed a vendor-visible effect (e.g. the webhook is
-                    // registered but activation will not publish): best-effort
-                    // run the Deregister half so the vendor is not left wired
-                    // to an extension that never activated.
-                    if failure.completed_calls > 0
-                        && let Err(unwind) = self
-                            .run_wiring_half(record, IngressWiring::Deregister)
-                            .await
-                    {
-                        tracing::debug!(
-                            extension_id = %record.extension_id,
-                            error = %unwind.reason,
-                            "unwind after failed activation wiring also failed"
-                        );
-                    }
-                    Err(ChannelWiringError::Failed {
-                        reason: failure.reason,
-                    })
-                }
-            },
-            IngressWiring::Deregister => {
-                self.run_wiring_half(record, wiring)
+            IngressWiring::Register => {
+                // ONE hook_deadline budgets the whole transition — the wiring
+                // half AND any unwind it triggers — because the caller holds
+                // the global lifecycle lock throughout. A fresh deadline for
+                // the unwind would let one unresponsive vendor double the
+                // lock hold.
+                // tokio's clock, not std's, so paused-time tests measure the
+                // same elapsed time the timeout machinery does.
+                let started = tokio::time::Instant::now();
+                match self
+                    .run_wiring_half(record, wiring, self.deps.hook_deadline)
                     .await
-                    .map_err(|failure| ChannelWiringError::Failed {
-                        reason: failure.reason,
-                    })
+                {
+                    Ok(()) => Ok(()),
+                    Err(failure) => {
+                        // A later recipe failed after an earlier one already
+                        // landed a vendor-visible effect (e.g. the webhook is
+                        // registered but activation will not publish):
+                        // best-effort run the Deregister half so the vendor is
+                        // not left wired to an extension that never activated.
+                        // The unwind gets only the REMAINING budget — after a
+                        // deadline expiry that is zero, and the vendor that
+                        // just hung would hang the unwind too.
+                        let remaining = self.deps.hook_deadline.saturating_sub(started.elapsed());
+                        if failure.completed_calls > 0 && remaining.is_zero() {
+                            tracing::debug!(
+                                extension_id = %record.extension_id,
+                                "no deadline budget left to unwind failed activation wiring"
+                            );
+                        } else if failure.completed_calls > 0
+                            && let Err(unwind) = self
+                                .run_wiring_half(record, IngressWiring::Deregister, remaining)
+                                .await
+                        {
+                            tracing::debug!(
+                                extension_id = %record.extension_id,
+                                error = %unwind.reason,
+                                "unwind after failed activation wiring also failed"
+                            );
+                        }
+                        Err(ChannelWiringError::Failed {
+                            reason: failure.reason,
+                        })
+                    }
+                }
             }
+            IngressWiring::Deregister => self
+                .run_wiring_half(record, wiring, self.deps.hook_deadline)
+                .await
+                .map_err(|failure| ChannelWiringError::Failed {
+                    reason: failure.reason,
+                }),
         }
     }
 
@@ -447,6 +468,7 @@ impl ExtensionHost {
         &self,
         record: &InstallationRecord,
         wiring: IngressWiring,
+        deadline: Duration,
     ) -> Result<(), WiringHalfFailure> {
         let Some(channel) = record.resolved.channel.as_ref() else {
             return Ok(());
@@ -493,7 +515,7 @@ impl ExtensionHost {
         );
         let mut completed_calls = 0usize;
         let mut first_failure: Option<String> = None;
-        let outcome = with_deadline(self.deps.hook_deadline, async {
+        let outcome = with_deadline(deadline, async {
             for (recipe, target) in &calls {
                 let label = vendor_call_label(wiring, recipe);
                 let result = crate::channel_vendor_calls::run_vendor_call(
@@ -531,8 +553,14 @@ impl ExtensionHost {
                     completed_calls,
                 }),
             },
+            // A deadline expiry must stay visible even when a vendor call
+            // already failed — hiding it makes a timeout look like a plain
+            // vendor error and misdirects the operator.
             Err(error) => Err(WiringHalfFailure {
-                reason: first_failure.unwrap_or_else(|| error.to_string()),
+                reason: match first_failure {
+                    Some(vendor_failure) => format!("{vendor_failure}; then {error}"),
+                    None => error.to_string(),
+                },
                 completed_calls,
             }),
         }

--- a/crates/extensions/ironclaw_extension_host/src/test_support.rs
+++ b/crates/extensions/ironclaw_extension_host/src/test_support.rs
@@ -883,6 +883,7 @@ impl EgressFactory for FakeEgressFactory {
 pub struct RecordingEgressFactory {
     pub requests: Arc<Mutex<Vec<RestrictedEgressRequest>>>,
     status: Arc<AtomicU16>,
+    fail_url: Arc<Mutex<Option<String>>>,
 }
 
 impl RecordingEgressFactory {
@@ -890,6 +891,7 @@ impl RecordingEgressFactory {
         Self {
             requests: Arc::new(Mutex::new(Vec::new())),
             status: Arc::new(AtomicU16::new(200)),
+            fail_url: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -897,6 +899,7 @@ impl RecordingEgressFactory {
         Self {
             requests: Arc::new(Mutex::new(Vec::new())),
             status: Arc::new(AtomicU16::new(500)),
+            fail_url: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -910,6 +913,16 @@ impl RecordingEgressFactory {
     pub fn set_status(&self, status: u16) {
         self.status.store(status, Ordering::SeqCst);
     }
+
+    /// Answer 500 to requests whose URL contains `substring`; every other
+    /// request keeps the default status. Lets a test fail one vendor call in
+    /// a multi-call lifecycle sequence.
+    pub fn fail_requests_matching(&self, substring: &str) {
+        *self
+            .fail_url
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(substring.to_string());
+    }
 }
 
 impl EgressFactory for RecordingEgressFactory {
@@ -922,6 +935,7 @@ impl EgressFactory for RecordingEgressFactory {
         Arc::new(RecordingEgress {
             requests: Arc::clone(&self.requests),
             status: Arc::clone(&self.status),
+            fail_url: Arc::clone(&self.fail_url),
         })
     }
 }
@@ -929,6 +943,7 @@ impl EgressFactory for RecordingEgressFactory {
 struct RecordingEgress {
     requests: Arc<Mutex<Vec<RestrictedEgressRequest>>>,
     status: Arc<AtomicU16>,
+    fail_url: Arc<Mutex<Option<String>>>,
 }
 
 #[async_trait]
@@ -937,13 +952,23 @@ impl RestrictedEgress for RecordingEgress {
         &self,
         request: RestrictedEgressRequest,
     ) -> Result<RestrictedEgressResponse, RestrictedEgressError> {
+        let failed = self
+            .fail_url
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_deref()
+            .is_some_and(|substring| request.url.contains(substring));
         self.requests
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .push(request);
         Ok(RestrictedEgressResponse {
             retry_after: None,
-            status: self.status.load(Ordering::SeqCst),
+            status: if failed {
+                500
+            } else {
+                self.status.load(Ordering::SeqCst)
+            },
             body: b"{\"ok\":true}".to_vec(),
         })
     }

--- a/crates/extensions/ironclaw_extension_host/src/test_support.rs
+++ b/crates/extensions/ironclaw_extension_host/src/test_support.rs
@@ -884,6 +884,7 @@ pub struct RecordingEgressFactory {
     pub requests: Arc<Mutex<Vec<RestrictedEgressRequest>>>,
     status: Arc<AtomicU16>,
     fail_url: Arc<Mutex<Option<String>>>,
+    delay: Arc<Mutex<Option<std::time::Duration>>>,
 }
 
 impl RecordingEgressFactory {
@@ -892,6 +893,7 @@ impl RecordingEgressFactory {
             requests: Arc::new(Mutex::new(Vec::new())),
             status: Arc::new(AtomicU16::new(200)),
             fail_url: Arc::new(Mutex::new(None)),
+            delay: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -900,6 +902,7 @@ impl RecordingEgressFactory {
             requests: Arc::new(Mutex::new(Vec::new())),
             status: Arc::new(AtomicU16::new(500)),
             fail_url: Arc::new(Mutex::new(None)),
+            delay: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -923,6 +926,16 @@ impl RecordingEgressFactory {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(substring.to_string());
     }
+
+    /// Delay every response by `delay` (after recording the request), so a
+    /// test can drive the lifecycle deadline deterministically under
+    /// `start_paused` tokio time.
+    pub fn set_delay(&self, delay: std::time::Duration) {
+        *self
+            .delay
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(delay);
+    }
 }
 
 impl EgressFactory for RecordingEgressFactory {
@@ -936,6 +949,7 @@ impl EgressFactory for RecordingEgressFactory {
             requests: Arc::clone(&self.requests),
             status: Arc::clone(&self.status),
             fail_url: Arc::clone(&self.fail_url),
+            delay: Arc::clone(&self.delay),
         })
     }
 }
@@ -944,6 +958,7 @@ struct RecordingEgress {
     requests: Arc<Mutex<Vec<RestrictedEgressRequest>>>,
     status: Arc<AtomicU16>,
     fail_url: Arc<Mutex<Option<String>>>,
+    delay: Arc<Mutex<Option<std::time::Duration>>>,
 }
 
 #[async_trait]
@@ -958,10 +973,19 @@ impl RestrictedEgress for RecordingEgress {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .as_deref()
             .is_some_and(|substring| request.url.contains(substring));
+        // Record BEFORE any delay: a call the deadline cuts off mid-flight
+        // must still be visible to assertions.
         self.requests
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .push(request);
+        let delay = *self
+            .delay
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(delay) = delay {
+            tokio::time::sleep(delay).await;
+        }
         Ok(RestrictedEgressResponse {
             retry_after: None,
             status: if failed {

--- a/crates/extensions/ironclaw_extension_host/tests/lifecycle_contract.rs
+++ b/crates/extensions/ironclaw_extension_host/tests/lifecycle_contract.rs
@@ -386,6 +386,173 @@ async fn a_channel_without_recipes_makes_no_vendor_call() {
     assert!(egress.requests().is_empty());
 }
 
+/// A channel manifest that declares additional surface recipes beside the
+/// ingress-wiring pair: a vendor command-menu registration at activation and
+/// its best-effort clear at deactivation (the Telegram `setMyCommands` shape).
+const COMMAND_MENU_CHANNEL_MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v3"
+id = "acme-hook"
+name = "Acme Hook"
+version = "0.1.0"
+description = "fixture: a channel with vendor-side command-menu registration"
+trust = "third_party"
+
+[runtime]
+kind = "first_party"
+service = "acme-hook.extension/v1"
+
+[channel]
+id = "messages"
+display_name = "Acme hook"
+conversation_model = "continuous"
+commands = ["status"]
+
+[channel.reply]
+transport = "message"
+
+[channel.delivery]
+transport = "message"
+
+[channel.ingress]
+route_suffix = "events"
+method = "post"
+
+[channel.ingress.verification]
+kind = "shared_secret_header"
+secret_handle = "acme_hook_secret"
+header = "X-Acme-Secret"
+
+[channel.ingress.registration]
+method = "post"
+path = "/bot{acme_hook_token}/setWebhook"
+body = { url = "{acme_webhook_url}" }
+body_credentials = ["acme_hook_secret"]
+
+[channel.ingress.deregistration]
+method = "post"
+path = "/bot{acme_hook_token}/deleteWebhook"
+
+[[channel.ingress.activation_calls]]
+method = "post"
+path = "/bot{acme_hook_token}/setMyCommands"
+body.commands = [ { command = "status", description = "Show status" } ]
+
+[[channel.ingress.deactivation_calls]]
+method = "post"
+path = "/bot{acme_hook_token}/deleteMyCommands"
+
+[admin_configuration]
+group_id = "acme.hook"
+display_name = "Acme Hook channel"
+fields = [
+  { handle = "acme_hook_secret", label = "Shared secret", secret = true },
+  { handle = "acme_hook_token", label = "Bot token", secret = true },
+]
+
+[[channel.egress]]
+scheme = "https"
+host = "api.acme.example"
+methods = ["post"]
+credential_handle = "acme_hook_token"
+injection = { type = "path_placeholder", placeholder = "acme_hook_token" }
+paths = [
+  "/bot{acme_hook_token}/setWebhook",
+  "/bot{acme_hook_token}/deleteWebhook",
+  "/bot{acme_hook_token}/setMyCommands",
+  "/bot{acme_hook_token}/deleteMyCommands",
+]
+body_credentials = [ { handle = "acme_hook_secret", pointer = "/secret_token" } ]
+"#;
+
+#[tokio::test]
+async fn activation_calls_run_after_registration_and_deactivation_calls_after_deregistration() {
+    let egress = Arc::new(RecordingEgressFactory::ok());
+    let h = harness_with_egress(
+        channel_only_bindings(Arc::new(FakeChannelAdapter::default())),
+        Arc::clone(&egress),
+    )
+    .await;
+    let mut record = record(
+        "acme-hook",
+        ironclaw_extension_host::test_support::resolve_manifest_toml(COMMAND_MENU_CHANNEL_MANIFEST),
+    );
+    record.config = webhook_config();
+    h.host.install(record).await.unwrap();
+    h.host.activate("acme-hook").await.unwrap();
+
+    let requests = egress.requests();
+    assert_eq!(
+        requests.len(),
+        2,
+        "activation runs the wiring recipe, then each activation call"
+    );
+    assert!(requests[0].url.ends_with("/setWebhook"));
+    assert!(
+        requests[1]
+            .url
+            .ends_with("/bot{acme_hook_token}/setMyCommands"),
+        "the credential placeholder reaches egress unresolved: {}",
+        requests[1].url
+    );
+    let body: serde_json::Value =
+        serde_json::from_slice(requests[1].body.as_deref().expect("menu body")).expect("json");
+    assert_eq!(
+        body["commands"][0]["command"], "status",
+        "the declared menu entries are sent verbatim"
+    );
+
+    h.host.deactivate("acme-hook").await.unwrap();
+    let requests = egress.requests();
+    assert_eq!(requests.len(), 4);
+    assert!(requests[2].url.ends_with("/deleteWebhook"));
+    assert!(requests[3].url.ends_with("/deleteMyCommands"));
+}
+
+#[tokio::test]
+async fn a_failing_activation_call_aborts_activation() {
+    let egress = Arc::new(RecordingEgressFactory::failing());
+    let h = harness_with_egress(
+        channel_only_bindings(Arc::new(FakeChannelAdapter::default())),
+        Arc::clone(&egress),
+    )
+    .await;
+    // Strip the wiring pair so the command-menu call is the ONLY recipe —
+    // the failure below can then only come from the activation-calls path.
+    let mut manifest =
+        ironclaw_extension_host::test_support::resolve_manifest_toml(COMMAND_MENU_CHANNEL_MANIFEST);
+    let ingress = manifest
+        .channel
+        .as_mut()
+        .expect("channel")
+        .ingress
+        .as_mut()
+        .expect("ingress");
+    ingress.registration = None;
+    ingress.deregistration = None;
+    let mut record = record("acme-hook", manifest);
+    record.config = webhook_config();
+    h.host.install(record).await.unwrap();
+
+    let error = h.host.activate("acme-hook").await.unwrap_err();
+    assert_eq!(
+        egress.requests().len(),
+        1,
+        "the command-menu recipe was attempted"
+    );
+
+    assert!(
+        matches!(error, LifecycleError::ActivationHook { .. }),
+        "{error:?}"
+    );
+    assert!(
+        h.host.snapshot().await.extension("acme-hook").is_none(),
+        "a failed activation call publishes nothing"
+    );
+    let stored = h.store.get("acme-hook").await.unwrap().unwrap();
+    assert_eq!(stored.state, InstallationState::Failed);
+    assert!(stored.last_error.is_some());
+}
+
 // -------------------------------------------------------------------------
 // Happy path activation publishes exactly one generation and resolves tools
 // -------------------------------------------------------------------------

--- a/crates/extensions/ironclaw_extension_host/tests/lifecycle_contract.rs
+++ b/crates/extensions/ironclaw_extension_host/tests/lifecycle_contract.rs
@@ -113,6 +113,14 @@ async fn harness_with_egress(
     bindings: ExtensionBindings,
     egress: Arc<RecordingEgressFactory>,
 ) -> Harness {
+    harness_with_egress_and_deadline(bindings, egress, Duration::from_secs(5)).await
+}
+
+async fn harness_with_egress_and_deadline(
+    bindings: ExtensionBindings,
+    egress: Arc<RecordingEgressFactory>,
+    hook_deadline: Duration,
+) -> Harness {
     let store = Arc::new(RehydratedInstallationRecordStore::default());
     let load_calls = Arc::new(AtomicUsize::new(0));
     let deps = ExtensionHostDeps {
@@ -126,7 +134,7 @@ async fn harness_with_egress(
         egress,
         reserved_capability_ids: Default::default(),
         reserved_ingress_routes: Default::default(),
-        hook_deadline: Duration::from_secs(5),
+        hook_deadline,
         linked_sessions: ironclaw_extension_host::LinkedSessionStore::unavailable(),
         linked_accounts: std::sync::Arc::new(
             ironclaw_extension_host::UnavailableLinkedAccountResolution,
@@ -635,6 +643,52 @@ async fn a_failing_deregistration_still_attempts_the_remaining_deactivation_call
     assert_eq!(
         h.store.get("acme-hook").await.unwrap().unwrap().state,
         InstallationState::Installed
+    );
+}
+
+/// ONE hook_deadline budgets the register half AND its unwind — the caller
+/// holds the global lifecycle lock throughout, so a fresh deadline for the
+/// unwind would let one unresponsive vendor double the lock hold. Paused
+/// tokio time: each vendor call sleeps 80ms against a 100ms budget, so the
+/// second call exhausts it and the unwind must get the zero remainder, not
+/// a new 100ms.
+#[tokio::test(start_paused = true)]
+async fn a_deadline_expiry_shares_its_budget_with_the_unwind() {
+    let egress = Arc::new(RecordingEgressFactory::ok());
+    egress.set_delay(Duration::from_millis(80));
+    let h = harness_with_egress_and_deadline(
+        channel_only_bindings(Arc::new(FakeChannelAdapter::default())),
+        Arc::clone(&egress),
+        Duration::from_millis(100),
+    )
+    .await;
+    let mut record = record(
+        "acme-hook",
+        ironclaw_extension_host::test_support::resolve_manifest_toml(COMMAND_MENU_CHANNEL_MANIFEST),
+    );
+    record.config = webhook_config();
+    h.host.install(record).await.unwrap();
+
+    let error = h.host.activate("acme-hook").await.unwrap_err();
+    assert!(
+        matches!(error, LifecycleError::ActivationHook { .. }),
+        "{error:?}"
+    );
+    let urls: Vec<String> = egress.requests().iter().map(|r| r.url.clone()).collect();
+    assert_eq!(
+        urls.len(),
+        2,
+        "an exhausted budget must not fund unwind calls: {urls:?}"
+    );
+    assert!(urls[1].ends_with("/setMyCommands"));
+    let stored = h.store.get("acme-hook").await.unwrap().unwrap();
+    assert_eq!(stored.state, InstallationState::Failed);
+    assert!(
+        stored
+            .last_error
+            .expect("failure recorded")
+            .contains("deadline"),
+        "the timeout must stay visible in last_error"
     );
 }
 

--- a/crates/extensions/ironclaw_extension_host/tests/lifecycle_contract.rs
+++ b/crates/extensions/ironclaw_extension_host/tests/lifecycle_contract.rs
@@ -553,6 +553,126 @@ async fn a_failing_activation_call_aborts_activation() {
     assert!(stored.last_error.is_some());
 }
 
+/// A later activation call failing after the wiring recipe landed must not
+/// leave the vendor webhook registered against an extension that never
+/// activated: the host best-effort runs the Deregister half before recording
+/// the failure.
+#[tokio::test]
+async fn a_failed_activation_call_unwinds_the_already_registered_webhook() {
+    let egress = Arc::new(RecordingEgressFactory::ok());
+    egress.fail_requests_matching("/setMyCommands");
+    let h = harness_with_egress(
+        channel_only_bindings(Arc::new(FakeChannelAdapter::default())),
+        Arc::clone(&egress),
+    )
+    .await;
+    let mut record = record(
+        "acme-hook",
+        ironclaw_extension_host::test_support::resolve_manifest_toml(COMMAND_MENU_CHANNEL_MANIFEST),
+    );
+    record.config = webhook_config();
+    h.host.install(record).await.unwrap();
+
+    let error = h.host.activate("acme-hook").await.unwrap_err();
+    assert!(
+        matches!(error, LifecycleError::ActivationHook { .. }),
+        "{error:?}"
+    );
+    let urls: Vec<String> = egress.requests().iter().map(|r| r.url.clone()).collect();
+    assert_eq!(
+        urls.len(),
+        4,
+        "wiring, failed call, then the unwind: {urls:?}"
+    );
+    assert!(urls[0].ends_with("/setWebhook"));
+    assert!(urls[1].ends_with("/setMyCommands"));
+    assert!(
+        urls[2].ends_with("/deleteWebhook") && urls[3].ends_with("/deleteMyCommands"),
+        "the registered webhook must be best-effort unwound: {urls:?}"
+    );
+    assert!(h.host.snapshot().await.extension("acme-hook").is_none());
+    let stored = h.store.get("acme-hook").await.unwrap().unwrap();
+    assert_eq!(stored.state, InstallationState::Failed);
+    let last_error = stored.last_error.expect("failure recorded");
+    assert!(
+        last_error.contains("setMyCommands"),
+        "last_error must name WHICH vendor call failed: {last_error}"
+    );
+}
+
+/// Deactivation cleanup is best-effort PER RECIPE: a failing deleteWebhook
+/// must not strand deleteMyCommands, or the vendor command menu outlives the
+/// channel forever (nothing retries after removal).
+#[tokio::test]
+async fn a_failing_deregistration_still_attempts_the_remaining_deactivation_calls() {
+    let egress = Arc::new(RecordingEgressFactory::ok());
+    let h = harness_with_egress(
+        channel_only_bindings(Arc::new(FakeChannelAdapter::default())),
+        Arc::clone(&egress),
+    )
+    .await;
+    let mut record = record(
+        "acme-hook",
+        ironclaw_extension_host::test_support::resolve_manifest_toml(COMMAND_MENU_CHANNEL_MANIFEST),
+    );
+    record.config = webhook_config();
+    h.host.install(record).await.unwrap();
+    h.host.activate("acme-hook").await.unwrap();
+
+    egress.fail_requests_matching("/deleteWebhook");
+    h.host
+        .deactivate("acme-hook")
+        .await
+        .expect("a vendor failure must not block deactivation");
+
+    let urls: Vec<String> = egress.requests().iter().map(|r| r.url.clone()).collect();
+    assert_eq!(urls.len(), 4, "{urls:?}");
+    assert!(urls[2].ends_with("/deleteWebhook"));
+    assert!(
+        urls[3].ends_with("/deleteMyCommands"),
+        "a failed deleteWebhook must not strand the menu cleanup: {urls:?}"
+    );
+    assert_eq!(
+        h.store.get("acme-hook").await.unwrap().unwrap().state,
+        InstallationState::Installed
+    );
+}
+
+/// A mis-declared recipe anywhere in the half fails the transition BEFORE any
+/// call reaches the live vendor — targets resolve as a batch, not lazily.
+#[tokio::test]
+async fn an_unallowlisted_activation_call_fails_before_any_vendor_call_runs() {
+    let egress = Arc::new(RecordingEgressFactory::ok());
+    let h = harness_with_egress(
+        channel_only_bindings(Arc::new(FakeChannelAdapter::default())),
+        Arc::clone(&egress),
+    )
+    .await;
+    let mut manifest =
+        ironclaw_extension_host::test_support::resolve_manifest_toml(COMMAND_MENU_CHANNEL_MANIFEST);
+    let ingress = manifest
+        .channel
+        .as_mut()
+        .expect("channel")
+        .ingress
+        .as_mut()
+        .expect("ingress");
+    ingress.activation_calls[0].path = "/bot{acme_hook_token}/unlisted".to_string();
+    let mut record = record("acme-hook", manifest);
+    record.config = webhook_config();
+    h.host.install(record).await.unwrap();
+
+    let error = h.host.activate("acme-hook").await.unwrap_err();
+    assert!(
+        matches!(error, LifecycleError::ActivationHook { .. }),
+        "{error:?}"
+    );
+    assert!(
+        egress.requests().is_empty(),
+        "no call may reach the vendor when a later recipe cannot resolve"
+    );
+}
+
 // -------------------------------------------------------------------------
 // Happy path activation publishes exactly one generation and resolves tools
 // -------------------------------------------------------------------------

--- a/crates/extensions/packages/telegram/AGENTS.md
+++ b/crates/extensions/packages/telegram/AGENTS.md
@@ -35,8 +35,10 @@
   through one shared send path. The sink's checkpoint
   (`{"terminal_applied", "message_refs"}`, version 1) is what makes a repeated
   terminal reconcile idempotent — never the revision number. Webhook
-  registration/deregistration are manifest recipes executed by the generic
-  host. This is a plain native crate (no WASM target), and there is no
+  registration/deregistration and the Bot API command menu
+  (`setMyCommands`/`deleteMyCommands`, `[[channel.ingress.activation_calls]]`
+  / `[[channel.ingress.deactivation_calls]]`) are manifest recipes executed
+  by the generic host. This is a plain native crate (no WASM target), and there is no
   `ProductAdapter` trait in this codebase.
 - Adapter-specific mapping between Telegram shapes and the shared channel DTOs.
 - Staying free of raw token bytes: hosts run the manifest-declared

--- a/crates/extensions/packages/telegram/manifest.toml
+++ b/crates/extensions/packages/telegram/manifest.toml
@@ -404,6 +404,28 @@ method = "post"
 path = "/bot{telegram_bot_token}/deleteWebhook"
 body = {}
 
+# The chat menu button: publish the declared `[channel] commands` to the Bot
+# API command menu at activation (`setMyCommands` replaces the stored list, so
+# it is idempotent) and clear it best-effort at deactivation. Entries must stay
+# in sync with `[channel] commands`; pinned by
+# `telegram_command_menu_matches_the_declared_channel_commands` in
+# crates/app/ironclaw_architecture_tests/tests/telegram_extension_gates.rs.
+[[channel.ingress.activation_calls]]
+method = "post"
+path = "/bot{telegram_bot_token}/setMyCommands"
+body.commands = [
+  { command = "model", description = "Show or choose your preferred LLM model" },
+  { command = "status", description = "Show what the assistant is doing in this conversation" },
+  { command = "new", description = "Start a fresh conversation without deleting the current one" },
+  { command = "stop", description = "Stop the active run in this conversation" },
+  { command = "interrupt", description = "Interrupt the active run in this conversation" },
+]
+
+[[channel.ingress.deactivation_calls]]
+method = "post"
+path = "/bot{telegram_bot_token}/deleteMyCommands"
+body = {}
+
 [[channel.egress]]
 scheme = "https"
 host = "api.telegram.org"
@@ -412,6 +434,8 @@ credential_handle = "telegram_bot_token"
 paths = [
   "/bot{telegram_bot_token}/setWebhook",
   "/bot{telegram_bot_token}/deleteWebhook",
+  "/bot{telegram_bot_token}/setMyCommands",
+  "/bot{telegram_bot_token}/deleteMyCommands",
   "/bot{telegram_bot_token}/sendMessage",
   "/bot{telegram_bot_token}/deleteMessage",
   "/bot{telegram_bot_token}/setMessageReaction",

--- a/docs/internal/reborn/extension-runtime/overview.md
+++ b/docs/internal/reborn/extension-runtime/overview.md
@@ -530,7 +530,11 @@ attached by composition to the same `surfaces.reply` slot every package-bound
 sink uses. Lifecycle wiring is manifest
 data too: `[channel.ingress.registration]` and `.deregistration` replace the
 old activation/cleanup hooks and run through restricted egress with host-side
-credential injection.
+credential injection. A channel may declare further activation-time vendor
+calls beside the wiring pair — `[[channel.ingress.activation_calls]]`
+(fail-closed, after registration; e.g. Telegram's `setMyCommands` command
+menu) and `[[channel.ingress.deactivation_calls]]` (best-effort per recipe,
+after deregistration) — same recipe grammar, same egress, at most 8 per list.
 
 `receive` returns a **complete** normalized outcome. It may use only the
 manifest-restricted egress provided for this verified installation. Vendor

--- a/tests/integration/extension_delivery.rs
+++ b/tests/integration/extension_delivery.rs
@@ -2254,6 +2254,29 @@ async fn telegram_update_becomes_a_turn_and_a_coordinated_reply_impl(storage: St
         !set_webhook_body.contains("secret_token_handle"),
         "the credential handle name must never reach the vendor; got {set_webhook_body}"
     );
+    // The command-menu activation call crossed the same recorded wire with
+    // the manifest-declared command list (`[[channel.ingress.activation_calls]]`).
+    let set_my_commands = requests
+        .iter()
+        .find(|request| request.url.ends_with("/setMyCommands"))
+        .unwrap_or_else(|| {
+            panic!(
+                "activation must publish the command menu over recorded egress; got {:?}",
+                requests.iter().map(|r| r.url.clone()).collect::<Vec<_>>()
+            )
+        });
+    assert_eq!(
+        set_my_commands.url,
+        format!("https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/setMyCommands"),
+        "the path placeholder must be substituted host-side"
+    );
+    let menu_body = String::from_utf8_lossy(&set_my_commands.body);
+    for command in ["model", "status", "new", "stop", "interrupt"] {
+        assert!(
+            menu_body.contains(&format!("\"command\":\"{command}\"")),
+            "the command menu must carry /{command}; got {menu_body}"
+        );
+    }
     // Redaction: the wire carries the secret by contract, but the
     // model-visible install result must not.
     lifecycle


### PR DESCRIPTION
## Summary

- Telegram's chat menu button (the "hamburger" next to the composer) now lists the channel's declared commands — `/model`, `/status`, `/new`, `/stop`, `/interrupt` — registered via the Bot API's `setMyCommands` at extension activation and cleared best-effort via `deleteMyCommands` at deactivation.
- Contract: `ChannelIngressDescriptor` gains two generic, optional vendor-recipe lists — `activation_calls` (run after `registration`, fail-closed) and `deactivation_calls` (run after `deregistration`, best-effort). Same `ChannelVendorCallRecipe` grammar as the existing webhook wiring; no new execution surface.
- Host: `run_ingress_registration` runs the wiring recipe plus each declared surface call in order, each resolved against the `[[channel.egress]]` allowlist and executed through the same restricted egress with host-side credential injection. The generic lifecycle stays vendor-blind.
- Telegram manifest: `setMyCommands` recipe with the five commands (descriptions copied from the product command registry) + `deleteMyCommands`, and both paths added to the egress allowlist. The bot token stays a `path_placeholder` — token bytes never enter adapter or executor scope.
- The `ironclaw_extension_contracts` size ceiling was raised 12 867 → 12 930 with a dated ledger entry: the two recipe-list fields, the per-list cap in `ChannelDescriptor::validate`, and the cap's test — declaration and shape validation only; execution stays in `ironclaw_extension_host`.

<img width="549" height="310" alt="2026-09-04 09 40 34" src="https://github.com/user-attachments/assets/f9c302ac-e766-4fe1-9188-c117249c3ad8" />



## Change Type

- [x] New feature

## Linked Issue

None (spec breadcrumb: `docs/internal/superpowers/specs/2026-07-29-product-command-train-design.md` flags `setMyCommands` as a cheap follow-up).

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_extension_contracts -p ironclaw_extension_host -p ironclaw_architecture_tests -p ironclaw_integration_tests --all-targets --all-features -- -D warnings`
- [x] `cargo build` (via test builds)
- [x] Relevant tests pass: see Test Strategy
- [ ] `cargo test -p <owning-crate> --features integration` — Not applicable: no database-backed behavior changed
- [ ] Manual testing: not yet run against a live bot; the `getMyCommands` read-back check is described below

## Test Strategy

User behavior: a Telegram user opens the workspace bot's chat and the menu button lists the five supported slash commands with descriptions; after the extension is deactivated the menu is cleared.

Risk areas:
- [x] Side effect
- [x] External provider
- [x] Cross-component behavior

Tests added or updated:
- Unit or contract: `ironclaw_extension_host tests/lifecycle_contract.rs` — ordering + rendered body over recorded egress; fail-closed activation (`Failed`, nothing published); best-effort unwind of an already-registered webhook when a later activation call fails (with `last_error` naming the failing call); a failing `deleteWebhook` still attempting `deleteMyCommands`; an un-allowlisted later recipe failing before ANY call reaches the vendor. Plus the recipe-list cap test in `ironclaw_extension_contracts`.
- Reborn integration: `tests/integration/extension_delivery.rs` (`telegram_update_becomes_a_turn_and_a_coordinated_reply`) — activation seam now also asserts `setMyCommands` crossed the recorded wire with the token substituted host-side and all five commands in the body.
- Recorded fixture: Not applicable: no model behavior changed.
- Browser E2E: Not applicable: no browser surface changed.
- Backend or runtime: Not applicable: no DB/runtime-lane behavior changed.
- Live canary: Not applicable (manual `getMyCommands` read-back documented below).
- Architecture: `telegram_extension_gates.rs::telegram_command_menu_matches_the_declared_channel_commands` (menu entries mirror `[channel] commands` exactly, obey Telegram's name/description grammar, and both calls are egress-allowlisted) and the `first_party_manifest_v3_parity.rs` pinned egress path list (also proves the live manifest parses through the production v3 parser).

What the tests prove: the generic executor runs the new recipes in declared order through the same mediated egress as `setWebhook`; a failing menu registration aborts activation instead of shipping a silently broken menu; the manifest's menu can never drift from the declared command allowlist; and the whole production wiring (real manifest → activation → recorded egress) emits the call with host-side credential substitution.

Commands run:
- `cargo test -p ironclaw_extension_host --features test-support`
- `cargo test -p ironclaw_architecture_tests`
- `cargo test -p ironclaw_composition --test first_party_manifest_v3_parity`
- `cargo test -p ironclaw_integration_tests --test reborn_integration_extension_delivery` (libSQL leg; the Postgres leg needs Docker, unavailable locally)
- `cargo test -p ironclaw_extension_contracts` / `-p ironclaw_extension_registry` / `-p ironclaw_telegram_extension`

Pre-existing failures on the branch base, untouched here: `retired_web_push_spelling_stays_at_zero_occurrences` (introduced by #8038's `api-boundary.test.ts`).

## Security Impact

Two new Bot API endpoints (`setMyCommands`, `deleteMyCommands`) added to Telegram's declared egress allowlist on the existing `api.telegram.org` POST target. Calls run through the same restricted egress with `path_placeholder` credential injection — no new credential exposure, no new ingress, no permission changes. Recipe bodies are static manifest data; placeholders resolve from non-secret config only.

## Reborn Trust-Boundary Checklist

- [x] Public policy/evidence/trust-bearing types: none added; the new fields are manifest descriptor data constructed only by the manifest parser.
- [x] Untrusted content enters prompts only through an envelope/escaping primitive — N/A, nothing model-visible changed.
- [x] Hashes — N/A.
- [x] New/changed variants: none; existing `ChannelWiringError`/`LifecycleError` paths reused. Audited via the lifecycle contract suite.
- [x] `serde(default)` on the two new `Vec` fields fails closed to empty (no calls), preserving every existing manifest and persisted resolved record byte-for-byte (`skip_serializing_if` keeps digests stable).
- [x] Bounds: recipe lists are manifest-authored data executed sequentially under the existing per-call `hook_deadline`.
- [x] Error classes unchanged (`VendorWiring` → `ActivationHook`, fail-closed at activation; logged best-effort at deactivation).
- [x] Naming accurately describes the boundary (generic `activation_calls`, no vendor knowledge in the host).

## Database Impact

None.

## Blast Radius

`ironclaw_extension_contracts` (descriptor shape), `ironclaw_extension_host` (lifecycle vendor-call loop), the Telegram manifest, and three test suites. Channels declaring no new recipes are byte-identical no-ops. The one behavioral edge: a deployment whose egress blocks `setMyCommands` would now fail Telegram activation (fail-closed by design) — the manifest allowlists it, so this only bites if the recipe and allowlist are edited inconsistently, which the new architecture gate pins. When an activation call fails after the webhook registered, the host now best-effort unwinds (runs the deregistration half) before recording `Failed`, so the vendor is not left delivering to an unpublished route.

## Rollback Plan

Revert the commit. **Constraint (found in review, ironloopai + /code-review):** the persisted resolved-manifest record embeds `ChannelIngressDescriptor`, whose pre-PR parser is `#[serde(deny_unknown_fields)]`. Deployments that never (re)install/activate Telegram on the new binary keep byte-identical rows (`skip_serializing_if` omits the empty lists) and roll back cleanly. A deployment where Telegram DID activate post-upgrade has a row carrying the non-empty `activation_calls`/`deactivation_calls` fields, which an older binary rejects while opening the installation store — so roll back such a deployment by removing (or deactivating + reinstalling) the Telegram extension first, or by deleting its manifest row before booting the old binary. This is the standing property of any manifest-vocabulary addition under `deny_unknown_fields` (same class as the `ChannelDescriptor.notifications` field, 2026-08-09); the #5459 precedent (keep the common-case byte shape identical) is followed here. A stale registered command menu after rollback is cleared by hand with `deleteMyCommands` or overwritten by the next activation.

## Review Follow-Through

Review findings from ironloopai, coderabbitai, and an internal /code-review pass were applied in the second commit: per-half failure policy (Register fails fast and best-effort unwinds an already-registered webhook; Deregister is best-effort per recipe), pre-run resolution of every recipe's egress target (fail-before-side-effects), one deadline over the whole wiring half instead of per recipe, a per-list cap (8) in `ChannelDescriptor::validate`, per-call error labels so `last_error` names which vendor call failed, gate fixes (the `deleteMyCommands` recipe's existence is now asserted; the description bound corrected to Telegram's real 1–256), menu descriptions pinned against the REAL `product_command_descriptors()` registry via a dev-only `ironclaw_assistant` import (existing pattern in that crate's Cargo.toml), and docs (extension-runtime overview, reborn-extension-surfaces skill, telegram AGENTS.md).

Deliberately deferred: provider read-back verification of `setMyCommands` (ironloopai) — `run_vendor_call` treats 2xx as success for the pre-existing `setWebhook` path too; adding `getMyCommands` read-back is new evidence machinery best done for both calls together as a follow-up. Slack has no programmatic equivalent (its slash commands live in the out-of-band `app_manifest.json`), so no other channel adopts the new fields yet.

---

**Review track**: B

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D17nRLsrwt6kmfXPtrLFxk
