### PR TITLE
fix(mcp): classify response leak diagnostics

### DIFF
--- a/crates/contracts/ironclaw_host_api/src/http.rs
+++ b/crates/contracts/ironclaw_host_api/src/http.rs
@@ -486,6 +486,13 @@ impl CapabilityHostHttpRequest {
 
 pub const RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED: &str = "response_body_limit_exceeded";
 
+/// Stable wire token emitted by host response sanitization when the leak
+/// detector blocks response headers or body content. Centralized here so MCP
+/// diagnostics can recognize the sentinel without minting a new global
+/// `RuntimeHttpEgressReasonCode` variant; `stable_runtime_reason()` continues
+/// to classify it as `response_error` for non-MCP consumers.
+pub const RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED: &str = "response_leak_blocked";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeHttpEgressReasonCode {
     CredentialUnavailable,

--- a/crates/kernel/ironclaw_host_runtime/src/egress/sanitize.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/egress/sanitize.rs
@@ -1,7 +1,7 @@
 use ironclaw_extension_contracts::hosted_mcp::extract_mcp_auth_metadata_locations;
 use ironclaw_host_api::http::{
-    RuntimeHttpEgressError, RuntimeHttpEgressRequest, is_sensitive_runtime_request_header,
-    is_sensitive_runtime_response_header,
+    RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
+    is_sensitive_runtime_request_header, is_sensitive_runtime_response_header,
 };
 use ironclaw_network::{NetworkHttpResponse, percent_decode_url_component_lossy};
 use ironclaw_safety::{LeakDetector, http_parts_contain_manual_credentials, redact_exact_values};
@@ -166,7 +166,7 @@ pub(super) fn sanitize_runtime_response(
         }
         let cleaned = leak_detector.scan_and_clean(&exact_redacted).map_err(|_| {
             RuntimeHttpEgressError::Response {
-                reason: "response_leak_blocked".to_string(),
+                reason: RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED.to_string(),
                 request_bytes: usage.request_bytes,
                 response_bytes: usage.response_bytes,
             }
@@ -183,7 +183,7 @@ pub(super) fn sanitize_runtime_response(
             let cleaned = leak_detector
                 .scan_and_clean(body_text.as_ref())
                 .map_err(|_| RuntimeHttpEgressError::Response {
-                    reason: "response_leak_blocked".to_string(),
+                    reason: RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED.to_string(),
                     request_bytes: usage.request_bytes,
                     response_bytes: usage.response_bytes,
                 })?;
@@ -197,7 +197,7 @@ pub(super) fn sanitize_runtime_response(
             let exact_body_redacted = exact_redacted.contains("[REDACTED]");
             let cleaned = leak_detector.scan_and_clean(&exact_redacted).map_err(|_| {
                 RuntimeHttpEgressError::Response {
-                    reason: "response_leak_blocked".to_string(),
+                    reason: RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED.to_string(),
                     request_bytes: usage.request_bytes,
                     response_bytes: usage.response_bytes,
                 }

--- a/crates/kernel/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -10,9 +10,10 @@ use ironclaw_host_api::{
     decision::Obligation,
     dispatch::CredentialStageError,
     http::{
-        CapabilityHostHttpRequest, RuntimeCredentialInjection, RuntimeCredentialSource,
-        RuntimeCredentialTarget, RuntimeHttpEgress, RuntimeHttpEgressError,
-        RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, RuntimeHttpSaveTarget,
+        CapabilityHostHttpRequest, RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED,
+        RuntimeCredentialInjection, RuntimeCredentialSource, RuntimeCredentialTarget,
+        RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
+        RuntimeHttpEgressResponse, RuntimeHttpSaveTarget,
     },
     ids::{
         AgentId, CapabilityId, ExtensionId, InvocationId, ProjectId, SecretHandle, TenantId,
@@ -4231,7 +4232,7 @@ async fn host_http_egress_blocks_credential_shaped_response_body() {
     assert!(matches!(
         error,
         ironclaw_host_api::http::RuntimeHttpEgressError::Response { ref reason, .. }
-            if reason == "response_leak_blocked"
+            if reason == RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED
     ));
     assert!(!error.to_string().contains("sk-proj-test"));
     assert_eq!(error.request_bytes(), 5);
@@ -4328,7 +4329,8 @@ async fn credential_exchange_passes_token_body_that_default_execute_blocks() {
     assert!(
         matches!(
             error,
-            RuntimeHttpEgressError::Response { ref reason, .. } if reason == "response_leak_blocked"
+            RuntimeHttpEgressError::Response { ref reason, .. }
+                if reason == RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED
         ),
         "expected response_leak_blocked, got {error:?}"
     );
@@ -4569,7 +4571,7 @@ async fn host_http_egress_blocks_leaky_response_header_values() {
     assert!(matches!(
         error,
         ironclaw_host_api::http::RuntimeHttpEgressError::Response { ref reason, .. }
-            if reason == "response_leak_blocked"
+            if reason == RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED
     ));
 }
 

--- a/crates/lanes/ironclaw_mcp/src/diagnostics.rs
+++ b/crates/lanes/ironclaw_mcp/src/diagnostics.rs
@@ -195,6 +195,8 @@ impl McpResponseErrorCause {
 pub(crate) enum McpEgressCause {
     /// The host runtime egress future panicked.
     RuntimeEgressPanicked,
+    /// The shared host leak detector blocked response headers/body content.
+    ResponseLeakBlocked,
     /// The host runtime egress refused or failed the request, reported as one
     /// of `RuntimeHttpEgressError`'s stable, host-owned reason codes.
     RuntimeEgressFailed(&'static str),
@@ -204,6 +206,7 @@ impl McpEgressCause {
     fn into_reason(self) -> String {
         match self {
             Self::RuntimeEgressPanicked => "runtime_http_egress_panicked".to_string(),
+            Self::ResponseLeakBlocked => "response_leak_blocked".to_string(),
             // Already a closed set of `&'static str` codes owned by
             // `ironclaw_host_api`, but bounded here anyway: the cap is this
             // module's invariant, not the producer's.
@@ -280,6 +283,22 @@ mod tests {
         assert_eq!(
             provider_error_code(McpProviderRejectionCause::ToolRejected).as_str(),
             "mcp_tool_rejected"
+        );
+    }
+
+    #[test]
+    fn egress_causes_map_to_stable_reasons() {
+        assert_eq!(
+            egress_failure(McpEgressCause::RuntimeEgressPanicked),
+            "runtime_http_egress_panicked"
+        );
+        assert_eq!(
+            egress_failure(McpEgressCause::ResponseLeakBlocked),
+            "response_leak_blocked"
+        );
+        assert_eq!(
+            egress_failure(McpEgressCause::RuntimeEgressFailed("response_error")),
+            "response_error"
         );
     }
 }

--- a/crates/lanes/ironclaw_mcp/src/egress.rs
+++ b/crates/lanes/ironclaw_mcp/src/egress.rs
@@ -15,14 +15,16 @@ use futures_util::FutureExt as _;
 use ironclaw_host_api::{
     action::{NetworkMethod, NetworkPolicy},
     http::{
-        CapabilityHostHttpRequest, RuntimeCredentialInjection, RuntimeHttpEgress,
-        RuntimeHttpEgressError, RuntimeHttpEgressResponse,
+        CapabilityHostHttpRequest, RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED,
+        RuntimeCredentialInjection, RuntimeHttpEgress, RuntimeHttpEgressError,
+        RuntimeHttpEgressResponse,
     },
     ids::{CapabilityId, ExtensionId},
     resource::ResourceScope,
     runtime::RuntimeKind,
 };
 use thiserror::Error;
+use tracing::warn;
 
 use crate::contract::McpClientError;
 use crate::diagnostics::{McpEgressCause, egress_failure};
@@ -66,11 +68,24 @@ where
 }
 
 fn mcp_http_error(error: RuntimeHttpEgressError) -> McpHostHttpError {
-    McpHostHttpError::Egress {
-        reason: egress_failure(McpEgressCause::RuntimeEgressFailed(
-            error.stable_runtime_reason(),
-        )),
-    }
+    let runtime_reason = error.stable_runtime_reason();
+    let mcp_cause = match &error {
+        RuntimeHttpEgressError::Response { reason, .. }
+            if reason == RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED =>
+        {
+            McpEgressCause::ResponseLeakBlocked
+        }
+        _ => McpEgressCause::RuntimeEgressFailed(runtime_reason),
+    };
+    let mcp_reason = egress_failure(mcp_cause);
+    warn!(
+        runtime_reason = %runtime_reason,
+        mcp_reason = %mcp_reason,
+        request_bytes = error.request_bytes(),
+        response_bytes = error.response_bytes(),
+        "MCP host HTTP egress failed"
+    );
+    McpHostHttpError::Egress { reason: mcp_reason }
 }
 
 #[async_trait]

--- a/crates/lanes/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/lanes/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -7,9 +7,10 @@ use ironclaw_host_api::{
     action::{NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern},
     host_port::HostPortCatalog,
     http::{
-        CapabilityHostHttpRequest, RuntimeCredentialInjection, RuntimeCredentialSource,
-        RuntimeCredentialTarget, RuntimeHttpEgress, RuntimeHttpEgressError,
-        RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+        CapabilityHostHttpRequest, RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED,
+        RuntimeCredentialInjection, RuntimeCredentialSource, RuntimeCredentialTarget,
+        RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
+        RuntimeHttpEgressResponse,
     },
     ids::{
         CapabilityId, ExtensionId, InvocationId, ProjectId, ResourceReservationId, SecretHandle,
@@ -176,6 +177,59 @@ async fn mcp_host_http_adapter_maps_panicking_runtime_egress_to_sanitized_error(
 
     let rendered = error.to_string();
     assert!(rendered.contains("runtime_http_egress_panicked"));
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn mcp_host_http_adapter_logs_safe_response_leak_diagnostics() {
+    let adapter = McpRuntimeHttpAdapter::new(Arc::new(LeakBlockedRuntimeEgress));
+
+    let error = adapter
+        .request(CapabilityHostHttpRequest {
+            scope: sample_scope(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            method: NetworkMethod::Get,
+            url: "https://mcp.example.test/mcp".to_string(),
+            headers: vec![],
+            body: vec![],
+            network_policy: mcp_http_policy(),
+            credential_injections: vec![],
+            response_body_limit: Some(4096),
+            timeout_ms: Some(1000),
+        })
+        .await
+        .expect_err("response leak blocking must fail closed");
+
+    assert!(error.to_string().contains("response_leak_blocked"));
+    assert!(logs_contain("runtime_reason=response_error"));
+    assert!(logs_contain("mcp_reason=response_leak_blocked"));
+    assert!(logs_contain("request_bytes=74"));
+    assert!(logs_contain("response_bytes=109922"));
+}
+
+#[tokio::test]
+async fn concrete_mcp_http_client_preserves_response_leak_blocked_reason() {
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(LeakBlockedRuntimeEgress)),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+
+    let error = client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "ironclaw"}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .expect_err("response leak blocking must fail the MCP call");
+
+    assert_eq!(error.stable_reason(), "response_leak_blocked");
 }
 
 #[tokio::test]
@@ -2983,6 +3037,23 @@ impl RuntimeHttpEgress for SecretEchoRuntimeEgress {
             reason: "private target 10.0.0.7 denied for sk-test-secret".to_string(),
             request_bytes: 0,
             response_bytes: 0,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct LeakBlockedRuntimeEgress;
+
+#[async_trait::async_trait]
+impl RuntimeHttpEgress for LeakBlockedRuntimeEgress {
+    async fn execute(
+        &self,
+        _request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        Err(RuntimeHttpEgressError::Response {
+            reason: RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED.to_string(),
+            request_bytes: 74,
+            response_bytes: 109_922,
         })
     }
 }


### PR DESCRIPTION
## Summary

Closes #8009.

Fix MCP egress diagnostics so host leak-blocking stays safe while preserving a distinct MCP-visible reason.

This PR does three things:
- centralizes the shared `response_leak_blocked` sentinel in `ironclaw_host_api::http`
- teaches the MCP lane to classify that sentinel as `response_leak_blocked` instead of collapsing it to `response_error`
- adds a structured warn at the MCP host HTTP boundary with only stable reason codes and byte counts

The runtime-facing behavior stays unchanged for non-MCP consumers:
- we do **not** add a new global `RuntimeHttpEgressReasonCode`
- `stable_runtime_reason()` still reports `response_error` for generic host-runtime consumers

`response_leak_blocked` is the only newly specific caller token. Unknown response reasons remain `response_error`, and the raw host reason is never forwarded.

## What changed

### Shared host API
- added `RUNTIME_HTTP_REASON_RESPONSE_LEAK_BLOCKED` next to the existing response-limit sentinel
- replaced host-runtime `sanitize.rs` response leak string literals with the shared constant

### MCP diagnostics
- added `McpEgressCause::ResponseLeakBlocked`
- map the shared sentinel to `response_leak_blocked` in the MCP lane
- keep all other response failures on the existing `stable_runtime_reason()` path

### MCP logging
- emit a structured `tracing::warn!` when host HTTP egress fails
- log only:
  - `runtime_reason`
  - `mcp_reason`
  - `request_bytes`
  - `response_bytes`
- do not log raw remote reason text, response payload, URL, headers, credentials, or private addresses

## Out of scope

- no global `RuntimeHttpEgressReasonCode` expansion
- no raw reason/error propagation or payload logging; unknown response reasons stay closed as `response_error`
- no retry/retryability changes
- no partial-catalog recovery from #8008
- no MCP/JSON-RPC protocol, session, or resource-accounting changes
- no new dependency or Cargo feature

## Tests

Added/updated regression coverage for:
- host-runtime shared sentinel centralization (literal to constant, byte counts and secret redaction retained)
- full MCP caller path (`McpHostHttpClient` -> `McpRuntimeHttpAdapter` -> failing egress -> `McpClientError`) preserving `response_leak_blocked`
- structured safe diagnostics logging for leak-blocked responses, asserting the four safe fields are present and no secret/private-address marker leaks

Red/green evidence:
- the caller-path regression failed on `main` with `left: "response_error"`, `right: "response_leak_blocked"`, and passes after the fix
- the log-field regression failed on `main` (no structured fields, token collapsed) and passes after the fix

Ran:
- `cargo test -p ironclaw_mcp` (37 unit + 49 adapter contract + 6 dispatch integration + 3 module charter)
- `cargo test -p ironclaw_host_runtime --test runtime_http_egress_contract` (83 passed)
- `cargo fmt --all -- --check`

## Review track

The patch changes diagnostics at a trust boundary, but the only `crates/kernel/` touch is a literal-to-constant refactor with no behavior change. Proposing **Track B with Track C-depth evidence** (red/green caller-path test, explicit non-leak assertions, stable-token matrix). Happy to defer to maintainer classification.

## Rollback

Single commit revert; no persisted state, schema, config, or migration involved.
