### PR TITLE
feat(mcp): opt-in SEP-414 caller attribution on outbound hosted-MCP calls

### DIFF
--- a/crates/extensions/ironclaw_extension_host/src/mcp.rs
+++ b/crates/extensions/ironclaw_extension_host/src/mcp.rs
@@ -87,6 +87,17 @@ impl McpHostHttpEgressPlanner for RegistryMcpEgressPlanner {
         }
         let credential_injections =
             self.credential_injections(request.provider, request.capability_id, &endpoint);
+        // Caller attribution is strictly opt-in: only a provider whose
+        // manifest declares `[mcp] attribution = "sep414"` gets the SEP-414
+        // `_meta` block stamped on its tool calls.
+        let sep414_attribution = self
+            .registry
+            .snapshot()
+            .get_extension(request.provider)
+            .is_some_and(|package| {
+                package.manifest.mcp_attribution
+                    == Some(ironclaw_extension_registry::McpAttribution::Sep414)
+            });
         McpHostHttpEgressPlan {
             // Credential-free hosted MCP providers are valid: the manifest may
             // expose a public/unauthenticated server, and host network policy
@@ -100,6 +111,7 @@ impl McpHostHttpEgressPlanner for RegistryMcpEgressPlanner {
             credential_injections,
             response_body_limit: Some(MCP_RESPONSE_BODY_LIMIT),
             timeout_ms: Some(MCP_TIMEOUT_MS),
+            sep414_attribution,
         }
     }
 }
@@ -538,6 +550,7 @@ mod tests {
                         host_apis: Vec::new(),
                         host_api_surfaces: Vec::new(),
                         hooks: Vec::new(),
+                        mcp_attribution: None,
                         capabilities: vec![ironclaw_extension_registry::CapabilityManifest {
                             id: CapabilityId::new(capability_id).unwrap(),
                             description: "Search".to_string(),

--- a/crates/extensions/ironclaw_extension_host/src/recipes.rs
+++ b/crates/extensions/ironclaw_extension_host/src/recipes.rs
@@ -312,6 +312,7 @@ mod tests {
                 ironclaw_extension_contracts::hosted_mcp::HostedMcpAuthSelection::OAuth {
                     client_profile_id: None,
                 },
+            attribution: None,
         });
         let legacy_wire = serde_json::to_value(&manifest).expect("legacy manifest serializes");
         assert!(

--- a/crates/extensions/ironclaw_extension_registry/src/lib.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/lib.rs
@@ -136,6 +136,9 @@ pub struct ExtensionManifest {
     /// capability declarations on demand — see
     /// [`Self::capability_surfaces`].
     pub host_api_surfaces: Vec<CapabilitySurfaceDeclV2>,
+    /// Hosted-MCP caller attribution the provider opted into (v3 `[mcp]
+    /// attribution`); `None` = the host stamps nothing.
+    pub mcp_attribution: Option<McpAttribution>,
     /// Declarative hook entries the extension declared. Structurally
     /// validated by the v2 parser; projected into typed hook entries by the
     /// composition loader. Empty for the common no-hooks case.
@@ -182,6 +185,7 @@ impl TryFrom<ExtensionManifestV2> for ExtensionManifest {
             capabilities: manifest.capabilities,
             host_api_surfaces: manifest.host_api_surfaces,
             hooks: manifest.hooks,
+            mcp_attribution: manifest.mcp_attribution,
         })
     }
 }
@@ -223,6 +227,7 @@ pub use resolved::{
     ResolvedHostApiRef, ResolvedMcpDeclaration, ResolvedSectionSurface,
 };
 pub use v2::{
+    McpAttribution,
     CapabilityDeclV2, CapabilitySurfaceDeclV2, CapabilityVisibility, ExtensionManifestV2,
     ExtensionRuntimeV2, HookSectionEntryV2, HostApiContractRegistry, HostApiId,
     HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,

--- a/crates/extensions/ironclaw_extension_registry/src/lib.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/lib.rs
@@ -227,13 +227,13 @@ pub use resolved::{
     ResolvedHostApiRef, ResolvedMcpDeclaration, ResolvedSectionSurface,
 };
 pub use v2::{
-    McpAttribution,
     CapabilityDeclV2, CapabilitySurfaceDeclV2, CapabilityVisibility, ExtensionManifestV2,
     ExtensionRuntimeV2, HookSectionEntryV2, HostApiContractRegistry, HostApiId,
     HostApiManifestContext, HostApiManifestContract, HostApiManifestProjection,
     HostApiMultiplicity, HostApiRefV2, HostApiSectionError, MANIFEST_SCHEMA_VERSION,
     MAX_HOOK_ENTRY_BYTES, MAX_MANIFEST_BYTES, MAX_MANIFEST_HOOKS, ManifestSectionPath,
-    ManifestSource, ManifestV2Error, RESERVED_HOST_BUNDLED_ID_PREFIX, RESERVED_MCP_ID_PREFIX,
+    ManifestSource, ManifestV2Error, McpAttribution, RESERVED_HOST_BUNDLED_ID_PREFIX,
+    RESERVED_MCP_ID_PREFIX,
 };
 pub use v3::{MANIFEST_SCHEMA_VERSION_V3, ManifestV3Error};
 

--- a/crates/extensions/ironclaw_extension_registry/src/resolved.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/resolved.rs
@@ -143,6 +143,10 @@ pub struct ResolvedMcpDeclaration {
     /// here because their concrete auth recipe remains the authority.
     #[serde(default)]
     pub registration_auth: ironclaw_extension_contracts::hosted_mcp::HostedMcpAuthSelection,
+    /// Opt-in SEP-414 caller attribution (`[mcp] attribution = "sep414"`).
+    /// `None` — the default — keeps today's wire shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribution: Option<crate::McpAttribution>,
 }
 
 /// One vendor the extension authenticates against: the account setup this
@@ -341,6 +345,8 @@ impl ResolvedExtensionManifest {
             capabilities: self.tools.clone(),
             host_api_surfaces,
             hooks: self.hooks.clone(),
+            // v2 manifests have no `[mcp]` section, so no attribution opt-in.
+            mcp_attribution: None,
         })
     }
 }

