### PR TITLE
fix(mcp): key discovered hosted-MCP catalogs per caller, not per extension

### DIFF
--- a/crates/app/ironclaw_architecture_tests/tests/reborn_deployment_mode_typename_ratchet.rs
+++ b/crates/app/ironclaw_architecture_tests/tests/reborn_deployment_mode_typename_ratchet.rs
@@ -111,6 +111,11 @@ const FROZEN_OTHER_MODE_TYPES: &[&str] = &[
     // avoid a same-name/different-concept collision, type-placement.md).
     // Same Bucket-3 domain-name class as its siblings.
     "HostedMcpEgressEndpoint",
+    // Turn-start refresher for per-caller hosted-MCP catalogs: it discovers a
+    // hosted MCP server's tools under the caller's own credential. Same
+    // Bucket-3 domain-name class as its siblings — "hosted MCP" names the
+    // server, not a deployment tier.
+    "HostedMcpOverlayRefresher",
     "HostedMcpPreparationDependencies",
     "HostedMcpPreparationService",
     "RegisterHostedMcpBody",

--- a/crates/app/ironclaw_composition/src/factory.rs
+++ b/crates/app/ironclaw_composition/src/factory.rs
@@ -359,6 +359,13 @@ pub(crate) struct RebornRuntimeStores {
     pub(crate) in_memory_budget_event_sink: Arc<ironclaw_resources::InMemoryBudgetEventSink>,
     pub(crate) extension_registry: Arc<ExtensionRegistry>,
     pub(crate) shared_extension_registry: Arc<SharedExtensionRegistry>,
+    /// Per-user discovered hosted-MCP overlay (P2b), shared with the host
+    /// runtime's scoped capability-resolution paths.
+    pub(crate) scoped_overlay: Arc<ironclaw_extension_registry::ScopedPackageOverlay>,
+    /// Product-auth runtime ports (egress + one-shot secret/policy staging) for
+    /// turn-start hosted-MCP discovery (P2b). None when host egress is absent.
+    pub(crate) product_auth_runtime_ports:
+        Option<ironclaw_host_runtime::ProductAuthProviderRuntimePorts>,
     pub(crate) scoped_filesystem: Arc<ScopedFilesystem<CompositeRootFilesystem>>,
     pub(crate) processes: ProcessRuntimeSystem,
     pub(crate) thread_service: Arc<dyn SessionThreadService>,

--- a/crates/app/ironclaw_composition/src/factory/production_backend_assembly.rs
+++ b/crates/app/ironclaw_composition/src/factory/production_backend_assembly.rs
@@ -1391,6 +1391,8 @@ pub(super) async fn build_backend_production(
         }
     }
     let shared_extension_registry = services.shared_extension_registry();
+    let scoped_overlay = services.scoped_package_overlay();
+    let product_auth_runtime_ports = services.product_auth_provider_runtime_ports();
 
     #[cfg(test)]
     let standalone_wasm_runtime_credential_provider_captured =
@@ -1457,6 +1459,8 @@ pub(super) async fn build_backend_production(
         in_memory_budget_event_sink,
         extension_registry: Arc::clone(&extension_registry),
         shared_extension_registry,
+        scoped_overlay,
+        product_auth_runtime_ports,
         scoped_filesystem: Arc::clone(&stores.scoped_filesystem),
         processes,
         thread_service,

--- a/crates/app/ironclaw_composition/src/factory/runtime_lane_assembly.rs
+++ b/crates/app/ironclaw_composition/src/factory/runtime_lane_assembly.rs
@@ -92,10 +92,14 @@ where
     };
     let runtime_http_egress = runtime_ports.runtime_http_egress();
     let registry = services.shared_extension_registry();
+    // The MCP lane reads the caller's discovered catalog through the same
+    // overlay the surface and dispatch paths use (P2b).
+    let scoped_overlay = services.scoped_package_overlay();
 
     Ok(services.with_mcp_runtime(Arc::new(hosted_http_mcp_runtime(
         registry,
         runtime_http_egress,
+        Some(scoped_overlay),
     ))))
 }
 

--- a/crates/app/ironclaw_composition/src/input.rs
+++ b/crates/app/ironclaw_composition/src/input.rs
@@ -1063,13 +1063,13 @@ impl RebornHostBindings {
     }
 }
 
-struct ResolvedPostgresStorage {
-    connection: PostgresConnectionConfig,
+pub(crate) struct ResolvedPostgresStorage {
+    pub(crate) connection: PostgresConnectionConfig,
     secret_master_key: ironclaw_secrets::SecretMaterial,
     process_local_resource_governor_singleton: bool,
 }
 
-fn resolve_postgres_storage_from_config_and_env(
+pub(crate) fn resolve_postgres_storage_from_config_and_env(
     profile: RebornCompositionProfile,
     config_file: Option<&ironclaw_config::RebornConfigFile>,
 ) -> Result<ResolvedPostgresStorage, RebornBuildError> {

--- a/crates/app/ironclaw_composition/src/runtime/approval.rs
+++ b/crates/app/ironclaw_composition/src/runtime/approval.rs
@@ -112,8 +112,14 @@ impl PolicyApprovalLeaseTermsProvider {
         // owner filter in `grants` then behaves exactly like dispatch did
         // (#5459 P1): their own private capability resolves, anyone else's
         // yields no grant and the lease stays unavailable.
+        let scope = gate.resource_scope();
+        let overlay_owner = ironclaw_extension_registry::OverlayScope::new(
+            scope.tenant_id.clone(),
+            scope.user_id.clone(),
+            scope.thread_id.clone(),
+        );
         let Some(grant) = surface
-            .grants(extension_id, &gate.resource_scope().user_id)
+            .grants(extension_id, &overlay_owner)
             .into_iter()
             .find(|grant| grant.capability == *capability)
         else {

--- a/crates/app/ironclaw_composition/src/runtime/capability_host.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host.rs
@@ -58,6 +58,7 @@ use ironclaw_assistant::projection::{
     CapabilityDisplayPreviewResult, CapabilityDisplayPreviewStore,
 };
 
+mod hosted_mcp_overlay;
 mod notification_channels_set;
 mod outbound_delivery;
 mod refreshing_capability_port;
@@ -150,7 +151,17 @@ pub(super) fn capability_wiring(
         &[EffectKind::ExternalWrite],
     );
     let extension_surface_source =
-        ExtensionCapabilitySurfaceSource::new(Some(services.extension_management.clone()));
+        ExtensionCapabilitySurfaceSource::new(Some(services.extension_management.clone()))
+            .with_scoped_overlay(services.scoped_overlay.clone());
+    // Turn-start per-user hosted-MCP discovery (P2b): only when the product-auth
+    // runtime ports are present (host egress + secret staging).
+    let hosted_mcp_overlay_refresher = services.product_auth_runtime_ports.clone().map(|ports| {
+        Arc::new(hosted_mcp_overlay::HostedMcpOverlayRefresher::new(
+            services.scoped_overlay.clone(),
+            services.shared_extension_registry.clone(),
+            ports,
+        ))
+    });
     // First-class project creation reuses the same access-controlled
     // `ProjectService` service the WebUI v2 surface wires (composition owns the
     // service, never the raw repository), so an agent-created project is a real
@@ -211,6 +222,7 @@ pub(super) fn capability_wiring(
             memory_mounts,
             system_extensions_lifecycle_mounts,
             extension_surface_source,
+            hosted_mcp_overlay_refresher,
             input_resolver: Arc::clone(&capability_input_resolver),
             result_writer: Arc::clone(&capability_result_writer),
             milestone_sink,
@@ -248,6 +260,7 @@ struct RefreshingLoopCapabilityPortFactory {
     memory_mounts: MountView,
     system_extensions_lifecycle_mounts: MountView,
     extension_surface_source: ExtensionCapabilitySurfaceSource,
+    hosted_mcp_overlay_refresher: Option<Arc<hosted_mcp_overlay::HostedMcpOverlayRefresher>>,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
@@ -326,6 +339,12 @@ impl LoopCapabilityPortFactory for RefreshingLoopCapabilityPortFactory {
         surface_policy: Arc<CapabilitySurfacePolicy>,
     ) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
         let resource_scope = resource_scope_for_run(run_context, &self.fallback_user_id);
+        // Per-user hosted-MCP discovery BEFORE the surface/resolver snapshot so
+        // this turn's grants, surface, and dispatch see the caller's discovered
+        // tools. Failures degrade to last-good/static and never fail the turn.
+        if let Some(refresher) = &self.hosted_mcp_overlay_refresher {
+            refresher.refresh_for_scope(&resource_scope).await;
+        }
         // Database-backed, same tree the reader and Settings use. This port is where an agent's own
         // `skill_install` lands, and it used to write host disk instead (nearai/ironclaw#7168).
         let skill_mounts = db_backed_skill_management_mount_view(&resource_scope)
@@ -1137,6 +1156,13 @@ fn visible_capability_request(
     // The caller is the run user — one contract derivation for grants, mounts,
     // and the gate dance alike (owner == actor, #7377).
     let user_id = run_context.acting_user_id(fallback_user_id);
+    // The discovered-package overlay is keyed by (tenant, user, thread), so the
+    // caller's own hosted-MCP catalog is the one this turn sees (P2b, #6778).
+    let overlay_owner = ironclaw_extension_registry::OverlayScope::new(
+        run_context.scope.tenant_id.clone(),
+        user_id.clone(),
+        Some(run_context.scope.thread_id.clone()),
+    );
     let mut grants = inputs.policy.builtin_grants(
         &extension_id,
         inputs.workspace_mounts,
@@ -1157,7 +1183,7 @@ fn visible_capability_request(
     }
     grants
         .grants
-        .extend(inputs.extension_surface.grants(&extension_id, &user_id));
+        .extend(inputs.extension_surface.grants(&extension_id, &overlay_owner));
     let mut context = ExecutionContext::local_default(
         user_id,
         extension_id,
@@ -1216,7 +1242,7 @@ fn visible_capability_request(
             },
         );
     }
-    provider_trust.extend(inputs.extension_surface.provider_trust(&context.user_id));
+    provider_trust.extend(inputs.extension_surface.provider_trust(&overlay_owner));
 
     Ok(HostVisibleCapabilityRequest::new(
         context,

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/hosted_mcp_overlay.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/hosted_mcp_overlay.rs
@@ -1,0 +1,355 @@
+//! Turn-start per-user hosted-MCP discovery (P2b).
+//!
+//! Hosted-MCP providers with a per-user secret credential (e.g. the agent
+//! marketplace) serve a **per-principal** `tools/list`. This refresher runs
+//! before a turn's capability port is built: for every active hosted-MCP
+//! extension whose discovery template binds a per-user-resolvable
+//! runtime credential, it stages the TURN USER's secret and re-runs
+//! `tools/list` discovery under that user's scope, caching the discovered
+//! package in the [`ScopedPackageOverlay`] the surface/dispatch/egress paths
+//! all read.
+//!
+//! Failure semantics (user-visible contract):
+//! - **Missing credential** (`CredentialStageError::AuthRequired`): the user
+//!   has no secret for the extension — discovery is skipped and
+//!   negative-cached, the static manifest surface stays, and a dispatch of a
+//!   static tool produces the model-visible auth gate naming the missing
+//!   handle (`required_secrets`). No silent success, no wasted egress.
+//! - **Transient failure** (provider down, timeout): the last-good discovered
+//!   surface is kept serving (its TTL is re-armed) so a provider blip does not
+//!   flap the user's tool surface; with no last-good entry the static
+//!   manifest fallback applies.
+//! - **Permanent failure** (malformed discovery result): negative-cached so a
+//!   broken provider is not re-probed every turn.
+//!
+//! Discovery here never mutates installation state — the overlay is a derived
+//! cache (see `ironclaw_extensions::scoped_overlay`).
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use ironclaw_extension_registry::{
+    DEFAULT_SCOPED_OVERLAY_TTL, ExtensionPackage, OverlayFreshness, OverlayScope,
+    ScopedPackageOverlay, SharedExtensionRegistry, is_hosted_http_mcp_package,
+};
+use ironclaw_host_api::{
+    capability::{RuntimeCredentialRequirement, RuntimeCredentialRequirementSource},
+    dispatch::CredentialStageError,
+    ids::{CapabilityId, ExtensionId},
+    resource::ResourceScope,
+};
+use ironclaw_host_runtime::ProductAuthProviderRuntimePorts;
+use std::sync::Mutex;
+
+use ironclaw_extension_host::{HostedMcpDiscoveryError, discover_hosted_mcp_package};
+
+/// Host ceiling for a per-turn discovery refresh, matching the MCP lane's own
+/// `MAX_DISCOVERED_MCP_TOOLS` cap.
+const TURN_DISCOVERY_MAX_TOOLS: u32 = 1024;
+
+/// Per-turn discovery is on the turn-start path: bound it well below the MCP
+/// lane's 60 s transport timeout so a hung provider costs one bounded wait,
+/// not a wedged turn.
+const TURN_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// How long a missing-credential / permanent-failure verdict suppresses
+/// re-probing. Long enough to keep failed discovery off every turn, short
+/// enough that a freshly provisioned token is picked up within ~2 minutes.
+const NEGATIVE_TTL: Duration = Duration::from_secs(120);
+
+/// Turn-start per-user hosted-MCP discovery driver. One instance per composed
+/// runtime, shared by every capability-port factory invocation.
+pub(super) struct HostedMcpOverlayRefresher {
+    overlay: Arc<ScopedPackageOverlay>,
+    registry: Arc<SharedExtensionRegistry>,
+    runtime_ports: ProductAuthProviderRuntimePorts,
+    /// Single-flight: an (owner, extension) pair being discovered by one turn
+    /// is skipped by concurrent turns, which serve the last-good overlay.
+    in_flight: Mutex<HashSet<(OverlayScope, ExtensionId)>>,
+    negative_until: Mutex<HashMap<(OverlayScope, ExtensionId), Instant>>,
+}
+
+impl HostedMcpOverlayRefresher {
+    pub(super) fn new(
+        overlay: Arc<ScopedPackageOverlay>,
+        registry: Arc<SharedExtensionRegistry>,
+        runtime_ports: ProductAuthProviderRuntimePorts,
+    ) -> Self {
+        Self {
+            overlay,
+            registry,
+            runtime_ports,
+            in_flight: Mutex::new(HashSet::new()),
+            negative_until: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Refresh the scope user's discovered surfaces for every eligible
+    /// hosted-MCP extension. Never fails the turn: every failure mode
+    /// degrades to the previous surface (last-good or static manifest).
+    pub(super) async fn refresh_for_scope(&self, scope: &ResourceScope) {
+        let snapshot = self.registry.snapshot();
+        let eligible: Vec<(ExtensionPackage, CapabilityId, RuntimeCredentialRequirement)> =
+            snapshot
+                .extensions()
+                .filter_map(|package| {
+                    per_user_secret_discovery_template(package).map(
+                        |(capability_id, requirement)| (package.clone(), capability_id, requirement),
+                    )
+                })
+                .collect();
+        let owner = OverlayScope::new(
+            scope.tenant_id.clone(),
+            scope.user_id.clone(),
+            scope.thread_id.clone(),
+        );
+        for (package, capability_id, requirement) in eligible {
+            let key = (owner.clone(), package.id.clone());
+            if matches!(
+                self.overlay.get(&owner, &package.id),
+                Some((_, OverlayFreshness::Fresh))
+            ) {
+                continue;
+            }
+            if self.negative_cache_active(&key) {
+                continue;
+            }
+            if !self.begin(&key) {
+                continue;
+            }
+            self.refresh_one(scope, &owner, &package, &capability_id, &requirement)
+                .await;
+            self.finish(&key);
+        }
+    }
+
+    async fn refresh_one(
+        &self,
+        scope: &ResourceScope,
+        owner: &OverlayScope,
+        package: &ExtensionPackage,
+        capability_id: &CapabilityId,
+        requirement: &RuntimeCredentialRequirement,
+    ) {
+        // Stage the turn user's credential for the discovery egress (the MCP
+        // lane consumes staged one-shot credentials only). The requirement
+        // router covers both source kinds — a raw secret-store handle AND a
+        // product-auth account (vendor-recipe credentials delivered through
+        // the extension setup channel). AuthRequired here IS the "user has no
+        // token" verdict.
+        match self
+            .runtime_ports
+            .stage_credential_requirement_once(scope, capability_id, requirement, &package.id)
+            .await
+        {
+            Ok(()) => {}
+            Err(CredentialStageError::AuthRequired) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    secret_handle = %requirement.handle,
+                    "hosted MCP per-user discovery skipped: credential not provisioned"
+                );
+                // The user has no credential: any previously discovered
+                // surface no longer authenticates — drop it so dispatch
+                // failures surface the missing credential instead of calling
+                // out with tools the provider will reject.
+                self.overlay.remove(owner, &package.id);
+                self.negative_insert(owner, package);
+                return;
+            }
+            Err(CredentialStageError::Backend) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    "hosted MCP per-user discovery skipped: credential staging backend failure"
+                );
+                self.keep_last_good(owner, package);
+                return;
+            }
+        }
+
+        // The egress pipeline requires a STAGED network policy for
+        // (scope, capability) — the dispatch path stages it via the
+        // ApplyNetworkPolicy obligation; stage the equivalent hosted-MCP
+        // policy for this discovery call.
+        self.runtime_ports.stage_network_policy_once(
+            scope,
+            capability_id,
+            hosted_mcp_discovery_network_policy(package),
+        );
+        let discovery = tokio::time::timeout(
+            TURN_DISCOVERY_TIMEOUT,
+            discover_hosted_mcp_package(
+                package,
+                // Per-turn refresh has no resolved manifest at hand; the host
+                // ceiling is the same bound the lane enforces anyway.
+                TURN_DISCOVERY_MAX_TOOLS,
+                scope.clone(),
+                self.runtime_ports.runtime_http_egress(),
+            ),
+        )
+        .await;
+        self.runtime_ports
+            .discard_staged_discovery_state(scope, capability_id);
+        match discovery {
+            Ok(Ok(discovered)) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    capability_count = discovered.capabilities.len(),
+                    "hosted MCP per-user discovery refreshed the user's tool surface"
+                );
+                self.overlay
+                    .insert(owner.clone(), discovered, DEFAULT_SCOPED_OVERLAY_TTL);
+            }
+            Ok(Err(HostedMcpDiscoveryError::Transient(reason))) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    reason,
+                    "hosted MCP per-user discovery failed transiently; keeping last-good surface"
+                );
+                self.keep_last_good(owner, package);
+            }
+            // A rejected credential is the caller's own auth problem, not a
+            // provider outage: suppress the re-probe like any permanent
+            // failure so one unauthenticated user cannot hammer the server
+            // every turn. The connect flow surfaces the challenge elsewhere.
+            Ok(Err(HostedMcpDiscoveryError::CredentialsRejected(_challenge))) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    "hosted MCP per-user discovery was rejected by the provider's auth; \
+                     suppressing re-probe until the caller reconnects"
+                );
+                self.negative_insert(owner, package);
+            }
+            Ok(Err(HostedMcpDiscoveryError::Permanent(reason))) => {
+                tracing::warn!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    reason,
+                    "hosted MCP per-user discovery failed permanently; suppressing re-probe"
+                );
+                self.negative_insert(owner, package);
+            }
+            Err(_elapsed) => {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    "hosted MCP per-user discovery timed out; keeping last-good surface"
+                );
+                self.keep_last_good(owner, package);
+            }
+        }
+    }
+
+    /// Re-arm a stale last-good entry so a transient provider failure does not
+    /// drop the user's discovered surface (and does not re-probe every turn).
+    fn keep_last_good(&self, owner: &OverlayScope, package: &ExtensionPackage) {
+        if self.overlay.get(owner, &package.id).is_some() {
+            self.overlay
+                .touch(owner, &package.id, DEFAULT_SCOPED_OVERLAY_TTL);
+        } else {
+            self.negative_insert(owner, package);
+        }
+    }
+
+    fn negative_cache_active(&self, key: &(OverlayScope, ExtensionId)) -> bool {
+        let Ok(mut negative) = self.negative_until.lock() else {
+            return false; // silent-ok: poisoned negative cache only re-probes
+        };
+        match negative.get(key) {
+            Some(until) if *until > Instant::now() => true,
+            Some(_) => {
+                negative.remove(key);
+                false
+            }
+            None => false,
+        }
+    }
+
+    fn negative_insert(&self, owner: &OverlayScope, package: &ExtensionPackage) {
+        if let Ok(mut negative) = self.negative_until.lock() {
+            negative.insert(
+                (owner.clone(), package.id.clone()),
+                Instant::now() + NEGATIVE_TTL,
+            );
+        }
+    }
+
+    fn begin(&self, key: &(OverlayScope, ExtensionId)) -> bool {
+        self.in_flight
+            .lock()
+            .map(|mut in_flight| in_flight.insert(key.clone()))
+            .unwrap_or(false) // silent-ok: poisoned single-flight skips refresh this turn
+    }
+
+    fn finish(&self, key: &(OverlayScope, ExtensionId)) {
+        if let Ok(mut in_flight) = self.in_flight.lock() {
+            in_flight.remove(key);
+        }
+    }
+}
+
+/// The discovery template for per-user hosted-MCP refresh: the package must be
+/// a hosted HTTP MCP provider whose FIRST capability (the discovery planning
+/// template) binds at least one [`SecretHandle`]-sourced runtime credential.
+/// Product-auth-account providers (e.g. NEAR AI) keep their activation-time
+/// discovery semantics and are not refreshed per user here.
+/// The discovery egress network policy: allow exactly the provider's audience
+/// host(s) over https, mirroring the grant-constraint policy the dispatch path
+/// stages for the same extension.
+fn hosted_mcp_discovery_network_policy(
+    package: &ExtensionPackage,
+) -> ironclaw_host_api::action::NetworkPolicy {
+    let mut allowed_targets = Vec::new();
+    for capability in &package.manifest.capabilities {
+        for credential in &capability.runtime_credentials {
+            if !allowed_targets.contains(&credential.audience) {
+                allowed_targets.push(credential.audience.clone());
+            }
+        }
+        for target in &capability.network_targets {
+            if !allowed_targets.contains(target) {
+                allowed_targets.push(target.clone());
+            }
+        }
+    }
+    ironclaw_host_api::action::NetworkPolicy {
+        allowed_targets,
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(2 * 1024 * 1024),
+    }
+}
+
+fn per_user_secret_discovery_template(
+    package: &ExtensionPackage,
+) -> Option<(CapabilityId, RuntimeCredentialRequirement)> {
+    if !is_hosted_http_mcp_package(package) {
+        return None;
+    }
+    let template = package.manifest.capabilities.first()?;
+    // Both credential kinds qualify: a raw `SecretHandle` credential, and a
+    // vendor-recipe (`ProductAuthAccount`) credential delivered through the
+    // extension's setup channel (the v3 `[mcp]` + `[auth.<vendor>]` shape,
+    // e.g. a vendor bearer). Staging routes by the requirement's
+    // SOURCE (`stage_credential_requirement_once`), and a user without the
+    // credential fails closed into the AuthRequired skip.
+    let requirement = template
+        .runtime_credentials
+        .iter()
+        .find(|credential| {
+            matches!(
+                credential.source,
+                RuntimeCredentialRequirementSource::SecretHandle
+                    | RuntimeCredentialRequirementSource::ProductAuthAccount { .. }
+            )
+        })
+        .cloned()?;
+    Some((template.id.clone(), requirement))
+}

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/hosted_mcp_overlay.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/hosted_mcp_overlay.rs
@@ -55,6 +55,13 @@ const TURN_DISCOVERY_MAX_TOOLS: u32 = 1024;
 /// not a wedged turn.
 const TURN_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(8);
 
