### PR TITLE
feat(loop): make the prompt-context limit an override instead of a constant

### DIFF
--- a/crates/loop/ironclaw_agent_loop/src/families/mod.rs
+++ b/crates/loop/ironclaw_agent_loop/src/families/mod.rs
@@ -4,8 +4,10 @@ use crate::default_planner::DefaultPlanner;
 use crate::family::{ComponentDigest, ComponentIdentity, LoopFamily};
 use crate::planner::AgentLoopPlanner;
 use crate::strategies::{
-    DEFAULT_ITERATION_BACKSTOP, DefaultBudgetStrategy, DefaultRecoveryStrategy,
+    ActiveTaskPreservingCompactionStrategy, DEFAULT_ITERATION_BACKSTOP, DefaultBudgetStrategy,
+    DefaultRecoveryStrategy,
 };
+use ironclaw_loop_contracts::PromptContextTokenBudget;
 
 mod subagent;
 mod unbound;
@@ -24,7 +26,11 @@ pub use unbound::{
 /// with their resolved values so a family's [`ComponentIdentity`] digest
 /// always identifies the configuration it actually runs with
 /// (see `family.rs` component-identity contract).
-fn default_family_fingerprint(iteration_limit: u32, model_availability_attempts: u32) -> String {
+fn default_family_fingerprint(
+    iteration_limit: u32,
+    model_availability_attempts: u32,
+    context_limit_tokens: u64,
+) -> String {
     format!(
         "ironclaw_agent_loop.default_family.v3:\
         family_id=default;\
@@ -32,7 +38,7 @@ fn default_family_fingerprint(iteration_limit: u32, model_availability_attempts:
         planner=DefaultPlanner;\
         strategies=\
         context:DefaultContextStrategy(max_messages=128),\
-        compaction:ActiveTaskPreservingCompactionStrategy(context_limit=128000,reserve=20000,preserve_tail=8000,min_compacted=3,min_tail=3,deadline_ms=30000,ineffective_trip_limit=3),\
+        compaction:ActiveTaskPreservingCompactionStrategy(context_limit={context_limit_tokens},reserve=20000,preserve_tail=8000,min_compacted=3,min_tail=3,deadline_ms=30000,ineffective_trip_limit=3),\
         capability:DefaultCapabilityStrategy(all),\
         model:DefaultModelStrategy(primary_or_fallback_index),\
         batch:model_emitted_calls(bounded_fanout=4),\
@@ -81,6 +87,11 @@ pub struct FamilyOverrides {
     /// Availability-class model retry budget
     /// (`DefaultRecoveryStrategy::max_model_availability_attempts`).
     pub model_availability_attempts: Option<u32>,
+    /// Prompt-context ceiling the compaction strategy works against; defaults
+    /// to [`PromptContextTokenBudget::DEFAULT_CONTEXT_LIMIT_TOKENS`]. A
+    /// deployment whose models carry a larger window raises it here rather
+    /// than editing the constant.
+    pub context_limit_tokens: Option<u64>,
 }
 
 impl FamilyOverrides {
@@ -91,6 +102,11 @@ impl FamilyOverrides {
 
     pub fn set_model_availability_attempts(mut self, attempts: u32) -> Self {
         self.model_availability_attempts = Some(attempts);
+        self
+    }
+
+    pub fn set_context_limit_tokens(mut self, context_limit_tokens: u64) -> Self {
+        self.context_limit_tokens = Some(context_limit_tokens);
         self
     }
 }
@@ -116,11 +132,18 @@ pub fn default_with_overrides(overrides: FamilyOverrides) -> LoopFamily {
     let max_model_availability_attempts = overrides
         .model_availability_attempts
         .unwrap_or(DefaultRecoveryStrategy::default().max_model_availability_attempts);
+    let context_limit_tokens = overrides
+        .context_limit_tokens
+        .unwrap_or(PromptContextTokenBudget::DEFAULT_CONTEXT_LIMIT_TOKENS);
     let digest = ComponentDigest::from_blake3(default_family_fingerprint(
         iteration_limit,
         max_model_availability_attempts,
+        context_limit_tokens,
     ));
+    let mut compaction = ActiveTaskPreservingCompactionStrategy::default();
+    compaction.base.prompt_context_budget.context_limit_tokens = context_limit_tokens;
     let planner = DefaultPlanner::compose_default()
+        .with_compaction(Arc::new(compaction))
         .with_version(ComponentIdentity::new("default", digest))
         .with_budget(Arc::new(DefaultBudgetStrategy {
             iteration_limit,
@@ -168,6 +191,7 @@ mod tests {
             ComponentDigest::from_blake3(default_family_fingerprint(
                 DEFAULT_ITERATION_BACKSTOP,
                 DefaultRecoveryStrategy::default().max_model_availability_attempts,
+                PromptContextTokenBudget::DEFAULT_CONTEXT_LIMIT_TOKENS,
             ))
         );
     }
@@ -181,6 +205,11 @@ mod tests {
             default_with_overrides(FamilyOverrides::default().set_model_availability_attempts(1));
         assert_ne!(attempts_override.version().digest, DEFAULT_FAMILY_DIGEST);
         assert_eq!(attempts_override.version().id, "default");
+
+        let context_override = default_with_overrides(
+            FamilyOverrides::default().set_context_limit_tokens(500_000),
+        );
+        assert_ne!(context_override.version().digest, DEFAULT_FAMILY_DIGEST);
 
         let iteration_override =
             default_with_overrides(FamilyOverrides::default().set_iteration_limit(5));


### PR DESCRIPTION
**A deployment whose models have a larger context window has to patch a constant to use it.** `PromptContextTokenBudget::DEFAULT_CONTEXT_LIMIT_TOKENS` is 128k. That is a fine default, but it is the only way to set the value, so anyone running models with a bigger window carries an edit to that line forever — and the compaction strategy keeps summarizing work that would have fit.

`set_context_limit_tokens` joins the two knobs that are already overridable, so the limit becomes configuration rather than a fork.

### Evidence

`override_built_families_carry_configuration_specific_digests` now covers the new knob: overriding the context limit changes the family digest, the same way overriding the iteration limit or the retry budget does. That is the property that matters — the limit is replay-relevant, so a family running with a different one must not claim the default identity.

### What changed

- `FamilyOverrides::context_limit_tokens` + `set_context_limit_tokens`, alongside the existing `set_iteration_limit` and `set_model_availability_attempts`.
- `default_family_fingerprint` takes the resolved limit, so the digest is derived from it.
- `default_with_overrides` composes the compaction strategy with the resolved limit instead of the default.

### Verify

```
cargo test -p ironclaw_agent_loop --lib families
```

15 tests. `default_family_digest_matches_blake3_fingerprint` pins that the pure-default path is unchanged.

### Risk

None to the default path: with no override, the fingerprint, digest and composed strategy are byte-identical to today, which is what the digest test asserts. Rollback is a revert.

Not covered: the subagent family. Its fingerprint is a constant with no overrides entry point, so raising its limit needs the same treatment separately — happy to add it here if you would rather have both in one change.

https://claude.ai/code/session_01MciaHokSWPNsR692c2cTw1