--- a/crates/extensions/ironclaw_extension_registry/src/resolved.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/resolved.rs
@@ -345,8 +345,13 @@ impl ResolvedExtensionManifest {
             capabilities: self.tools.clone(),
             host_api_surfaces,
             hooks: self.hooks.clone(),
-            // v2 manifests have no `[mcp]` section, so no attribution opt-in.
-            mcp_attribution: None,
+            // Carried from the stored `[mcp] attribution`. A v2 manifest has
+            // no `[mcp]` section and yields `None`; dropping the field
+            // unconditionally would instead lose a v3 provider's opt-in every
+            // time its package is rebuilt from the persisted record, so the
+            // provider silently stops receiving caller attribution after the
+            // first restart.
+            mcp_attribution: self.mcp.as_ref().and_then(|mcp| mcp.attribution),
         })
     }
 }

--- a/crates/extensions/ironclaw_extension_registry/src/v2.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/v2.rs
@@ -685,6 +685,17 @@ impl ExtensionRuntimeV2 {
     }
 }
 
+/// Attribution contract a hosted-MCP provider opted into (v3 `[mcp]
+/// attribution`). Absent for every provider that did not explicitly request
+/// caller attribution — the host stamps nothing for them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum McpAttribution {
+    /// SEP-414 `_meta` block (`io.ironclaw/userId` / `invocationId` /
+    /// optional `threadId`) on outbound `tools/list` + `tools/call`.
+    #[serde(rename = "sep414")]
+    Sep414,
+}
+
 /// Validated v2 manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExtensionManifestV2 {
@@ -736,6 +747,9 @@ pub struct ExtensionManifestV2 {
     /// declare no hooks (the common case). See [`HookSectionEntryV2`] for
     /// the clean-boundary rationale.
     pub hooks: Vec<HookSectionEntryV2>,
+    /// Hosted-MCP caller attribution the provider opted into (v3 `[mcp]
+    /// attribution`); `None` = never stamp.
+    pub mcp_attribution: Option<McpAttribution>,
 }
 
 /// v2 manifest parser/validator errors.
@@ -1125,6 +1139,8 @@ impl ExtensionManifestV2 {
             capabilities: Vec::new(),
             host_api_surfaces: Vec::new(),
             hooks,
+            // v2 manifests predate hosted-MCP attribution — never stamped.
+            mcp_attribution: None,
         })
     }
 }