+/// Ceiling on ALL of a turn's discovery, not just one call. The per-call bound
+/// is multiplied by however many hosted-MCP providers are eligible, so without
+/// this a turn with N slow providers stalls for N × [`TURN_DISCOVERY_TIMEOUT`]
+/// before its capability port is even built. Packages past the budget keep
+/// their last-good surface, exactly as a per-call timeout leaves them.
+const TURN_DISCOVERY_BUDGET: Duration = Duration::from_secs(12);
+
 /// How long a missing-credential / permanent-failure verdict suppresses
 /// re-probing. Long enough to keep failed discovery off every turn, short
 /// enough that a freshly provisioned token is picked up within ~2 minutes.
@@ -97,7 +104,9 @@ impl HostedMcpOverlayRefresher {
                 .extensions()
                 .filter_map(|package| {
                     per_user_secret_discovery_template(package).map(
-                        |(capability_id, requirement)| (package.clone(), capability_id, requirement),
+                        |(capability_id, requirement)| {
+                            (package.clone(), capability_id, requirement)
+                        },
                     )
                 })
                 .collect();
@@ -106,7 +115,17 @@ impl HostedMcpOverlayRefresher {
             scope.user_id.clone(),
             scope.thread_id.clone(),
         );
+        let deadline = tokio::time::Instant::now() + TURN_DISCOVERY_BUDGET;
         for (package, capability_id, requirement) in eligible {
+            if tokio::time::Instant::now() >= deadline {
+                tracing::debug!(
+                    extension_id = %package.id,
+                    user_id = %scope.user_id,
+                    "hosted MCP per-user discovery skipped: turn budget spent; \
+                     keeping last-good surface"
+                );
+                continue;
+            }
             let key = (owner.clone(), package.id.clone());
             if matches!(
                 self.overlay.get(&owner, &package.id),
@@ -117,12 +136,11 @@ impl HostedMcpOverlayRefresher {
             if self.negative_cache_active(&key) {
                 continue;
             }
-            if !self.begin(&key) {
+            let Some(_in_flight) = InFlightGuard::acquire(self, key) else {
                 continue;
-            }
+            };
             self.refresh_one(scope, &owner, &package, &capability_id, &requirement)
                 .await;
-            self.finish(&key);
         }
     }
 
@@ -229,7 +247,9 @@ impl HostedMcpOverlayRefresher {
                 self.negative_insert(owner, package);
             }
             Ok(Err(HostedMcpDiscoveryError::Permanent(reason))) => {
-                tracing::warn!(
+                // `debug!`, not `warn!`: this runs on a background turn path
+                // and `warn!` corrupts the REPL/TUI (CLAUDE.md logging rule).
+                tracing::debug!(
                     extension_id = %package.id,
                     user_id = %scope.user_id,
                     reason,
@@ -352,4 +372,33 @@ fn per_user_secret_discovery_template(
         })
         .cloned()?;
     Some((template.id.clone(), requirement))
+}
+
+/// Releases the single-flight slot on drop.
+///
+/// `finish` used to run only after `refresh_one` returned. A turn future
+/// dropped mid-await — turn abort, client disconnect, shutdown — skipped it,
+/// leaving `(owner, extension)` pinned in `in_flight` for the process
+/// lifetime; every later turn for that caller then short-circuited and never
+/// re-discovered, so the caller stayed on its last-good surface (or the static
+/// manifest) until restart. `tokio::time::timeout` does not help: it bounds
+/// the inner discovery, not the dropping of the outer future.
+struct InFlightGuard<'a> {
+    refresher: &'a HostedMcpOverlayRefresher,
+    key: (OverlayScope, ExtensionId),
+}
+
+impl<'a> InFlightGuard<'a> {
+    fn acquire(
+        refresher: &'a HostedMcpOverlayRefresher,
+        key: (OverlayScope, ExtensionId),
+    ) -> Option<Self> {
+        refresher.begin(&key).then(|| Self { refresher, key })
+    }
+}
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.refresher.finish(&self.key);
+    }
 }

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/shell_tests.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/shell_tests.rs
@@ -98,6 +98,7 @@ async fn standalone_yolo_shell_translates_workspace_workdir_without_scoped_mount
             .system_extensions_lifecycle_mounts_for_test()
             .clone(),
         extension_surface_source: ExtensionCapabilitySurfaceSource::default(),
+        hosted_mcp_overlay_refresher: None,
         input_resolver,
         result_writer,
         milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/tests.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/tests.rs
