### PR TITLE
feat(common): distinguish a set-but-empty env var from an unset one

### DIFF
--- a/crates/contracts/ironclaw_common/src/env_helpers.rs
+++ b/crates/contracts/ironclaw_common/src/env_helpers.rs
@@ -160,6 +160,42 @@ pub fn env_or_override(key: &str) -> Option<String> {
     None
 }
 
+/// Like [`env_or_override`], but a SET-but-empty value is returned as
+/// `Some("")` instead of being folded into "unset". For configuration whose
+/// mere presence is a deployment decision (e.g. an endpoint override), the
+/// caller must see the difference so a blank value can fail loudly instead of
+/// silently selecting the unconfigured default. A runtime mask still reads as
+/// unset — masking exists to simulate absence.
+pub fn env_or_override_present(key: &str) -> Option<String> {
+    {
+        let overrides = runtime_overrides()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if let Some(RuntimeEnvOverride::Mask) = overrides.get(key) {
+            return None;
+        }
+    }
+
+    if let Ok(val) = std::env::var(key) {
+        return Some(val);
+    }
+
+    let runtime_value = {
+        let overrides = runtime_overrides()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        match overrides.get(key) {
+            Some(RuntimeEnvOverride::Value(value)) => Some(value.clone()),
+            _ => None,
+        }
+    };
+    if runtime_value.is_some() {
+        return runtime_value;
+    }
+
+    SECONDARY_FALLBACK.get().and_then(|fallback| fallback(key))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
**Setting a configuration variable to the empty string silently selects the default.** `env_or_override` treats `FOO=` and an absent `FOO` as the same thing. For a variable whose mere presence is a deployment decision — an endpoint override, for instance — that turns an operator typo into a quiet fallback to the unconfigured behavior, with nothing in the logs.

### What changed

- `env_or_override_present` returns `Some("")` for a set-but-empty value, so a caller can reject it instead of falling back.
- A runtime mask still reads as unset — masking exists to simulate absence, and that meaning is unchanged.
- `env_or_override` is untouched; callers that genuinely want empty-means-unset keep it.

### Verify

```
cargo test -p ironclaw_common --lib env
```

### Risk

Additive: a new function, no existing behavior changed. Rollback is a revert.

https://claude.ai/code/session_01MciaHokSWPNsR692c2cTw1