--- a/crates/extensions/ironclaw_extension_registry/src/v2.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/v2.rs
@@ -688,7 +688,11 @@ impl ExtensionRuntimeV2 {
 /// Attribution contract a hosted-MCP provider opted into (v3 `[mcp]
 /// attribution`). Absent for every provider that did not explicitly request
 /// caller attribution — the host stamps nothing for them.
+// Persisted on `ResolvedExtensionManifest`, so it follows the repo's
+// snake_case convention for stored enums; the current variant keeps its
+// explicit wire name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum McpAttribution {
     /// SEP-414 `_meta` block (`io.ironclaw/userId` / `invocationId` /
     /// optional `threadId`) on outbound `tools/list` + `tools/call`.

--- a/crates/extensions/ironclaw_extension_registry/src/v3.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/v3.rs
@@ -46,6 +46,7 @@ use crate::resolved::{
     PackageRootBinding, ResolvedAuthSurface, ResolvedExtensionManifest, ResolvedMcpDeclaration,
 };
 use crate::v2::{
+    McpAttribution,
     CapabilityDeclV2, CapabilitySurfaceDeclV2, ExtensionManifestV2, ExtensionRuntimeV2,
     MAX_MANIFEST_BYTES, ManifestSource, RawCapabilityV2, RawRuntimeCredentialV2,
     requested_trust_to_descriptor_trust,
@@ -233,10 +234,21 @@ struct RawMcpV3 {
     effects: Vec<EffectKind>,
     #[serde(default)]
     credentials: Vec<RawMcpCredentialV3>,
+    /// Opt-in caller attribution on outbound tools/list + tools/call. Absent
+    /// (the default) means the host stamps nothing for this provider.
+    #[serde(default)]
+    attribution: Option<RawMcpAttributionV3>,
 }
 
 fn default_mcp_permission() -> PermissionMode {
     PermissionMode::Ask
+}
+
+/// Raw `[mcp] attribution` value.
+#[derive(Debug, Clone, Copy, Deserialize)]
+enum RawMcpAttributionV3 {
+    #[serde(rename = "sep414")]
+    Sep414,
 }
 
 #[derive(Debug, Deserialize)]
@@ -600,7 +612,6 @@ pub(crate) fn parse_v3(
         let raw_capability = match (&mcp, &mcp_template_credentials) {
             (Some(mcp), Some(template_credentials)) => {
                 if !tool.credentials.is_empty()
-                    || !tool.effects.is_empty()
                     || tool.resource_profile.is_some()
                     || !tool.network_targets.is_empty()
                     || tool.max_egress_bytes.is_some()
@@ -609,19 +620,47 @@ pub(crate) fn parse_v3(
                     return Err(ManifestV3Error::Invalid {
                         reason: format!(
                             "static tool `{}` on an [mcp] manifest inherits the server \
-                             connection template; remove its credentials, effects, \
+                             connection template; remove its credentials, \
                              network_targets, max_egress_bytes, output_schema_ref, and \
                              resource_profile",
                             tool.id
                         ),
                     });
                 }
+                // A static tool may declare ADDITIVE effects on top of the
+                // connection template — e.g. a marketplace hire tool marks
+                // itself `financial` so the host's hard approval floor gates
+                // it, while sibling read tools stay at the template set. It
+                // must be a strict superset: dropping a template effect here
+                // would understate what every call through the shared
+                // connection can do.
+                if !tool.effects.is_empty() {
+                    if let Some(missing) = mcp
+                        .effects
+                        .iter()
+                        .find(|effect| !tool.effects.contains(effect))
+                    {
+                        return Err(ManifestV3Error::Invalid {
+                            reason: format!(
+                                "static tool `{}` narrows the [mcp] template effects \
+                                 (missing {missing:?}); per-tool effects may only ADD \
+                                 to the template",
+                                tool.id
+                            ),
+                        });
+                    }
+                }
+                let tool_effects = if tool.effects.is_empty() {
+                    mcp.effects.clone()
+                } else {
+                    tool.effects.clone()
+                };
                 RawCapabilityV2 {
                     id: tool.id,
                     network_targets: Vec::new(),
                     max_egress_bytes: None,
                     description: tool.description,
-                    effects: with_dispatch_effect(mcp.effects.clone()),
+                    effects: with_dispatch_effect(tool_effects),
                     default_permission: tool.default_permission,
                     visibility: tool.visibility,
                     // The guard above rejects standard operations on MCP
@@ -728,6 +767,9 @@ pub(crate) fn parse_v3(
         capabilities,
         host_api_surfaces,
         hooks: Vec::new(),
+        mcp_attribution: mcp.as_ref().and_then(|m| m.attribution).map(|a| match a {
+            RawMcpAttributionV3::Sep414 => McpAttribution::Sep414,
+        }),
     };
 
     let auth = recipes
@@ -774,6 +816,7 @@ pub(crate) fn parse_v3(
             dynamic_input_schemas: std::collections::BTreeMap::new(),
             registration_auth:
                 ironclaw_extension_contracts::hosted_mcp::HostedMcpAuthSelection::NoAuth,
+            attribution: manifest.mcp_attribution,
         }),
         tools: manifest.capabilities.clone(),
         channel: raw.channel,

--- a/crates/extensions/ironclaw_extension_registry/src/v3.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/v3.rs
@@ -46,9 +46,8 @@ use crate::resolved::{
     PackageRootBinding, ResolvedAuthSurface, ResolvedExtensionManifest, ResolvedMcpDeclaration,
 };
 use crate::v2::{
-    McpAttribution,
     CapabilityDeclV2, CapabilitySurfaceDeclV2, ExtensionManifestV2, ExtensionRuntimeV2,
-    MAX_MANIFEST_BYTES, ManifestSource, RawCapabilityV2, RawRuntimeCredentialV2,
+    MAX_MANIFEST_BYTES, ManifestSource, McpAttribution, RawCapabilityV2, RawRuntimeCredentialV2,
     requested_trust_to_descriptor_trust,
 };
 
@@ -660,7 +659,7 @@ pub(crate) fn parse_v3(
                     network_targets: Vec::new(),
                     max_egress_bytes: None,
                     description: tool.description,
-                    effects: with_dispatch_effect(tool_effects),
+                    effects: with_dispatch_effect(tool_effects.clone()),
                     default_permission: tool.default_permission,
                     visibility: tool.visibility,
                     // The guard above rejects standard operations on MCP
@@ -670,7 +669,12 @@ pub(crate) fn parse_v3(
                     input_schema_ref,
                     output_schema_ref: None,
                     prompt_doc_ref: tool.prompt_doc_ref,
-                    required_host_ports: derived_host_ports(&mcp.effects, true),
+                    // From the tool's EFFECTIVE effects, not the connection
+                    // template's: a tool that adds `network` on top of a
+                    // template without it would otherwise carry
+                    // `EffectKind::Network` and no HTTP-egress port, so its
+                    // egress would not be host-mediated.
+                    required_host_ports: derived_host_ports(&tool_effects, true),
                     runtime_credentials: template_credentials.clone(),
                     resource_profile: None,
                     origin_gate_matrix: mcp.origin_gate_matrix.clone(),

--- a/crates/extensions/ironclaw_extension_registry/tests/manifest_v3_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/manifest_v3_contract.rs
@@ -767,6 +767,36 @@ fn mcp_is_mutually_exclusive_with_runtime_and_channel() {
 /// template's credential/effect/host-port shape — a static tool declaring
 /// its own credentials, effects, or resource_profile is rejected.
 #[test]
+fn mcp_static_tool_network_effect_carries_the_http_egress_port() {
+    // A static tool may ADD effects on top of the connection template. Host
+    // ports were derived from the template, so a tool that adds `network` to a
+    // template without it got `EffectKind::Network` and no HTTP-egress port —
+    // network use that is not host-mediated.
+    let template_without_network = mcp_manifest().replace(
+        r#"effects = ["network", "use_secret"]"#,
+        r#"effects = ["use_secret"]"#,
+    );
+    let manifest = format!(
+        "{template_without_network}\n[[tools]]\nid = \"zeta.fetch\"\ndescription = \"Fetch over the network.\"\ndefault_permission = \"ask\"\neffects = [\"use_secret\", \"network\"]\ninput_schema_ref = \"schemas/zeta/fetch.input.v1.json\"\n"
+    );
+    let record = parse_v3(&manifest).expect("additive-network manifest parses");
+    let tool = record
+        .manifest()
+        .capabilities
+        .iter()
+        .find(|capability| capability.id.as_str() == "zeta.fetch")
+        .expect("the static tool is emitted");
+    assert!(tool.effects.contains(&EffectKind::Network));
+    assert!(
+        tool.required_host_ports
+            .iter()
+            .any(|port| port.as_str() == HOST_RUNTIME_HTTP_EGRESS_PORT_ID),
+        "a tool declaring `network` must require host-mediated egress: {:?}",
+        tool.required_host_ports
+    );
+}
+
+#[test]
 fn mcp_static_tools_parse_and_inherit_the_connection_template() {
     let with_static_tool = format!(
         "{}\n[[tools]]\nid = \"zeta.search\"\ndescription = \"Search through Zeta.\"\ndefault_permission = \"ask\"\ninput_schema_ref = \"schemas/zeta/search.input.v1.json\"\n",
@@ -1789,10 +1819,7 @@ fn mcp_attribution_defaults_to_none() {
 
 #[test]
 fn mcp_attribution_sep414_parses() {
-    let manifest = mcp_manifest().replace(
-        "[mcp]\n",
-        "[mcp]\nattribution = \"sep414\"\n",
-    );
+    let manifest = mcp_manifest().replace("[mcp]\n", "[mcp]\nattribution = \"sep414\"\n");
     let record = parse_v3(&manifest).expect("attributed mcp manifest parses");
     assert_eq!(
         record.manifest().mcp_attribution,
@@ -1822,9 +1849,6 @@ fn mcp_attribution_survives_rehydration_from_the_persisted_record() {
 
 #[test]
 fn mcp_attribution_unknown_value_is_rejected() {
-    let manifest = mcp_manifest().replace(
-        "[mcp]\n",
-        "[mcp]\nattribution = \"telemetry-v9\"\n",
-    );
+    let manifest = mcp_manifest().replace("[mcp]\n", "[mcp]\nattribution = \"telemetry-v9\"\n");
     parse_v3(&manifest).expect_err("unknown attribution value must not parse");
 }

--- a/crates/extensions/ironclaw_extension_registry/tests/manifest_v3_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/manifest_v3_contract.rs
@@ -1778,3 +1778,33 @@ fn legacy_resolved_record_without_standard_op_rehydrates_to_none() {
     assert_eq!(rehydrated_descriptor.standard_op, None);
     assert_eq!(rehydrated_descriptor.id, descriptor.id);
 }
+
+#[test]
+fn mcp_attribution_defaults_to_none() {
+    // A manifest that says nothing about attribution must never be stamped —
+    // the privacy default for every existing provider.
+    let record = parse_v3(&mcp_manifest()).expect("mcp manifest parses");
+    assert_eq!(record.manifest().mcp_attribution, None);
+}
+
+#[test]
+fn mcp_attribution_sep414_parses() {
+    let manifest = mcp_manifest().replace(
+        "[mcp]\n",
+        "[mcp]\nattribution = \"sep414\"\n",
+    );
+    let record = parse_v3(&manifest).expect("attributed mcp manifest parses");
+    assert_eq!(
+        record.manifest().mcp_attribution,
+        Some(ironclaw_extension_registry::McpAttribution::Sep414)
+    );
+}
+
+#[test]
+fn mcp_attribution_unknown_value_is_rejected() {
+    let manifest = mcp_manifest().replace(
+        "[mcp]\n",
+        "[mcp]\nattribution = \"telemetry-v9\"\n",
+    );
+    parse_v3(&manifest).expect_err("unknown attribution value must not parse");
+}

--- a/crates/extensions/ironclaw_extension_registry/tests/manifest_v3_contract.rs
+++ b/crates/extensions/ironclaw_extension_registry/tests/manifest_v3_contract.rs
@@ -1801,6 +1801,26 @@ fn mcp_attribution_sep414_parses() {
 }
 
 #[test]
+fn mcp_attribution_survives_rehydration_from_the_persisted_record() {
+    // An installed extension is rebuilt from its persisted resolved record on
+    // every load, never by reparsing its TOML. If that path drops the opt-in,
+    // attribution works until the first restart and then silently stops.
+    let manifest = mcp_manifest().replace("[mcp]\n", "[mcp]\nattribution = \"sep414\"\n");
+    let record = parse_v3(&manifest).expect("attributed mcp manifest parses");
+    let rehydrated = ExtensionManifestRecord::from_resolved(
+        record.raw_toml(),
+        ManifestSource::HostBundled,
+        record.resolved().clone(),
+        None,
+    )
+    .expect("persisted record rehydrates");
+    assert_eq!(
+        rehydrated.manifest().mcp_attribution,
+        Some(ironclaw_extension_registry::McpAttribution::Sep414)
+    );
+}
+
+#[test]
 fn mcp_attribution_unknown_value_is_rejected() {
     let manifest = mcp_manifest().replace(
         "[mcp]\n",

--- a/crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -266,6 +266,8 @@ pub fn builtin_first_party_package() -> Result<ExtensionPackage, ExtensionError>
             // first-party builtin hooks are installed by the composition
             // loader directly, not via this manifest surface.
             hooks: Vec::new(),
+            // Built-ins speak no MCP, so no attribution opt-in.
+            mcp_attribution: None,
         },
         VirtualPath::new("/system/extensions/builtin")?,
     )

--- a/crates/kernel/ironclaw_host_runtime/src/services/tests/extension_tool_binder.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/tests/extension_tool_binder.rs
@@ -54,6 +54,7 @@ fn first_party_test_package(service: &str, capability_id: &str) -> ExtensionPack
                 origin_gate_matrix: None,
             }],
             hooks: Vec::new(),
+            mcp_attribution: None,
         },
         VirtualPath::new(format!("/system/extensions/{service}")).unwrap(),
     )

--- a/crates/kernel/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -708,6 +708,7 @@ fn first_party_registry_with_effects(effects: Vec<EffectKind>) -> ExtensionRegis
                 origin_gate_matrix: None,
             }],
             hooks: Vec::new(),
+            mcp_attribution: None,
         },
         VirtualPath::new("/system/extensions/host").unwrap(),
     )

--- a/crates/kernel/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/kernel/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -2648,6 +2648,7 @@ async fn mcp_http_client_reuses_real_host_staged_network_policy_for_json_rpc_ses
             credential_injections: vec![],
             response_body_limit: Some(4096),
             timeout_ms: Some(1000),
+            sep414_attribution: false,
         }),
     );
 
@@ -2719,6 +2720,7 @@ async fn mcp_http_client_reuses_staged_credential_for_json_rpc_session() {
             }],
             response_body_limit: Some(4096),
             timeout_ms: Some(1000),
+            sep414_attribution: false,
         }),
     );
 