@@ -1803,6 +1803,7 @@ mod tests {
         // `result_read` capability and confirm the two chunks concatenate
         // with no gap or overlap.
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id: fallback_user_id.clone(),
             policy: Arc::clone(runtime_surfaces.capability_policy_for_test()),
@@ -2179,6 +2180,7 @@ mod tests {
             .expect("finalized reference exists");
 
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id: fallback_user_id.clone(),
             policy: Arc::clone(runtime_surfaces.capability_policy_for_test()),
@@ -2822,6 +2824,7 @@ mod tests {
             crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses"),
         );
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id: UserId::new("skill-activate-user").expect("user id"),
             policy,
@@ -3104,6 +3107,7 @@ mod tests {
             crate::builtin_capability_policy::builtin_capability_policy().expect("policy parses"),
         );
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id: UserId::new("external-tool-provider-name-user").expect("user id"),
             policy,
@@ -3188,6 +3192,7 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id: UserId::new("project-create-fallback-user").expect("user id"),
             policy: Arc::clone(runtime_surfaces.capability_policy_for_test()),
@@ -3392,6 +3397,7 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id,
             policy: Arc::clone(runtime_surfaces.capability_policy_for_test()),
@@ -3788,6 +3794,7 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id,
             policy: Arc::clone(runtime_surfaces.capability_policy_for_test()),
@@ -4271,6 +4278,7 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id,
             policy: Arc::clone(runtime_surfaces.capability_policy_for_test()),
@@ -4427,6 +4435,7 @@ mod tests {
                 crate::wrap_scoped(Arc::clone(runtime_surfaces.extension_filesystem_for_test())),
             ));
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id: fallback_user_id.clone(),
             policy,
@@ -5127,6 +5136,7 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io;
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id: UserId::new("outbound-delivery-fallback-user").expect("user id"),
             policy,
@@ -5241,6 +5251,7 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id: UserId::new("local-yolo-host-user").expect("user id"), // safety: literal test id is valid.
             policy,
@@ -5490,6 +5501,7 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id: UserId::new("standalone-skill-port-user").expect("user id"), // safety: literal test id is valid.
             policy,
@@ -5625,6 +5637,7 @@ mod tests {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
             runtime,
             fallback_user_id: UserId::new("standalone-no-host-user").expect("user id"), // safety: literal test id is valid.
             policy,

--- a/crates/app/ironclaw_composition/src/runtime/capability_host/workspace_scoping_tests.rs
+++ b/crates/app/ironclaw_composition/src/runtime/capability_host/workspace_scoping_tests.rs
@@ -79,6 +79,7 @@ async fn invoke_workspace_tool_as(
     let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
     let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
     let factory = RefreshingLoopCapabilityPortFactory {
+            hosted_mcp_overlay_refresher: None,
         runtime: services.host_runtime.clone(),
         fallback_user_id: UserId::new("workspace-scoping-fallback").expect("user id"), // safety: test-only literal id.
         policy: Arc::new(

--- a/crates/extensions/ironclaw_extension_host/src/active.rs
+++ b/crates/extensions/ironclaw_extension_host/src/active.rs
@@ -230,6 +230,34 @@ impl ActiveSnapshot {
         })
     }
 
+    /// Resolve a per-user DISCOVERED hosted-MCP tool id whose exact id is not
+    /// in the static `capability_owner` map. A hosted-MCP extension's
+    /// capability adapter is per-extension and derives the wire tool name from
+    /// the request's capability id, so any `<provider>.<tool>` of an active
+    /// hosted-MCP provider dispatches through that provider's one adapter.
+    /// Authorization (per-user grants) still gates which discovered ids are
+    /// allowed, and the server rejects tools the caller may not use, so
+    /// resolving broadly by provider is safe.
+    pub fn resolve_hosted_mcp_tool(
+        &self,
+        capability_id: &CapabilityId,
+    ) -> Option<ResolvedToolBinding> {
+        if self.capability_owner.contains_key(capability_id) {
+            return None;
+        }
+        let (provider, _tool) = capability_id.as_str().split_once('.')?;
+        let extension = self.extensions.get(provider)?;
+        if extension.resolved.runtime.kind() != ironclaw_host_api::runtime::RuntimeKind::Mcp {
+            return None;
+        }
+        let adapter = extension.extension.capability_adapter()?;
+        Some(ResolvedToolBinding {
+            adapter,
+            declaration: Arc::clone(&extension.resolved),
+            generation: self.generation,
+        })
+    }
+
     /// Resolve a prebound device-link adapter by extension id.
     ///
     /// Keyed on the extension rather than a capability id because a device-link

--- a/crates/extensions/ironclaw_extension_host/src/capability_surface.rs
+++ b/crates/extensions/ironclaw_extension_host/src/capability_surface.rs
@@ -18,53 +18,62 @@ use ironclaw_extension_registry::{InstallationOwner, OverlayScope, ScopedPackage
 use ironclaw_product_contracts::error::ProductOperationFailure;
 
 #[derive(Clone, Default)]
-pub struct ExtensionCapabilitySurfaceSource {
-    extension_management: Option<Arc<RebornLocalExtensionManagementPort>>,
-    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
+pub enum ExtensionCapabilitySurfaceSource {
+    #[default]
+    Empty,
+    /// The live management port, plus the caller's discovered-package overlay
+    /// when one is attached. The overlay rides in the variant rather than in a
+    /// struct field so the test-only `Static` seam stays a variant too.
+    Management(
+        Arc<RebornLocalExtensionManagementPort>,
+        Option<Arc<ScopedPackageOverlay>>,
+    ),
     #[cfg(any(test, feature = "test-support"))]
-    static_surface: Option<ExtensionCapabilitySurface>,
+    Static(ExtensionCapabilitySurface),
 }
 
 impl ExtensionCapabilitySurfaceSource {
     pub fn new(extension_management: Option<Arc<RebornLocalExtensionManagementPort>>) -> Self {
-        Self {
-            extension_management,
-            scoped_overlay: None,
-            #[cfg(any(test, feature = "test-support"))]
-            static_surface: None,
+        match extension_management {
+            Some(extension_management) => Self::Management(extension_management, None),
+            None => Self::Empty,
         }
     }
 
     /// Attach the per-user discovered-package overlay so grants and provider
-    /// trust cover the caller's discovered hosted-MCP surface (P2b).
-    pub fn with_scoped_overlay(mut self, overlay: Arc<ScopedPackageOverlay>) -> Self {
-        self.scoped_overlay = Some(overlay);
-        self
+    /// trust cover the caller's discovered hosted-MCP surface. Without a
+    /// management port there is no surface to overlay, so the other variants
+    /// are returned unchanged.
+    pub fn with_scoped_overlay(self, overlay: Arc<ScopedPackageOverlay>) -> Self {
+        match self {
+            Self::Management(extension_management, _) => {
+                Self::Management(extension_management, Some(overlay))
+            }
+            other => other,
+        }
     }
 
     #[cfg(any(test, feature = "test-support"))]
     pub fn from_surface(surface: ExtensionCapabilitySurface) -> Self {
-        Self {
-            extension_management: None,
-            scoped_overlay: None,
-            static_surface: Some(surface),
-        }
+        Self::Static(surface)
     }
 
     pub async fn snapshot(&self) -> Result<ExtensionCapabilitySurface, ProductOperationFailure> {
-        #[cfg(any(test, feature = "test-support"))]
-        if let Some(surface) = &self.static_surface {
-            return Ok(surface.clone());
+        match self {
+            Self::Empty => Ok(ExtensionCapabilitySurface::default()),
+            Self::Management(extension_management, scoped_overlay) => {
+                let mut surface =
+                    ExtensionCapabilitySurface::from_extension_management(extension_management)
+                        .await?;
+                // The caller's discovered-package overlay rides with the
+                // surface, so grants and provider trust see the same catalog
+                // dispatch will.
+                surface.scoped_overlay = scoped_overlay.clone();
+                Ok(surface)
+            }
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Static(surface) => Ok(surface.clone()),
         }
-        let Some(extension_management) = self.extension_management.as_deref() else {
-            return Ok(ExtensionCapabilitySurface::default());
-        };
-        let mut surface =
-            ExtensionCapabilitySurface::from_extension_management(extension_management).await?;
-        // The caller's discovered-package overlay rides with the surface, so
-        // grants and provider trust see the same catalog dispatch will (P2b).
-        surface.scoped_overlay = self.scoped_overlay.clone();
-        Ok(surface)
     }
 }
 
@@ -152,11 +161,7 @@ impl ExtensionCapabilitySurface {
     /// authorization reuses the grants minted here, so a capability filtered
     /// out is both invisible in the surface AND denied at dispatch — grant
     /// absence fails closed with no separate preflight.
-    pub fn grants(
-        &self,
-        grantee: &ExtensionId,
-        caller: &OverlayScope,
-    ) -> Vec<CapabilityGrant> {
+    pub fn grants(&self, grantee: &ExtensionId, caller: &OverlayScope) -> Vec<CapabilityGrant> {
         self.caller_capabilities(caller)
             .iter()
             .map(|capability| CapabilityGrant {
@@ -200,10 +205,7 @@ impl ExtensionCapabilitySurface {
     /// Provider trust for the same request; filtered by the same owner rule as
     /// [`Self::grants`] so a user-private extension's provider is not even
     /// advertised to other users' surfaces.
-    pub fn provider_trust(
-        &self,
-        caller: &OverlayScope,
-    ) -> BTreeMap<ExtensionId, TrustDecision> {
+    pub fn provider_trust(&self, caller: &OverlayScope) -> BTreeMap<ExtensionId, TrustDecision> {
         let mut effects_by_provider: BTreeMap<ExtensionId, Vec<EffectKind>> = BTreeMap::new();
         for capability in &self.caller_capabilities(caller) {
             let effects = effects_by_provider

--- a/crates/extensions/ironclaw_extension_host/src/capability_surface.rs
+++ b/crates/extensions/ironclaw_extension_host/src/capability_surface.rs
@@ -14,45 +14,64 @@ use ironclaw_host_api::{
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 
 use crate::extension_lifecycle::RebornLocalExtensionManagementPort;
+use ironclaw_extension_registry::{InstallationOwner, OverlayScope, ScopedPackageOverlay};
 use ironclaw_product_contracts::error::ProductOperationFailure;
 
 #[derive(Clone, Default)]
-pub enum ExtensionCapabilitySurfaceSource {
-    #[default]
-    Empty,
-    Management(Arc<RebornLocalExtensionManagementPort>),
+pub struct ExtensionCapabilitySurfaceSource {
+    extension_management: Option<Arc<RebornLocalExtensionManagementPort>>,
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
     #[cfg(any(test, feature = "test-support"))]
-    Static(ExtensionCapabilitySurface),
+    static_surface: Option<ExtensionCapabilitySurface>,
 }
 
 impl ExtensionCapabilitySurfaceSource {
     pub fn new(extension_management: Option<Arc<RebornLocalExtensionManagementPort>>) -> Self {
-        match extension_management {
-            Some(extension_management) => Self::Management(extension_management),
-            None => Self::Empty,
+        Self {
+            extension_management,
+            scoped_overlay: None,
+            #[cfg(any(test, feature = "test-support"))]
+            static_surface: None,
         }
+    }
+
+    /// Attach the per-user discovered-package overlay so grants and provider
+    /// trust cover the caller's discovered hosted-MCP surface (P2b).
+    pub fn with_scoped_overlay(mut self, overlay: Arc<ScopedPackageOverlay>) -> Self {
+        self.scoped_overlay = Some(overlay);
+        self
     }
 
     #[cfg(any(test, feature = "test-support"))]
     pub fn from_surface(surface: ExtensionCapabilitySurface) -> Self {
-        Self::Static(surface)
+        Self {
+            extension_management: None,
+            scoped_overlay: None,
+            static_surface: Some(surface),
+        }
     }
 
     pub async fn snapshot(&self) -> Result<ExtensionCapabilitySurface, ProductOperationFailure> {
-        match self {
-            Self::Empty => Ok(ExtensionCapabilitySurface::default()),
-            Self::Management(extension_management) => {
-                ExtensionCapabilitySurface::from_extension_management(extension_management).await
-            }
-            #[cfg(any(test, feature = "test-support"))]
-            Self::Static(surface) => Ok(surface.clone()),
+        #[cfg(any(test, feature = "test-support"))]
+        if let Some(surface) = &self.static_surface {
+            return Ok(surface.clone());
         }
+        let Some(extension_management) = self.extension_management.as_deref() else {
+            return Ok(ExtensionCapabilitySurface::default());
+        };
+        let mut surface =
+            ExtensionCapabilitySurface::from_extension_management(extension_management).await?;
+        // The caller's discovered-package overlay rides with the surface, so
+        // grants and provider trust see the same catalog dispatch will (P2b).
+        surface.scoped_overlay = self.scoped_overlay.clone();
+        Ok(surface)
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct ExtensionCapabilitySurface {
     active_capabilities: Vec<ActiveExtensionCapability>,
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
 }
 
 impl ExtensionCapabilitySurface {
@@ -60,6 +79,7 @@ impl ExtensionCapabilitySurface {
     pub fn from_active_capabilities(active_capabilities: Vec<ActiveExtensionCapability>) -> Self {
         Self {
             active_capabilities,
+            scoped_overlay: None,
         }
     }
 
@@ -70,7 +90,60 @@ impl ExtensionCapabilitySurface {
             active_capabilities: extension_management
                 .active_model_visible_capabilities()
                 .await?,
+            scoped_overlay: None,
         })
+    }
+
+    /// The caller's effective capability set: active capabilities visible to
+    /// the caller, with any extension the caller holds a discovered overlay
+    /// for replaced by its discovered (per-principal) capability set. The
+    /// overlay applies only to extensions with a caller-visible active
+    /// installation (fail closed).
+    fn caller_capabilities(&self, caller: &OverlayScope) -> Vec<ActiveExtensionCapability> {
+        let user = caller.user_id();
+        let overlay_capabilities = self.overlay_capabilities(caller);
+        let overlaid_providers: Vec<&ExtensionId> = overlay_capabilities
+            .iter()
+            .map(|capability| &capability.provider)
+            .collect();
+        let mut merged: Vec<ActiveExtensionCapability> = self
+            .active_capabilities
+            .iter()
+            .filter(|capability| capability.owner.visible_to(user))
+            .filter(|capability| !overlaid_providers.contains(&&capability.provider))
+            .cloned()
+            .collect();
+        merged.extend(overlay_capabilities);
+        merged
+    }
+
+    fn overlay_capabilities(&self, caller: &OverlayScope) -> Vec<ActiveExtensionCapability> {
+        let Some(overlay) = &self.scoped_overlay else {
+            return Vec::new();
+        };
+        let user = caller.user_id();
+        let mut capabilities = Vec::new();
+        for package in overlay.packages_for(caller) {
+            let caller_sees_provider = self.active_capabilities.iter().any(|capability| {
+                capability.provider == package.id && capability.owner.visible_to(user)
+            });
+            if !caller_sees_provider {
+                continue;
+            }
+            for descriptor in &package.capabilities {
+                capabilities.push(ActiveExtensionCapability {
+                    id: descriptor.id.clone(),
+                    provider: descriptor.provider.clone(),
+                    effects: descriptor.effects.clone(),
+                    default_permission: descriptor.default_permission,
+                    runtime_credentials: descriptor.runtime_credentials.clone(),
+                    network_targets: descriptor.network_targets.clone(),
+                    max_egress_bytes: None,
+                    owner: InstallationOwner::user(user.clone()),
+                });
+            }
+        }
+        capabilities
     }
 
     /// Mint capability grants for one request (#5459 P1: filtered to the
@@ -82,11 +155,10 @@ impl ExtensionCapabilitySurface {
     pub fn grants(
         &self,
         grantee: &ExtensionId,
-        caller: &ironclaw_host_api::ids::UserId,
+        caller: &OverlayScope,
     ) -> Vec<CapabilityGrant> {
-        self.active_capabilities
+        self.caller_capabilities(caller)
             .iter()
-            .filter(|capability| capability.owner.visible_to(caller))
             .map(|capability| CapabilityGrant {
                 id: CapabilityGrantId::new(),
                 capability: capability.id.clone(),
@@ -130,13 +202,10 @@ impl ExtensionCapabilitySurface {
     /// advertised to other users' surfaces.
     pub fn provider_trust(
         &self,
-        caller: &ironclaw_host_api::ids::UserId,
+        caller: &OverlayScope,
     ) -> BTreeMap<ExtensionId, TrustDecision> {
         let mut effects_by_provider: BTreeMap<ExtensionId, Vec<EffectKind>> = BTreeMap::new();
-        for capability in &self.active_capabilities {
-            if !capability.owner.visible_to(caller) {
-                continue;
-            }
+        for capability in &self.caller_capabilities(caller) {
             let effects = effects_by_provider
                 .entry(capability.provider.clone())
                 .or_default();
@@ -230,6 +299,11 @@ pub fn extension_network_policy(capability: &ActiveExtensionCapability) -> Netwo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironclaw_host_api::ids::TenantId;
+
+    fn test_owner(user: &ironclaw_host_api::ids::UserId) -> OverlayScope {
+        OverlayScope::new(TenantId::new("tenant-a").unwrap(), user.clone(), None)
+    }
     use ironclaw_host_api::{
         action::{NetworkScheme, NetworkTargetPattern},
         capability::PermissionMode,
@@ -312,7 +386,7 @@ mod tests {
 
         for member in [&alice, &bob] {
             let member_capabilities: Vec<_> = surface
-                .grants(&grantee, member)
+                .grants(&grantee, &test_owner(member))
                 .into_iter()
                 .map(|grant| grant.capability.as_str().to_string())
                 .collect();
@@ -324,7 +398,7 @@ mod tests {
         }
 
         let carol_capabilities: Vec<_> = surface
-            .grants(&grantee, &carol)
+            .grants(&grantee, &test_owner(&carol))
             .into_iter()
             .map(|grant| grant.capability.as_str().to_string())
             .collect();
@@ -335,10 +409,10 @@ mod tests {
         assert!(carol_capabilities.contains(&"hacker-news.top_stories".to_string()));
 
         for member in [&alice, &bob] {
-            let member_trust = surface.provider_trust(member);
+            let member_trust = surface.provider_trust(&test_owner(member));
             assert!(member_trust.contains_key(&ExtensionId::new("market-data").unwrap()));
         }
-        let carol_trust = surface.provider_trust(&carol);
+        let carol_trust = surface.provider_trust(&test_owner(&carol));
         assert!(
             !carol_trust.contains_key(&ExtensionId::new("market-data").unwrap()),
             "a member-held provider must not be advertised to a non-member"

--- a/crates/extensions/ironclaw_extension_host/src/generic_host.rs
+++ b/crates/extensions/ironclaw_extension_host/src/generic_host.rs
@@ -285,10 +285,6 @@ pub fn effective_resolved_for_package(
     base: &ResolvedExtensionManifest,
     package: &ExtensionPackage,
 ) -> ResolvedExtensionManifest {
-    let mut resolved = ResolvedExtensionManifest {
-        tools: merged_effective_tools(base, package),
-        ..base.clone()
-    };
     // Discovered per-tool schemas must be persisted for both the virtual
     // (user-registered, remote-only) package shape and the materialized
     // host-bundled shape whose descriptors are inline-dynamic (hosted MCP
@@ -303,8 +299,20 @@ pub fn effective_resolved_for_package(
             ironclaw_extension_registry::PackageRootBinding::Materialized(_)
         ) && package.descriptor_schema_mode
             == ironclaw_extension_registry::CapabilityDescriptorSchemaMode::InlineDynamic);
+    let mut resolved = ResolvedExtensionManifest {
+        tools: merged_effective_tools(base, package, captures_dynamic_schemas),
+        ..base.clone()
+    };
+    let kept: std::collections::BTreeSet<String> = resolved
+        .tools
+        .iter()
+        .map(|tool| tool.id.as_str().to_string())
+        .collect();
     if captures_dynamic_schemas && let Some(mcp) = resolved.mcp.as_mut() {
-        mcp.dynamic_input_schemas = package
+        // Overlay onto the stored map rather than replacing it: a tool carried
+        // over from an earlier discovery keeps the schema that made carrying it
+        // safe. Entries for tools no longer in the catalog are pruned below.
+        let fresh: std::collections::BTreeMap<String, serde_json::Value> = package
             .capabilities
             .iter()
             .map(|descriptor| {
@@ -314,6 +322,8 @@ pub fn effective_resolved_for_package(
                 )
             })
             .collect();
+        mcp.dynamic_input_schemas.extend(fresh);
+        mcp.dynamic_input_schemas.retain(|id, _| kept.contains(id));
     }
     resolved
 }
@@ -325,28 +335,43 @@ pub fn effective_resolved_for_package(
 fn merged_effective_tools(
     base: &ResolvedExtensionManifest,
     package: &ExtensionPackage,
+    captures_dynamic_schemas: bool,
 ) -> Vec<ironclaw_extension_registry::CapabilityDeclV2> {
     let published = &package.manifest.capabilities;
     if base.tools.is_empty() {
         return published.clone();
     }
-    let mut merged: Vec<_> =
-        base.tools
-            .iter()
-            .filter_map(|declared| {
-                match published.iter().find(|fresh| fresh.id == declared.id) {
-                    // Discovered this time: the fresh entry carries the live
-                    // schema and wins.
-                    Some(fresh) => Some(fresh.clone()),
-                    // Not discovered by this caller. Carry a real tool over, but
-                    // never the `[mcp]` discovery template: it is HostInternal,
-                    // it is not a callable tool, and the published package
-                    // legitimately drops it once discovery has run.
-                    None => (declared.visibility == CapabilityVisibility::Model)
-                        .then(|| declared.clone()),
-                }
-            })
-            .collect();
+    // A carried-over tool must still have a schema, or rebuilding the package
+    // from this record fails closed and the extension stops activating at all.
+    // Where schemas are dynamic, that means the base already recorded one for
+    // it from an earlier discovery; a tool that has never been discovered is
+    // not invented here. Where they are not, the manifest's own `$ref`
+    // resolves and every declared tool is safe to carry.
+    let has_schema = |id: &ironclaw_host_api::ids::CapabilityId| {
+        !captures_dynamic_schemas
+            || base
+                .mcp
+                .as_ref()
+                .is_some_and(|mcp| mcp.dynamic_input_schemas.contains_key(id.as_str()))
+    };
+    let mut merged: Vec<_> = base
+        .tools
+        .iter()
+        .filter_map(|declared| {
+            match published.iter().find(|fresh| fresh.id == declared.id) {
+                // Discovered this time: the fresh entry carries the live
+                // schema and wins.
+                Some(fresh) => Some(fresh.clone()),
+                // Not discovered by this caller. Carry a real tool over, but
+                // never the `[mcp]` discovery template: it is HostInternal,
+                // it is not a callable tool, and the published package
+                // legitimately drops it once discovery has run.
+                None => (declared.visibility == CapabilityVisibility::Model
+                    && has_schema(&declared.id))
+                .then(|| declared.clone()),
+            }
+        })
+        .collect();
     // `max_tools` bounds what a REMOTE server may inject into the surface, so
     // it is spent on discovered-only entries. Declared tools are manifest
     // authored and already counted against the ceiling at parse time, so they

--- a/crates/extensions/ironclaw_extension_host/src/generic_host.rs
+++ b/crates/extensions/ironclaw_extension_host/src/generic_host.rs
@@ -37,8 +37,8 @@ use ironclaw_extension_contracts::tool_adapter::{
     ToolAdapter, ToolCall, ToolError, ToolPorts, ToolResult,
 };
 use ironclaw_extension_registry::{
-    ExtensionInstallationError, ExtensionInstallationStorePort, ExtensionManifest,
-    ExtensionPackage, ResolvedExtensionManifest,
+    CapabilityVisibility, ExtensionInstallationError, ExtensionInstallationStorePort,
+    ExtensionManifest, ExtensionPackage, ResolvedExtensionManifest,
 };
 use ironclaw_host_api::path::VirtualPath;
 use ironclaw_host_api::{dispatch::RuntimeDispatchErrorKind, ids::ExtensionId};
@@ -267,15 +267,26 @@ pub async fn build_generic_extension_host(
 }
 
 /// The effective contract an activation publishes: the persisted declaration
-/// with the tool set replaced by the package actually being published
+/// with the tool set taken from the package actually being published
 /// (identical for static manifests; the ceiling-validated discovered set for
 /// hosted MCP).
+///
+/// A hosted-MCP catalog is per-principal upstream while this record is the
+/// installation's ONE persisted catalog (#6778). Replacing the declared set
+/// with what a single caller happened to see therefore deletes every tool that
+/// caller is not entitled to — permanently, for every other member of the
+/// installation. So a discovery that runs against a manifest which DECLARES
+/// its tools merges instead: discovered entries win per capability id (they
+/// carry the live schema), declared-but-undiscovered entries survive, and
+/// discovered-only entries are appended. A manifest with no declared tools —
+/// the user-registered/virtual shape, whose catalog only ever comes from
+/// discovery — keeps the plain replace.
 pub fn effective_resolved_for_package(
     base: &ResolvedExtensionManifest,
     package: &ExtensionPackage,
 ) -> ResolvedExtensionManifest {
     let mut resolved = ResolvedExtensionManifest {
-        tools: package.manifest.capabilities.clone(),
+        tools: merged_effective_tools(base, package),
         ..base.clone()
     };
     // Discovered per-tool schemas must be persisted for both the virtual
@@ -305,6 +316,55 @@ pub fn effective_resolved_for_package(
             .collect();
     }
     resolved
+}
+
+/// Tool set for [`effective_resolved_for_package`]: the published package's
+/// capabilities, widened by any capability the base declaration carries that
+/// this publication did not observe. Order follows the base declaration so a
+/// persisted catalog stays stable across discoveries.
+fn merged_effective_tools(
+    base: &ResolvedExtensionManifest,
+    package: &ExtensionPackage,
+) -> Vec<ironclaw_extension_registry::CapabilityDeclV2> {
+    let published = &package.manifest.capabilities;
+    if base.tools.is_empty() {
+        return published.clone();
+    }
+    let mut merged: Vec<_> =
+        base.tools
+            .iter()
+            .filter_map(|declared| {
+                match published.iter().find(|fresh| fresh.id == declared.id) {
+                    // Discovered this time: the fresh entry carries the live
+                    // schema and wins.
+                    Some(fresh) => Some(fresh.clone()),
+                    // Not discovered by this caller. Carry a real tool over, but
+                    // never the `[mcp]` discovery template: it is HostInternal,
+                    // it is not a callable tool, and the published package
+                    // legitimately drops it once discovery has run.
+                    None => (declared.visibility == CapabilityVisibility::Model)
+                        .then(|| declared.clone()),
+                }
+            })
+            .collect();
+    // `max_tools` bounds what a REMOTE server may inject into the surface, so
+    // it is spent on discovered-only entries. Declared tools are manifest
+    // authored and already counted against the ceiling at parse time, so they
+    // are never dropped to make room — the alternative silently deletes a
+    // capability the operator wrote down.
+    let room = base
+        .mcp
+        .as_ref()
+        .map(|mcp| (mcp.max_tools as usize).saturating_sub(merged.len()))
+        .unwrap_or(usize::MAX);
+    merged.extend(
+        published
+            .iter()
+            .filter(|fresh| !base.tools.iter().any(|declared| declared.id == fresh.id))
+            .take(room)
+            .cloned(),
+    );
+    merged
 }
 
 /// Loader over the host-runtime lanes and the binary-assembled native
@@ -1265,6 +1325,84 @@ input_schema_ref = "schemas/{id}/web_search.input.v1.json"
 "#,
             id = id,
         )
+    }
+
+    /// A hosted-MCP catalog is per-principal upstream, but the installation
+    /// persists ONE catalog (#6778). A discovery run by a caller who is only
+    /// entitled to a subset must therefore not delete the rest: the stand hit
+    /// exactly this, and an installation that declared nine marketplace tools
+    /// was permanently reduced to the single tool a worker credential could
+    /// see, for every user of that installation.
+    #[test]
+    fn a_partial_discovery_does_not_delete_the_declared_catalog() {
+        let id = "hosted-mcp-partial";
+        let toml = format!(
+            r#"
+schema_version = "reborn.extension_manifest.v3"
+id = "{id}"
+name = "Hosted MCP partial fixture"
+version = "0.1.0"
+description = "declares two tools; one caller only ever discovers one of them"
+trust = "first_party_requested"
+
+[mcp]
+server = "https://mcp.example.test/mcp"
+namespace = "{id}"
+max_tools = 8
+default_permission = "ask"
+effects = ["network"]
+
+[[tools]]
+id = "{id}.search"
+description = "Only some principals may call this"
+default_permission = "ask"
+input_schema_ref = "schemas/{id}/search.input.v1.json"
+
+[[tools]]
+id = "{id}.submit"
+description = "Every principal may call this"
+default_permission = "ask"
+input_schema_ref = "schemas/{id}/submit.input.v1.json"
+"#
+        );
+        let root = VirtualPath::new(format!("/system/extensions/{id}")).expect("test root");
+        let record = ExtensionManifestRecord::from_toml_with_root_binding(
+            toml,
+            ManifestSource::HostBundled,
+            &ironclaw_host_api::host_port::default_host_port_catalog().expect("host port catalog"),
+            None,
+            &crate::product_extension_host_api_contract_registry().expect("test contracts"),
+            ironclaw_extension_registry::PackageRootBinding::Materialized(root.clone()),
+        )
+        .expect("fixture manifest resolves");
+        let base_resolved = record.resolved().clone();
+        // Plus the `[mcp]` template capability the v3 parser synthesizes.
+        assert_eq!(base_resolved.tools.len(), 3);
+
+        // The package this caller's discovery produced: only `submit`.
+        let mut narrowed = record.manifest().clone();
+        narrowed
+            .capabilities
+            .retain(|tool| tool.id.as_str().ends_with(".submit"));
+        let manifest = ironclaw_extension_registry::ExtensionManifest::try_from(narrowed)
+            .expect("narrowed manifest rebuilds");
+        let partial =
+            ExtensionPackage::from_manifest(manifest, root).expect("narrowed package constructs");
+        assert_eq!(partial.manifest.capabilities.len(), 1);
+
+        let effective = effective_resolved_for_package(&base_resolved, &partial);
+        let ids: Vec<_> = effective
+            .tools
+            .iter()
+            .map(|tool| tool.id.as_str().to_string())
+            .collect();
+        assert!(
+            ids.contains(&format!("{id}.search")) && ids.contains(&format!("{id}.submit")),
+            "a caller who cannot see `search` must not delete it from the installation: {ids:?}"
+        );
+        // The `[mcp]` template capability is HostInternal and is dropped once
+        // discovery has run, exactly as before this change.
+        assert_eq!(ids.len(), 2, "{ids:?}");
     }
 
     /// Regression test for the production incident: "The run failed while

--- a/crates/extensions/ironclaw_extension_host/src/mcp.rs
+++ b/crates/extensions/ironclaw_extension_host/src/mcp.rs
@@ -2,12 +2,15 @@ use std::sync::Arc;
 
 use ironclaw_extension_contracts::runtime::ExtensionRuntime;
 use ironclaw_extension_registry::{
-    ExtensionPackage, SharedExtensionRegistry, is_hosted_http_mcp_package,
+    ExtensionPackage, OverlayScope, ScopedPackageOverlay, SharedExtensionRegistry,
+    is_hosted_http_mcp_package,
 };
 use ironclaw_host_api::{
     action::{NetworkPolicy, NetworkScheme, NetworkTargetPattern},
+    capability::CapabilityDescriptor,
     http::{RuntimeCredentialInjection, RuntimeCredentialSource, RuntimeHttpEgress},
     ids::{CapabilityId, ExtensionId},
+    resource::ResourceScope,
 };
 use ironclaw_mcp::{
     McpHostHttpClient, McpHostHttpEgressPlan, McpHostHttpEgressPlanRequest,
@@ -21,35 +24,76 @@ const MCP_TIMEOUT_MS: u32 = 60_000;
 pub fn hosted_http_mcp_runtime(
     registry: Arc<SharedExtensionRegistry>,
     runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
 ) -> McpRuntime<
     McpHostHttpClient<McpRuntimeHttpAdapter<Arc<dyn RuntimeHttpEgress>>, RegistryMcpEgressPlanner>,
 > {
-    let client = McpHostHttpClient::new(
-        McpRuntimeHttpAdapter::new(runtime_http_egress),
-        RegistryMcpEgressPlanner::new(registry),
-    );
+    let mut planner = RegistryMcpEgressPlanner::new(registry);
+    if let Some(overlay) = scoped_overlay {
+        planner = planner.with_scoped_overlay(overlay);
+    }
+    let client = McpHostHttpClient::new(McpRuntimeHttpAdapter::new(runtime_http_egress), planner);
     McpRuntime::new(McpRuntimeConfig::default(), client)
 }
 
 #[derive(Debug, Clone)]
 pub struct RegistryMcpEgressPlanner {
     registry: Arc<SharedExtensionRegistry>,
+    /// Per-user discovered-package overlay (P2b). Credential injection for a
+    /// DISCOVERED hosted-MCP tool must resolve its descriptor from the caller's
+    /// overlay — the discovered capability id is not in the global registry, so
+    /// resolving against `registry` alone injects no credential and the call
+    /// egresses unauthenticated. `None` for callers with no overlay (discovery,
+    /// static-only providers).
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
 }
 
 impl RegistryMcpEgressPlanner {
     pub fn new(registry: Arc<SharedExtensionRegistry>) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            scoped_overlay: None,
+        }
+    }
+
+    pub fn with_scoped_overlay(mut self, overlay: Arc<ScopedPackageOverlay>) -> Self {
+        self.scoped_overlay = Some(overlay);
+        self
+    }
+
+    /// Resolve `capability_id`'s descriptor for `scope`, consulting the caller's
+    /// per-user overlay so a DISCOVERED capability (absent from the global
+    /// registry) still resolves. Falls back to the global snapshot when there is
+    /// no overlay.
+    fn scoped_capability(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) -> Option<CapabilityDescriptor> {
+        match &self.scoped_overlay {
+            Some(overlay) => {
+                let owner = OverlayScope::new(
+                    scope.tenant_id.clone(),
+                    scope.user_id.clone(),
+                    scope.thread_id.clone(),
+                );
+                overlay
+                    .view_for(&owner, self.registry.snapshot())
+                    .get_capability(capability_id)
+                    .cloned()
+            }
+            None => self.registry.snapshot().get_capability(capability_id).cloned(),
+        }
     }
 
     fn credential_injections(
         &self,
+        scope: &ResourceScope,
         provider: &ExtensionId,
         capability_id: &CapabilityId,
         endpoint: &HostedMcpEgressEndpoint,
     ) -> Vec<RuntimeCredentialInjection> {
-        self.registry
-            .snapshot()
-            .get_capability(capability_id)
+        self.scoped_capability(scope, capability_id)
             .filter(|descriptor| &descriptor.provider == provider)
             .map(|descriptor| {
                 descriptor
@@ -85,8 +129,12 @@ impl McpHostHttpEgressPlanner for RegistryMcpEgressPlanner {
         if !hosted_mcp_url_allowed(request.url, &endpoint) {
             return McpHostHttpEgressPlan::default();
         }
-        let credential_injections =
-            self.credential_injections(request.provider, request.capability_id, &endpoint);
+        let credential_injections = self.credential_injections(
+            request.scope,
+            request.provider,
+            request.capability_id,
+            &endpoint,
+        );
         McpHostHttpEgressPlan {
             // Credential-free hosted MCP providers are valid: the manifest may
             // expose a public/unauthenticated server, and host network policy
@@ -230,7 +278,8 @@ mod tests {
         let capability_id = CapabilityId::new("notion.notion-search").unwrap();
         let endpoint = HostedMcpEgressEndpoint::parse(NOTION_MCP_URL).unwrap();
 
-        let injections = planner.credential_injections(&provider, &capability_id, &endpoint);
+        let injections =
+            planner.credential_injections(&sample_scope(), &provider, &capability_id, &endpoint);
 
         assert_eq!(injections.len(), 1);
         assert_eq!(

--- a/crates/extensions/ironclaw_extension_host/src/product_lifecycle.rs
+++ b/crates/extensions/ironclaw_extension_host/src/product_lifecycle.rs
@@ -80,6 +80,7 @@ use crate::{
     manifest_runtime_credential_auth_requirements, package_activation_credential_auth_requirements,
     package_declares_inbound_product_adapter, package_runtime_credential_auth_requirements,
 };
+use ironclaw_extension_registry::merge_discovered_hosted_mcp_package;
 
 use crate::ActiveExtensionPublisher;
 use crate::{
@@ -1538,6 +1539,28 @@ impl ExtensionLifecycleManager {
                 return activation_credentials_incomplete_response(package_ref, missing);
             }
         }
+        // Hosted-MCP catalogs are per-principal upstream but the active
+        // registry keys one package per extension (#6778): publishing this
+        // caller's discovery verbatim would evict every other principal's
+        // tools. Merge with the published package so fresh tools win per
+        // capability id and the rest of the catalog survives.
+        let package = match self
+            .active_extensions
+            .snapshot()
+            .get_extension(&extension_id)
+        {
+            Some(published) => merge_discovered_hosted_mcp_package(&package, published)
+                .unwrap_or_else(|error| {
+                    tracing::warn!(
+                        %error,
+                        extension_id = %extension_id.as_str(),
+                        "hosted MCP discovery could not merge with the published catalog; \
+                         publishing the fresh discovery only"
+                    );
+                    package
+                }),
+            None => package,
+        };
         self.commit_activation(
             package_ref,
             &extension_id,

--- a/crates/extensions/ironclaw_extension_host/src/resolver.rs
+++ b/crates/extensions/ironclaw_extension_host/src/resolver.rs
@@ -53,7 +53,11 @@ impl SnapshotToolResolver {
 impl ToolResolver for SnapshotToolResolver {
     fn resolve(&self, capability_id: &CapabilityId) -> Option<ResolvedCapability> {
         let snapshot = self.watch.current();
-        let binding = snapshot.resolve_tool(capability_id)?;
+        // A per-user DISCOVERED hosted-MCP tool is not in the static
+        // capability map — fall back to its provider's one adapter.
+        let binding = snapshot
+            .resolve_tool(capability_id)
+            .or_else(|| snapshot.resolve_hosted_mcp_tool(capability_id))?;
         let provider = ExtensionId::new(binding.declaration.id.as_str()).ok()?;
         let runtime = binding.declaration.runtime.kind();
         Some(ResolvedCapability {

--- a/crates/extensions/ironclaw_extension_manager/src/test_support/lifecycle.rs
+++ b/crates/extensions/ironclaw_extension_manager/src/test_support/lifecycle.rs
@@ -496,6 +496,7 @@ async fn build_lifecycle_test_services_over_backing(
         host_services = host_services.with_mcp_runtime(Arc::new(hosted_http_mcp_runtime(
             shared_registry,
             runtime_http_egress,
+            None,
         )));
     }
     let runtime_ports = host_services.product_auth_provider_runtime_ports();

--- a/crates/extensions/ironclaw_extension_registry/src/hosted_mcp_discovery.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/hosted_mcp_discovery.rs
@@ -1,4 +1,5 @@
 use ironclaw_extension_contracts::hosted_mcp::HostedMcpDiscoveredTool;
+use crate::resolved::PackageRootBinding;
 use ironclaw_extension_contracts::runtime::ExtensionRuntime;
 use ironclaw_host_api::{
     action::{NetworkScheme, NetworkTargetPattern},
@@ -76,6 +77,74 @@ pub fn package_with_discovered_hosted_mcp_tools(
         _ => Err(invalid_hosted_mcp_manifest(
             "hosted MCP discovery requires bundled or user-registered provenance".to_string(),
         )),
+    }
+}
+
+/// Merge a freshly discovered hosted-MCP package with the currently published
+/// package for the same extension.
+///
+/// The marketplace serves a different `tools/list` catalog per authenticated
+/// principal, but the active registry keys one package per extension id
+/// (#6778): publishing one principal's discovery verbatim evicts every other
+/// principal's tools — a worker activation would remove the concierge's
+/// catalog and strand its in-flight tool calls. Until catalogs are keyed
+/// per user, publication keeps a superset: fresh discovery wins per
+/// capability id, and published capabilities the fresh catalog did not
+/// return are carried over (both the manifest declaration and its
+/// descriptor, so package consistency validation still holds).
+pub fn merge_discovered_hosted_mcp_package(
+    discovered: &ExtensionPackage,
+    published: &ExtensionPackage,
+) -> Result<ExtensionPackage, ExtensionError> {
+    if published.id != discovered.id {
+        return Err(invalid_hosted_mcp_manifest(format!(
+            "cannot merge discovered package {} with published package {}",
+            discovered.id, published.id
+        )));
+    }
+    let mut manifest = discovered.manifest.clone();
+    let mut capabilities = discovered.capabilities.clone();
+    for declared in &published.manifest.capabilities {
+        if manifest
+            .capabilities
+            .iter()
+            .any(|capability| capability.id == declared.id)
+        {
+            continue;
+        }
+        let Some(descriptor) = published
+            .capabilities
+            .iter()
+            .find(|descriptor| descriptor.id == declared.id)
+        else {
+            // A published package always carries a descriptor per manifest
+            // declaration; a missing one means the published record is not a
+            // validated package, so skip the row rather than fail activation.
+            continue;
+        };
+        manifest.capabilities.push(declared.clone());
+        capabilities.push(descriptor.clone());
+    }
+    // The merged package keeps the discovered package's root binding; a
+    // remote-only (virtual-rooted) catalog has no materialized root to carry.
+    match &discovered.root_binding {
+        PackageRootBinding::Materialized(root) => {
+            ExtensionPackage::from_host_bundled_manifest_with_inline_dynamic_schemas(
+                manifest,
+                root.clone(),
+                discovered.manifest_digest(),
+                capabilities,
+            )
+        }
+        // A remote-only (or not-yet-materialized) catalog has no package tree
+        // to carry into the merge.
+        PackageRootBinding::Virtual | PackageRootBinding::FabricateOnLoad => {
+            ExtensionPackage::from_virtual_manifest(
+                manifest,
+                discovered.manifest_digest(),
+                capabilities,
+            )
+        }
     }
 }
 
@@ -196,6 +265,39 @@ fn discovered_capability_manifest(
         effects.push(EffectKind::ExternalWrite);
     }
 
+    // A HOST-BUNDLED manifest may pre-declare known tools of its server (the
+    // static fallback catalog). Those declarations went through the same
+    // review as the rest of the manifest, so a discovered tool with a
+    // matching capability id ADOPTS its declared effects and permission —
+    // e.g. a marketplace hire tool keeps its `financial` marking (and the
+    // hard approval floor keyed on it) when the live catalog replaces the
+    // static one, and an `allow` declared for autonomous read tools survives
+    // discovery. Unknown discovered tools keep the conservative derived
+    // effects + Ask. Only MODEL-visible declarations participate: a
+    // host-internal row (the synthesized `<id>.mcp_server` connection
+    // template) is host plumbing, and a server returning a tool named after
+    // it must not inherit that row's permissions.
+    let declared = package
+        .manifest
+        .capabilities
+        .iter()
+        .filter(|capability| capability.visibility == CapabilityVisibility::Model)
+        .find(|capability| capability.id == capability_id);
+    let (effects, default_permission) = match declared {
+        Some(capability) => {
+            // Union with the derived set: the manifest may add (financial),
+            // never hide what the connection mechanically does.
+            let mut merged = effects;
+            for effect in &capability.effects {
+                if !merged.contains(effect) {
+                    merged.push(*effect);
+                }
+            }
+            (merged, capability.default_permission)
+        }
+        None => (effects, PermissionMode::Ask),
+    };
+
     Ok(CapabilityManifest {
         id: capability_id,
         description: if tool.description.trim().is_empty() {
@@ -204,7 +306,7 @@ fn discovered_capability_manifest(
             tool.description.clone()
         },
         effects,
-        default_permission: PermissionMode::Ask,
+        default_permission,
         visibility: CapabilityVisibility::Model,
         // Discovered MCP tools are never a `standard_op` binding — that is
         // static `[[tools]]` vocabulary validated at manifest parse time;
@@ -395,6 +497,201 @@ runtime_credentials = [
                 port: None,
             }]
         );
+    }
+
+    /// A discovered tool whose id matches a manifest-declared static tool
+    /// adopts that declaration's effects (unioned with the derived set) and
+    /// default_permission — the reviewed manifest keeps authority over known
+    /// tools across discovery. Unknown discovered tools stay conservative
+    /// (derived effects + Ask).
+    #[test]
+    fn discovered_tool_adopts_matching_manifest_declaration() {
+        let mut package = notion_package();
+        // Declare notion.notion-buy as a known static tool with financial +
+        // allow — the shape a marketplace hire tool ships with.
+        let mut declared = package.manifest.capabilities[0].clone();
+        declared.id = ironclaw_host_api::ids::CapabilityId::new("notion.notion-buy").unwrap();
+        declared.effects = vec![
+            EffectKind::DispatchCapability,
+            EffectKind::Network,
+            EffectKind::UseSecret,
+            EffectKind::Financial,
+        ];
+        declared.default_permission = ironclaw_host_api::capability::PermissionMode::Allow;
+        package.manifest.capabilities.push(declared);
+
+        let tools = vec![
+            HostedMcpDiscoveredTool {
+                name: "notion-buy".to_string(),
+                description: "Spends money".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+                annotations: HostedMcpDiscoveredToolAnnotations::default(),
+            },
+            HostedMcpDiscoveredTool {
+                name: "notion-unknown".to_string(),
+                description: "Not declared anywhere".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+                annotations: HostedMcpDiscoveredToolAnnotations::default(),
+            },
+        ];
+        let discovered = package_with_discovered_hosted_mcp_tools(&package, &tools)
+            .expect("build discovered package");
+
+        let buy = discovered
+            .capabilities
+            .iter()
+            .find(|c| c.id.as_str() == "notion.notion-buy")
+            .expect("declared tool discovered");
+        assert!(buy.effects.contains(&EffectKind::Financial), "declared financial survives discovery");
+        assert_eq!(buy.default_permission, ironclaw_host_api::capability::PermissionMode::Allow);
+
+        let unknown = discovered
+            .capabilities
+            .iter()
+            .find(|c| c.id.as_str() == "notion.notion-unknown")
+            .expect("unknown tool discovered");
+        assert!(!unknown.effects.contains(&EffectKind::Financial));
+        assert_eq!(unknown.default_permission, ironclaw_host_api::capability::PermissionMode::Ask, "unknown discovered tools stay Ask");
+    }
+
+    /// A host-internal manifest row (the synthesized `<id>.mcp_server`
+    /// connection template) is host plumbing, not a reviewed tool grant: a
+    /// server returning a tool with the matching name must NOT adopt its
+    /// declaration — it stays on derived effects + Ask.
+    #[test]
+    fn discovered_tool_does_not_adopt_host_internal_declarations() {
+        let template_id = "notion.mcp_server";
+        let mut package = notion_package();
+        let mut template = package.manifest.capabilities[0].clone();
+        template.id = ironclaw_host_api::ids::CapabilityId::new(template_id).unwrap();
+        template.visibility = CapabilityVisibility::HostInternal;
+        template.default_permission = ironclaw_host_api::capability::PermissionMode::Allow;
+        package.manifest.capabilities.push(template);
+
+        let tools = vec![HostedMcpDiscoveredTool {
+            // Derived from the template so the collision cannot drift.
+            name: template_id
+                .rsplit('.')
+                .next()
+                .expect("template id has a suffix")
+                .to_string(),
+            description: "Tool named after the connection template".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+            annotations: HostedMcpDiscoveredToolAnnotations::default(),
+        }];
+        let discovered = package_with_discovered_hosted_mcp_tools(&package, &tools)
+            .expect("build discovered package");
+
+        let shadowed = discovered
+            .capabilities
+            .iter()
+            .find(|c| c.id.as_str() == template_id)
+            .expect("tool discovered");
+        assert_eq!(
+            shadowed.default_permission,
+            ironclaw_host_api::capability::PermissionMode::Ask,
+            "a host-internal declaration must not hand its permission to a discovered tool"
+        );
+    }
+
+    fn discovered_tool(name: &str, description: &str) -> HostedMcpDiscoveredTool {
+        HostedMcpDiscoveredTool {
+            name: name.to_string(),
+            description: description.to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+            annotations: HostedMcpDiscoveredToolAnnotations::default(),
+        }
+    }
+
+    /// One principal's discovery must not evict another principal's published
+    /// tools (#6778): the merged package is fresh-wins-per-id superset.
+    #[test]
+    fn merged_discovery_keeps_other_principals_catalog() {
+        let package = notion_package();
+        let concierge = package_with_discovered_hosted_mcp_tools(
+            &package,
+            &[discovered_tool("notion-hire", "Hire an agent")],
+        )
+        .expect("concierge discovery");
+        let worker = package_with_discovered_hosted_mcp_tools(
+            &package,
+            &[discovered_tool("notion-deliver", "Submit a deliverable")],
+        )
+        .expect("worker discovery");
+
+        let merged =
+            merge_discovered_hosted_mcp_package(&worker, &concierge).expect("merged package");
+
+        for id in ["notion.notion-deliver", "notion.notion-hire"] {
+            assert!(
+                merged
+                    .capabilities
+                    .iter()
+                    .any(|capability| capability.id.as_str() == id),
+                "merged package must keep {id}"
+            );
+        }
+        assert_eq!(merged.manifest.capabilities.len(), 2);
+        assert_eq!(merged.capabilities.len(), 2);
+    }
+
+    #[test]
+    fn merged_discovery_prefers_fresh_tool_over_published() {
+        let package = notion_package();
+        let stale = package_with_discovered_hosted_mcp_tools(
+            &package,
+            &[discovered_tool("notion-search", "Stale description")],
+        )
+        .expect("stale discovery");
+        let fresh = package_with_discovered_hosted_mcp_tools(
+            &package,
+            &[discovered_tool("notion-search", "Fresh description")],
+        )
+        .expect("fresh discovery");
+
+        let merged = merge_discovered_hosted_mcp_package(&fresh, &stale).expect("merged package");
+
+        assert_eq!(merged.capabilities.len(), 1);
+        assert_eq!(merged.capabilities[0].description, "Fresh description");
+    }
+
+    /// Merging against the published static-fallback package (pre-discovery
+    /// state after a restart) keeps the reviewed static catalog alive for the
+    /// principals that still rely on it.
+    #[test]
+    fn merged_discovery_keeps_static_fallback_from_published_base() {
+        let base = notion_package();
+        let worker = package_with_discovered_hosted_mcp_tools(
+            &base,
+            &[discovered_tool("notion-deliver", "Submit a deliverable")],
+        )
+        .expect("worker discovery");
+
+        let merged = merge_discovered_hosted_mcp_package(&worker, &base).expect("merged package");
+
+        for id in ["notion.notion-deliver", "notion.notion-fetch"] {
+            assert!(
+                merged
+                    .capabilities
+                    .iter()
+                    .any(|capability| capability.id.as_str() == id),
+                "merged package must keep {id}"
+            );
+        }
+    }
+
+    #[test]
+    fn merged_discovery_rejects_mismatched_extension_ids() {
+        let package = notion_package();
+        let discovered = package_with_discovered_hosted_mcp_tools(
+            &package,
+            &[discovered_tool("notion-search", "Search")],
+        )
+        .expect("discovery");
+        let mut foreign = package.clone();
+        foreign.id = ironclaw_host_api::ids::ExtensionId::new("other").expect("valid id");
+
+        assert!(merge_discovered_hosted_mcp_package(&discovered, &foreign).is_err());
     }
 
     #[test]

--- a/crates/extensions/ironclaw_extension_registry/src/lib.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/lib.rs
@@ -194,6 +194,7 @@ mod installations;
 mod lifecycle;
 mod package;
 mod registry;
+mod scoped_overlay;
 pub mod resolved;
 pub mod v2;
 pub mod v3;
@@ -216,7 +217,8 @@ pub use host_api::default_host_api_contract_registry;
 // `ironclaw_extension_contracts::hosted_mcp`, and §11.2.4's one-import-path
 // rule forbids a second path to a contract.
 pub use hosted_mcp_discovery::{
-    is_hosted_http_mcp_package, package_with_discovered_hosted_mcp_tools,
+    is_hosted_http_mcp_package, merge_discovered_hosted_mcp_package,
+    package_with_discovered_hosted_mcp_tools,
 };
 pub use resolved::{
     PackageRootBinding, PackageRootError, ResolvedAuthSurface, ResolvedExtensionManifest,
@@ -245,6 +247,10 @@ pub use installations::{
 };
 pub use lifecycle::{
     ExtensionLifecycleEvent, ExtensionLifecycleEventSink, ExtensionLifecycleService,
+};
+pub use scoped_overlay::{
+    DEFAULT_SCOPED_OVERLAY_TTL, OverlaidRegistryView, OverlayFreshness, OverlayScope,
+    ScopedPackageOverlay,
 };
 pub use registry::{ExtensionRegistry, SharedExtensionRegistry};
 

--- a/crates/extensions/ironclaw_extension_registry/src/scoped_overlay.rs
+++ b/crates/extensions/ironclaw_extension_registry/src/scoped_overlay.rs
@@ -1,0 +1,835 @@
+//! Per-user discovered-package overlay over the global extension registry.
+//!
+//! Hosted-MCP providers can serve a **per-principal** `tools/list` (e.g. the
+//! agent marketplace returns concierge tools for a concierge bearer and the
+//! hirer-granted connector tools for a worker-agent bearer). The global
+//! [`crate::SharedExtensionRegistry`] holds exactly one surface per extension
+//! id, so per-principal discovered surfaces live here instead: an in-memory,
+//! TTL-bounded cache keyed by ([`OverlayScope`] = tenant + user + thread,
+//! `ExtensionId`).
+//!
+//! This is a **derived cache**, not lifecycle state: nothing here is
+//! persisted, installation records are never touched, and a restart simply
+//! re-discovers lazily. Consumers read through [`OverlaidRegistryView`], which
+//! prefers the caller's overlay entries and falls back to the global
+//! snapshot — the same view feeds the model surface, authorization, dispatch
+//! and egress planning so no parallel resolution pipeline exists.
+//!
+//! Security invariant: entries are keyed by the full tenant + user + thread
+//! scope whose credential produced the discovery result — never by a bare
+//! `UserId` (unique only within a tenant), and never by owner alone (a managed
+//! agent serves many hires under one identity, distinguished only by thread) —
+//! and a view only ever merges entries for the single scope it was built for.
+//! Cross-user, cross-tenant AND cross-thread leakage are regression-tested
+//! failure modes.
+
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use ironclaw_host_api::{
+    capability::CapabilityDescriptor,
+    ids::{CapabilityId, ExtensionId, TenantId, ThreadId, UserId},
+};
+use parking_lot::RwLock;
+
+use crate::{CapabilityVisibility, ExtensionPackage, ExtensionRegistry};
+
+/// The scope axes a discovered surface is keyed by: `tenant_id`, `user_id`,
+/// **and** `thread_id`.
+///
+/// The tenant axis is non-negotiable — a bare `UserId` is unique only within a
+/// tenant, so keying by user alone lets one tenant's discovered tool surface
+/// (and the refresher's negative-cache / single-flight verdicts) bleed into
+/// another tenant that reuses the same user id.
+///
+/// The thread axis is load-bearing for **isolation**, not merely cache
+/// efficiency. A managed worker agent serves several hires under ONE IronClaw
+/// identity (its own tenant + user); the only thing distinguishing hire A's
+/// discovered surface (e.g. a buyer's `timeless__*` connector) from hire B's
+/// (`firefly__*`) is the thread each job runs on. Keyed by owner alone, hire
+/// A's cached tools would serve hire B — a cross-buyer personal-data leak.
+/// `thread_id` is `None` only for non-threaded runtimes (one execution context,
+/// so the owner axis is sufficient); consumers treat `None` as its own bucket,
+/// never a wildcard. Every overlay and refresher operation takes this scope so
+/// no axis can be dropped at a call site.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OverlayScope {
+    tenant_id: TenantId,
+    user_id: UserId,
+    thread_id: Option<ThreadId>,
+}
+
+impl OverlayScope {
+    pub fn new(tenant_id: TenantId, user_id: UserId, thread_id: Option<ThreadId>) -> Self {
+        Self {
+            tenant_id,
+            user_id,
+            thread_id,
+        }
+    }
+
+    pub fn tenant_id(&self) -> &TenantId {
+        &self.tenant_id
+    }
+
+    pub fn user_id(&self) -> &UserId {
+        &self.user_id
+    }
+
+    pub fn thread_id(&self) -> Option<&ThreadId> {
+        self.thread_id.as_ref()
+    }
+}
+
+/// Default lifetime of a discovered per-user surface. It MUST comfortably
+/// exceed the longest single run: discovery runs at turn start and the
+/// discovered tools are then read live on every capability dispatch, so a TTL
+/// shorter than the run makes late tool calls (e.g. a worker agent's final
+/// `marketplace__submit_deliverable` after minutes of work — worse under an
+/// LLM-provider 5xx storm that stretches the run) vanish from the surface
+/// mid-run with `unknown_capability`. 30 min covers any realistic bounded run;
+/// a stable per-agent tool set (all of the agent's active connector grants)
+/// means the long window does not stale a worker's surface across dispatches,
+/// and the turn-start refresher still re-discovers once an idle entry expires.
+pub const DEFAULT_SCOPED_OVERLAY_TTL: Duration = Duration::from_secs(1800);
+
+/// How long past its TTL a discovered entry is retained (still served as
+/// last-good) before eviction.
+///
+/// Bounds the growth the thread cache axis would otherwise cause: a one-off
+/// job's thread never recurs, so freshness (which only gates *re-discovery* of
+/// the same scope) never expires it and it would be served-stale forever.
+/// Serving stays available within `[expiry, expiry + retention]` so a
+/// concurrent turn that skips the in-flight refresh keeps the surface, but a
+/// finished thread's entry is swept once it has been stale this long.
+/// Comfortably exceeds any bounded run plus the refresh gap.
+pub const OVERLAY_STALE_RETENTION: Duration = Duration::from_secs(1800);
+
+/// Hard cap on total live entries — a backstop against pathological growth
+/// (e.g. a burst of concurrent one-off jobs faster than the retention sweep).
+/// When exceeded, the entries closest to (or furthest past) expiry are evicted
+/// first.
+const MAX_OVERLAY_ENTRIES: usize = 4096;
+
+#[derive(Debug, Clone)]
+struct OverlayEntry {
+    package: Arc<ExtensionPackage>,
+    expires_at: Instant,
+}
+
+/// Freshness of a cached discovered surface. Freshness gates whether the
+/// turn-start refresher **re-discovers**; it does NOT gate whether readers
+/// **serve** the entry. Readers always serve the last-good package (fresh or
+/// stale) so a concurrent turn that skips the in-flight refresh — or any turn
+/// hitting an entry right at TTL expiry — keeps the discovered surface instead
+/// of flapping back to the static manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverlayFreshness {
+    /// Within TTL — no re-discovery needed.
+    Fresh,
+    /// Past TTL — the turn-start refresher should re-discover. The entry stays
+    /// served as last-good until discovery replaces it or an auth failure
+    /// removes it.
+    Stale,
+}
+
+/// In-memory discovered-package cache keyed by scope ([`OverlayScope`]:
+/// tenant + user + thread) and extension. Composition owns one instance and shares it
+/// (via `Arc`) with every registry consumer that resolves capabilities for a
+/// scoped request.
+#[derive(Debug)]
+pub struct ScopedPackageOverlay {
+    entries: RwLock<HashMap<(OverlayScope, ExtensionId), OverlayEntry>>,
+    /// How long past its TTL an entry is kept (still served last-good) before
+    /// eviction. A composition knob: production uses [`OVERLAY_STALE_RETENTION`];
+    /// a shorter value tightens the bound where discovered surfaces churn fast.
+    stale_retention: Duration,
+}
+
+impl Default for ScopedPackageOverlay {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ScopedPackageOverlay {
+    pub fn new() -> Self {
+        Self::with_stale_retention(OVERLAY_STALE_RETENTION)
+    }
+
+    /// Construct with an explicit stale-retention window (see the field).
+    pub fn with_stale_retention(stale_retention: Duration) -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            stale_retention,
+        }
+    }
+
+    /// Store (or refresh) `owner`'s discovered surface for `package.id`.
+    ///
+    /// Opportunistically evicts entries stale beyond the retention window (and
+    /// enforces [`MAX_OVERLAY_ENTRIES`]) on the same lock, so the per-thread key
+    /// axis cannot grow the cache without bound — inserts run at every turn-start
+    /// discovery, so the sweep keeps pace with new threads.
+    pub fn insert(&self, owner: OverlayScope, package: ExtensionPackage, ttl: Duration) {
+        let key = (owner, package.id.clone());
+        let entry = OverlayEntry {
+            package: Arc::new(package),
+            expires_at: Instant::now() + ttl,
+        };
+        let mut entries = self.entries.write();
+        entries.insert(key, entry);
+        self.evict_locked(&mut entries, Instant::now());
+    }
+
+    /// Evict entries stale beyond the retention window, then enforce the hard
+    /// cap (most-expired first). Called under the write lock from `insert`.
+    fn evict_locked(
+        &self,
+        entries: &mut HashMap<(OverlayScope, ExtensionId), OverlayEntry>,
+        now: Instant,
+    ) {
+        entries.retain(|_, entry| entry.expires_at + self.stale_retention > now);
+        if entries.len() > MAX_OVERLAY_ENTRIES {
+            let mut by_expiry: Vec<((OverlayScope, ExtensionId), Instant)> = entries
+                .iter()
+                .map(|(key, entry)| (key.clone(), entry.expires_at))
+                .collect();
+            by_expiry.sort_by_key(|(_, expires_at)| *expires_at);
+            let excess = entries.len() - MAX_OVERLAY_ENTRIES;
+            for (key, _) in by_expiry.into_iter().take(excess) {
+                entries.remove(&key);
+            }
+        }
+    }
+
+    /// Drop `owner`'s entry for `extension_id` (e.g. missing credential).
+    pub fn remove(&self, owner: &OverlayScope, extension_id: &ExtensionId) {
+        self.entries
+            .write()
+            .remove(&(owner.clone(), extension_id.clone()));
+    }
+
+    /// Drop every owner's entry for `extension_id` (extension deactivated or
+    /// replaced tenant-wide).
+    pub fn remove_extension(&self, extension_id: &ExtensionId) {
+        self.entries
+            .write()
+            .retain(|(_, entry_extension), _| entry_extension != extension_id);
+    }
+
+    /// The cached package for `(owner, extension_id)` with its freshness, if
+    /// any. The turn-start refresher uses the freshness to decide whether to
+    /// re-discover; the stale entry is still served as last-good by the reader
+    /// paths below.
+    pub fn get(
+        &self,
+        owner: &OverlayScope,
+        extension_id: &ExtensionId,
+    ) -> Option<(Arc<ExtensionPackage>, OverlayFreshness)> {
+        let entries = self.entries.read();
+        let entry = entries.get(&(owner.clone(), extension_id.clone()))?;
+        let freshness = if entry.expires_at > Instant::now() {
+            OverlayFreshness::Fresh
+        } else {
+            OverlayFreshness::Stale
+        };
+        Some((Arc::clone(&entry.package), freshness))
+    }
+
+    /// Re-arm the TTL on an existing entry (a transient discovery failure kept
+    /// the last-good surface; avoid re-running discovery every turn while the
+    /// provider is down).
+    pub fn touch(&self, owner: &OverlayScope, extension_id: &ExtensionId, ttl: Duration) {
+        if let Some(entry) = self
+            .entries
+            .write()
+            .get_mut(&(owner.clone(), extension_id.clone()))
+        {
+            entry.expires_at = Instant::now() + ttl;
+        }
+    }
+
+    /// The owner's last-good overlay packages (for grant/provider-trust minting
+    /// at surface-request time). Serves stale entries too — see
+    /// [`OverlayFreshness`]: freshness gates re-discovery, not serving.
+    pub fn packages_for(&self, owner: &OverlayScope) -> Vec<Arc<ExtensionPackage>> {
+        self.entries
+            .read()
+            .iter()
+            .filter(|((entry_owner, _), _)| entry_owner == owner)
+            .map(|(_, entry)| Arc::clone(&entry.package))
+            .collect()
+    }
+
+    /// A concrete `ExtensionRegistry` snapshot with the owner's last-good
+    /// discovered packages merged in (each overlaid extension's static package
+    /// replaced by its discovered one). Returns the `global` Arc unchanged when
+    /// the owner has no overlay entries — zero cost for the common case, so
+    /// every existing `self.registry.snapshot()` consumer can resolve an
+    /// owner's discovered capabilities by reading this instead, with no change
+    /// to its `&ExtensionRegistry` API.
+    pub fn merged_snapshot(
+        &self,
+        owner: &OverlayScope,
+        global: Arc<ExtensionRegistry>,
+    ) -> Arc<ExtensionRegistry> {
+        let packages = self.packages_for(owner);
+        if packages.is_empty() {
+            return global;
+        }
+        let mut merged = global.as_ref().clone();
+        for package in packages {
+            // Replace the static package with the discovered one. The
+            // discovered package was already validated at discovery time, so use
+            // the trusted (non-revalidating) insert to keep this off the
+            // per-invocation hot path; the preceding `remove` clears the static
+            // capability ids so there is no id collision to check.
+            merged.remove(&package.id);
+            merged.insert_validated(package.as_ref().clone());
+        }
+        Arc::new(merged)
+    }
+
+    /// Build the owner's merged view over `global` from the last-good
+    /// discovered packages (fresh or stale — serving is not freshness-gated).
+    pub fn view_for(
+        &self,
+        owner: &OverlayScope,
+        global: Arc<ExtensionRegistry>,
+    ) -> OverlaidRegistryView {
+        let overlays = self.packages_for(owner);
+        OverlaidRegistryView { global, overlays }
+    }
+}
+
+/// A single user's capability-resolution view: the global registry snapshot
+/// with that user's discovered packages layered on top. For an overlaid
+/// extension the overlay package **replaces** the global one — its discovered
+/// capability set is the extension's surface for this user.
+#[derive(Debug, Clone)]
+pub struct OverlaidRegistryView {
+    global: Arc<ExtensionRegistry>,
+    overlays: Vec<Arc<ExtensionPackage>>,
+}
+
+impl OverlaidRegistryView {
+    /// A view with no overlay entries (scope-less callers).
+    pub fn global_only(global: Arc<ExtensionRegistry>) -> Self {
+        Self {
+            global,
+            overlays: Vec::new(),
+        }
+    }
+
+    pub fn has_overlays(&self) -> bool {
+        !self.overlays.is_empty()
+    }
+
+    fn overlaid_extension(&self, id: &ExtensionId) -> Option<&ExtensionPackage> {
+        self.overlays
+            .iter()
+            .find(|package| &package.id == id)
+            .map(Arc::as_ref)
+    }
+
+    pub fn get_extension(&self, id: &ExtensionId) -> Option<&ExtensionPackage> {
+        self.overlaid_extension(id)
+            .or_else(|| self.global.get_extension(id))
+    }
+
+    pub fn get_capability(&self, id: &CapabilityId) -> Option<&CapabilityDescriptor> {
+        for package in &self.overlays {
+            if let Some(descriptor) = package
+                .capabilities
+                .iter()
+                .find(|descriptor| &descriptor.id == id)
+            {
+                return Some(descriptor);
+            }
+            // The overlay replaces this extension's whole surface: a global
+            // capability belonging to an overlaid extension is masked even
+            // when the discovered set no longer contains it.
+            if self
+                .global
+                .get_capability(id)
+                .is_some_and(|descriptor| descriptor.provider == package.id)
+            {
+                return None;
+            }
+        }
+        self.global.get_capability(id)
+    }
+
+    pub fn capability_visibility(&self, id: &CapabilityId) -> Option<CapabilityVisibility> {
+        for package in &self.overlays {
+            if let Some(capability) = package
+                .manifest
+                .capabilities
+                .iter()
+                .find(|capability| &capability.id == id)
+            {
+                return Some(capability.visibility);
+            }
+            if self
+                .global
+                .get_capability(id)
+                .is_some_and(|descriptor| descriptor.provider == package.id)
+            {
+                return None;
+            }
+        }
+        self.global.capability_visibility(id)
+    }
+
+    /// All capabilities visible in this view: global capabilities of
+    /// non-overlaid extensions plus every overlay capability.
+    pub fn capabilities(&self) -> impl Iterator<Item = &CapabilityDescriptor> {
+        let overlaid_ids: Vec<&ExtensionId> =
+            self.overlays.iter().map(|package| &package.id).collect();
+        self.global
+            .capabilities()
+            .filter(move |descriptor| !overlaid_ids.contains(&&descriptor.provider))
+            .chain(
+                self.overlays
+                    .iter()
+                    .flat_map(|package| package.capabilities.iter()),
+            )
+    }
+
+    /// The overlay packages themselves (for grant/provider-trust minting).
+    pub fn overlay_packages(&self) -> impl Iterator<Item = &ExtensionPackage> {
+        self.overlays.iter().map(Arc::as_ref)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ExtensionManifest, HostPortCatalog, ManifestSource};
+    use ironclaw_host_api::path::VirtualPath;
+
+    const STATIC_MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "agent-market"
+name = "Agent Market"
+version = "0.1.0"
+description = "Marketplace tools"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "http"
+url = "https://market.example.com/mcp"
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "agent-market.search_agents"
+description = "Search the marketplace"
+effects = ["dispatch_capability", "network", "use_secret"]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/search.input.json"
+output_schema_ref = "schemas/search.output.json"
+runtime_credentials = [
+  { handle = "agent-market-token", audience = { scheme = "https", host_pattern = "market.example.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " }, required = true }
+]
+"#;
+
+    fn capability_provider_contracts() -> crate::HostApiContractRegistry {
+        let mut contracts = crate::HostApiContractRegistry::new();
+        contracts
+            .register(std::sync::Arc::new(
+                crate::host_api::capability_provider::CapabilityProviderHostApiContract::new()
+                    .expect("capability provider contract"),
+            ))
+            .expect("register capability provider contract");
+        contracts
+    }
+
+    fn static_package() -> ExtensionPackage {
+        let manifest = ExtensionManifest::parse(
+            STATIC_MANIFEST,
+            ManifestSource::HostBundled,
+            &HostPortCatalog::default(),
+            &capability_provider_contracts(),
+        )
+        .expect("valid manifest");
+        ExtensionPackage::from_manifest(
+            manifest,
+            VirtualPath::new("/system/extensions/agent-market").expect("root"),
+        )
+        .expect("valid package")
+    }
+
+    fn discovered_package(tool: &str) -> ExtensionPackage {
+        let tools = vec![ironclaw_extension_contracts::hosted_mcp::HostedMcpDiscoveredTool {
+            name: tool.to_string(),
+            description: format!("discovered {tool}"),
+            input_schema: serde_json::json!({"type": "object"}),
+            annotations: Default::default(),
+        }];
+        crate::package_with_discovered_hosted_mcp_tools(&static_package(), &tools)
+            .expect("discoverable package")
+    }
+
+    fn global_registry() -> Arc<ExtensionRegistry> {
+        let mut registry = ExtensionRegistry::new();
+        registry.insert(static_package()).expect("insert static");
+        Arc::new(registry)
+    }
+
+    fn user(id: &str) -> UserId {
+        UserId::new(id).expect("user id")
+    }
+
+    fn owner(id: &str) -> OverlayScope {
+        OverlayScope::new(TenantId::new("tenant-a").expect("tenant"), user(id), None)
+    }
+
+    fn owner_in(tenant: &str, id: &str) -> OverlayScope {
+        OverlayScope::new(TenantId::new(tenant).expect("tenant"), user(id), None)
+    }
+
+    fn owner_thread(id: &str, thread: &str) -> OverlayScope {
+        OverlayScope::new(
+            TenantId::new("tenant-a").expect("tenant"),
+            user(id),
+            Some(ThreadId::new(thread).expect("thread id")),
+        )
+    }
+
+    fn capability(id: &str) -> CapabilityId {
+        CapabilityId::new(id).expect("capability id")
+    }
+
+    #[test]
+    fn stale_entries_beyond_retention_are_evicted_so_one_off_threads_dont_leak() {
+        // The thread cache axis means a one-off job's thread never recurs, so
+        // freshness alone never expires its entry — retention-based eviction
+        // bounds the growth. With a zero retention window, a stale (TTL-0) entry
+        // is swept by the next insert's opportunistic eviction.
+        let overlay = ScopedPackageOverlay::with_stale_retention(Duration::ZERO);
+        let one_off = owner_thread("worker-agent", "thread-a");
+        overlay.insert(
+            one_off.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::ZERO,
+        );
+        // A later job's insert triggers the sweep.
+        let live = owner_thread("worker-agent", "thread-b");
+        overlay.insert(
+            live.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+
+        assert!(
+            overlay.packages_for(&one_off).is_empty(),
+            "one-off thread's stale-beyond-retention entry must be evicted"
+        );
+        assert_eq!(
+            overlay.packages_for(&live).len(),
+            1,
+            "a fresh entry must survive the sweep"
+        );
+    }
+
+    #[test]
+    fn stale_within_retention_is_still_served_last_good() {
+        // Default (non-zero) retention keeps a just-expired entry served, so a
+        // concurrent turn that skips the in-flight refresh keeps the surface.
+        let overlay = ScopedPackageOverlay::new();
+        let job = owner_thread("worker-agent", "thread-a");
+        overlay.insert(
+            job.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::ZERO,
+        );
+        // Trigger a sweep with another insert; the just-expired entry is within
+        // the retention window, so it is retained.
+        overlay.insert(
+            owner_thread("worker-agent", "thread-b"),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+        assert_eq!(
+            overlay.packages_for(&job).len(),
+            1,
+            "stale-but-within-retention entry must still be served last-good"
+        );
+    }
+
+    #[test]
+    fn view_prefers_overlay_and_masks_replaced_static_capabilities() {
+        let overlay = ScopedPackageOverlay::new();
+        let worker = owner("worker-user");
+        overlay.insert(
+            worker.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+
+        let view = overlay.view_for(&worker, global_registry());
+        assert!(view.has_overlays());
+        assert!(
+            view.get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_some(),
+            "discovered capability must resolve"
+        );
+        assert!(
+            view.get_capability(&capability("agent-market.search_agents"))
+                .is_none(),
+            "static capability of an overlaid extension must be masked"
+        );
+        let ids: Vec<&str> = view
+            .capabilities()
+            .map(|descriptor| descriptor.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["agent-market.timeless__list_meetings"]);
+    }
+
+    #[test]
+    fn merged_snapshot_replaces_static_package_for_owner_and_is_untouched_for_others() {
+        let overlay = ScopedPackageOverlay::new();
+        let worker = owner("worker-user");
+        overlay.insert(
+            worker.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+
+        let worker_reg = overlay.merged_snapshot(&worker, global_registry());
+        assert!(
+            worker_reg
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_some(),
+            "merged snapshot resolves the discovered capability by plain get_capability"
+        );
+        assert!(
+            worker_reg
+                .get_capability(&capability("agent-market.search_agents"))
+                .is_none(),
+            "the static capability is replaced in the owner's merged snapshot"
+        );
+
+        let other_reg = overlay.merged_snapshot(&owner("other"), global_registry());
+        assert!(
+            other_reg
+                .get_capability(&capability("agent-market.search_agents"))
+                .is_some(),
+            "another user's merged snapshot keeps the static surface"
+        );
+        assert!(
+            other_reg
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn merged_snapshot_returns_global_arc_unchanged_without_overlay() {
+        let overlay = ScopedPackageOverlay::new();
+        let global = global_registry();
+        let merged = overlay.merged_snapshot(&owner("nobody"), Arc::clone(&global));
+        assert!(Arc::ptr_eq(&global, &merged), "zero-cost passthrough");
+    }
+
+    #[test]
+    fn overlay_entries_never_leak_across_users() {
+        let overlay = ScopedPackageOverlay::new();
+        let worker = owner("worker-user");
+        let other = owner("concierge-user");
+        overlay.insert(
+            worker.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+
+        let other_view = overlay.view_for(&other, global_registry());
+        assert!(!other_view.has_overlays());
+        assert!(
+            other_view
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_none(),
+            "another user's discovered capability must not resolve"
+        );
+        assert!(
+            other_view
+                .get_capability(&capability("agent-market.search_agents"))
+                .is_some(),
+            "the static surface must remain intact for other users"
+        );
+    }
+
+    #[test]
+    fn overlay_entries_never_leak_across_tenants_for_the_same_user_id() {
+        // The exact isolation Ilya flagged: same UserId, different tenant must
+        // not share a discovered surface or negative-cache verdict.
+        let overlay = ScopedPackageOverlay::new();
+        let tenant_a = owner_in("tenant-a", "shared-user");
+        let tenant_b = owner_in("tenant-b", "shared-user");
+        overlay.insert(
+            tenant_a.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+
+        let a_view = overlay.view_for(&tenant_a, global_registry());
+        assert!(a_view.has_overlays(), "owning tenant sees its surface");
+
+        let b_view = overlay.view_for(&tenant_b, global_registry());
+        assert!(
+            !b_view.has_overlays(),
+            "a different tenant with the same user id must not see it"
+        );
+        assert!(
+            b_view
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_none()
+        );
+        assert!(overlay.get(&tenant_b, &static_package().id).is_none());
+    }
+
+    #[test]
+    fn overlay_entries_never_leak_across_threads_for_the_same_owner() {
+        // The managed-agent isolation case: buyer A hires the agent and grants
+        // `timeless`, buyer B hires the SAME agent and grants `firefly`. Both
+        // jobs run under the agent's single IronClaw identity (same tenant +
+        // user), distinguished only by the thread each dispatch runs on. Keyed
+        // by owner alone, job B would see job A's `timeless` — a cross-buyer
+        // personal-data leak. Keyed by thread, each job sees only its own.
+        let overlay = ScopedPackageOverlay::new();
+        let job_a = owner_thread("worker-agent", "thread-a");
+        let job_b = owner_thread("worker-agent", "thread-b");
+        overlay.insert(
+            job_a.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(60),
+        );
+        overlay.insert(
+            job_b.clone(),
+            discovered_package("firefly__list_documents"),
+            Duration::from_secs(60),
+        );
+
+        let a_view = overlay.view_for(&job_a, global_registry());
+        assert!(
+            a_view
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_some(),
+            "job A sees its own connector"
+        );
+        assert!(
+            a_view
+                .get_capability(&capability("agent-market.firefly__list_documents"))
+                .is_none(),
+            "job A must NOT see buyer B's connector"
+        );
+
+        let b_view = overlay.view_for(&job_b, global_registry());
+        assert!(
+            b_view
+                .get_capability(&capability("agent-market.firefly__list_documents"))
+                .is_some(),
+            "job B sees its own connector"
+        );
+        assert!(
+            b_view
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_none(),
+            "job B must NOT see buyer A's connector"
+        );
+
+        // And a thread-less scope for the same owner is its own bucket — it sees
+        // neither job's surface.
+        let threadless = owner("worker-agent");
+        assert!(!overlay.view_for(&threadless, global_registry()).has_overlays());
+    }
+
+    #[test]
+    fn readers_serve_stale_last_good_so_concurrent_skipped_turns_keep_the_surface() {
+        // Point 2: an entry past TTL is still served (last-good). A concurrent
+        // turn that skips the in-flight refresh must not flap to the static
+        // manifest.
+        let overlay = ScopedPackageOverlay::new();
+        let worker = owner("worker-user");
+        overlay.insert(
+            worker.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(0), // already expired
+        );
+
+        assert_eq!(
+            overlay.get(&worker, &static_package().id).map(|(_, f)| f),
+            Some(OverlayFreshness::Stale),
+            "the entry is stale (refresher would re-discover)"
+        );
+        let view = overlay.view_for(&worker, global_registry());
+        assert!(
+            view.get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_some(),
+            "but readers still serve the stale last-good surface"
+        );
+        assert!(
+            overlay
+                .merged_snapshot(&worker, global_registry())
+                .get_capability(&capability("agent-market.timeless__list_meetings"))
+                .is_some(),
+            "merged_snapshot serves last-good too"
+        );
+    }
+
+    #[test]
+    fn get_reports_stale_after_ttl_and_touch_re_arms_to_fresh() {
+        let overlay = ScopedPackageOverlay::new();
+        let worker = owner("worker-user");
+        overlay.insert(
+            worker.clone(),
+            discovered_package("timeless__list_meetings"),
+            Duration::from_secs(0),
+        );
+
+        let (package, freshness) = overlay
+            .get(&worker, &static_package().id)
+            .expect("stale entry retained");
+        assert_eq!(
+            freshness,
+            OverlayFreshness::Stale,
+            "get() reports Stale so the refresher re-discovers"
+        );
+        assert_eq!(package.id.as_str(), "agent-market");
+
+        overlay.touch(&worker, &static_package().id, Duration::from_secs(60));
+        let (_, freshness) = overlay
+            .get(&worker, &static_package().id)
+            .expect("touched entry");
+        assert_eq!(freshness, OverlayFreshness::Fresh);
+    }
+
+    #[test]
+    fn remove_extension_clears_every_user() {
+        let overlay = ScopedPackageOverlay::new();
+        overlay.insert(
+            owner("a"),
+            discovered_package("t1"),
+            Duration::from_secs(60),
+        );
+        overlay.insert(
+            owner("b"),
+            discovered_package("t2"),
+            Duration::from_secs(60),
+        );
+        overlay.remove_extension(&static_package().id);
+        assert!(overlay.get(&owner("a"), &static_package().id).is_none());
+        assert!(overlay.get(&owner("b"), &static_package().id).is_none());
+    }
+}

--- a/crates/kernel/ironclaw_host_runtime/src/production.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/production.rs
@@ -27,7 +27,9 @@ use ironclaw_capabilities::{
     CapabilityHost, CapabilityInvocationError, CapabilityObligationHandler, CapabilitySpawnRequest,
     CapabilitySpawnResult,
 };
-use ironclaw_extension_registry::{ExtensionRegistry, SharedExtensionRegistry};
+use ironclaw_extension_registry::{
+    ExtensionRegistry, OverlayScope, ScopedPackageOverlay, SharedExtensionRegistry,
+};
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::capability::{CapabilityDescriptor, PROCESS_SANDBOX_CAPABILITY_ID};
 use ironclaw_host_api::{
@@ -115,6 +117,7 @@ use crate::{
 /// Default production wiring for [`HostRuntime`].
 pub struct DefaultHostRuntime {
     registry: Arc<SharedExtensionRegistry>,
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
     dispatcher: Arc<dyn CapabilityDispatcher>,
     authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer>,
     trust_policy: Arc<dyn TrustPolicy>,
@@ -184,6 +187,29 @@ impl DefaultHostRuntime {
         )
     }
 
+    /// Attach the per-user discovered-package overlay (P2b): per-invocation
+    /// capability resolution then merges the request user's discovered
+    /// hosted-MCP surface over the global registry.
+    pub fn with_scoped_overlay(mut self, overlay: Arc<ScopedPackageOverlay>) -> Self {
+        self.scoped_overlay = Some(overlay);
+        self
+    }
+
+    fn scoped_snapshot(
+        &self,
+        tenant_id: &ironclaw_host_api::ids::TenantId,
+        user_id: &ironclaw_host_api::ids::UserId,
+        thread_id: Option<&ironclaw_host_api::ids::ThreadId>,
+    ) -> Arc<ExtensionRegistry> {
+        match &self.scoped_overlay {
+            Some(overlay) => overlay.merged_snapshot(
+                &OverlayScope::new(tenant_id.clone(), user_id.clone(), thread_id.cloned()),
+                self.registry.snapshot(),
+            ),
+            None => self.registry.snapshot(),
+        }
+    }
+
     pub fn from_shared_registry(
         registry: Arc<SharedExtensionRegistry>,
         dispatcher: Arc<dyn CapabilityDispatcher>,
@@ -193,6 +219,7 @@ impl DefaultHostRuntime {
     ) -> Self {
         Self {
             registry,
+            scoped_overlay: None,
             dispatcher,
             authorizer,
             trust_policy: Arc::new(HostTrustPolicy::fail_closed()),
@@ -393,7 +420,11 @@ impl HostRuntime for DefaultHostRuntime {
         let invocation_id = context.invocation_id;
         let total_started_at = live_latency_started_at();
 
-        let registry = self.registry.snapshot();
+        let registry = self.scoped_snapshot(
+            &context.resource_scope.tenant_id,
+            &context.resource_scope.user_id,
+            context.resource_scope.thread_id.as_ref(),
+        );
 
         // Validate the execution context before the kernel's credential pre-flight
         // queries the secret store. Without this guard a malformed
@@ -492,7 +523,11 @@ impl HostRuntime for DefaultHostRuntime {
         let scope = context.resource_scope.clone();
         let invocation_id = context.invocation_id;
 
-        let registry = self.registry.snapshot();
+        let registry = self.scoped_snapshot(
+            &context.resource_scope.tenant_id,
+            &context.resource_scope.user_id,
+            context.resource_scope.thread_id.as_ref(),
+        );
 
         // Validate the execution context before the kernel's credential pre-flight
         // queries the secret store. Without this guard a malformed
@@ -560,7 +595,14 @@ impl HostRuntime for DefaultHostRuntime {
         // Trust classification runs inside the kernel's `authorize_resumed` fold,
         // which fails the blocked run on a trust rejection (replacing the former
         // host_runtime pre-authorization + `context.trust` stamp).
-        let registry = self.registry.snapshot();
+        // Per-(tenant, user, thread) discovered-package view, so a resumed
+        // invocation resolves against the caller's own hosted-MCP catalog
+        // rather than a globally clobbered one (P2b, #6778).
+        let registry = self.scoped_snapshot(
+            &context.resource_scope.tenant_id,
+            &context.resource_scope.user_id,
+            context.resource_scope.thread_id.as_ref(),
+        );
         // `context` is moved into `resume_json` below, so `resource_scope` must be
         // cloned out first. The response processor uses it if a dispatch failure
         // also needs to transition this resumed invocation to a terminal state.
@@ -617,7 +659,14 @@ impl HostRuntime for DefaultHostRuntime {
         // credential gate, and a trust rejection fails the blocked run there —
         // replacing the former host_runtime pre-authorization + `context.trust`
         // stamp.
-        let registry = self.registry.snapshot();
+        // Per-(tenant, user, thread) discovered-package view, so a resumed
+        // invocation resolves against the caller's own hosted-MCP catalog
+        // rather than a globally clobbered one (P2b, #6778).
+        let registry = self.scoped_snapshot(
+            &context.resource_scope.tenant_id,
+            &context.resource_scope.user_id,
+            context.resource_scope.thread_id.as_ref(),
+        );
         // Same clone-before-move as `resume_capability` above: `context` is
         // consumed by `auth_resume_json`, while the response processor uses the
         // scope if a dispatch failure must transition this resumed invocation.
@@ -713,7 +762,14 @@ impl HostRuntime for DefaultHostRuntime {
         // `resume_spawn_json` fold, which fails the blocked run on rejection —
         // replacing the former host_runtime pre-authorization + `context.trust`
         // stamp.
-        let registry = self.registry.snapshot();
+        // Per-(tenant, user, thread) discovered-package view, so a resumed
+        // invocation resolves against the caller's own hosted-MCP catalog
+        // rather than a globally clobbered one (P2b, #6778).
+        let registry = self.scoped_snapshot(
+            &context.resource_scope.tenant_id,
+            &context.resource_scope.user_id,
+            context.resource_scope.thread_id.as_ref(),
+        );
         let scope = context.resource_scope.clone();
         let invocation_id = context.invocation_id;
         let host = self.capability_host(&registry);
@@ -756,7 +812,11 @@ impl HostRuntime for DefaultHostRuntime {
         &self,
         request: VisibleCapabilityRequest,
     ) -> Result<VisibleCapabilitySurface, HostRuntimeError> {
-        let registry = self.registry.snapshot();
+        let registry = self.scoped_snapshot(
+            &request.context.tenant_id,
+            &request.context.user_id,
+            request.context.thread_id.as_ref(),
+        );
         let catalog = CapabilityCatalog::new(
             &registry,
             self.authorizer.as_ref(),

--- a/crates/kernel/ironclaw_host_runtime/src/services.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services.rs
@@ -27,7 +27,9 @@ use ironclaw_event_store::{
     RebornEventStores, RebornProfile, build_reborn_event_stores,
 };
 use ironclaw_extension_contracts::runtime::ExtensionRuntime;
-use ironclaw_extension_registry::{ExtensionRegistry, SharedExtensionRegistry};
+use ironclaw_extension_registry::{
+    ExtensionRegistry, ScopedPackageOverlay, SharedExtensionRegistry,
+};
 use ironclaw_filesystem::LibSqlRootFilesystem;
 use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::{DiskFilesystem, RootFilesystem, ScopedFilesystem};
@@ -133,6 +135,7 @@ where
     G: ResourceGovernor + 'static,
 {
     registry: Arc<SharedExtensionRegistry>,
+    scoped_overlay: Arc<ScopedPackageOverlay>,
     trust_policy: Arc<dyn TrustPolicy>,
     trust_policy_configured: bool,
     filesystem: Arc<F>,
@@ -298,6 +301,49 @@ impl ProductAuthProviderRuntimePorts {
             .await
     }
 
+    /// Resolve the owning scope for `handle` (caller's own secret first, then
+    /// the tenant-shared admin-managed secret — the same rule the dispatch-time
+    /// obligation preflight uses) and stage it. `AuthRequired` when no owner
+    /// scope holds the handle. Used by turn-start hosted-MCP discovery (P2b),
+    /// whose run scope is not the canonical scope user secrets are stored under.
+    pub async fn stage_owner_resolved_secret_once(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+    ) -> Result<(), ProductAuthCredentialStageError> {
+        let owner = crate::obligations::secret_owner_scope(self.secret_store.as_ref(), scope, handle)
+            .await
+            .map_err(stage_secret_error)?;
+        let Some(source_scope) = owner else {
+            return Err(ProductAuthCredentialStageError::AuthRequired);
+        };
+        self.stage_secret_from_scope_once(&source_scope, scope, capability_id, handle)
+            .await
+    }
+
+    /// Discard staged discovery state (network policy + secret material) for
+    /// (scope, capability) after a host-driven egress call completes (P2b
+    /// turn-start discovery).
+    pub fn discard_staged_discovery_state(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) {
+        self.network_policy_store
+            .discard_for_capability(scope, capability_id);
+        if let Err(error) = self
+            .secret_injection_store
+            .discard_for_capability(scope, capability_id)
+        {
+            tracing::debug!(
+                error = ?error,
+                capability_id = %capability_id,
+                "failed to discard staged discovery secret material"
+            );
+        }
+    }
+
     /// Stage one declared credential requirement for a host-driven call that
     /// bypasses the dispatch obligation pipeline (hosted-MCP discovery runs
     /// at activation, not through a capability invocation, so nothing else
@@ -447,6 +493,7 @@ where
         let credential_session_store: Arc<dyn CredentialSessionStore> = credential_broker;
         Self {
             registry: Arc::new(SharedExtensionRegistry::new((*registry).clone())),
+            scoped_overlay: Arc::new(ScopedPackageOverlay::new()),
             trust_policy: Arc::new(HostTrustPolicy::fail_closed()),
             trust_policy_configured: false,
             filesystem,
@@ -643,7 +690,10 @@ where
         });
         let mcp = self.mcp_runtime.as_ref().map(|runtime| {
             ServiceResolvedRuntimeAdapter::new(
-                Arc::new(McpRuntimeAdapter::from_executor(Arc::clone(runtime))),
+                Arc::new(
+                    McpRuntimeAdapter::from_executor(Arc::clone(runtime))
+                        .with_scoped_overlay(Arc::clone(&self.scoped_overlay)),
+                ),
                 Arc::clone(&invocation_services),
             )
         });
@@ -665,6 +715,12 @@ where
     /// Builds the upper service without production validation.
     pub fn shared_extension_registry(&self) -> Arc<SharedExtensionRegistry> {
         Arc::clone(&self.registry)
+    }
+
+    /// The per-user discovered-package overlay shared by every scoped
+    /// capability-resolution path (P2b).
+    pub fn scoped_package_overlay(&self) -> Arc<ScopedPackageOverlay> {
+        Arc::clone(&self.scoped_overlay)
     }
 
     /// Returns the canonical host-runtime HTTP egress port when configured.
@@ -782,6 +838,7 @@ where
             self.surface_version.clone(),
             runtime_policy,
         )
+        .with_scoped_overlay(Arc::clone(&self.scoped_overlay))
         .with_surface_filesystem(surface_filesystem)
         .with_trust_policy_dyn(Arc::clone(&self.trust_policy))
         .with_process_manager(process_manager)

--- a/crates/kernel/ironclaw_host_runtime/src/services/builder.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/builder.rs
@@ -35,6 +35,7 @@ where
     {
         let Self {
             registry,
+            scoped_overlay,
             trust_policy,
             trust_policy_configured,
             filesystem: _,
@@ -79,6 +80,7 @@ where
         component_types.filesystem = ProductionComponentType::of::<T>();
         HostRuntimeServices {
             registry,
+            scoped_overlay,
             trust_policy,
             trust_policy_configured,
             filesystem,
@@ -142,6 +144,7 @@ where
     {
         let Self {
             registry,
+            scoped_overlay,
             trust_policy,
             trust_policy_configured,
             filesystem,
@@ -188,6 +191,7 @@ where
         component_types.resource_governor = ProductionComponentType::of::<T>();
         HostRuntimeServices {
             registry,
+            scoped_overlay,
             trust_policy,
             trust_policy_configured,
             filesystem,

--- a/crates/kernel/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/kernel/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -8,7 +8,7 @@ use std::{
 use async_trait::async_trait;
 use futures_util::FutureExt;
 
-use ironclaw_extension_registry::ExtensionPackage;
+use ironclaw_extension_registry::{ExtensionPackage, OverlayScope, ScopedPackageOverlay};
 use ironclaw_host_api::{
     capability::CapabilityDescriptor,
     dispatch::DispatchAuthRequirement,
@@ -467,11 +467,51 @@ where
 #[derive(Clone)]
 pub(super) struct McpRuntimeAdapter {
     executor: Arc<dyn McpExecutor>,
+    /// Per-user discovered-package overlay (P2b). The scope-free resolver binds
+    /// the STATIC package, so a DISCOVERED hosted-MCP tool would fail
+    /// `CapabilityNotDeclared` (its id is not in the static package). At
+    /// dispatch the scope is known, so we swap in the caller's discovered
+    /// package when it declares the requested capability. `None` when no overlay
+    /// is wired (static-only deployments).
+    scoped_overlay: Option<Arc<ScopedPackageOverlay>>,
 }
 
 impl McpRuntimeAdapter {
     pub(super) fn from_executor(executor: Arc<dyn McpExecutor>) -> Self {
-        Self { executor }
+        Self {
+            executor,
+            scoped_overlay: None,
+        }
+    }
+
+    pub(super) fn with_scoped_overlay(mut self, overlay: Arc<ScopedPackageOverlay>) -> Self {
+        self.scoped_overlay = Some(overlay);
+        self
+    }
+
+    /// The caller's discovered package for `capability_id`'s provider, when the
+    /// overlay holds one that actually declares this capability. Returned as an
+    /// owned `Arc` so the borrow used as `McpExecutionRequest.package` lives for
+    /// the dispatch call.
+    fn discovered_package(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) -> Option<Arc<ExtensionPackage>> {
+        let overlay = self.scoped_overlay.as_ref()?;
+        let (provider, _tool) = capability_id.as_str().split_once('.')?;
+        let extension_id = ironclaw_host_api::ids::ExtensionId::new(provider).ok()?;
+        let owner = OverlayScope::new(
+            scope.tenant_id.clone(),
+            scope.user_id.clone(),
+            scope.thread_id.clone(),
+        );
+        let (package, _freshness) = overlay.get(&owner, &extension_id)?;
+        package
+            .capabilities
+            .iter()
+            .any(|descriptor| &descriptor.id == capability_id)
+            .then_some(package)
     }
 }
 
@@ -488,14 +528,21 @@ where
         // The lane holds no budget authority: it is handed the narrow
         // reserve/reconcile/release port, not the governor (#7067).
         let budget = GovernorRuntimeBudget::new(request.governor);
+        // The scope-free resolver bound the STATIC package; swap in the caller's
+        // discovered package (P2b) when it declares this capability, so a
+        // per-user hosted-MCP tool is not rejected as `CapabilityNotDeclared`
+        // and its descriptor's credential requirements resolve. Held as an owned
+        // `Arc` so the `&ExtensionPackage` borrow lives for the executor call.
+        let discovered = self.discovered_package(&request.scope, request.capability_id);
+        let package = discovered.as_deref().unwrap_or(request.package);
         let execution = self
             .executor
             .execute_extension_json(
                 &budget,
                 McpExecutionRequest {
-                    extension: &request.package.id,
-                    capabilities: &request.package.capabilities,
-                    runtime: &request.package.manifest.runtime,
+                    extension: &package.id,
+                    capabilities: &package.capabilities,
+                    runtime: &package.manifest.runtime,
                     capability_id: request.capability_id,
                     scope: request.scope,
                     estimate: request.estimate,

--- a/docs/internal/plans/composition-pubuse.snapshot
+++ b/docs/internal/plans/composition-pubuse.snapshot
@@ -28,6 +28,9 @@ pub use ironclaw_skills::{
 };
 pub use ironclaw_turns::TurnStatus;
 pub use llm_admin::openai_compat_serve::build_openai_compat_route_mount;
+#[cfg(any(test, feature = "test-support"))]
+pub use local_skill_listing::seed_skill_for_test;
+pub use local_skill_listing::{SkillListingSource, SkillOwner, open_skill_listing_source};
 pub use memory_binding::{memory_binding_diagnostics, resolve_memory_binding_policy};
 pub use memory_provider_factory::{
     Mem0ConnectionConfig, MemoryLifecycleConsumers, MemoryProviderDeps, ResolvedMemoryProvider,


### PR DESCRIPTION
**On a hosted-MCP server whose tool list depends on the credential, users overwrite each other's tools.** The discovered catalog is published per extension id — one shared slot — so the most recent discovery wins outright:

```
user A's turn → discovery → A's tools in the registry
user B's turn → discovery → A's tools replaced by B's
user A's turn → sees B's tools
```

The model watches tools appear and disappear between turns, and one caller's tool metadata is visible to another. Closes #6778.

### Evidence

From a deployment running this change, per turn, two providers in the same run:

```
hosted MCP per-user discovery refreshed the user's tool surface
  extension_id=<provider> user_id=<caller> capability_count=1
hosted MCP per-user discovery skipped: credential not provisioned
  extension_id=<other> user_id=<caller> secret_handle=<handle>
```

The second line is the degradation path: the caller has no credential for that provider, so it is skipped and the turn completes normally rather than failing or publishing an empty catalog over someone else's.

`merged_discovery_keeps_other_principals_catalog` is the unit-level version of the same property.

### What changed

- `ScopedPackageOverlay` holds discovered packages keyed by `(tenant, user, thread)`, with a TTL, a bounded size, and negative entries so a provider that rejected a caller's credential is not re-probed every turn.
- Discovery runs at turn start under the caller's own scope and credential — never a shared one.
- Surface, grants, provider trust, dispatch and egress read one overlaid view with global-registry fallback, so they cannot disagree about what the caller sees. That single read path is why the diff touches several crates.
- Publication merges instead of replacing: fresh wins per capability id, the rest of the published catalog survives. Per-caller publication is only safe once this holds.
- A discovered tool whose id matches a manifest-declared capability keeps that declaration's effects and `default_permission`, so discovery cannot downgrade a reviewed tool. Host-internal connection templates are excluded — they are plumbing, not a grant.
- Failure handling degrades rather than failing the turn: transient keeps the last-good surface, permanent suppresses the re-probe, a rejected credential is the caller's own auth problem.

### Verify

```
cargo test -p ironclaw_extension_registry --lib          # 72
cargo test -p ironclaw_composition --lib capability_host
RUST_MIN_STACK=67108864 cargo test --workspace --lib
```

`RUST_MIN_STACK` is needed for the composition suite regardless of this change.

### Risk

Callers with no overlay entry fall back to the global registry, so a deployment with a single principal per extension behaves as before. Rollback is a revert; the overlay is in-memory, nothing is persisted in a new shape, and there is no migration.

Not covered: the overlay is per-process. A multi-process deployment discovers per process rather than sharing one cache — correct, just not shared.

This merges the catalog-merge change (previously #8083, now closed) into the fix that needs it, since reviewing them apart meant reading the merge without the caller that makes it necessary.

https://claude.ai/code/session_01MciaHokSWPNsR692c2cTw1