@@ -2903,6 +2905,7 @@ async fn mcp_http_client_reuses_product_auth_staged_credential_for_json_rpc_sess
             }],
             response_body_limit: Some(4096),
             timeout_ms: Some(1000),
+            sep414_attribution: false,
         }),
     );
 
@@ -2977,6 +2980,7 @@ async fn mcp_http_client_cannot_use_direct_secret_store_lease_with_production_eg
             }],
             response_body_limit: Some(4096),
             timeout_ms: Some(1000),
+            sep414_attribution: false,
         }),
     );
 

--- a/crates/lanes/ironclaw_mcp/src/client.rs
+++ b/crates/lanes/ironclaw_mcp/src/client.rs
@@ -43,6 +43,7 @@ use crate::egress::{
 use crate::jsonrpc::{
     MCP_PROTOCOL_VERSION_HEADER, McpJsonRpcExchange, McpJsonRpcMethod, McpJsonRpcResponse,
     encode_json_rpc_request, is_mcp_auth_response_status, json_rpc_initialize_params,
+    params_with_sep414_meta,
     mcp_auth_challenge_from_response, mcp_session_id_from_response, parse_mcp_response,
     protocol_version_from_initialize_response, validate_staged_credential_injections,
     validate_tools_call_credential_injections,
@@ -200,8 +201,8 @@ where
         let url = request.url.as_deref().ok_or_else(|| {
             McpClientError::client(request_denied(McpRequestDeniedCause::MissingUrl))
         })?;
-        let body =
-            encode_json_rpc_request(id, method.as_str(), params).map_err(McpClientError::client)?;
+        let body = encode_json_rpc_request(id, method.as_str(), params.clone())
+            .map_err(McpClientError::client)?;
         let policy_headers = vec![
             ("Content-Type".to_string(), "application/json".to_string()),
             (
@@ -220,6 +221,26 @@ where
             headers: &policy_headers,
             body: &body,
         });
+        // Stamp the SEP-414 `_meta` attribution on the tool-facing methods,
+        // and ONLY for providers whose manifest opted in ([mcp] attribution =
+        // "sep414", which the planner turns into the flag). Every other
+        // provider keeps today's wire shape — no host identity or conversation
+        // identifiers reach a server that never asked for them. `initialize`
+        // keeps its exact handshake params, and neither it nor the
+        // post-handshake `notifications/initialized` carries per-turn
+        // attribution. Threading this through the shared planner (rather than
+        // each call site) guarantees `tools/list` and `tools/call` agree.
+        let body = if plan.sep414_attribution
+            && matches!(
+                method,
+                McpJsonRpcMethod::ToolsList | McpJsonRpcMethod::ToolsCall
+            ) {
+            let params = Some(params_with_sep414_meta(params, &request.scope));
+            encode_json_rpc_request(id, method.as_str(), params)
+                .map_err(McpClientError::client)?
+        } else {
+            body
+        };
         Ok(PlannedMcpJsonRpc {
             id,
             method,
@@ -884,6 +905,14 @@ fn accumulate_usage(total: &mut ResourceUsage, usage: ResourceUsage) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::egress::{
+        McpHostHttpError, McpHostHttpResponse, StaticMcpHostHttpEgressPlanner,
+    };
+    use ironclaw_host_api::http::CapabilityHostHttpRequest;
+    use ironclaw_host_api::ids::{
+        AgentId, InvocationId, MissionId, ProjectId, TenantId, ThreadId, UserId,
+    };
+    use serde_json::json;
 
     #[test]
     fn mcp_tool_name_strips_provider_prefix_for_canonical_tool_name() {
@@ -938,5 +967,171 @@ mod tests {
         let result = serde_json::json!({"isError": false, "content": []});
 
         assert_eq!(call_tool_rejection_message(&result), None);
+    }
+
+    struct UnusedHttp;
+
+    #[async_trait::async_trait]
+    impl McpHostHttp for UnusedHttp {
+        async fn request(
+            &self,
+            _request: CapabilityHostHttpRequest,
+        ) -> Result<McpHostHttpResponse, McpHostHttpError> {
+            unreachable!("plan_json_rpc must not touch the transport")
+        }
+    }
+
+    fn planning_client() -> McpHostHttpClient<UnusedHttp, StaticMcpHostHttpEgressPlanner> {
+        McpHostHttpClient::new(
+            UnusedHttp,
+            StaticMcpHostHttpEgressPlanner::new(McpHostHttpEgressPlan::default()),
+        )
+    }
+
+    /// A planner whose provider opted into SEP-414 attribution
+    /// (`[mcp] attribution = "sep414"`).
+    fn attributed_planning_client() -> McpHostHttpClient<UnusedHttp, StaticMcpHostHttpEgressPlanner>
+    {
+        McpHostHttpClient::new(
+            UnusedHttp,
+            StaticMcpHostHttpEgressPlanner::new(McpHostHttpEgressPlan {
+                sep414_attribution: true,
+                ..McpHostHttpEgressPlan::default()
+            }),
+        )
+    }
+
+    fn scope_with_thread(thread_id: Option<&str>) -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new("tenant-a").unwrap(),
+            user_id: UserId::new("user-a").unwrap(),
+            agent_id: Some(AgentId::new("agent-a").unwrap()),
+            project_id: Some(ProjectId::new("project-a").unwrap()),
+            mission_id: Some(MissionId::new("mission-a").unwrap()),
+            thread_id: thread_id.map(|id| ThreadId::new(id).unwrap()),
+            invocation_id: InvocationId::new(),
+        }
+    }
+
+    fn meta_probe_request(scope: ResourceScope, input: Value) -> McpClientRequest {
+        McpClientRequest {
+            provider: ExtensionId::new("agent-market").unwrap(),
+            capability_id: CapabilityId::new("agent-market.search_agents").unwrap(),
+            scope,
+            transport: "http".to_string(),
+            command: None,
+            args: Vec::new(),
+            url: Some("https://mcp.example.test/rpc".to_string()),
+            input,
+            max_output_bytes: 1_000_000,
+        }
+    }
+
+    /// The outbound `params` object that `plan_json_rpc` actually encodes.
+    fn planned_params(
+        client: &McpHostHttpClient<UnusedHttp, StaticMcpHostHttpEgressPlanner>,
+        request: &McpClientRequest,
+        method: McpJsonRpcMethod,
+        params: Option<Value>,
+    ) -> Value {
+        let planned = client
+            .plan_json_rpc(request, Some(1), method, params)
+            .expect("planning succeeds");
+        let decoded: Value = serde_json::from_slice(&planned.body).expect("body is JSON");
+        decoded.get("params").cloned().unwrap_or(Value::Null)
+    }
+
+    #[test]
+    fn tools_call_stamps_sep414_thread_attribution_on_the_wire() {
+        let client = attributed_planning_client();
+        let scope = scope_with_thread(Some("thread-a"));
+        let expected_invocation = scope.invocation_id.to_string();
+        let request = meta_probe_request(scope, json!({"limit": 10}));
+
+        let params = planned_params(
+            &client,
+            &request,
+            McpJsonRpcMethod::ToolsCall,
+            Some(json!({ "name": "search_agents", "arguments": { "limit": 10 } })),
+        );
+
+        // Attribution is carried in `_meta`, never derived from arguments — this
+        // is what lets one stable per-user token serve concurrent jobs without a
+        // buyer seeing another buyer's connector.
+        assert_eq!(params["_meta"]["io.ironclaw/threadId"], json!("thread-a"));
+        assert_eq!(params["_meta"]["io.ironclaw/userId"], json!("user-a"));
+        // The invocation id must be THE turn's id, not merely some string —
+        // it is the provider-side replay-dedup key.
+        assert_eq!(
+            params["_meta"]["io.ironclaw/invocationId"],
+            json!(expected_invocation)
+        );
+        // Original tool arguments survive the merge untouched.
+        assert_eq!(params["name"], json!("search_agents"));
+        assert_eq!(params["arguments"], json!({ "limit": 10 }));
+    }
+
+    #[test]
+    fn tools_list_stamps_sep414_thread_attribution_even_without_other_params() {
+        let client = attributed_planning_client();
+        let request = meta_probe_request(scope_with_thread(Some("thread-a")), Value::Null);
+
+        // `tools/list` carries no other params (`None`) — the block must still
+        // materialize so per-turn discovery is attributed to its thread.
+        let params = planned_params(&client, &request, McpJsonRpcMethod::ToolsList, None);
+
+        assert_eq!(params["_meta"]["io.ironclaw/threadId"], json!("thread-a"));
+        assert_eq!(params["_meta"]["io.ironclaw/userId"], json!("user-a"));
+    }
+
+    #[test]
+    fn initialize_handshake_is_not_stamped_with_attribution() {
+        let client = attributed_planning_client();
+        let request = meta_probe_request(scope_with_thread(Some("thread-a")), Value::Null);
+
+        // The handshake predates any turn attribution; stamping it would corrupt
+        // the exact `initialize` params contract.
+        let params = planned_params(
+            &client,
+            &request,
+            McpJsonRpcMethod::Initialize,
+            Some(json!({ "protocolVersion": "2025-06-18" })),
+        );
+
+        assert!(params.get("_meta").is_none());
+        assert_eq!(params["protocolVersion"], json!("2025-06-18"));
+    }
+
+    /// The privacy contract: a provider that did NOT opt in receives no
+    /// attribution at all — its wire shape is byte-identical to today's.
+    #[test]
+    fn non_opted_provider_gets_no_attribution() {
+        let client = planning_client();
+        let request =
+            meta_probe_request(scope_with_thread(Some("thread-a")), json!({"limit": 10}));
+
+        let params = planned_params(
+            &client,
+            &request,
+            McpJsonRpcMethod::ToolsCall,
+            Some(json!({ "name": "search_agents", "arguments": { "limit": 10 } })),
+        );
+
+        assert!(params.get("_meta").is_none(), "no opt-in ⇒ no _meta block");
+        assert_eq!(params["name"], json!("search_agents"));
+        assert_eq!(params["arguments"], json!({ "limit": 10 }));
+    }
+
+    #[test]
+    fn thread_less_scope_omits_thread_id_but_keeps_user_attribution() {
+        let client = attributed_planning_client();
+        let request = meta_probe_request(scope_with_thread(None), Value::Null);
+
+        let params = planned_params(&client, &request, McpJsonRpcMethod::ToolsList, None);
+
+        // A non-threaded runtime sends no thread key (absent, not empty) but is
+        // still user-attributed.
+        assert!(params["_meta"].get("io.ironclaw/threadId").is_none());
+        assert_eq!(params["_meta"]["io.ironclaw/userId"], json!("user-a"));
     }
 }

--- a/crates/lanes/ironclaw_mcp/src/client.rs
+++ b/crates/lanes/ironclaw_mcp/src/client.rs
@@ -235,6 +235,18 @@ where
                 method,
                 McpJsonRpcMethod::ToolsList | McpJsonRpcMethod::ToolsCall
             ) {
+            // A provider that opted in and gets no thread key cannot correlate
+            // the call to a conversation, and silently falls back to guessing.
+            // Say so once per call rather than let it degrade quietly.
+            if request.scope.thread_id.is_none() {
+                tracing::debug!(
+                    provider = %request.provider,
+                    capability_id = %request.capability_id,
+                    method = method.as_str(),
+                    "SEP-414 attribution is on but the turn scope carries no thread; \
+                     omitting io.ironclaw/threadId"
+                );
+            }
             let params = Some(params_with_sep414_meta(params, &request.scope));
             encode_json_rpc_request(id, method.as_str(), params)
                 .map_err(McpClientError::client)?

--- a/crates/lanes/ironclaw_mcp/src/egress.rs
+++ b/crates/lanes/ironclaw_mcp/src/egress.rs
@@ -113,6 +113,10 @@ pub struct McpHostHttpEgressPlan {
     pub credential_injections: Vec<RuntimeCredentialInjection>,
     pub response_body_limit: Option<u64>,
     pub timeout_ms: Option<u32>,
+    /// `true` only when the provider's manifest opted into SEP-414 caller
+    /// attribution (`[mcp] attribution = "sep414"`); the default plan stamps
+    /// nothing.
+    pub sep414_attribution: bool,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/lanes/ironclaw_mcp/src/jsonrpc.rs
+++ b/crates/lanes/ironclaw_mcp/src/jsonrpc.rs
@@ -11,6 +11,7 @@ use ironclaw_extension_contracts::hosted_mcp::McpAuthChallenge;
 use ironclaw_host_api::{
     http::{RuntimeCredentialInjection, RuntimeCredentialSource},
     resource::ResourceUsage,
+    resource::ResourceScope,
 };
 use serde_json::Value;
 
@@ -195,6 +196,63 @@ pub(crate) fn protocol_version_from_initialize_response(
         ));
     }
     Ok(protocol_version.to_string())
+}
+
+/// Builds the SEP-414 `_meta` attribution block the host stamps on outbound
+/// MCP `tools/list` / `tools/call` — ONLY for providers whose manifest opted
+/// in via `[mcp] attribution = "sep414"` (the egress planner sets
+/// [`McpHostHttpEgressPlan::sep414_attribution`]); every other provider's
+/// wire shape is unchanged.
+///
+/// "SEP-414" refers to the Model Context Protocol spec-enhancement proposal
+/// for propagating caller context through the reserved `_meta` request field
+/// (modelcontextprotocol/modelcontextprotocol#414); the `io.ironclaw/*` keys
+/// follow `_meta`'s reverse-DNS naming rule, so servers that don't know them
+/// ignore the block entirely.
+///
+/// It is derived from the trusted turn [`ResourceScope`] and merged into
+/// `params` *after* argument serialization, so extension and model code can
+/// neither read nor forge it. Hosted providers (the marketplace connector
+/// endpoint) resolve the caller's dispatch/hire from `io.ironclaw/threadId` —
+/// never from tool arguments — which is what lets one stable per-user token
+/// serve concurrent jobs without cross-job data bleed. Absent a thread scope
+/// (non-threaded runtime) the key is omitted rather than sent empty.
+pub(crate) fn sep414_meta(scope: &ResourceScope) -> Value {
+    let mut meta = serde_json::Map::new();
+    meta.insert(
+        "io.ironclaw/userId".to_string(),
+        Value::String(scope.user_id.as_str().to_string()),
+    );
+    meta.insert(
+        "io.ironclaw/invocationId".to_string(),
+        Value::String(scope.invocation_id.to_string()),
+    );
+    if let Some(thread_id) = scope.thread_id.as_ref() {
+        meta.insert(
+            "io.ironclaw/threadId".to_string(),
+            Value::String(thread_id.as_str().to_string()),
+        );
+    }
+    Value::Object(meta)
+}
+
+/// Merge [`sep414_meta`] into an outbound `params` object, creating the object
+/// when the method carries no other params (e.g. `tools/list`, whose params are
+/// `None`). Both call sites (`call_tool`, `discover_tools`) pass either an
+/// object or `None`; a non-object value is preserved under `"params"` so a
+/// future caller cannot silently drop it.
+pub(crate) fn params_with_sep414_meta(params: Option<Value>, scope: &ResourceScope) -> Value {
+    let mut object = match params {
+        Some(Value::Object(map)) => map,
+        None => serde_json::Map::new(),
+        Some(other) => {
+            let mut map = serde_json::Map::new();
+            map.insert("params".to_string(), other);
+            map
+        }
+    };
+    object.insert("_meta".to_string(), sep414_meta(scope));
+    Value::Object(object)
 }
 
 pub(crate) fn encode_json_rpc_request(

--- a/crates/lanes/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/lanes/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -2632,6 +2632,7 @@ fn host_http_plan() -> McpHostHttpEgressPlan {
         }],
         response_body_limit: Some(4096),
         timeout_ms: Some(2_500),
+        sep414_attribution: false,
     }
 }
 

--- a/tests/integration/support/harness_mcp.rs
+++ b/tests/integration/support/harness_mcp.rs
@@ -136,6 +136,7 @@ pub(super) fn mock_mcp_extension_package(
         host_apis: Vec::new(),
         host_api_surfaces: Vec::new(),
         hooks: Vec::new(),
+        mcp_attribution: None,
         capabilities: vec![CapabilityManifest {
             id: CapabilityId::new(capability_id)?,
             description: "Mock MCP capability".to_string(),


### PR DESCRIPTION
**A hosted MCP server cannot tell which conversation a call came from, or that a call it already handled is a retry.** It sees one bearer token per user and nothing else. Providers that need per-conversation state, or that need to not charge twice for a retried side-effecting call, end up inventing their own convention in tool arguments — which the model can fill in wrong and a caller can forge.

This lets a provider ask for that context on the wire, and lets the host supply it from a source neither the model nor extension code can touch.

Replaces #6759, which predates the workspace reorganization.

### Evidence

`tools_call_stamps_sep414_thread_attribution_on_the_wire` asserts the block on the encoded request body, including that `io.ironclaw/invocationId` equals the turn's own id — it is the provider's dedup key, so "some string" would not do.

`non_opted_provider_gets_no_attribution` is the privacy half: a provider that did not opt in sees no `_meta` at all.

`mcp_attribution_survives_rehydration_from_the_persisted_record` covers the case that made this fail in practice: an installed extension is rebuilt from its persisted resolved record, never by reparsing its TOML, and the first draft of this PR dropped the opt-in on that path. Attribution worked until the host restarted and then silently stopped. Reverting the one-line carry turns that test red (`left: None, right: Some(Sep414)`).

### What changed

- Manifests may declare `[mcp] attribution = "sep414"`; anything else is rejected at parse time and the field defaults to none.
- The opt-in is carried when a package is rebuilt from its persisted resolved record, so it survives a restart. v2 manifests have no `[mcp]` section and still resolve to none.
- `RegistryMcpEgressPlanner` sets `McpHostHttpEgressPlan::sep414_attribution` only for a provider that declared it.
- `tools/list` and `tools/call` carry `_meta` with `io.ironclaw/userId`, `io.ironclaw/invocationId`, and `io.ironclaw/threadId` when the runtime has a thread; a thread-less runtime omits the key rather than sending it empty.
- The block is merged into `params` after argument serialization, from the trusted `ResourceScope` — extension and model code can neither read nor forge it.
- `initialize` is never stamped, so the handshake contract is unchanged.

The keys follow `_meta`'s reverse-DNS rule, so a server that does not know them ignores the block. "SEP-414" is the MCP spec-enhancement proposal for propagating caller context through `_meta` (modelcontextprotocol/modelcontextprotocol#414).

### Verify

```
cargo test -p ironclaw_mcp --lib
cargo test -p ironclaw_extension_registry --test manifest_v3_contract mcp_attribution
```

41 + 4 tests. The lane tests cover both modes and the `initialize` carve-out; the manifest tests cover the opt-in, the default, rejection of an unknown value, and survival across rehydration.

Also exercised end to end against a live hosted-MCP provider: before the rehydration fix the receiving server could not correlate the call and fell back to a heuristic (3 fallbacks logged); after it, every call correlated on the `_meta` thread id and the fallback path was never entered.

### Risk

No provider is opted in by this PR, so the default wire shape is unchanged and nothing is disclosed to a server that did not ask. Rollback is a revert.

Adding `mcp_attribution` to `ExtensionManifest` touches a number of struct literals in tests. If you would rather not grow that struct, the field could live only on the resolved MCP declaration — that is already where it is persisted, so the move is just having the planner read the resolved manifest instead.

https://claude.ai/code/session_01MciaHokSWPNsR692c2cTw1
